### PR TITLE
COE-260: Define domain models and scheduler state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "opensymphony-cli"
 version = "0.1.0"
 
@@ -13,6 +25,11 @@ version = "0.1.0"
 [[package]]
 name = "opensymphony-domain"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "opensymphony-linear"
@@ -29,6 +46,9 @@ version = "0.1.0"
 [[package]]
 name = "opensymphony-orchestrator"
 version = "0.1.0"
+dependencies = [
+ "opensymphony-domain",
+]
 
 [[package]]
 name = "opensymphony-testkit"
@@ -45,3 +65,107 @@ version = "0.1.0"
 [[package]]
 name = "opensymphony-workspace"
 version = "0.1.0"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ repository = "https://github.com/kumanday/OpenSymphony"
 rust-version = "1.85"
 version = "0.1.0"
 
+[workspace.dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+thiserror = "2.0.17"
+
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 unsafe_code = "forbid"

--- a/crates/opensymphony-domain/Cargo.toml
+++ b/crates/opensymphony-domain/Cargo.toml
@@ -9,3 +9,10 @@ version.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/opensymphony-domain/src/identifiers.rs
+++ b/crates/opensymphony-domain/src/identifiers.rs
@@ -1,0 +1,64 @@
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IdentifierError {
+    #[error("{kind} cannot be empty")]
+    Empty { kind: &'static str },
+}
+
+macro_rules! string_identifier {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, IdentifierError> {
+                let value = value.into();
+                if value.trim().is_empty() {
+                    return Err(IdentifierError::Empty {
+                        kind: stringify!($name),
+                    });
+                }
+
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(self.as_str())
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = IdentifierError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::new(value)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = IdentifierError;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+    };
+}
+
+string_identifier!(ConversationId);
+string_identifier!(IssueId);
+string_identifier!(IssueIdentifier);
+string_identifier!(TrackerStateId);
+string_identifier!(WorkspaceKey);
+string_identifier!(WorkerId);

--- a/crates/opensymphony-domain/src/identifiers.rs
+++ b/crates/opensymphony-domain/src/identifiers.rs
@@ -60,5 +60,60 @@ string_identifier!(ConversationId);
 string_identifier!(IssueId);
 string_identifier!(IssueIdentifier);
 string_identifier!(TrackerStateId);
-string_identifier!(WorkspaceKey);
 string_identifier!(WorkerId);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkspaceKey(String);
+
+impl WorkspaceKey {
+    pub fn new(value: impl Into<String>) -> Result<Self, IdentifierError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(IdentifierError::Empty {
+                kind: stringify!(WorkspaceKey),
+            });
+        }
+
+        Ok(Self(sanitize_workspace_key(&value)))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for WorkspaceKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WorkspaceKey {
+    type Err = IdentifierError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for WorkspaceKey {
+    type Error = IdentifierError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+fn sanitize_workspace_key(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/crates/opensymphony-domain/src/issue.rs
+++ b/crates/opensymphony-domain/src/issue.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{IssueId, IssueIdentifier, TimestampMs, TrackerStateId};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueStateCategory {
+    Active,
+    NonActive,
+    Terminal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueState {
+    pub id: Option<TrackerStateId>,
+    pub name: String,
+    pub category: IssueStateCategory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockerRef {
+    pub id: Option<IssueId>,
+    pub identifier: Option<IssueIdentifier>,
+    pub state: Option<String>,
+    pub created_at: Option<TimestampMs>,
+    pub updated_at: Option<TimestampMs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedIssue {
+    pub id: IssueId,
+    pub identifier: IssueIdentifier,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: Option<u8>,
+    pub state: IssueState,
+    pub branch_name: Option<String>,
+    pub url: Option<String>,
+    pub labels: Vec<String>,
+    pub blocked_by: Vec<BlockerRef>,
+    pub created_at: Option<TimestampMs>,
+    pub updated_at: Option<TimestampMs>,
+}

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -318,6 +318,58 @@ mod tests {
     }
 
     #[test]
+    fn start_running_requires_conversation_metadata_for_first_run() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let error = match execution.start_running(ts(50), super::DurationMs::new(300), None) {
+            Ok(_) => panic!("starting the first run without conversation metadata should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::ConversationNotAttached
+        ));
+    }
+
+    #[test]
+    fn start_running_can_reuse_retained_conversation_metadata() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let execution = must(execution.start_running(
+            ts(50),
+            super::DurationMs::new(300),
+            Some(sample_conversation(false)),
+        ));
+        let execution = must(execution.release(ts(60), ReleaseReason::TrackerInactive, None));
+        let execution = must(execution.reopen(ts(70)));
+
+        let run = sample_run(&issue, &workspace, None, ts(80));
+        let execution = must(execution.claim(run));
+        let execution = must(execution.start_running(ts(90), super::DurationMs::new(300), None));
+
+        assert_eq!(
+            must_some(
+                execution.conversation(),
+                "retained conversation metadata should be reused",
+            )
+            .conversation_id
+            .as_str(),
+            "conv_260"
+        );
+        assert_eq!(execution.status(), SchedulerStatus::Running);
+    }
+
+    #[test]
     fn claim_accepts_equivalent_normalized_workspace_paths() {
         let issue = sample_issue();
         let workspace = sample_workspace();
@@ -609,6 +661,27 @@ mod tests {
     }
 
     #[test]
+    fn attach_workspace_rejects_first_binding_for_the_wrong_issue_path() {
+        let issue = sample_issue();
+        let workspace = WorkspaceRecord {
+            path: PathBuf::from("/tmp/workspaces/COE-261"),
+            workspace_key: must(WorkspaceKey::new("COE-260")),
+            ..sample_workspace()
+        };
+        let mut execution = IssueExecution::new(issue, ts(30));
+
+        let error = match execution.attach_workspace(workspace) {
+            Ok(_) => panic!("first workspace attachment for a different issue path should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::WorkspaceIssueMismatch { .. }
+        ));
+        assert!(execution.workspace().is_none());
+    }
+
+    #[test]
     fn attach_workspace_allows_refresh_for_same_identity() {
         let issue = sample_issue();
         let workspace = sample_workspace();
@@ -653,5 +726,98 @@ mod tests {
                 .map(|worker| worker.normal_retry_count),
             Some(0)
         );
+    }
+
+    #[test]
+    fn queue_retry_rejects_outcomes_from_a_different_worker() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let outcome = WorkerOutcomeRecord {
+            worker_id: must(WorkerId::new("worker-2")),
+            attempt: None,
+            outcome: WorkerOutcomeKind::Failed,
+            started_at: ts(40),
+            finished_at: ts(41),
+            turn_count: 0,
+            summary: Some("stale worker".to_owned()),
+            error: Some("boom".to_owned()),
+        };
+        let retry = must(RetryEntry::failure(
+            &issue,
+            None,
+            0,
+            ts(41),
+            RetryReason::Failure,
+            Some("boom".to_owned()),
+            RetryPolicy::default(),
+        ));
+
+        let error = match execution.queue_retry(retry, outcome) {
+            Ok(_) => panic!("queue_retry should reject stale worker outcomes"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, StateTransitionError::WorkerMismatch { .. }));
+    }
+
+    #[test]
+    fn queue_retry_rejects_outcomes_from_a_different_attempt() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let first_run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(first_run));
+        let first_outcome = WorkerOutcomeRecord::from_run(
+            must_some(execution.current_run(), "claimed run must exist"),
+            WorkerOutcomeKind::Succeeded,
+            ts(50),
+            Some("completed".to_owned()),
+            None,
+        );
+        let first_retry = must(RetryEntry::continuation(
+            &issue,
+            None,
+            0,
+            ts(50),
+            RetryPolicy::default(),
+        ));
+        let execution = must(execution.queue_retry(first_retry.clone(), first_outcome));
+
+        let retry_run = sample_run(&issue, &workspace, Some(first_retry.attempt), ts(60));
+        let execution = must(execution.claim(retry_run));
+        let stale_outcome = WorkerOutcomeRecord {
+            worker_id: must(WorkerId::new("worker-1")),
+            attempt: None,
+            outcome: WorkerOutcomeKind::Failed,
+            started_at: ts(40),
+            finished_at: ts(61),
+            turn_count: 1,
+            summary: Some("old attempt".to_owned()),
+            error: Some("boom".to_owned()),
+        };
+        let retry = must(RetryEntry::failure(
+            &issue,
+            Some(first_retry.attempt),
+            1,
+            ts(61),
+            RetryReason::Failure,
+            Some("boom".to_owned()),
+            RetryPolicy::default(),
+        ));
+
+        let error = match execution.queue_retry(retry, stale_outcome) {
+            Ok(_) => panic!("queue_retry should reject stale attempt outcomes"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::AttemptMismatch { .. }
+        ));
     }
 }

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -172,6 +172,16 @@ mod tests {
             must_some(execution.retry(), "retry metadata must exist").attempt,
             retry.attempt
         );
+        let retry_snapshot = execution.snapshot();
+        assert_eq!(
+            must_some(
+                retry_snapshot.conversation,
+                "retry-queued snapshots must retain conversation metadata",
+            )
+            .conversation_id
+            .as_str(),
+            "conv_260"
+        );
         assert_eq!(
             must_some(
                 execution.last_worker_outcome(),
@@ -320,5 +330,54 @@ mod tests {
             json!("/tmp/workspaces/COE-260")
         );
         assert_eq!(json["issues"][0]["retry"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn replayed_runtime_events_do_not_hide_existing_stalls() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let session = ConversationMetadata {
+            conversation_id: must(super::ConversationId::new("conv_260")),
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            fresh_conversation: false,
+            runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
+            stream_state: RuntimeStreamState::Ready,
+            last_event_id: None,
+            last_event_kind: None,
+            last_event_at: None,
+            last_event_summary: None,
+        };
+
+        let mut execution =
+            must(execution.start_running(ts(50), super::DurationMs::new(300), Some(session)));
+
+        must(execution.observe_runtime_event(
+            ts(60),
+            Some("evt_latest".to_owned()),
+            Some("conversation_state_update".to_owned()),
+            Some("ready".to_owned()),
+        ));
+        must(execution.observe_runtime_event(
+            ts(55),
+            Some("evt_old".to_owned()),
+            Some("tool_call".to_owned()),
+            Some("replayed".to_owned()),
+        ));
+
+        let conversation = must_some(
+            execution.conversation(),
+            "running execution must keep conversation metadata",
+        );
+        assert_eq!(conversation.last_event_at, Some(ts(60)));
+        assert_eq!(conversation.last_event_id.as_deref(), Some("evt_latest"));
+
+        let snapshot = execution.snapshot();
+        assert_eq!(snapshot.runtime.last_event_at, Some(ts(60)));
+        assert_eq!(snapshot.runtime.stalled_at, Some(ts(360)));
     }
 }

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -1,16 +1,324 @@
+mod identifiers;
+mod issue;
+mod runtime;
+mod snapshot;
+mod state_machine;
+mod time;
+
 pub const CRATE_NAME: &str = "opensymphony-domain";
 
-pub fn placeholder_summary() -> &'static str {
-    "shared domain types, runtime enums, snapshot models, and config-independent constants"
-}
+pub use identifiers::{
+    ConversationId, IdentifierError, IssueId, IssueIdentifier, TrackerStateId, WorkerId,
+    WorkspaceKey,
+};
+pub use issue::{BlockerRef, IssueState, IssueStateCategory, NormalizedIssue};
+pub use runtime::{
+    ConversationMetadata, ReleaseReason, RetryAttempt, RetryCalculationError, RetryEntry,
+    RetryPolicy, RetryReason, RunAttempt, RuntimeStreamState, StallMetadata, WorkerOutcomeKind,
+    WorkerOutcomeRecord, WorkspaceRecord,
+};
+pub use snapshot::{
+    ComponentHealthSnapshot, DaemonSnapshot, HealthStatus, IssueSnapshot, OrchestratorSnapshot,
+    RetrySnapshot, RuntimeStateSnapshot, RuntimeUsageTotals, WorkerAttemptSnapshot,
+};
+pub use state_machine::{
+    IssueExecution, SchedulerState, SchedulerStatus, StateTransitionError, TransitionAction,
+};
+pub use time::{DurationMs, TimestampMs};
 
 #[cfg(test)]
 mod tests {
-    use super::{CRATE_NAME, placeholder_summary};
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use super::{
+        ComponentHealthSnapshot, ConversationMetadata, HealthStatus, IssueExecution, IssueId,
+        IssueIdentifier, IssueSnapshot, IssueState, IssueStateCategory, NormalizedIssue,
+        OrchestratorSnapshot, ReleaseReason, RetryAttempt, RetryEntry, RetryPolicy, RetryReason,
+        RunAttempt, RuntimeStreamState, RuntimeUsageTotals, SchedulerStatus, StateTransitionError,
+        TimestampMs, WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey,
+        WorkspaceRecord,
+    };
+
+    fn must<T, E: std::fmt::Display>(result: Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("{error}"),
+        }
+    }
+
+    fn must_some<T>(value: Option<T>, message: &str) -> T {
+        match value {
+            Some(value) => value,
+            None => panic!("{message}"),
+        }
+    }
+
+    fn ts(value: u64) -> TimestampMs {
+        TimestampMs::new(value)
+    }
+
+    fn sample_issue() -> NormalizedIssue {
+        NormalizedIssue {
+            id: must(IssueId::new("lin_260")),
+            identifier: must(IssueIdentifier::new("COE-260")),
+            title: "Domain model and orchestrator state machine".to_owned(),
+            description: Some("Define the shared orchestration model.".to_owned()),
+            priority: Some(1),
+            state: IssueState {
+                id: None,
+                name: "In Progress".to_owned(),
+                category: IssueStateCategory::Active,
+            },
+            branch_name: Some(
+                "leonardogonzalez/coe-260-domain-model-and-orchestrator-state-machine".to_owned(),
+            ),
+            url: Some(
+                "https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine"
+                    .to_owned(),
+            ),
+            labels: vec!["foundation".to_owned(), "contracts".to_owned()],
+            blocked_by: Vec::new(),
+            created_at: Some(ts(10)),
+            updated_at: Some(ts(20)),
+        }
+    }
+
+    fn sample_workspace() -> WorkspaceRecord {
+        WorkspaceRecord {
+            path: PathBuf::from("/tmp/workspaces/COE-260"),
+            workspace_key: must(WorkspaceKey::new("COE-260")),
+            created_now: false,
+            created_at: Some(ts(11)),
+            updated_at: Some(ts(21)),
+            last_seen_tracker_refresh_at: Some(ts(22)),
+        }
+    }
+
+    fn sample_run(
+        issue: &NormalizedIssue,
+        workspace: &WorkspaceRecord,
+        attempt: Option<RetryAttempt>,
+        claimed_at: TimestampMs,
+    ) -> RunAttempt {
+        RunAttempt::new(
+            must(WorkerId::new("worker-1")),
+            issue.id.clone(),
+            issue.identifier.clone(),
+            workspace.path.clone(),
+            claimed_at,
+            attempt,
+            8,
+        )
+    }
 
     #[test]
-    fn reports_its_boundary() {
-        assert_eq!(CRATE_NAME, "opensymphony-domain");
-        assert!(placeholder_summary().contains("shared domain types"));
+    fn state_transitions_are_explicit_and_testable() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        assert_eq!(execution.status(), SchedulerStatus::Claimed);
+
+        let session = ConversationMetadata {
+            conversation_id: must(super::ConversationId::new("conv_260")),
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            fresh_conversation: true,
+            runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
+            stream_state: RuntimeStreamState::Attaching,
+            last_event_id: None,
+            last_event_kind: None,
+            last_event_at: None,
+            last_event_summary: None,
+        };
+
+        let mut execution =
+            must(execution.start_running(ts(50), super::DurationMs::new(300_000), Some(session)));
+        assert_eq!(execution.status(), SchedulerStatus::Running);
+
+        must(execution.record_turn_started(ts(55)));
+        must(execution.observe_runtime_event(
+            ts(56),
+            Some("evt_1".to_owned()),
+            Some("conversation_state_update".to_owned()),
+            Some("ready".to_owned()),
+        ));
+
+        let running = must_some(execution.current_run(), "running attempt must exist");
+        assert_eq!(running.turn_count, 1);
+        let outcome = WorkerOutcomeRecord::from_run(
+            running,
+            WorkerOutcomeKind::Succeeded,
+            ts(60),
+            Some("worker exited cleanly".to_owned()),
+            None,
+        );
+
+        let retry = must(RetryEntry::continuation(
+            &issue,
+            running.attempt,
+            0,
+            ts(60),
+            RetryPolicy::default(),
+        ));
+
+        let execution = must(execution.queue_retry(retry.clone(), outcome.clone()));
+        assert_eq!(execution.status(), SchedulerStatus::RetryQueued);
+        assert_eq!(
+            must_some(execution.retry(), "retry metadata must exist").attempt,
+            retry.attempt
+        );
+        assert_eq!(
+            must_some(
+                execution.last_worker_outcome(),
+                "last worker outcome must be recorded",
+            )
+            .outcome,
+            WorkerOutcomeKind::Succeeded
+        );
+
+        let retry_run = sample_run(&issue, &workspace, Some(retry.attempt), ts(61));
+        let execution = must(execution.claim(retry_run));
+        assert_eq!(execution.status(), SchedulerStatus::Claimed);
+
+        let execution = must(execution.release(ts(70), ReleaseReason::TrackerInactive, None));
+        assert_eq!(execution.status(), SchedulerStatus::Released);
+
+        let snapshot = execution.snapshot();
+        assert_eq!(snapshot.runtime.state, SchedulerStatus::Released);
+        assert_eq!(
+            snapshot.runtime.release_reason,
+            Some(ReleaseReason::TrackerInactive)
+        );
+        assert_eq!(snapshot.recent_worker_outcomes.len(), 1);
+    }
+
+    #[test]
+    fn invalid_transitions_and_attempt_mismatches_are_rejected() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+
+        let execution = IssueExecution::new(issue.clone(), ts(30));
+        let error = match execution.start_running(ts(50), super::DurationMs::new(10_000), None) {
+            Ok(_) => panic!("starting from unclaimed should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::InvalidTransition { .. }
+        ));
+
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let outcome = WorkerOutcomeRecord {
+            worker_id: must(WorkerId::new("worker-1")),
+            attempt: None,
+            outcome: WorkerOutcomeKind::Failed,
+            started_at: ts(40),
+            finished_at: ts(41),
+            turn_count: 0,
+            summary: None,
+            error: Some("boom".to_owned()),
+        };
+        let retry = must(RetryEntry::failure(
+            &issue,
+            None,
+            0,
+            ts(41),
+            RetryReason::Failure,
+            Some("boom".to_owned()),
+            RetryPolicy::default(),
+        ));
+        let execution = must(execution.queue_retry(retry.clone(), outcome));
+
+        let wrong_attempt_run = sample_run(&issue, &workspace, None, ts(42));
+        let error = match execution.claim(wrong_attempt_run) {
+            Ok(_) => panic!("claiming with the wrong retry attempt should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::AttemptMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn retry_delay_math_matches_continuation_and_failure_rules() {
+        let issue = sample_issue();
+        let policy = RetryPolicy::default();
+
+        let continuation = must(RetryEntry::continuation(&issue, None, 0, ts(100), policy));
+        assert_eq!(continuation.attempt.get(), 1);
+        assert_eq!(continuation.normal_retry_count, 1);
+        assert_eq!(continuation.due_at, ts(1_100));
+
+        let first_failure = must(RetryEntry::failure(
+            &issue,
+            None,
+            1,
+            ts(100),
+            RetryReason::Failure,
+            Some("first failure".to_owned()),
+            policy,
+        ));
+        assert_eq!(first_failure.attempt.get(), 1);
+        assert_eq!(first_failure.due_at, ts(10_100));
+
+        let capped_policy = RetryPolicy {
+            continuation_delay_ms: super::DurationMs::new(1_000),
+            failure_base_delay_ms: super::DurationMs::new(10_000),
+            max_backoff_ms: super::DurationMs::new(25_000),
+        };
+        let fifth_attempt = must(RetryAttempt::new(5));
+        assert_eq!(
+            capped_policy.failure_delay(fifth_attempt),
+            super::DurationMs::new(25_000)
+        );
+    }
+
+    #[test]
+    fn snapshot_models_serialize_stably() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let issue_snapshot = IssueSnapshot::from(&execution);
+
+        let snapshot = OrchestratorSnapshot::new(
+            ts(100),
+            super::DaemonSnapshot::new(
+                HealthStatus::Healthy,
+                30_000,
+                4,
+                Some(ts(90)),
+                ComponentHealthSnapshot {
+                    status: HealthStatus::Healthy,
+                    detail: Some("ready".to_owned()),
+                    updated_at: Some(ts(95)),
+                },
+                RuntimeUsageTotals::default(),
+            ),
+            vec![issue_snapshot],
+        );
+
+        let json = must(serde_json::to_value(&snapshot));
+        assert_eq!(json["generated_at"], json!(100));
+        assert_eq!(json["daemon"]["health"], json!("healthy"));
+        assert_eq!(json["daemon"]["running_issue_count"], json!(0));
+        assert_eq!(json["issues"][0]["issue"]["identifier"], json!("COE-260"));
+        assert_eq!(json["issues"][0]["runtime"]["state"], json!("claimed"));
+        assert_eq!(
+            json["issues"][0]["workspace"]["path"],
+            json!("/tmp/workspaces/COE-260")
+        );
+        assert_eq!(json["issues"][0]["retry"], serde_json::Value::Null);
     }
 }

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -165,7 +165,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
@@ -232,6 +232,10 @@ mod tests {
         let retry_run = sample_run(&issue, &workspace, Some(retry.attempt), ts(61));
         let execution = must(execution.claim(retry_run));
         assert_eq!(execution.status(), SchedulerStatus::Claimed);
+        assert_eq!(
+            must_some(execution.current_run(), "claimed retry run must exist").normal_retry_count,
+            1
+        );
 
         let execution = must(execution.release(ts(70), ReleaseReason::TrackerInactive, None));
         assert_eq!(execution.status(), SchedulerStatus::Released);
@@ -261,7 +265,7 @@ mod tests {
         ));
 
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
         let outcome = WorkerOutcomeRecord {
@@ -318,7 +322,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let mut run = sample_run(&issue, &workspace, None, ts(40));
         run.workspace_path = PathBuf::from("/tmp/workspaces/../workspaces/COE-260");
@@ -346,7 +350,7 @@ mod tests {
         };
 
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let mut run = sample_run(&issue, &workspace, None, ts(40));
         run.workspace_path = canonical_workspace;
@@ -404,7 +408,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
@@ -426,7 +430,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
@@ -448,7 +452,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let mut next_attempt = None;
 
@@ -505,7 +509,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
         let issue_snapshot = IssueSnapshot::from(&execution);
@@ -545,7 +549,7 @@ mod tests {
         let issue = sample_issue();
         let workspace = sample_workspace();
         let mut execution = IssueExecution::new(issue.clone(), ts(30));
-        execution.attach_workspace(workspace.clone());
+        must(execution.attach_workspace(workspace.clone()));
 
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
@@ -578,5 +582,76 @@ mod tests {
         let snapshot = execution.snapshot();
         assert_eq!(snapshot.runtime.last_event_at, Some(ts(60)));
         assert_eq!(snapshot.runtime.stalled_at, Some(ts(360)));
+    }
+
+    #[test]
+    fn attach_workspace_rejects_rebinding_to_different_identity() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue, ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let rebound_workspace = WorkspaceRecord {
+            path: PathBuf::from("/tmp/workspaces/COE-260-alt"),
+            workspace_key: must(WorkspaceKey::new("COE-260-alt")),
+            ..workspace.clone()
+        };
+
+        let error = match execution.attach_workspace(rebound_workspace) {
+            Ok(_) => panic!("rebinding a different workspace identity should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::WorkspaceIdentityMismatch { .. }
+        ));
+        assert_eq!(execution.workspace(), Some(&workspace));
+    }
+
+    #[test]
+    fn attach_workspace_allows_refresh_for_same_identity() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue, ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let refreshed_workspace = WorkspaceRecord {
+            updated_at: Some(ts(99)),
+            last_seen_tracker_refresh_at: Some(ts(100)),
+            ..workspace.clone()
+        };
+
+        must(execution.attach_workspace(refreshed_workspace.clone()));
+        assert_eq!(execution.workspace(), Some(&refreshed_workspace));
+    }
+
+    #[test]
+    fn running_snapshot_last_event_at_stays_none_without_runtime_events() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let mut execution = must(execution.start_running(
+            ts(50),
+            super::DurationMs::new(300),
+            Some(sample_conversation(false)),
+        ));
+
+        must(execution.record_turn_started(ts(55)));
+
+        let snapshot = execution.snapshot();
+        assert_eq!(snapshot.runtime.last_event_at, None);
+        assert_eq!(snapshot.runtime.stalled_at, Some(ts(355)));
+        assert_eq!(
+            snapshot
+                .runtime
+                .worker
+                .as_ref()
+                .map(|worker| worker.normal_retry_count),
+            Some(0)
+        );
     }
 }

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -297,6 +297,23 @@ mod tests {
     }
 
     #[test]
+    fn claim_rejects_runs_without_an_attached_workspace() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let execution = IssueExecution::new(issue.clone(), ts(30));
+        let run = sample_run(&issue, &workspace, None, ts(40));
+
+        let error = match execution.claim(run) {
+            Ok(_) => panic!("claiming without an attached workspace should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StateTransitionError::WorkspaceNotAttached { .. }
+        ));
+    }
+
+    #[test]
     fn claim_accepts_equivalent_normalized_workspace_paths() {
         let issue = sample_issue();
         let workspace = sample_workspace();

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -28,7 +28,14 @@ pub use time::{DurationMs, TimestampMs};
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
 
     use serde_json::json;
 
@@ -57,6 +64,32 @@ mod tests {
 
     fn ts(value: u64) -> TimestampMs {
         TimestampMs::new(value)
+    }
+
+    fn unique_temp_path(prefix: &str) -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        std::env::temp_dir().join(format!(
+            "opensymphony-domain-{prefix}-{}-{unique_suffix}",
+            std::process::id()
+        ))
+    }
+
+    struct TempPathGuard(PathBuf);
+
+    impl TempPathGuard {
+        fn new(path: PathBuf) -> Self {
+            Self(path)
+        }
+    }
+
+    impl Drop for TempPathGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
     }
 
     fn sample_issue() -> NormalizedIssue {
@@ -256,6 +289,58 @@ mod tests {
             error,
             StateTransitionError::AttemptMismatch { .. }
         ));
+    }
+
+    #[test]
+    fn claim_accepts_equivalent_normalized_workspace_paths() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let mut run = sample_run(&issue, &workspace, None, ts(40));
+        run.workspace_path = PathBuf::from("/tmp/workspaces/../workspaces/COE-260");
+
+        let execution = must(execution.claim(run));
+        assert_eq!(execution.status(), SchedulerStatus::Claimed);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claim_accepts_workspace_paths_with_equivalent_symlink_roots() {
+        let issue = sample_issue();
+        let temp_root = unique_temp_path("workspace-symlink");
+        let _temp_root_guard = TempPathGuard::new(temp_root.clone());
+        let canonical_root = temp_root.join("canonical-root");
+        let canonical_workspace = canonical_root.join("COE-260");
+        let symlink_root = temp_root.join("symlink-root");
+
+        must(fs::create_dir_all(&canonical_workspace));
+        must(symlink(&canonical_root, &symlink_root));
+
+        let workspace = WorkspaceRecord {
+            path: symlink_root.join("COE-260"),
+            ..sample_workspace()
+        };
+
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let mut run = sample_run(&issue, &workspace, None, ts(40));
+        run.workspace_path = canonical_workspace;
+
+        let execution = must(execution.claim(run));
+        assert_eq!(execution.status(), SchedulerStatus::Claimed);
+    }
+
+    #[test]
+    fn workspace_keys_are_sanitized_on_creation() {
+        assert_eq!(must(WorkspaceKey::new("feature/42")).as_str(), "feature_42");
+        assert_eq!(must(WorkspaceKey::new("../tmp")).as_str(), ".._tmp");
+        assert_eq!(
+            must(WorkspaceKey::new("Bug: weird path")).as_str(),
+            "Bug__weird_path"
+        );
     }
 
     #[test]

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -146,6 +146,20 @@ mod tests {
         )
     }
 
+    fn sample_conversation(fresh_conversation: bool) -> ConversationMetadata {
+        ConversationMetadata {
+            conversation_id: must(super::ConversationId::new("conv_260")),
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            fresh_conversation,
+            runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
+            stream_state: RuntimeStreamState::Ready,
+            last_event_id: None,
+            last_event_kind: None,
+            last_event_at: None,
+            last_event_summary: None,
+        }
+    }
+
     #[test]
     fn state_transitions_are_explicit_and_testable() {
         let issue = sample_issue();
@@ -157,17 +171,8 @@ mod tests {
         let execution = must(execution.claim(run));
         assert_eq!(execution.status(), SchedulerStatus::Claimed);
 
-        let session = ConversationMetadata {
-            conversation_id: must(super::ConversationId::new("conv_260")),
-            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
-            fresh_conversation: true,
-            runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
-            stream_state: RuntimeStreamState::Attaching,
-            last_event_id: None,
-            last_event_kind: None,
-            last_event_at: None,
-            last_event_summary: None,
-        };
+        let mut session = sample_conversation(true);
+        session.stream_state = RuntimeStreamState::Attaching;
 
         let mut execution =
             must(execution.start_running(ts(50), super::DurationMs::new(300_000), Some(session)));
@@ -378,6 +383,107 @@ mod tests {
     }
 
     #[test]
+    fn reopen_preserves_workspace_and_conversation_after_inactive_release() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let execution = must(execution.start_running(
+            ts(50),
+            super::DurationMs::new(300_000),
+            Some(sample_conversation(false)),
+        ));
+        let execution = must(execution.release(ts(60), ReleaseReason::TrackerInactive, None));
+        let execution = must(execution.reopen(ts(70)));
+
+        assert_eq!(execution.status(), SchedulerStatus::Unclaimed);
+        assert_eq!(execution.workspace(), Some(&workspace));
+        assert!(execution.conversation().is_some());
+    }
+
+    #[test]
+    fn reopen_clears_workspace_and_conversation_after_terminal_release() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let execution = must(execution.start_running(
+            ts(50),
+            super::DurationMs::new(300_000),
+            Some(sample_conversation(false)),
+        ));
+        let execution = must(execution.release(ts(60), ReleaseReason::TrackerTerminal, None));
+        let execution = must(execution.reopen(ts(70)));
+
+        assert_eq!(execution.status(), SchedulerStatus::Unclaimed);
+        assert!(execution.workspace().is_none());
+        assert!(execution.conversation().is_none());
+    }
+
+    #[test]
+    fn recent_worker_outcomes_are_bounded_to_latest_window() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        execution.attach_workspace(workspace.clone());
+
+        let mut next_attempt = None;
+
+        for index in 0_u64..12 {
+            let claimed_at = ts(40 + index * 10);
+            let run = sample_run(&issue, &workspace, next_attempt, claimed_at);
+            execution = must(execution.claim(run));
+
+            let current_run = must_some(execution.current_run(), "claimed run must exist");
+            let summary = format!("outcome {index}");
+            let finished_at = ts(45 + index * 10);
+            let outcome = WorkerOutcomeRecord::from_run(
+                current_run,
+                WorkerOutcomeKind::Failed,
+                finished_at,
+                Some(summary.clone()),
+                Some("boom".to_owned()),
+            );
+            let retry = must(RetryEntry::failure(
+                &issue,
+                current_run.attempt,
+                0,
+                finished_at,
+                RetryReason::Failure,
+                Some("boom".to_owned()),
+                RetryPolicy::default(),
+            ));
+
+            next_attempt = Some(retry.attempt);
+            execution = must(execution.queue_retry(retry, outcome));
+        }
+
+        let snapshot = execution.snapshot();
+        assert_eq!(
+            snapshot
+                .last_worker_outcome
+                .as_ref()
+                .and_then(|outcome| outcome.summary.as_deref()),
+            Some("outcome 11")
+        );
+        assert_eq!(snapshot.recent_worker_outcomes.len(), 10);
+        assert_eq!(
+            snapshot.recent_worker_outcomes[0].summary.as_deref(),
+            Some("outcome 2")
+        );
+        assert_eq!(
+            snapshot.recent_worker_outcomes[9].summary.as_deref(),
+            Some("outcome 11")
+        );
+    }
+
+    #[test]
     fn snapshot_models_serialize_stably() {
         let issue = sample_issue();
         let workspace = sample_workspace();
@@ -426,20 +532,11 @@ mod tests {
 
         let run = sample_run(&issue, &workspace, None, ts(40));
         let execution = must(execution.claim(run));
-        let session = ConversationMetadata {
-            conversation_id: must(super::ConversationId::new("conv_260")),
-            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
-            fresh_conversation: false,
-            runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
-            stream_state: RuntimeStreamState::Ready,
-            last_event_id: None,
-            last_event_kind: None,
-            last_event_at: None,
-            last_event_summary: None,
-        };
-
-        let mut execution =
-            must(execution.start_running(ts(50), super::DurationMs::new(300), Some(session)));
+        let mut execution = must(execution.start_running(
+            ts(50),
+            super::DurationMs::new(300),
+            Some(sample_conversation(false)),
+        ));
 
         must(execution.observe_runtime_event(
             ts(60),

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -337,3 +337,9 @@ pub enum ReleaseReason {
     Cancelled,
     RetryExhausted,
 }
+
+impl ReleaseReason {
+    pub const fn preserves_reactivation_state(self) -> bool {
+        matches!(self, Self::TrackerInactive)
+    }
+}

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -1,0 +1,328 @@
+use std::{fmt, num::NonZeroU32, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    ConversationId, DurationMs, IssueId, IssueIdentifier, TimestampMs, WorkerId, WorkspaceKey,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceRecord {
+    pub path: PathBuf,
+    pub workspace_key: WorkspaceKey,
+    pub created_now: bool,
+    pub created_at: Option<TimestampMs>,
+    pub updated_at: Option<TimestampMs>,
+    pub last_seen_tracker_refresh_at: Option<TimestampMs>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RetryAttempt(NonZeroU32);
+
+impl RetryAttempt {
+    pub const fn first() -> Self {
+        Self(NonZeroU32::MIN)
+    }
+
+    pub fn new(value: u32) -> Result<Self, RetryCalculationError> {
+        match NonZeroU32::new(value) {
+            Some(value) => Ok(Self(value)),
+            None => Err(RetryCalculationError::ZeroAttempt),
+        }
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+
+    pub fn after(previous: Option<Self>) -> Result<Self, RetryCalculationError> {
+        match previous {
+            Some(previous) => previous
+                .checked_next()
+                .ok_or(RetryCalculationError::AttemptOverflow),
+            None => Ok(Self::first()),
+        }
+    }
+
+    pub fn checked_next(self) -> Option<Self> {
+        self.0
+            .get()
+            .checked_add(1)
+            .and_then(NonZeroU32::new)
+            .map(Self)
+    }
+}
+
+impl fmt::Display for RetryAttempt {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.get())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RetryCalculationError {
+    #[error("retry attempt must be greater than zero")]
+    ZeroAttempt,
+    #[error("retry attempt overflowed the supported range")]
+    AttemptOverflow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStreamState {
+    Detached,
+    Attaching,
+    Ready,
+    Reconnecting,
+    Closed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationMetadata {
+    pub conversation_id: ConversationId,
+    pub server_base_url: Option<String>,
+    pub fresh_conversation: bool,
+    pub runtime_contract_version: Option<String>,
+    pub stream_state: RuntimeStreamState,
+    pub last_event_id: Option<String>,
+    pub last_event_kind: Option<String>,
+    pub last_event_at: Option<TimestampMs>,
+    pub last_event_summary: Option<String>,
+}
+
+impl ConversationMetadata {
+    pub fn observe_event(
+        &mut self,
+        observed_at: TimestampMs,
+        event_id: Option<String>,
+        event_kind: Option<String>,
+        summary: Option<String>,
+    ) {
+        self.last_event_at = Some(observed_at);
+        self.last_event_id = event_id;
+        self.last_event_kind = event_kind;
+        self.last_event_summary = summary;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetryPolicy {
+    pub continuation_delay_ms: DurationMs,
+    pub failure_base_delay_ms: DurationMs,
+    pub max_backoff_ms: DurationMs,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            continuation_delay_ms: DurationMs::new(1_000),
+            failure_base_delay_ms: DurationMs::new(10_000),
+            max_backoff_ms: DurationMs::new(300_000),
+        }
+    }
+}
+
+impl RetryPolicy {
+    pub fn failure_delay(self, attempt: RetryAttempt) -> DurationMs {
+        let exponent = attempt.get().saturating_sub(1).min(63);
+        let multiplier = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+        let uncapped = self
+            .failure_base_delay_ms
+            .as_u64()
+            .saturating_mul(multiplier);
+
+        DurationMs::new(uncapped.min(self.max_backoff_ms.as_u64()))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryReason {
+    Continuation,
+    Failure,
+    Stalled,
+    Cancelled,
+    Reconciliation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetryEntry {
+    pub issue_id: IssueId,
+    pub identifier: IssueIdentifier,
+    pub attempt: RetryAttempt,
+    pub normal_retry_count: u32,
+    pub scheduled_at: TimestampMs,
+    pub due_at: TimestampMs,
+    pub reason: RetryReason,
+    pub error: Option<String>,
+}
+
+impl RetryEntry {
+    pub fn continuation(
+        issue: &crate::NormalizedIssue,
+        previous_attempt: Option<RetryAttempt>,
+        normal_retry_count: u32,
+        scheduled_at: TimestampMs,
+        policy: RetryPolicy,
+    ) -> Result<Self, RetryCalculationError> {
+        let attempt = RetryAttempt::after(previous_attempt)?;
+
+        Ok(Self {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            attempt,
+            normal_retry_count: normal_retry_count.saturating_add(1),
+            scheduled_at,
+            due_at: scheduled_at.saturating_add(policy.continuation_delay_ms),
+            reason: RetryReason::Continuation,
+            error: None,
+        })
+    }
+
+    pub fn failure(
+        issue: &crate::NormalizedIssue,
+        previous_attempt: Option<RetryAttempt>,
+        normal_retry_count: u32,
+        scheduled_at: TimestampMs,
+        reason: RetryReason,
+        error: Option<String>,
+        policy: RetryPolicy,
+    ) -> Result<Self, RetryCalculationError> {
+        let attempt = RetryAttempt::after(previous_attempt)?;
+
+        Ok(Self {
+            issue_id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            attempt,
+            normal_retry_count,
+            scheduled_at,
+            due_at: scheduled_at.saturating_add(policy.failure_delay(attempt)),
+            reason,
+            error,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunAttempt {
+    pub worker_id: WorkerId,
+    pub issue_id: IssueId,
+    pub issue_identifier: IssueIdentifier,
+    pub workspace_path: PathBuf,
+    pub claimed_at: TimestampMs,
+    pub started_at: Option<TimestampMs>,
+    pub attempt: Option<RetryAttempt>,
+    pub turn_count: u32,
+    pub max_turns: u32,
+}
+
+impl RunAttempt {
+    pub fn new(
+        worker_id: WorkerId,
+        issue_id: IssueId,
+        issue_identifier: IssueIdentifier,
+        workspace_path: PathBuf,
+        claimed_at: TimestampMs,
+        attempt: Option<RetryAttempt>,
+        max_turns: u32,
+    ) -> Self {
+        Self {
+            worker_id,
+            issue_id,
+            issue_identifier,
+            workspace_path,
+            claimed_at,
+            started_at: None,
+            attempt,
+            turn_count: 0,
+            max_turns,
+        }
+    }
+
+    pub fn mark_started(mut self, started_at: TimestampMs) -> Self {
+        self.started_at = Some(started_at);
+        self
+    }
+
+    pub fn record_turn_started(&mut self) {
+        self.turn_count = self.turn_count.saturating_add(1);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StallMetadata {
+    pub last_activity_at: TimestampMs,
+    pub stall_timeout_ms: DurationMs,
+    pub stalled_at: TimestampMs,
+}
+
+impl StallMetadata {
+    pub fn new(last_activity_at: TimestampMs, stall_timeout_ms: DurationMs) -> Self {
+        Self {
+            last_activity_at,
+            stall_timeout_ms,
+            stalled_at: last_activity_at.saturating_add(stall_timeout_ms),
+        }
+    }
+
+    pub fn observe_activity(&mut self, observed_at: TimestampMs) {
+        self.last_activity_at = observed_at;
+        self.stalled_at = observed_at.saturating_add(self.stall_timeout_ms);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerOutcomeKind {
+    Succeeded,
+    Failed,
+    TimedOut,
+    Stalled,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerOutcomeRecord {
+    pub worker_id: WorkerId,
+    pub attempt: Option<RetryAttempt>,
+    pub outcome: WorkerOutcomeKind,
+    pub started_at: TimestampMs,
+    pub finished_at: TimestampMs,
+    pub turn_count: u32,
+    pub summary: Option<String>,
+    pub error: Option<String>,
+}
+
+impl WorkerOutcomeRecord {
+    pub fn from_run(
+        run: &RunAttempt,
+        outcome: WorkerOutcomeKind,
+        finished_at: TimestampMs,
+        summary: Option<String>,
+        error: Option<String>,
+    ) -> Self {
+        Self {
+            worker_id: run.worker_id.clone(),
+            attempt: run.attempt,
+            outcome,
+            started_at: run.started_at.unwrap_or(run.claimed_at),
+            finished_at,
+            turn_count: run.turn_count,
+            summary,
+            error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseReason {
+    Completed,
+    TrackerInactive,
+    TrackerTerminal,
+    Cancelled,
+    RetryExhausted,
+}

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -222,6 +222,7 @@ pub struct RunAttempt {
     pub claimed_at: TimestampMs,
     pub started_at: Option<TimestampMs>,
     pub attempt: Option<RetryAttempt>,
+    pub normal_retry_count: u32,
     pub turn_count: u32,
     pub max_turns: u32,
 }
@@ -244,9 +245,15 @@ impl RunAttempt {
             claimed_at,
             started_at: None,
             attempt,
+            normal_retry_count: 0,
             turn_count: 0,
             max_turns,
         }
+    }
+
+    pub fn with_normal_retry_count(mut self, normal_retry_count: u32) -> Self {
+        self.normal_retry_count = normal_retry_count;
+        self
     }
 
     pub fn mark_started(mut self, started_at: TimestampMs) -> Self {

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -96,12 +96,19 @@ pub struct ConversationMetadata {
 impl ConversationMetadata {
     pub fn observe_event(
         &mut self,
-        observed_at: TimestampMs,
+        event_at: TimestampMs,
         event_id: Option<String>,
         event_kind: Option<String>,
         summary: Option<String>,
     ) {
-        self.last_event_at = Some(observed_at);
+        if self
+            .last_event_at
+            .is_some_and(|last_event_at| event_at < last_event_at)
+        {
+            return;
+        }
+
+        self.last_event_at = Some(event_at);
         self.last_event_id = event_id;
         self.last_event_kind = event_kind;
         self.last_event_summary = summary;
@@ -268,9 +275,13 @@ impl StallMetadata {
         }
     }
 
-    pub fn observe_activity(&mut self, observed_at: TimestampMs) {
-        self.last_activity_at = observed_at;
-        self.stalled_at = observed_at.saturating_add(self.stall_timeout_ms);
+    pub fn observe_activity(&mut self, activity_at: TimestampMs) {
+        if activity_at < self.last_activity_at {
+            return;
+        }
+
+        self.last_activity_at = activity_at;
+        self.stalled_at = activity_at.saturating_add(self.stall_timeout_ms);
     }
 }
 

--- a/crates/opensymphony-domain/src/snapshot.rs
+++ b/crates/opensymphony-domain/src/snapshot.rs
@@ -121,8 +121,10 @@ pub struct RuntimeStateSnapshot {
 }
 
 impl RuntimeStateSnapshot {
-    fn from_state(state: &SchedulerState) -> Self {
-        match state {
+    fn from_execution(execution: &IssueExecution) -> Self {
+        let conversation = execution.conversation();
+
+        match execution.state() {
             SchedulerState::Unclaimed { .. } => Self {
                 state: SchedulerStatus::Unclaimed,
                 claimed_at: None,
@@ -130,7 +132,7 @@ impl RuntimeStateSnapshot {
                 released_at: None,
                 release_reason: None,
                 worker: None,
-                last_event_at: None,
+                last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
             },
             SchedulerState::Claimed { run } => Self {
@@ -140,23 +142,18 @@ impl RuntimeStateSnapshot {
                 released_at: None,
                 release_reason: None,
                 worker: Some(WorkerAttemptSnapshot::from(run)),
-                last_event_at: None,
+                last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
             },
-            SchedulerState::Running {
-                run,
-                session,
-                stall,
-            } => Self {
+            SchedulerState::Running { run, stall } => Self {
                 state: SchedulerStatus::Running,
                 claimed_at: Some(run.claimed_at),
                 started_at: run.started_at,
                 released_at: None,
                 release_reason: None,
                 worker: Some(WorkerAttemptSnapshot::from(run)),
-                last_event_at: session
-                    .as_ref()
-                    .and_then(|session| session.last_event_at)
+                last_event_at: conversation
+                    .and_then(|conversation| conversation.last_event_at)
                     .or(Some(stall.last_activity_at)),
                 stalled_at: Some(stall.stalled_at),
             },
@@ -167,7 +164,7 @@ impl RuntimeStateSnapshot {
                 released_at: None,
                 release_reason: None,
                 worker: None,
-                last_event_at: None,
+                last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
             },
             SchedulerState::Released {
@@ -180,7 +177,7 @@ impl RuntimeStateSnapshot {
                 released_at: Some(*released_at),
                 release_reason: Some(*reason),
                 worker: None,
-                last_event_at: None,
+                last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
             },
         }
@@ -202,7 +199,7 @@ impl From<&IssueExecution> for IssueSnapshot {
     fn from(execution: &IssueExecution) -> Self {
         Self {
             issue: execution.issue().clone(),
-            runtime: RuntimeStateSnapshot::from_state(execution.state()),
+            runtime: RuntimeStateSnapshot::from_execution(execution),
             workspace: execution.workspace().cloned(),
             conversation: execution.conversation().cloned(),
             retry: execution.retry().map(RetrySnapshot::from),

--- a/crates/opensymphony-domain/src/snapshot.rs
+++ b/crates/opensymphony-domain/src/snapshot.rs
@@ -70,6 +70,7 @@ impl DaemonSnapshot {
 pub struct WorkerAttemptSnapshot {
     pub worker_id: crate::WorkerId,
     pub attempt: Option<crate::RetryAttempt>,
+    pub normal_retry_count: u32,
     pub turn_count: u32,
     pub max_turns: u32,
 }
@@ -79,6 +80,7 @@ impl From<&crate::RunAttempt> for WorkerAttemptSnapshot {
         Self {
             worker_id: run.worker_id.clone(),
             attempt: run.attempt,
+            normal_retry_count: run.normal_retry_count,
             turn_count: run.turn_count,
             max_turns: run.max_turns,
         }
@@ -152,9 +154,7 @@ impl RuntimeStateSnapshot {
                 released_at: None,
                 release_reason: None,
                 worker: Some(WorkerAttemptSnapshot::from(run)),
-                last_event_at: conversation
-                    .and_then(|conversation| conversation.last_event_at)
-                    .or(Some(stall.last_activity_at)),
+                last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: Some(stall.stalled_at),
             },
             SchedulerState::RetryQueued { .. } => Self {

--- a/crates/opensymphony-domain/src/snapshot.rs
+++ b/crates/opensymphony-domain/src/snapshot.rs
@@ -1,0 +1,247 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ConversationMetadata, IssueExecution, NormalizedIssue, ReleaseReason, RetryEntry,
+    SchedulerState, SchedulerStatus, TimestampMs, WorkerOutcomeRecord, WorkspaceRecord,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthStatus {
+    #[default]
+    Unknown,
+    Starting,
+    Healthy,
+    Degraded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComponentHealthSnapshot {
+    pub status: HealthStatus,
+    pub detail: Option<String>,
+    pub updated_at: Option<TimestampMs>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeUsageTotals {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub runtime_seconds: u64,
+    pub estimated_cost_usd_micros: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonSnapshot {
+    pub health: HealthStatus,
+    pub poll_interval_ms: u64,
+    pub max_concurrent_agents: u32,
+    pub running_issue_count: usize,
+    pub retry_queue_count: usize,
+    pub last_poll_at: Option<TimestampMs>,
+    pub agent_server: ComponentHealthSnapshot,
+    pub usage: RuntimeUsageTotals,
+}
+
+impl DaemonSnapshot {
+    pub fn new(
+        health: HealthStatus,
+        poll_interval_ms: u64,
+        max_concurrent_agents: u32,
+        last_poll_at: Option<TimestampMs>,
+        agent_server: ComponentHealthSnapshot,
+        usage: RuntimeUsageTotals,
+    ) -> Self {
+        Self {
+            health,
+            poll_interval_ms,
+            max_concurrent_agents,
+            running_issue_count: 0,
+            retry_queue_count: 0,
+            last_poll_at,
+            agent_server,
+            usage,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerAttemptSnapshot {
+    pub worker_id: crate::WorkerId,
+    pub attempt: Option<crate::RetryAttempt>,
+    pub turn_count: u32,
+    pub max_turns: u32,
+}
+
+impl From<&crate::RunAttempt> for WorkerAttemptSnapshot {
+    fn from(run: &crate::RunAttempt) -> Self {
+        Self {
+            worker_id: run.worker_id.clone(),
+            attempt: run.attempt,
+            turn_count: run.turn_count,
+            max_turns: run.max_turns,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetrySnapshot {
+    pub attempt: crate::RetryAttempt,
+    pub normal_retry_count: u32,
+    pub scheduled_at: TimestampMs,
+    pub due_at: TimestampMs,
+    pub reason: crate::RetryReason,
+    pub error: Option<String>,
+}
+
+impl From<&RetryEntry> for RetrySnapshot {
+    fn from(retry: &RetryEntry) -> Self {
+        Self {
+            attempt: retry.attempt,
+            normal_retry_count: retry.normal_retry_count,
+            scheduled_at: retry.scheduled_at,
+            due_at: retry.due_at,
+            reason: retry.reason,
+            error: retry.error.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeStateSnapshot {
+    pub state: SchedulerStatus,
+    pub claimed_at: Option<TimestampMs>,
+    pub started_at: Option<TimestampMs>,
+    pub released_at: Option<TimestampMs>,
+    pub release_reason: Option<ReleaseReason>,
+    pub worker: Option<WorkerAttemptSnapshot>,
+    pub last_event_at: Option<TimestampMs>,
+    pub stalled_at: Option<TimestampMs>,
+}
+
+impl RuntimeStateSnapshot {
+    fn from_state(state: &SchedulerState) -> Self {
+        match state {
+            SchedulerState::Unclaimed { .. } => Self {
+                state: SchedulerStatus::Unclaimed,
+                claimed_at: None,
+                started_at: None,
+                released_at: None,
+                release_reason: None,
+                worker: None,
+                last_event_at: None,
+                stalled_at: None,
+            },
+            SchedulerState::Claimed { run } => Self {
+                state: SchedulerStatus::Claimed,
+                claimed_at: Some(run.claimed_at),
+                started_at: run.started_at,
+                released_at: None,
+                release_reason: None,
+                worker: Some(WorkerAttemptSnapshot::from(run)),
+                last_event_at: None,
+                stalled_at: None,
+            },
+            SchedulerState::Running {
+                run,
+                session,
+                stall,
+            } => Self {
+                state: SchedulerStatus::Running,
+                claimed_at: Some(run.claimed_at),
+                started_at: run.started_at,
+                released_at: None,
+                release_reason: None,
+                worker: Some(WorkerAttemptSnapshot::from(run)),
+                last_event_at: session
+                    .as_ref()
+                    .and_then(|session| session.last_event_at)
+                    .or(Some(stall.last_activity_at)),
+                stalled_at: Some(stall.stalled_at),
+            },
+            SchedulerState::RetryQueued { .. } => Self {
+                state: SchedulerStatus::RetryQueued,
+                claimed_at: None,
+                started_at: None,
+                released_at: None,
+                release_reason: None,
+                worker: None,
+                last_event_at: None,
+                stalled_at: None,
+            },
+            SchedulerState::Released {
+                released_at,
+                reason,
+            } => Self {
+                state: SchedulerStatus::Released,
+                claimed_at: None,
+                started_at: None,
+                released_at: Some(*released_at),
+                release_reason: Some(*reason),
+                worker: None,
+                last_event_at: None,
+                stalled_at: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueSnapshot {
+    pub issue: NormalizedIssue,
+    pub runtime: RuntimeStateSnapshot,
+    pub workspace: Option<WorkspaceRecord>,
+    pub conversation: Option<ConversationMetadata>,
+    pub retry: Option<RetrySnapshot>,
+    pub last_worker_outcome: Option<WorkerOutcomeRecord>,
+    pub recent_worker_outcomes: Vec<WorkerOutcomeRecord>,
+}
+
+impl From<&IssueExecution> for IssueSnapshot {
+    fn from(execution: &IssueExecution) -> Self {
+        Self {
+            issue: execution.issue().clone(),
+            runtime: RuntimeStateSnapshot::from_state(execution.state()),
+            workspace: execution.workspace().cloned(),
+            conversation: execution.conversation().cloned(),
+            retry: execution.retry().map(RetrySnapshot::from),
+            last_worker_outcome: execution.last_worker_outcome().cloned(),
+            recent_worker_outcomes: execution.recent_worker_outcomes().to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorSnapshot {
+    pub generated_at: TimestampMs,
+    pub daemon: DaemonSnapshot,
+    pub issues: Vec<IssueSnapshot>,
+}
+
+impl OrchestratorSnapshot {
+    pub fn new(
+        generated_at: TimestampMs,
+        daemon: DaemonSnapshot,
+        issues: Vec<IssueSnapshot>,
+    ) -> Self {
+        let running_issue_count = issues
+            .iter()
+            .filter(|issue| issue.runtime.state == SchedulerStatus::Running)
+            .count();
+        let retry_queue_count = issues
+            .iter()
+            .filter(|issue| issue.runtime.state == SchedulerStatus::RetryQueued)
+            .count();
+
+        Self {
+            generated_at,
+            daemon: DaemonSnapshot {
+                running_issue_count,
+                retry_queue_count,
+                ..daemon
+            },
+            issues,
+        }
+    }
+}

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -87,6 +87,8 @@ pub enum StateTransitionError {
     },
     #[error("issue mismatch: expected {expected}, got {actual}")]
     IssueMismatch { expected: IssueId, actual: IssueId },
+    #[error("cannot claim issue without attached workspace; run requested path {attempted:?}")]
+    WorkspaceNotAttached { attempted: PathBuf },
     #[error("workspace path mismatch: expected {expected:?}, got {actual:?}")]
     WorkspacePathMismatch { expected: PathBuf, actual: PathBuf },
 }
@@ -380,13 +382,17 @@ impl IssueExecution {
             });
         }
 
-        if let Some(workspace) = &self.workspace {
-            let expected = comparable_workspace_path(&workspace.path);
-            let actual = comparable_workspace_path(&run.workspace_path);
+        let Some(workspace) = &self.workspace else {
+            return Err(StateTransitionError::WorkspaceNotAttached {
+                attempted: run.workspace_path.clone(),
+            });
+        };
 
-            if expected != actual {
-                return Err(StateTransitionError::WorkspacePathMismatch { expected, actual });
-            }
+        let expected = comparable_workspace_path(&workspace.path);
+        let actual = comparable_workspace_path(&run.workspace_path);
+
+        if expected != actual {
+            return Err(StateTransitionError::WorkspacePathMismatch { expected, actual });
         }
 
         Ok(())

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -8,8 +8,8 @@ use thiserror::Error;
 
 use crate::{
     ConversationMetadata, DurationMs, IssueId, NormalizedIssue, ReleaseReason, RetryAttempt,
-    RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerOutcomeRecord, WorkspaceKey,
-    WorkspaceRecord,
+    RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerId, WorkerOutcomeRecord,
+    WorkspaceKey, WorkspaceRecord,
 };
 
 const MAX_RECENT_WORKER_OUTCOMES: usize = 10;
@@ -91,6 +91,14 @@ pub enum StateTransitionError {
     #[error("cannot claim issue without attached workspace; run requested path {attempted:?}")]
     WorkspaceNotAttached { attempted: PathBuf },
     #[error(
+        "workspace does not match issue identity: expected key {expected_key} at a path ending in {expected_key}, got key {actual_key} at {actual_path:?}"
+    )]
+    WorkspaceIssueMismatch {
+        expected_key: WorkspaceKey,
+        actual_key: WorkspaceKey,
+        actual_path: PathBuf,
+    },
+    #[error(
         "workspace identity mismatch: expected key {expected_key} at {expected_path:?}, got key {actual_key} at {actual_path:?}"
     )]
     WorkspaceIdentityMismatch {
@@ -101,6 +109,13 @@ pub enum StateTransitionError {
     },
     #[error("workspace path mismatch: expected {expected:?}, got {actual:?}")]
     WorkspacePathMismatch { expected: PathBuf, actual: PathBuf },
+    #[error("cannot start running issue without conversation metadata")]
+    ConversationNotAttached,
+    #[error("worker mismatch: expected {expected}, got {actual}")]
+    WorkerMismatch {
+        expected: WorkerId,
+        actual: WorkerId,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -217,6 +232,19 @@ impl IssueExecution {
                     actual_path,
                 });
             }
+        } else {
+            let expected_key = issue_workspace_key(&self.issue);
+            let actual_path = comparable_workspace_path(&workspace.path);
+
+            if workspace.workspace_key != expected_key
+                || !workspace_path_matches_key(&actual_path, &expected_key)
+            {
+                return Err(StateTransitionError::WorkspaceIssueMismatch {
+                    expected_key,
+                    actual_key: workspace.workspace_key.clone(),
+                    actual_path,
+                });
+            }
         }
 
         self.workspace = Some(workspace);
@@ -269,6 +297,9 @@ impl IssueExecution {
             SchedulerState::Claimed { run } => {
                 if let Some(session) = session {
                     self.conversation = Some(session);
+                }
+                if self.conversation.is_none() {
+                    return Err(StateTransitionError::ConversationNotAttached);
                 }
                 self.state = SchedulerState::Running {
                     run: run.mark_started(started_at),
@@ -331,6 +362,7 @@ impl IssueExecution {
 
         let expected_attempt = match &self.state {
             SchedulerState::Claimed { run } | SchedulerState::Running { run, .. } => {
+                self.validate_outcome_binding(run, &outcome)?;
                 RetryAttempt::after(run.attempt).ok()
             }
             _ => {
@@ -440,6 +472,38 @@ impl IssueExecution {
 
         Ok(())
     }
+
+    fn validate_outcome_binding(
+        &self,
+        run: &RunAttempt,
+        outcome: &WorkerOutcomeRecord,
+    ) -> Result<(), StateTransitionError> {
+        if outcome.worker_id != run.worker_id {
+            return Err(StateTransitionError::WorkerMismatch {
+                expected: run.worker_id.clone(),
+                actual: outcome.worker_id.clone(),
+            });
+        }
+
+        if outcome.attempt != run.attempt {
+            return Err(StateTransitionError::AttemptMismatch {
+                expected: run.attempt,
+                actual: outcome.attempt,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+fn issue_workspace_key(issue: &NormalizedIssue) -> WorkspaceKey {
+    WorkspaceKey::new(issue.identifier.as_str())
+        .expect("normalized issue identifiers cannot be empty")
+}
+
+fn workspace_path_matches_key(path: &Path, key: &WorkspaceKey) -> bool {
+    path.file_name()
+        .is_some_and(|name| name == OsStr::new(key.as_str()))
 }
 
 fn comparable_workspace_path(path: &Path) -> PathBuf {

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -8,7 +8,8 @@ use thiserror::Error;
 
 use crate::{
     ConversationMetadata, DurationMs, IssueId, NormalizedIssue, ReleaseReason, RetryAttempt,
-    RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerOutcomeRecord, WorkspaceRecord,
+    RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerOutcomeRecord, WorkspaceKey,
+    WorkspaceRecord,
 };
 
 const MAX_RECENT_WORKER_OUTCOMES: usize = 10;
@@ -89,6 +90,15 @@ pub enum StateTransitionError {
     IssueMismatch { expected: IssueId, actual: IssueId },
     #[error("cannot claim issue without attached workspace; run requested path {attempted:?}")]
     WorkspaceNotAttached { attempted: PathBuf },
+    #[error(
+        "workspace identity mismatch: expected key {expected_key} at {expected_path:?}, got key {actual_key} at {actual_path:?}"
+    )]
+    WorkspaceIdentityMismatch {
+        expected_key: WorkspaceKey,
+        actual_key: WorkspaceKey,
+        expected_path: PathBuf,
+        actual_path: PathBuf,
+    },
     #[error("workspace path mismatch: expected {expected:?}, got {actual:?}")]
     WorkspacePathMismatch { expected: PathBuf, actual: PathBuf },
 }
@@ -191,14 +201,32 @@ impl IssueExecution {
         }
     }
 
-    pub fn attach_workspace(&mut self, workspace: WorkspaceRecord) {
+    pub fn attach_workspace(
+        &mut self,
+        workspace: WorkspaceRecord,
+    ) -> Result<(), StateTransitionError> {
+        if let Some(current) = &self.workspace {
+            let expected_path = comparable_workspace_path(&current.path);
+            let actual_path = comparable_workspace_path(&workspace.path);
+
+            if current.workspace_key != workspace.workspace_key || expected_path != actual_path {
+                return Err(StateTransitionError::WorkspaceIdentityMismatch {
+                    expected_key: current.workspace_key.clone(),
+                    actual_key: workspace.workspace_key.clone(),
+                    expected_path,
+                    actual_path,
+                });
+            }
+        }
+
         self.workspace = Some(workspace);
+        Ok(())
     }
 
     pub fn claim(mut self, run: RunAttempt) -> Result<Self, StateTransitionError> {
         self.validate_run_binding(&run)?;
 
-        match &self.state {
+        let normal_retry_count = match &self.state {
             SchedulerState::Unclaimed { .. } => {
                 if run.attempt.is_some() {
                     return Err(StateTransitionError::AttemptMismatch {
@@ -206,6 +234,7 @@ impl IssueExecution {
                         actual: run.attempt,
                     });
                 }
+                0
             }
             SchedulerState::RetryQueued { retry } => {
                 if run.attempt != Some(retry.attempt) {
@@ -214,6 +243,7 @@ impl IssueExecution {
                         actual: run.attempt,
                     });
                 }
+                retry.normal_retry_count
             }
             _ => {
                 return Err(StateTransitionError::InvalidTransition {
@@ -221,9 +251,11 @@ impl IssueExecution {
                     action: TransitionAction::Claim,
                 });
             }
-        }
+        };
 
-        self.state = SchedulerState::Claimed { run };
+        self.state = SchedulerState::Claimed {
+            run: run.with_normal_retry_count(normal_retry_count),
+        };
         Ok(self)
     }
 

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -1,0 +1,397 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    ConversationMetadata, DurationMs, IssueId, NormalizedIssue, ReleaseReason, RetryAttempt,
+    RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerOutcomeRecord, WorkspaceRecord,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerStatus {
+    Unclaimed,
+    Claimed,
+    Running,
+    RetryQueued,
+    Released,
+}
+
+impl SchedulerStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unclaimed => "unclaimed",
+            Self::Claimed => "claimed",
+            Self::Running => "running",
+            Self::RetryQueued => "retry_queued",
+            Self::Released => "released",
+        }
+    }
+}
+
+impl std::fmt::Display for SchedulerStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransitionAction {
+    Claim,
+    StartRunning,
+    RecordTurnStarted,
+    ObserveRuntimeEvent,
+    QueueRetry,
+    Release,
+    Reopen,
+}
+
+impl TransitionAction {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Claim => "claim",
+            Self::StartRunning => "start_running",
+            Self::RecordTurnStarted => "record_turn_started",
+            Self::ObserveRuntimeEvent => "observe_runtime_event",
+            Self::QueueRetry => "queue_retry",
+            Self::Release => "release",
+            Self::Reopen => "reopen",
+        }
+    }
+}
+
+impl std::fmt::Display for TransitionAction {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum StateTransitionError {
+    #[error("cannot {action} while issue is {from}")]
+    InvalidTransition {
+        from: SchedulerStatus,
+        action: TransitionAction,
+    },
+    #[error("retry attempt mismatch: expected {expected:?}, got {actual:?}")]
+    AttemptMismatch {
+        expected: Option<RetryAttempt>,
+        actual: Option<RetryAttempt>,
+    },
+    #[error("issue mismatch: expected {expected}, got {actual}")]
+    IssueMismatch { expected: IssueId, actual: IssueId },
+    #[error("workspace path mismatch: expected {expected:?}, got {actual:?}")]
+    WorkspacePathMismatch {
+        expected: std::path::PathBuf,
+        actual: std::path::PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state", content = "details")]
+pub enum SchedulerState {
+    Unclaimed {
+        since: TimestampMs,
+    },
+    Claimed {
+        run: RunAttempt,
+    },
+    Running {
+        run: RunAttempt,
+        session: Option<ConversationMetadata>,
+        stall: StallMetadata,
+    },
+    RetryQueued {
+        retry: RetryEntry,
+    },
+    Released {
+        released_at: TimestampMs,
+        reason: ReleaseReason,
+    },
+}
+
+impl SchedulerState {
+    pub const fn status(&self) -> SchedulerStatus {
+        match self {
+            Self::Unclaimed { .. } => SchedulerStatus::Unclaimed,
+            Self::Claimed { .. } => SchedulerStatus::Claimed,
+            Self::Running { .. } => SchedulerStatus::Running,
+            Self::RetryQueued { .. } => SchedulerStatus::RetryQueued,
+            Self::Released { .. } => SchedulerStatus::Released,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueExecution {
+    issue: NormalizedIssue,
+    workspace: Option<WorkspaceRecord>,
+    state: SchedulerState,
+    last_worker_outcome: Option<WorkerOutcomeRecord>,
+    recent_worker_outcomes: Vec<WorkerOutcomeRecord>,
+}
+
+impl IssueExecution {
+    pub fn new(issue: NormalizedIssue, observed_at: TimestampMs) -> Self {
+        Self {
+            issue,
+            workspace: None,
+            state: SchedulerState::Unclaimed { since: observed_at },
+            last_worker_outcome: None,
+            recent_worker_outcomes: Vec::new(),
+        }
+    }
+
+    pub fn issue(&self) -> &NormalizedIssue {
+        &self.issue
+    }
+
+    pub fn workspace(&self) -> Option<&WorkspaceRecord> {
+        self.workspace.as_ref()
+    }
+
+    pub fn state(&self) -> &SchedulerState {
+        &self.state
+    }
+
+    pub fn status(&self) -> SchedulerStatus {
+        self.state.status()
+    }
+
+    pub fn last_worker_outcome(&self) -> Option<&WorkerOutcomeRecord> {
+        self.last_worker_outcome.as_ref()
+    }
+
+    pub fn recent_worker_outcomes(&self) -> &[WorkerOutcomeRecord] {
+        &self.recent_worker_outcomes
+    }
+
+    pub fn current_run(&self) -> Option<&RunAttempt> {
+        match &self.state {
+            SchedulerState::Claimed { run } | SchedulerState::Running { run, .. } => Some(run),
+            _ => None,
+        }
+    }
+
+    pub fn conversation(&self) -> Option<&ConversationMetadata> {
+        match &self.state {
+            SchedulerState::Running {
+                session: Some(session),
+                ..
+            } => Some(session),
+            _ => None,
+        }
+    }
+
+    pub fn retry(&self) -> Option<&RetryEntry> {
+        match &self.state {
+            SchedulerState::RetryQueued { retry } => Some(retry),
+            _ => None,
+        }
+    }
+
+    pub fn attach_workspace(&mut self, workspace: WorkspaceRecord) {
+        self.workspace = Some(workspace);
+    }
+
+    pub fn claim(mut self, run: RunAttempt) -> Result<Self, StateTransitionError> {
+        self.validate_run_binding(&run)?;
+
+        match &self.state {
+            SchedulerState::Unclaimed { .. } => {
+                if run.attempt.is_some() {
+                    return Err(StateTransitionError::AttemptMismatch {
+                        expected: None,
+                        actual: run.attempt,
+                    });
+                }
+            }
+            SchedulerState::RetryQueued { retry } => {
+                if run.attempt != Some(retry.attempt) {
+                    return Err(StateTransitionError::AttemptMismatch {
+                        expected: Some(retry.attempt),
+                        actual: run.attempt,
+                    });
+                }
+            }
+            _ => {
+                return Err(StateTransitionError::InvalidTransition {
+                    from: self.status(),
+                    action: TransitionAction::Claim,
+                });
+            }
+        }
+
+        self.state = SchedulerState::Claimed { run };
+        Ok(self)
+    }
+
+    pub fn start_running(
+        mut self,
+        started_at: TimestampMs,
+        stall_timeout_ms: DurationMs,
+        session: Option<ConversationMetadata>,
+    ) -> Result<Self, StateTransitionError> {
+        match self.state {
+            SchedulerState::Claimed { run } => {
+                self.state = SchedulerState::Running {
+                    run: run.mark_started(started_at),
+                    session,
+                    stall: StallMetadata::new(started_at, stall_timeout_ms),
+                };
+                Ok(self)
+            }
+            _ => Err(StateTransitionError::InvalidTransition {
+                from: self.status(),
+                action: TransitionAction::StartRunning,
+            }),
+        }
+    }
+
+    pub fn record_turn_started(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<(), StateTransitionError> {
+        match &mut self.state {
+            SchedulerState::Running { run, stall, .. } => {
+                run.record_turn_started();
+                stall.observe_activity(observed_at);
+                Ok(())
+            }
+            _ => Err(StateTransitionError::InvalidTransition {
+                from: self.status(),
+                action: TransitionAction::RecordTurnStarted,
+            }),
+        }
+    }
+
+    pub fn observe_runtime_event(
+        &mut self,
+        observed_at: TimestampMs,
+        event_id: Option<String>,
+        event_kind: Option<String>,
+        summary: Option<String>,
+    ) -> Result<(), StateTransitionError> {
+        match &mut self.state {
+            SchedulerState::Running { session, stall, .. } => {
+                if let Some(session) = session {
+                    session.observe_event(observed_at, event_id, event_kind, summary);
+                }
+                stall.observe_activity(observed_at);
+                Ok(())
+            }
+            _ => Err(StateTransitionError::InvalidTransition {
+                from: self.status(),
+                action: TransitionAction::ObserveRuntimeEvent,
+            }),
+        }
+    }
+
+    pub fn queue_retry(
+        mut self,
+        retry: RetryEntry,
+        outcome: WorkerOutcomeRecord,
+    ) -> Result<Self, StateTransitionError> {
+        self.validate_retry_binding(&retry)?;
+
+        let expected_attempt = match &self.state {
+            SchedulerState::Claimed { run } | SchedulerState::Running { run, .. } => {
+                RetryAttempt::after(run.attempt).ok()
+            }
+            _ => {
+                return Err(StateTransitionError::InvalidTransition {
+                    from: self.status(),
+                    action: TransitionAction::QueueRetry,
+                });
+            }
+        };
+
+        if expected_attempt != Some(retry.attempt) {
+            return Err(StateTransitionError::AttemptMismatch {
+                expected: expected_attempt,
+                actual: Some(retry.attempt),
+            });
+        }
+
+        self.record_outcome(outcome);
+        self.state = SchedulerState::RetryQueued { retry };
+        Ok(self)
+    }
+
+    pub fn release(
+        mut self,
+        released_at: TimestampMs,
+        reason: ReleaseReason,
+        outcome: Option<WorkerOutcomeRecord>,
+    ) -> Result<Self, StateTransitionError> {
+        if matches!(self.state, SchedulerState::Released { .. }) {
+            return Err(StateTransitionError::InvalidTransition {
+                from: self.status(),
+                action: TransitionAction::Release,
+            });
+        }
+
+        if let Some(outcome) = outcome {
+            self.record_outcome(outcome);
+        }
+
+        self.state = SchedulerState::Released {
+            released_at,
+            reason,
+        };
+        Ok(self)
+    }
+
+    pub fn reopen(mut self, observed_at: TimestampMs) -> Result<Self, StateTransitionError> {
+        match self.state {
+            SchedulerState::Released { .. } => {
+                self.state = SchedulerState::Unclaimed { since: observed_at };
+                Ok(self)
+            }
+            _ => Err(StateTransitionError::InvalidTransition {
+                from: self.status(),
+                action: TransitionAction::Reopen,
+            }),
+        }
+    }
+
+    pub fn snapshot(&self) -> crate::IssueSnapshot {
+        crate::IssueSnapshot::from(self)
+    }
+
+    fn record_outcome(&mut self, outcome: WorkerOutcomeRecord) {
+        self.last_worker_outcome = Some(outcome.clone());
+        self.recent_worker_outcomes.push(outcome);
+    }
+
+    fn validate_run_binding(&self, run: &RunAttempt) -> Result<(), StateTransitionError> {
+        if run.issue_id != self.issue.id {
+            return Err(StateTransitionError::IssueMismatch {
+                expected: self.issue.id.clone(),
+                actual: run.issue_id.clone(),
+            });
+        }
+
+        if let Some(workspace) = &self.workspace {
+            if workspace.path != run.workspace_path {
+                return Err(StateTransitionError::WorkspacePathMismatch {
+                    expected: workspace.path.clone(),
+                    actual: run.workspace_path.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_retry_binding(&self, retry: &RetryEntry) -> Result<(), StateTransitionError> {
+        if retry.issue_id != self.issue.id {
+            return Err(StateTransitionError::IssueMismatch {
+                expected: self.issue.id.clone(),
+                actual: retry.issue_id.clone(),
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -11,6 +11,8 @@ use crate::{
     RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerOutcomeRecord, WorkspaceRecord,
 };
 
+const MAX_RECENT_WORKER_OUTCOMES: usize = 10;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SchedulerStatus {
@@ -343,7 +345,11 @@ impl IssueExecution {
 
     pub fn reopen(mut self, observed_at: TimestampMs) -> Result<Self, StateTransitionError> {
         match self.state {
-            SchedulerState::Released { .. } => {
+            SchedulerState::Released { reason, .. } => {
+                if !reason.preserves_reactivation_state() {
+                    self.workspace = None;
+                    self.conversation = None;
+                }
                 self.state = SchedulerState::Unclaimed { since: observed_at };
                 Ok(self)
             }
@@ -360,6 +366,9 @@ impl IssueExecution {
 
     fn record_outcome(&mut self, outcome: WorkerOutcomeRecord) {
         self.last_worker_outcome = Some(outcome.clone());
+        if self.recent_worker_outcomes.len() == MAX_RECENT_WORKER_OUTCOMES {
+            self.recent_worker_outcomes.remove(0);
+        }
         self.recent_worker_outcomes.push(outcome);
     }
 

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -98,7 +98,6 @@ pub enum SchedulerState {
     },
     Running {
         run: RunAttempt,
-        session: Option<ConversationMetadata>,
         stall: StallMetadata,
     },
     RetryQueued {
@@ -126,6 +125,7 @@ impl SchedulerState {
 pub struct IssueExecution {
     issue: NormalizedIssue,
     workspace: Option<WorkspaceRecord>,
+    conversation: Option<ConversationMetadata>,
     state: SchedulerState,
     last_worker_outcome: Option<WorkerOutcomeRecord>,
     recent_worker_outcomes: Vec<WorkerOutcomeRecord>,
@@ -136,6 +136,7 @@ impl IssueExecution {
         Self {
             issue,
             workspace: None,
+            conversation: None,
             state: SchedulerState::Unclaimed { since: observed_at },
             last_worker_outcome: None,
             recent_worker_outcomes: Vec::new(),
@@ -174,13 +175,7 @@ impl IssueExecution {
     }
 
     pub fn conversation(&self) -> Option<&ConversationMetadata> {
-        match &self.state {
-            SchedulerState::Running {
-                session: Some(session),
-                ..
-            } => Some(session),
-            _ => None,
-        }
+        self.conversation.as_ref()
     }
 
     pub fn retry(&self) -> Option<&RetryEntry> {
@@ -234,9 +229,11 @@ impl IssueExecution {
     ) -> Result<Self, StateTransitionError> {
         match self.state {
             SchedulerState::Claimed { run } => {
+                if let Some(session) = session {
+                    self.conversation = Some(session);
+                }
                 self.state = SchedulerState::Running {
                     run: run.mark_started(started_at),
-                    session,
                     stall: StallMetadata::new(started_at, stall_timeout_ms),
                 };
                 Ok(self)
@@ -267,17 +264,17 @@ impl IssueExecution {
 
     pub fn observe_runtime_event(
         &mut self,
-        observed_at: TimestampMs,
+        event_at: TimestampMs,
         event_id: Option<String>,
         event_kind: Option<String>,
         summary: Option<String>,
     ) -> Result<(), StateTransitionError> {
         match &mut self.state {
-            SchedulerState::Running { session, stall, .. } => {
-                if let Some(session) = session {
-                    session.observe_event(observed_at, event_id, event_kind, summary);
+            SchedulerState::Running { stall, .. } => {
+                if let Some(session) = &mut self.conversation {
+                    session.observe_event(event_at, event_id, event_kind, summary);
                 }
-                stall.observe_activity(observed_at);
+                stall.observe_activity(event_at);
                 Ok(())
             }
             _ => Err(StateTransitionError::InvalidTransition {

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -1,3 +1,8 @@
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Component, Path, PathBuf},
+};
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -81,10 +86,7 @@ pub enum StateTransitionError {
     #[error("issue mismatch: expected {expected}, got {actual}")]
     IssueMismatch { expected: IssueId, actual: IssueId },
     #[error("workspace path mismatch: expected {expected:?}, got {actual:?}")]
-    WorkspacePathMismatch {
-        expected: std::path::PathBuf,
-        actual: std::path::PathBuf,
-    },
+    WorkspacePathMismatch { expected: PathBuf, actual: PathBuf },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -370,11 +372,11 @@ impl IssueExecution {
         }
 
         if let Some(workspace) = &self.workspace {
-            if workspace.path != run.workspace_path {
-                return Err(StateTransitionError::WorkspacePathMismatch {
-                    expected: workspace.path.clone(),
-                    actual: run.workspace_path.clone(),
-                });
+            let expected = comparable_workspace_path(&workspace.path);
+            let actual = comparable_workspace_path(&run.workspace_path);
+
+            if expected != actual {
+                return Err(StateTransitionError::WorkspacePathMismatch { expected, actual });
             }
         }
 
@@ -390,5 +392,52 @@ impl IssueExecution {
         }
 
         Ok(())
+    }
+}
+
+fn comparable_workspace_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        std::fs::canonicalize(path).unwrap_or_else(|_| normalize_workspace_path(path))
+    } else {
+        normalize_workspace_path(path)
+    }
+}
+
+fn normalize_workspace_path(path: &Path) -> PathBuf {
+    let mut prefix: Option<OsString> = None;
+    let mut has_root = false;
+    let mut parts: Vec<OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(component) => prefix = Some(component.as_os_str().to_os_string()),
+            Component::RootDir => has_root = true,
+            Component::CurDir => {}
+            Component::ParentDir => match parts.last() {
+                Some(last) if last != OsStr::new("..") => {
+                    parts.pop();
+                }
+                _ if !has_root => parts.push(OsString::from("..")),
+                _ => {}
+            },
+            Component::Normal(component) => parts.push(component.to_os_string()),
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    if let Some(prefix) = prefix {
+        normalized.push(prefix);
+    }
+    if has_root {
+        normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+    }
+    for part in parts {
+        normalized.push(part);
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
     }
 }

--- a/crates/opensymphony-domain/src/time.rs
+++ b/crates/opensymphony-domain/src/time.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct DurationMs(u64);
+
+impl DurationMs {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct TimestampMs(u64);
+
+impl TimestampMs {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    pub fn saturating_add(self, duration: DurationMs) -> Self {
+        Self(self.0.saturating_add(duration.as_u64()))
+    }
+}

--- a/crates/opensymphony-orchestrator/Cargo.toml
+++ b/crates/opensymphony-orchestrator/Cargo.toml
@@ -9,3 +9,6 @@ version.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+opensymphony-domain = { path = "../opensymphony-domain" }

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -1,16 +1,85 @@
 pub const CRATE_NAME: &str = "opensymphony-orchestrator";
 
-pub fn placeholder_summary() -> &'static str {
+pub use opensymphony_domain::{
+    ComponentHealthSnapshot, ConversationId, ConversationMetadata, DaemonSnapshot, DurationMs,
+    HealthStatus, IdentifierError, IssueExecution, IssueId, IssueIdentifier, IssueSnapshot,
+    IssueState, IssueStateCategory, NormalizedIssue, OrchestratorSnapshot, ReleaseReason,
+    RetryAttempt, RetryCalculationError, RetryEntry, RetryPolicy, RetryReason, RunAttempt,
+    RuntimeStreamState, RuntimeUsageTotals, SchedulerState, SchedulerStatus, StallMetadata,
+    StateTransitionError, TimestampMs, TrackerStateId, TransitionAction, WorkerAttemptSnapshot,
+    WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
+};
+
+pub fn boundary_summary() -> &'static str {
     "poll tick, runtime state machine, worker supervision, retry queue, cancellation/reconciliation, and snapshot derivation inputs"
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CRATE_NAME, placeholder_summary};
+    use std::path::PathBuf;
+
+    use super::{
+        DurationMs, IssueExecution, IssueId, IssueIdentifier, IssueState, IssueStateCategory,
+        NormalizedIssue, ReleaseReason, RunAttempt, SchedulerStatus, TimestampMs, WorkerId,
+        WorkspaceKey, WorkspaceRecord, boundary_summary,
+    };
+
+    fn must<T, E: std::fmt::Display>(result: Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("{error}"),
+        }
+    }
 
     #[test]
-    fn reports_its_boundary() {
-        assert_eq!(CRATE_NAME, "opensymphony-orchestrator");
-        assert!(placeholder_summary().contains("runtime state machine"));
+    fn exposes_domain_state_machine_as_the_orchestrator_boundary() {
+        let issue = NormalizedIssue {
+            id: must(IssueId::new("lin_260")),
+            identifier: must(IssueIdentifier::new("COE-260")),
+            title: "Domain model and orchestrator state machine".to_owned(),
+            description: None,
+            priority: Some(1),
+            state: IssueState {
+                id: None,
+                name: "In Progress".to_owned(),
+                category: IssueStateCategory::Active,
+            },
+            branch_name: None,
+            url: None,
+            labels: Vec::new(),
+            blocked_by: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        };
+
+        let workspace = WorkspaceRecord {
+            path: PathBuf::from("/tmp/workspaces/COE-260"),
+            workspace_key: must(WorkspaceKey::new("COE-260")),
+            created_now: false,
+            created_at: None,
+            updated_at: None,
+            last_seen_tracker_refresh_at: None,
+        };
+
+        let run = RunAttempt::new(
+            must(WorkerId::new("worker-1")),
+            issue.id.clone(),
+            issue.identifier.clone(),
+            workspace.path.clone(),
+            TimestampMs::new(10),
+            None,
+            8,
+        );
+
+        let mut execution = IssueExecution::new(issue, TimestampMs::new(0));
+        execution.attach_workspace(workspace);
+        let execution = must(execution.claim(run));
+        let execution =
+            must(execution.start_running(TimestampMs::new(11), DurationMs::new(300_000), None));
+        let execution =
+            must(execution.release(TimestampMs::new(12), ReleaseReason::TrackerInactive, None));
+
+        assert_eq!(execution.status(), SchedulerStatus::Released);
+        assert!(boundary_summary().contains("runtime state machine"));
     }
 }

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -19,9 +19,10 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{
-        boundary_summary, DurationMs, IssueExecution, IssueId, IssueIdentifier, IssueState,
-        IssueStateCategory, NormalizedIssue, ReleaseReason, RunAttempt, SchedulerStatus,
-        TimestampMs, WorkerId, WorkspaceKey, WorkspaceRecord,
+        boundary_summary, ConversationId, ConversationMetadata, DurationMs, IssueExecution,
+        IssueId, IssueIdentifier, IssueState, IssueStateCategory, NormalizedIssue, ReleaseReason,
+        RunAttempt, RuntimeStreamState, SchedulerStatus, TimestampMs, WorkerId, WorkspaceKey,
+        WorkspaceRecord,
     };
 
     fn must<T, E: std::fmt::Display>(result: Result<T, E>) -> T {
@@ -74,8 +75,21 @@ mod tests {
         let mut execution = IssueExecution::new(issue, TimestampMs::new(0));
         must(execution.attach_workspace(workspace));
         let execution = must(execution.claim(run));
-        let execution =
-            must(execution.start_running(TimestampMs::new(11), DurationMs::new(300_000), None));
+        let execution = must(execution.start_running(
+            TimestampMs::new(11),
+            DurationMs::new(300_000),
+            Some(ConversationMetadata {
+                conversation_id: must(ConversationId::new("conv_260")),
+                server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+                fresh_conversation: true,
+                runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
+                stream_state: RuntimeStreamState::Ready,
+                last_event_id: None,
+                last_event_kind: None,
+                last_event_at: None,
+                last_event_summary: None,
+            }),
+        ));
         let execution =
             must(execution.release(TimestampMs::new(12), ReleaseReason::TrackerInactive, None));
 

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -72,7 +72,7 @@ mod tests {
         );
 
         let mut execution = IssueExecution::new(issue, TimestampMs::new(0));
-        execution.attach_workspace(workspace);
+        must(execution.attach_workspace(workspace));
         let execution = must(execution.claim(run));
         let execution =
             must(execution.start_running(TimestampMs::new(11), DurationMs::new(300_000), None));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,7 @@ Recommended crate boundaries:
   - issue model
   - run-attempt model
   - retry-entry model
+  - scheduler state and transition types
   - orchestrator snapshot model
 - `opensymphony-workflow`
   - `WORKFLOW.md` loader
@@ -148,7 +149,7 @@ Recommended crate boundaries:
   - issue session runner
 - `opensymphony-orchestrator`
   - poll tick
-  - runtime state machine
+  - scheduler actor and policy decisions over the shared state machine
   - worker supervision
   - retry timers
   - reconciliation

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -27,6 +27,7 @@ Purpose:
 
 - shared domain types
 - runtime enums
+- scheduler state and transition helpers
 - snapshot models
 - config-independent constants
 
@@ -85,7 +86,7 @@ This crate owns all OpenHands-specific transport details.
 Purpose:
 
 - poll tick
-- runtime state machine
+- scheduler actor and policy decisions over the shared state machine
 - worker supervision
 - retry queue
 - cancellation and reconciliation

--- a/docs/symphony-spec-alignment.md
+++ b/docs/symphony-spec-alignment.md
@@ -53,12 +53,13 @@ OpenSymphony preserves the major Symphony runtime entities:
 - normalized issue record
 - run attempt
 - retry entry
-- orchestrator runtime state
+- issue execution state and transition rules
 - workspace record
 - runtime snapshot
 
 Implementation note:
 
+- the shared scheduler state machine lives in `opensymphony-domain` so downstream crates can consume one stable model
 - the agent-specific fields refer to OpenHands concepts instead of Codex fields
 - OpenSymphony adds conversation metadata such as `conversation_id`, `server_base_url`, `stream_state`, and `last_event_id`
 


### PR DESCRIPTION
## Summary
- define normalized issue, workspace, retry, runtime, and snapshot models in opensymphony-domain
- add explicit scheduler state transitions and shared error/outcome types, then keep opensymphony-orchestrator as a thin boundary crate
- reconcile the branch with the latest origin/main merge and regenerate Cargo.lock from the merged manifests

## Validation
- cargo test -p opensymphony-domain -p opensymphony-orchestrator
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings

Linear: https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine