### PR TITLE
COE-264: Linear read adapter and issue normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,10 +946,25 @@ version = "0.1.0"
 [[package]]
 name = "opensymphony-domain"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+]
 
 [[package]]
 name = "opensymphony-linear"
 version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "opensymphony-domain",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "opensymphony-linear-mcp"

--- a/crates/opensymphony-domain/Cargo.toml
+++ b/crates/opensymphony-domain/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[dependencies]
+chrono.workspace = true
+serde.workspace = true
+
 [lib]
 path = "src/lib.rs"
-

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -1,1 +1,166 @@
-pub const CRATE_NAME: &str = "opensymphony-domain";
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerIssue {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: Option<u8>,
+    pub state: TrackerIssueState,
+    pub labels: Vec<String>,
+    pub blocked_by: Vec<TrackerIssueBlocker>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerIssueStateSnapshot {
+    pub id: String,
+    pub identifier: String,
+    pub state: TrackerIssueState,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerIssueState {
+    pub id: String,
+    pub name: String,
+    pub kind: TrackerIssueStateKind,
+}
+
+impl TrackerIssueState {
+    pub fn is_active(&self) -> bool {
+        self.kind.is_active()
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.kind.is_terminal()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerIssueBlocker {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub state: TrackerIssueState,
+}
+
+impl TrackerIssueBlocker {
+    pub fn is_terminal(&self) -> bool {
+        self.state.is_terminal()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackerIssueStateKind {
+    Backlog,
+    Unstarted,
+    Started,
+    Completed,
+    Canceled,
+    Triage,
+    Unknown(String),
+}
+
+impl TrackerIssueStateKind {
+    pub fn from_tracker_type(value: impl AsRef<str>) -> Self {
+        match value.as_ref().trim().to_ascii_lowercase().as_str() {
+            "backlog" => Self::Backlog,
+            "unstarted" => Self::Unstarted,
+            "started" => Self::Started,
+            "completed" => Self::Completed,
+            "canceled" => Self::Canceled,
+            "triage" | "triaged" => Self::Triage,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Started | Self::Triage)
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Canceled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackerErrorCategory {
+    Auth,
+    RateLimited,
+    Transport,
+    Timeout,
+    InvalidResponse,
+    NotFound,
+    InvalidStateTransition,
+    PermissionDenied,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TrackerErrorCategory, TrackerIssueState, TrackerIssueStateKind};
+
+    #[test]
+    fn tracker_state_kind_maps_known_linear_types() {
+        assert_eq!(
+            TrackerIssueStateKind::from_tracker_type("started"),
+            TrackerIssueStateKind::Started
+        );
+        assert_eq!(
+            TrackerIssueStateKind::from_tracker_type("completed"),
+            TrackerIssueStateKind::Completed
+        );
+        assert_eq!(
+            TrackerIssueStateKind::from_tracker_type("triaged"),
+            TrackerIssueStateKind::Triage
+        );
+    }
+
+    #[test]
+    fn tracker_state_kind_preserves_unknown_values() {
+        assert_eq!(
+            TrackerIssueStateKind::from_tracker_type("custom-state"),
+            TrackerIssueStateKind::Unknown("custom-state".to_string())
+        );
+    }
+
+    #[test]
+    fn tracker_state_helpers_report_active_and_terminal() {
+        let active = TrackerIssueState {
+            id: "state-started".to_string(),
+            name: "In Progress".to_string(),
+            kind: TrackerIssueStateKind::Started,
+        };
+        let terminal = TrackerIssueState {
+            id: "state-done".to_string(),
+            name: "Done".to_string(),
+            kind: TrackerIssueStateKind::Completed,
+        };
+
+        assert!(active.is_active());
+        assert!(!active.is_terminal());
+        assert!(terminal.is_terminal());
+        assert!(!terminal.is_active());
+    }
+
+    #[test]
+    fn tracker_error_category_variants_remain_stable() {
+        let categories = [
+            TrackerErrorCategory::Auth,
+            TrackerErrorCategory::RateLimited,
+            TrackerErrorCategory::Transport,
+            TrackerErrorCategory::Timeout,
+            TrackerErrorCategory::InvalidResponse,
+            TrackerErrorCategory::NotFound,
+            TrackerErrorCategory::InvalidStateTransition,
+            TrackerErrorCategory::PermissionDenied,
+        ];
+
+        assert_eq!(categories.len(), 8);
+    }
+}

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -9,7 +9,7 @@ pub struct TrackerIssue {
     pub title: String,
     pub description: Option<String>,
     pub priority: Option<u8>,
-    pub state: TrackerIssueState,
+    pub state: String,
     pub labels: Vec<String>,
     pub blocked_by: Vec<TrackerIssueBlocker>,
     pub created_at: DateTime<Utc>,
@@ -32,10 +32,6 @@ pub struct TrackerIssueState {
 }
 
 impl TrackerIssueState {
-    pub fn is_active(&self) -> bool {
-        self.kind.is_active()
-    }
-
     pub fn is_terminal(&self) -> bool {
         self.kind.is_terminal()
     }
@@ -78,10 +74,6 @@ impl TrackerIssueStateKind {
             "triage" | "triaged" => Self::Triage,
             other => Self::Unknown(other.to_string()),
         }
-    }
-
-    pub fn is_active(&self) -> bool {
-        matches!(self, Self::Started | Self::Triage)
     }
 
     pub fn is_terminal(&self) -> bool {
@@ -131,8 +123,8 @@ mod tests {
     }
 
     #[test]
-    fn tracker_state_helpers_report_active_and_terminal() {
-        let active = TrackerIssueState {
+    fn tracker_state_helpers_report_terminal_only() {
+        let non_terminal = TrackerIssueState {
             id: "state-started".to_string(),
             name: "In Progress".to_string(),
             kind: TrackerIssueStateKind::Started,
@@ -143,10 +135,8 @@ mod tests {
             kind: TrackerIssueStateKind::Completed,
         };
 
-        assert!(active.is_active());
-        assert!(!active.is_terminal());
+        assert!(!non_terminal.is_terminal());
         assert!(terminal.is_terminal());
-        assert!(!terminal.is_active());
     }
 
     #[test]

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct TrackerIssue {
     pub id: String,
     pub identifier: String,
+    pub url: String,
     pub title: String,
     pub description: Option<String>,
     pub priority: Option<u8>,

--- a/crates/opensymphony-domain/src/tracker.rs
+++ b/crates/opensymphony-domain/src/tracker.rs
@@ -28,6 +28,8 @@ pub struct TrackerIssueStateSnapshot {
 pub struct TrackerIssueState {
     pub id: String,
     pub name: String,
+    #[serde(rename = "type")]
+    pub tracker_type: String,
     pub kind: TrackerIssueStateKind,
 }
 
@@ -127,16 +129,33 @@ mod tests {
         let non_terminal = TrackerIssueState {
             id: "state-started".to_string(),
             name: "In Progress".to_string(),
+            tracker_type: "started".to_string(),
             kind: TrackerIssueStateKind::Started,
         };
         let terminal = TrackerIssueState {
             id: "state-done".to_string(),
             name: "Done".to_string(),
+            tracker_type: "completed".to_string(),
             kind: TrackerIssueStateKind::Completed,
         };
 
         assert!(!non_terminal.is_terminal());
         assert!(terminal.is_terminal());
+    }
+
+    #[test]
+    fn tracker_state_serialization_preserves_raw_tracker_type() {
+        let state = TrackerIssueState {
+            id: "state-triaged".to_string(),
+            name: "Triage".to_string(),
+            tracker_type: "triaged".to_string(),
+            kind: TrackerIssueStateKind::from_tracker_type("triaged"),
+        };
+
+        let json = serde_json::to_value(&state).expect("state should serialize");
+
+        assert_eq!(json["type"], serde_json::json!("triaged"));
+        assert_eq!(json["kind"], serde_json::json!("triage"));
     }
 
     #[test]

--- a/crates/opensymphony-linear/Cargo.toml
+++ b/crates/opensymphony-linear/Cargo.toml
@@ -5,6 +5,19 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[dependencies]
+chrono.workspace = true
+opensymphony-domain = { path = "../opensymphony-domain" }
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+tokio.workspace = true
+
 [lib]
 path = "src/lib.rs"
-

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -12,8 +12,10 @@ use tracing::debug;
 
 use crate::error::{GraphqlError, LinearError};
 use crate::graphql::{
-    GraphqlEnvelope, GraphqlErrorPayload, IssueStatesByIdsData, IssueStatesByIdsVariables,
-    IssuesByStateData, IssuesByStateVariables, ISSUES_BY_STATE_QUERY, ISSUE_STATES_BY_IDS_QUERY,
+    GraphqlEnvelope, GraphqlErrorPayload, IssueInverseRelationsData,
+    IssueInverseRelationsVariables, IssueStatesByIdsData, IssueStatesByIdsVariables,
+    IssuesByStateData, IssuesByStateVariables, LinearIssueNode, LinearRelationConnection,
+    ISSUES_BY_STATE_QUERY, ISSUE_INVERSE_RELATIONS_QUERY, ISSUE_STATES_BY_IDS_QUERY,
 };
 use crate::normalize::{normalize_issue, normalize_issue_state};
 
@@ -137,7 +139,7 @@ impl LinearClient {
 
             let page_info = response.issues.page_info;
             for node in response.issues.nodes {
-                issues.push(normalize_issue(node)?);
+                issues.push(normalize_issue(self.expand_inverse_relations(node).await?)?);
             }
 
             if !page_info.has_next_page {
@@ -183,7 +185,7 @@ impl LinearClient {
             }
 
             if !page_info.has_next_page {
-                return Ok(snapshots);
+                return ensure_complete_issue_states(&issue_ids, snapshots);
             }
 
             after = Some(page_info.end_cursor.ok_or_else(|| {
@@ -193,6 +195,55 @@ impl LinearClient {
                 )
             })?);
         }
+    }
+
+    async fn expand_inverse_relations(
+        &self,
+        mut issue: LinearIssueNode,
+    ) -> Result<LinearIssueNode, LinearError> {
+        issue.inverse_relations = self
+            .load_all_inverse_relations(&issue.id, issue.inverse_relations)
+            .await?;
+        Ok(issue)
+    }
+
+    async fn load_all_inverse_relations(
+        &self,
+        issue_id: &str,
+        mut connection: LinearRelationConnection,
+    ) -> Result<LinearRelationConnection, LinearError> {
+        let mut after = connection.page_info.end_cursor.clone();
+
+        while connection.page_info.has_next_page {
+            let cursor = after.clone().ok_or_else(|| {
+                LinearError::InvalidResponse(format!(
+                    "Linear inverseRelations page for issue {issue_id} indicated a next page without an end cursor"
+                ))
+            })?;
+            let variables = IssueInverseRelationsVariables {
+                issue_id: issue_id.to_string(),
+                first: self.config.page_size,
+                after: Some(cursor),
+            };
+            let response: IssueInverseRelationsData = self
+                .execute_graphql(ISSUE_INVERSE_RELATIONS_QUERY, json!(variables))
+                .await?;
+            let issue = response.issue.ok_or_else(|| LinearError::MissingIssueIds {
+                issue_ids: vec![issue_id.to_string()],
+            })?;
+            if issue.id != issue_id {
+                return Err(LinearError::InvalidResponse(format!(
+                    "Linear inverseRelations page returned mismatched issue ID {} for {}",
+                    issue.id, issue_id
+                )));
+            }
+
+            connection.nodes.extend(issue.inverse_relations.nodes);
+            connection.page_info = issue.inverse_relations.page_info;
+            after = connection.page_info.end_cursor.clone();
+        }
+
+        Ok(connection)
     }
 
     async fn execute_graphql<T>(
@@ -292,7 +343,9 @@ impl LinearClient {
                 *status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
             }
             LinearError::Graphql { .. } => error.is_rate_limited(),
-            LinearError::InvalidConfiguration(_) | LinearError::InvalidResponse(_) => false,
+            LinearError::MissingIssueIds { .. }
+            | LinearError::InvalidConfiguration(_)
+            | LinearError::InvalidResponse(_) => false,
         }
     }
 
@@ -346,6 +399,26 @@ where
         }
     }
     normalized
+}
+
+fn ensure_complete_issue_states(
+    requested_issue_ids: &[String],
+    snapshots: Vec<TrackerIssueStateSnapshot>,
+) -> Result<Vec<TrackerIssueStateSnapshot>, LinearError> {
+    let mut missing_issue_ids = Vec::new();
+    for issue_id in requested_issue_ids {
+        if !snapshots.iter().any(|snapshot| snapshot.id == *issue_id) {
+            missing_issue_ids.push(issue_id.clone());
+        }
+    }
+
+    if missing_issue_ids.is_empty() {
+        Ok(snapshots)
+    } else {
+        Err(LinearError::MissingIssueIds {
+            issue_ids: missing_issue_ids,
+        })
+    }
 }
 
 fn parse_retry_after(header_value: Option<&reqwest::header::HeaderValue>) -> Option<Duration> {

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -1,0 +1,354 @@
+use std::time::Duration;
+
+use opensymphony_domain::{TrackerIssue, TrackerIssueStateSnapshot};
+use reqwest::{
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, RETRY_AFTER},
+    Client, StatusCode,
+};
+use serde::de::DeserializeOwned;
+use serde_json::{json, Value};
+use tokio::time::sleep;
+use tracing::debug;
+
+use crate::error::{GraphqlError, LinearError};
+use crate::graphql::{
+    GraphqlEnvelope, GraphqlErrorPayload, IssueStatesByIdsData, IssueStatesByIdsVariables,
+    IssuesByStateData, IssuesByStateVariables, ISSUES_BY_STATE_QUERY, ISSUE_STATES_BY_IDS_QUERY,
+};
+use crate::normalize::{normalize_issue, normalize_issue_state};
+
+const DEFAULT_BASE_URL: &str = "https://api.linear.app/graphql";
+const DEFAULT_PAGE_SIZE: usize = 50;
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_attempts: usize,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(250),
+            max_backoff: Duration::from_secs(2),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LinearConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub project_slug: String,
+    pub active_states: Vec<String>,
+    pub terminal_states: Vec<String>,
+    pub page_size: usize,
+    pub request_timeout: Duration,
+    pub retry_policy: RetryPolicy,
+}
+
+impl LinearConfig {
+    pub fn new(api_key: impl Into<String>, project_slug: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            project_slug: project_slug.into(),
+            active_states: Vec::new(),
+            terminal_states: Vec::new(),
+            page_size: DEFAULT_PAGE_SIZE,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            retry_policy: RetryPolicy::default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct LinearClient {
+    http: Client,
+    config: LinearConfig,
+}
+
+impl LinearClient {
+    pub fn new(mut config: LinearConfig) -> Result<Self, LinearError> {
+        if config.base_url.trim().is_empty() {
+            config.base_url = DEFAULT_BASE_URL.to_string();
+        }
+        if config.page_size == 0 {
+            config.page_size = DEFAULT_PAGE_SIZE;
+        }
+        if config.request_timeout.is_zero() {
+            config.request_timeout = DEFAULT_REQUEST_TIMEOUT;
+        }
+        if config.retry_policy.max_attempts == 0 {
+            config.retry_policy.max_attempts = 1;
+        }
+        if config.retry_policy.initial_backoff.is_zero() {
+            config.retry_policy.initial_backoff = Duration::from_millis(1);
+        }
+        if config.retry_policy.max_backoff < config.retry_policy.initial_backoff {
+            config.retry_policy.max_backoff = config.retry_policy.initial_backoff;
+        }
+
+        let http = Client::builder()
+            .timeout(config.request_timeout)
+            .build()
+            .map_err(|error| LinearError::InvalidConfiguration(error.to_string()))?;
+
+        Ok(Self { http, config })
+    }
+
+    pub async fn candidate_issues(&self) -> Result<Vec<TrackerIssue>, LinearError> {
+        self.issues_by_state_names(&self.config.active_states).await
+    }
+
+    pub async fn terminal_issues(&self) -> Result<Vec<TrackerIssue>, LinearError> {
+        self.issues_by_state_names(&self.config.terminal_states)
+            .await
+    }
+
+    pub async fn issues_by_state_names<S>(
+        &self,
+        state_names: &[S],
+    ) -> Result<Vec<TrackerIssue>, LinearError>
+    where
+        S: AsRef<str>,
+    {
+        let state_names = normalize_strings(state_names);
+        if state_names.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut after = None;
+        let mut issues = Vec::new();
+
+        loop {
+            let variables = IssuesByStateVariables {
+                project_slug: self.config.project_slug.clone(),
+                state_names: state_names.clone(),
+                first: self.config.page_size,
+                after: after.clone(),
+            };
+            let response: IssuesByStateData = self
+                .execute_graphql(ISSUES_BY_STATE_QUERY, json!(variables))
+                .await?;
+
+            let page_info = response.issues.page_info;
+            for node in response.issues.nodes {
+                issues.push(normalize_issue(node)?);
+            }
+
+            if !page_info.has_next_page {
+                return Ok(issues);
+            }
+
+            after = Some(page_info.end_cursor.ok_or_else(|| {
+                LinearError::InvalidResponse(
+                    "Linear issues page indicated a next page without an end cursor".to_string(),
+                )
+            })?);
+        }
+    }
+
+    pub async fn issue_states_by_ids<S>(
+        &self,
+        issue_ids: &[S],
+    ) -> Result<Vec<TrackerIssueStateSnapshot>, LinearError>
+    where
+        S: AsRef<str>,
+    {
+        let issue_ids = normalize_strings(issue_ids);
+        if issue_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut after = None;
+        let mut snapshots = Vec::new();
+
+        loop {
+            let variables = IssueStatesByIdsVariables {
+                issue_ids: issue_ids.clone(),
+                first: self.config.page_size,
+                after: after.clone(),
+            };
+            let response: IssueStatesByIdsData = self
+                .execute_graphql(ISSUE_STATES_BY_IDS_QUERY, json!(variables))
+                .await?;
+
+            let page_info = response.issues.page_info;
+            for node in response.issues.nodes {
+                snapshots.push(normalize_issue_state(node));
+            }
+
+            if !page_info.has_next_page {
+                return Ok(snapshots);
+            }
+
+            after = Some(page_info.end_cursor.ok_or_else(|| {
+                LinearError::InvalidResponse(
+                    "Linear issue-state page indicated a next page without an end cursor"
+                        .to_string(),
+                )
+            })?);
+        }
+    }
+
+    async fn execute_graphql<T>(
+        &self,
+        query: &'static str,
+        variables: Value,
+    ) -> Result<T, LinearError>
+    where
+        T: DeserializeOwned,
+    {
+        let body = json!({
+            "query": query,
+            "variables": variables,
+        });
+        let authorization = format!("Bearer {}", self.config.api_key);
+        let mut attempt = 1;
+
+        loop {
+            let response = self
+                .http
+                .post(&self.config.base_url)
+                .header(AUTHORIZATION, authorization.as_str())
+                .header(CONTENT_TYPE, "application/json")
+                .header(ACCEPT, "application/json")
+                .json(&body)
+                .send()
+                .await;
+
+            match response {
+                Ok(response) => {
+                    let status = response.status();
+                    let retry_after = parse_retry_after(response.headers().get(RETRY_AFTER));
+                    let payload = response
+                        .text()
+                        .await
+                        .map_err(|error| LinearError::Request(Box::new(error)))?;
+
+                    if !status.is_success() {
+                        let error = LinearError::HttpStatus {
+                            status,
+                            body: payload,
+                            retry_after,
+                        };
+                        if self.should_retry(&error, attempt) {
+                            self.sleep_before_retry(&error, attempt).await;
+                            attempt += 1;
+                            continue;
+                        }
+                        return Err(error);
+                    }
+
+                    let envelope: GraphqlEnvelope<T> =
+                        serde_json::from_str(&payload).map_err(|error| {
+                            LinearError::InvalidResponse(format!(
+                                "failed to decode Linear GraphQL response: {error}"
+                            ))
+                        })?;
+
+                    if let Some(errors) = envelope.errors {
+                        let error =
+                            LinearError::from_graphql_errors(convert_graphql_errors(errors));
+                        if self.should_retry(&error, attempt) {
+                            self.sleep_before_retry(&error, attempt).await;
+                            attempt += 1;
+                            continue;
+                        }
+                        return Err(error);
+                    }
+
+                    return envelope.data.ok_or_else(|| {
+                        LinearError::InvalidResponse(
+                            "Linear GraphQL response omitted both data and errors".to_string(),
+                        )
+                    });
+                }
+                Err(error) => {
+                    let error = LinearError::Request(Box::new(error));
+                    if self.should_retry(&error, attempt) {
+                        self.sleep_before_retry(&error, attempt).await;
+                        attempt += 1;
+                        continue;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    fn should_retry(&self, error: &LinearError, attempt: usize) -> bool {
+        if attempt >= self.config.retry_policy.max_attempts {
+            return false;
+        }
+
+        match error {
+            LinearError::Request(_) => true,
+            LinearError::HttpStatus { status, .. } => {
+                *status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+            }
+            LinearError::Graphql { .. } => error.is_rate_limited(),
+            LinearError::InvalidConfiguration(_) | LinearError::InvalidResponse(_) => false,
+        }
+    }
+
+    async fn sleep_before_retry(&self, error: &LinearError, attempt: usize) {
+        let delay = error
+            .retry_after()
+            .unwrap_or_else(|| self.exponential_backoff(attempt));
+        debug!(
+            attempt,
+            delay_ms = delay.as_millis(),
+            category = ?error.category(),
+            "retrying Linear GraphQL request"
+        );
+        sleep(delay).await;
+    }
+
+    fn exponential_backoff(&self, attempt: usize) -> Duration {
+        let mut delay = self.config.retry_policy.initial_backoff;
+        for _ in 1..attempt {
+            match delay.checked_mul(2) {
+                Some(next) if next <= self.config.retry_policy.max_backoff => delay = next,
+                _ => return self.config.retry_policy.max_backoff,
+            }
+        }
+        delay
+    }
+}
+
+fn convert_graphql_errors(errors: Vec<GraphqlErrorPayload>) -> Vec<GraphqlError> {
+    errors
+        .into_iter()
+        .map(|error| GraphqlError {
+            message: error.message,
+            code: error.extensions.and_then(|extensions| extensions.code),
+        })
+        .collect()
+}
+
+fn normalize_strings<S>(values: &[S]) -> Vec<String>
+where
+    S: AsRef<str>,
+{
+    let mut normalized = Vec::new();
+    for value in values {
+        let value = value.as_ref().trim();
+        if value.is_empty() {
+            continue;
+        }
+        if !normalized.iter().any(|existing| existing == value) {
+            normalized.push(value.to_string());
+        }
+    }
+    normalized
+}
+
+fn parse_retry_after(header_value: Option<&reqwest::header::HeaderValue>) -> Option<Duration> {
+    let seconds = header_value?.to_str().ok()?.trim().parse::<u64>().ok()?;
+    Some(Duration::from_secs(seconds))
+}

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -94,6 +94,8 @@ impl LinearClient {
         if config.retry_policy.max_backoff < config.retry_policy.initial_backoff {
             config.retry_policy.max_backoff = config.retry_policy.initial_backoff;
         }
+        config.project_slug =
+            normalize_required_string("tracker.project_slug", &config.project_slug)?;
         config.active_states =
             normalize_required_state_names("tracker.active_states", &config.active_states)?;
         config.terminal_states =
@@ -265,14 +267,14 @@ impl LinearClient {
             "query": query,
             "variables": variables,
         });
-        let authorization = format!("Bearer {}", self.config.api_key);
+        let authorization = self.config.api_key.as_str();
         let mut attempt = 1;
 
         loop {
             let response = self
                 .http
                 .post(&self.config.base_url)
-                .header(AUTHORIZATION, authorization.as_str())
+                .header(AUTHORIZATION, authorization)
                 .header(CONTENT_TYPE, "application/json")
                 .header(ACCEPT, "application/json")
                 .json(&body)
@@ -450,6 +452,17 @@ where
         )))
     } else {
         Ok(normalized)
+    }
+}
+
+fn normalize_required_string(field_name: &str, value: &str) -> Result<String, LinearError> {
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        Err(LinearError::InvalidConfiguration(format!(
+            "workflow {field_name} must be a non-empty string"
+        )))
+    } else {
+        Ok(normalized.to_string())
     }
 }
 

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -115,13 +115,25 @@ impl LinearClient {
     }
 
     pub async fn terminal_issues(&self) -> Result<Vec<TrackerIssue>, LinearError> {
-        self.issues_by_state_names(&self.config.terminal_states)
+        self.issues_by_state_names_with_archived(&self.config.terminal_states, true)
             .await
     }
 
     pub async fn issues_by_state_names<S>(
         &self,
         state_names: &[S],
+    ) -> Result<Vec<TrackerIssue>, LinearError>
+    where
+        S: AsRef<str>,
+    {
+        self.issues_by_state_names_with_archived(state_names, false)
+            .await
+    }
+
+    async fn issues_by_state_names_with_archived<S>(
+        &self,
+        state_names: &[S],
+        include_archived: bool,
     ) -> Result<Vec<TrackerIssue>, LinearError>
     where
         S: AsRef<str>,
@@ -138,6 +150,7 @@ impl LinearClient {
             let variables = IssuesByStateVariables {
                 project_slug: self.config.project_slug.clone(),
                 state_names: state_names.clone(),
+                include_archived,
                 first: self.config.page_size,
                 after: after.clone(),
                 relation_first: self.config.page_size.min(MAX_INITIAL_RELATION_PAGE_SIZE),

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -94,6 +94,10 @@ impl LinearClient {
         if config.retry_policy.max_backoff < config.retry_policy.initial_backoff {
             config.retry_policy.max_backoff = config.retry_policy.initial_backoff;
         }
+        config.active_states =
+            normalize_required_state_names("tracker.active_states", &config.active_states)?;
+        config.terminal_states =
+            normalize_required_state_names("tracker.terminal_states", &config.terminal_states)?;
 
         let http = Client::builder()
             .timeout(config.request_timeout)
@@ -173,6 +177,7 @@ impl LinearClient {
 
         loop {
             let variables = IssueStatesByIdsVariables {
+                project_slug: self.config.project_slug.clone(),
                 issue_ids: issue_ids.clone(),
                 first: self.config.page_size,
                 after: after.clone(),
@@ -429,6 +434,23 @@ where
         }
     }
     normalized
+}
+
+fn normalize_required_state_names<S>(
+    field_name: &str,
+    values: &[S],
+) -> Result<Vec<String>, LinearError>
+where
+    S: AsRef<str>,
+{
+    let normalized = normalize_strings(values);
+    if normalized.is_empty() {
+        Err(LinearError::InvalidConfiguration(format!(
+            "workflow {field_name} must contain at least one non-empty state name"
+        )))
+    } else {
+        Ok(normalized)
+    }
 }
 
 fn ensure_complete_issue_states(

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -22,6 +22,7 @@ use crate::normalize::{normalize_issue, normalize_issue_state};
 const DEFAULT_BASE_URL: &str = "https://api.linear.app/graphql";
 const DEFAULT_PAGE_SIZE: usize = 50;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_INITIAL_RELATION_PAGE_SIZE: usize = 10;
 
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
@@ -132,6 +133,7 @@ impl LinearClient {
                 state_names: state_names.clone(),
                 first: self.config.page_size,
                 after: after.clone(),
+                relation_first: self.config.page_size.min(MAX_INITIAL_RELATION_PAGE_SIZE),
             };
             let response: IssuesByStateData = self
                 .execute_graphql(ISSUES_BY_STATE_QUERY, json!(variables))
@@ -281,6 +283,15 @@ impl LinearClient {
                         .await
                         .map_err(|error| LinearError::Request(Box::new(error)))?;
 
+                    if let Some(error) = decode_graphql_error_response(&payload, retry_after)? {
+                        if self.should_retry(&error, attempt) {
+                            self.sleep_before_retry(&error, attempt).await;
+                            attempt += 1;
+                            continue;
+                        }
+                        return Err(error);
+                    }
+
                     if !status.is_success() {
                         let error = LinearError::HttpStatus {
                             status,
@@ -303,8 +314,10 @@ impl LinearClient {
                         })?;
 
                     if let Some(errors) = envelope.errors {
-                        let error =
-                            LinearError::from_graphql_errors(convert_graphql_errors(errors));
+                        let error = LinearError::from_graphql_errors_with_retry_after(
+                            convert_graphql_errors(errors),
+                            retry_after,
+                        );
                         if self.should_retry(&error, attempt) {
                             self.sleep_before_retry(&error, attempt).await;
                             attempt += 1;
@@ -382,6 +395,23 @@ fn convert_graphql_errors(errors: Vec<GraphqlErrorPayload>) -> Vec<GraphqlError>
             code: error.extensions.and_then(|extensions| extensions.code),
         })
         .collect()
+}
+
+fn decode_graphql_error_response(
+    payload: &str,
+    retry_after: Option<Duration>,
+) -> Result<Option<LinearError>, LinearError> {
+    let envelope: GraphqlEnvelope<Value> = match serde_json::from_str(payload) {
+        Ok(envelope) => envelope,
+        Err(_) => return Ok(None),
+    };
+
+    Ok(envelope.errors.map(|errors| {
+        LinearError::from_graphql_errors_with_retry_after(
+            convert_graphql_errors(errors),
+            retry_after,
+        )
+    }))
 }
 
 fn normalize_strings<S>(values: &[S]) -> Vec<String>

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -13,9 +13,10 @@ use tracing::debug;
 use crate::error::{GraphqlError, LinearError};
 use crate::graphql::{
     GraphqlEnvelope, GraphqlErrorPayload, IssueInverseRelationsData,
-    IssueInverseRelationsVariables, IssueStatesByIdsData, IssueStatesByIdsVariables,
-    IssuesByStateData, IssuesByStateVariables, LinearIssueNode, LinearRelationConnection,
-    ISSUES_BY_STATE_QUERY, ISSUE_INVERSE_RELATIONS_QUERY, ISSUE_STATES_BY_IDS_QUERY,
+    IssueInverseRelationsVariables, IssueLabelsData, IssueLabelsVariables, IssueStatesByIdsData,
+    IssueStatesByIdsVariables, IssuesByStateData, IssuesByStateVariables, LinearIssueNode,
+    LinearLabelConnection, LinearRelationConnection, ISSUES_BY_STATE_QUERY,
+    ISSUE_INVERSE_RELATIONS_QUERY, ISSUE_LABELS_QUERY, ISSUE_STATES_BY_IDS_QUERY,
 };
 use crate::normalize::{normalize_issue, normalize_issue_state};
 
@@ -23,6 +24,7 @@ const DEFAULT_BASE_URL: &str = "https://api.linear.app/graphql";
 const DEFAULT_PAGE_SIZE: usize = 50;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_INITIAL_RELATION_PAGE_SIZE: usize = 10;
+const MAX_INITIAL_LABEL_PAGE_SIZE: usize = 10;
 
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
@@ -154,6 +156,7 @@ impl LinearClient {
                 first: self.config.page_size,
                 after: after.clone(),
                 relation_first: self.config.page_size.min(MAX_INITIAL_RELATION_PAGE_SIZE),
+                label_first: self.config.page_size.min(MAX_INITIAL_LABEL_PAGE_SIZE),
             };
             let response: IssuesByStateData = self
                 .execute_graphql(ISSUES_BY_STATE_QUERY, json!(variables))
@@ -161,7 +164,7 @@ impl LinearClient {
 
             let page_info = response.issues.page_info;
             for node in response.issues.nodes {
-                issues.push(normalize_issue(self.expand_inverse_relations(node).await?)?);
+                issues.push(normalize_issue(self.expand_issue(node).await?)?);
             }
 
             if !page_info.has_next_page {
@@ -220,14 +223,54 @@ impl LinearClient {
         }
     }
 
-    async fn expand_inverse_relations(
+    async fn expand_issue(
         &self,
         mut issue: LinearIssueNode,
     ) -> Result<LinearIssueNode, LinearError> {
+        issue.labels = self.load_all_labels(&issue.id, issue.labels).await?;
         issue.inverse_relations = self
             .load_all_inverse_relations(&issue.id, issue.inverse_relations)
             .await?;
         Ok(issue)
+    }
+
+    async fn load_all_labels(
+        &self,
+        issue_id: &str,
+        mut connection: LinearLabelConnection,
+    ) -> Result<LinearLabelConnection, LinearError> {
+        let mut after = connection.page_info.end_cursor.clone();
+
+        while connection.page_info.has_next_page {
+            let cursor = after.clone().ok_or_else(|| {
+                LinearError::InvalidResponse(format!(
+                    "Linear labels page for issue {issue_id} indicated a next page without an end cursor"
+                ))
+            })?;
+            let variables = IssueLabelsVariables {
+                issue_id: issue_id.to_string(),
+                first: self.config.page_size,
+                after: Some(cursor),
+            };
+            let response: IssueLabelsData = self
+                .execute_graphql(ISSUE_LABELS_QUERY, json!(variables))
+                .await?;
+            let issue = response.issue.ok_or_else(|| LinearError::MissingIssueIds {
+                issue_ids: vec![issue_id.to_string()],
+            })?;
+            if issue.id != issue_id {
+                return Err(LinearError::InvalidResponse(format!(
+                    "Linear labels page returned mismatched issue ID {} for {}",
+                    issue.id, issue_id
+                )));
+            }
+
+            connection.nodes.extend(issue.labels.nodes);
+            connection.page_info = issue.labels.page_info;
+            after = connection.page_info.end_cursor.clone();
+        }
+
+        Ok(connection)
     }
 
     async fn load_all_inverse_relations(
@@ -303,6 +346,20 @@ impl LinearClient {
                         .text()
                         .await
                         .map_err(|error| LinearError::Request(Box::new(error)))?;
+
+                    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+                        let error = LinearError::HttpStatus {
+                            status,
+                            body: payload,
+                            retry_after,
+                        };
+                        if self.should_retry(&error, attempt) {
+                            self.sleep_before_retry(&error, attempt).await;
+                            attempt += 1;
+                            continue;
+                        }
+                        return Err(error);
+                    }
 
                     if let Some(error) = decode_graphql_error_response(&payload, retry_after)? {
                         if self.should_retry(&error, attempt) {

--- a/crates/opensymphony-linear/src/error.rs
+++ b/crates/opensymphony-linear/src/error.rs
@@ -1,0 +1,172 @@
+use std::time::Duration;
+
+use opensymphony_domain::TrackerErrorCategory;
+use reqwest::StatusCode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphqlError {
+    pub message: String,
+    pub code: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LinearError {
+    #[error("invalid Linear client configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("Linear request failed: {0}")]
+    Request(Box<reqwest::Error>),
+    #[error("Linear API returned HTTP {status}: {body}")]
+    HttpStatus {
+        status: StatusCode,
+        body: String,
+        retry_after: Option<Duration>,
+    },
+    #[error("Linear GraphQL returned errors: {summary}")]
+    Graphql {
+        errors: Vec<GraphqlError>,
+        summary: String,
+    },
+    #[error("Linear API returned an invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+impl LinearError {
+    pub fn from_graphql_errors(errors: Vec<GraphqlError>) -> Self {
+        let summary = errors
+            .iter()
+            .map(|error| match &error.code {
+                Some(code) => format!("{code}: {}", error.message),
+                None => error.message.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        Self::Graphql { errors, summary }
+    }
+
+    pub fn category(&self) -> TrackerErrorCategory {
+        match self {
+            Self::InvalidConfiguration(_) | Self::InvalidResponse(_) => {
+                TrackerErrorCategory::InvalidResponse
+            }
+            Self::Request(error) if error.is_timeout() => TrackerErrorCategory::Timeout,
+            Self::Request(_) => TrackerErrorCategory::Transport,
+            Self::HttpStatus { status, .. } => http_status_category(*status),
+            Self::Graphql { errors, .. } => graphql_category(errors),
+        }
+    }
+
+    pub fn is_rate_limited(&self) -> bool {
+        self.category() == TrackerErrorCategory::RateLimited
+    }
+
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::HttpStatus { retry_after, .. } => *retry_after,
+            _ => None,
+        }
+    }
+}
+
+fn http_status_category(status: StatusCode) -> TrackerErrorCategory {
+    match status {
+        StatusCode::UNAUTHORIZED => TrackerErrorCategory::Auth,
+        StatusCode::FORBIDDEN => TrackerErrorCategory::PermissionDenied,
+        StatusCode::NOT_FOUND => TrackerErrorCategory::NotFound,
+        StatusCode::TOO_MANY_REQUESTS => TrackerErrorCategory::RateLimited,
+        status if status.is_server_error() => TrackerErrorCategory::Transport,
+        _ => TrackerErrorCategory::InvalidResponse,
+    }
+}
+
+fn graphql_category(errors: &[GraphqlError]) -> TrackerErrorCategory {
+    for error in errors {
+        if let Some(code) = &error.code {
+            let code = code.to_ascii_lowercase();
+            if code.contains("auth") {
+                return TrackerErrorCategory::Auth;
+            }
+            if code.contains("forbidden") || code.contains("permission") {
+                return TrackerErrorCategory::PermissionDenied;
+            }
+            if code.contains("rate") || code.contains("throttle") {
+                return TrackerErrorCategory::RateLimited;
+            }
+            if code.contains("not_found") || code.contains("notfound") {
+                return TrackerErrorCategory::NotFound;
+            }
+            if code.contains("invalid_state") {
+                return TrackerErrorCategory::InvalidStateTransition;
+            }
+        }
+
+        let message = error.message.to_ascii_lowercase();
+        if message.contains("permission") || message.contains("forbidden") {
+            return TrackerErrorCategory::PermissionDenied;
+        }
+        if message.contains("rate limit") || message.contains("too many requests") {
+            return TrackerErrorCategory::RateLimited;
+        }
+        if message.contains("authentication") || message.contains("unauthorized") {
+            return TrackerErrorCategory::Auth;
+        }
+        if message.contains("not found") {
+            return TrackerErrorCategory::NotFound;
+        }
+        if message.contains("invalid state transition") {
+            return TrackerErrorCategory::InvalidStateTransition;
+        }
+    }
+
+    TrackerErrorCategory::InvalidResponse
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use opensymphony_domain::TrackerErrorCategory;
+    use reqwest::StatusCode;
+
+    use crate::error::{GraphqlError, LinearError};
+
+    #[test]
+    fn http_statuses_map_to_tracker_categories() {
+        let auth = LinearError::HttpStatus {
+            status: StatusCode::UNAUTHORIZED,
+            body: "unauthorized".to_string(),
+            retry_after: None,
+        };
+        let permission_denied = LinearError::HttpStatus {
+            status: StatusCode::FORBIDDEN,
+            body: "forbidden".to_string(),
+            retry_after: None,
+        };
+        let rate_limited = LinearError::HttpStatus {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: "slow down".to_string(),
+            retry_after: Some(Duration::from_secs(1)),
+        };
+
+        assert_eq!(auth.category(), TrackerErrorCategory::Auth);
+        assert_eq!(
+            permission_denied.category(),
+            TrackerErrorCategory::PermissionDenied
+        );
+        assert_eq!(rate_limited.category(), TrackerErrorCategory::RateLimited);
+    }
+
+    #[test]
+    fn graphql_errors_map_to_tracker_categories() {
+        let forbidden = LinearError::from_graphql_errors(vec![GraphqlError {
+            message: "viewer does not have permission".to_string(),
+            code: Some("FORBIDDEN".to_string()),
+        }]);
+        let not_found = LinearError::from_graphql_errors(vec![GraphqlError {
+            message: "issue not found".to_string(),
+            code: Some("NOT_FOUND".to_string()),
+        }]);
+
+        assert_eq!(forbidden.category(), TrackerErrorCategory::PermissionDenied);
+        assert_eq!(not_found.category(), TrackerErrorCategory::NotFound);
+    }
+}

--- a/crates/opensymphony-linear/src/error.rs
+++ b/crates/opensymphony-linear/src/error.rs
@@ -25,6 +25,7 @@ pub enum LinearError {
     Graphql {
         errors: Vec<GraphqlError>,
         summary: String,
+        retry_after: Option<Duration>,
     },
     #[error("Linear omitted requested issue IDs from state refresh: {issue_ids:?}")]
     MissingIssueIds { issue_ids: Vec<String> },
@@ -34,6 +35,13 @@ pub enum LinearError {
 
 impl LinearError {
     pub fn from_graphql_errors(errors: Vec<GraphqlError>) -> Self {
+        Self::from_graphql_errors_with_retry_after(errors, None)
+    }
+
+    pub fn from_graphql_errors_with_retry_after(
+        errors: Vec<GraphqlError>,
+        retry_after: Option<Duration>,
+    ) -> Self {
         let summary = errors
             .iter()
             .map(|error| match &error.code {
@@ -42,7 +50,11 @@ impl LinearError {
             })
             .collect::<Vec<_>>()
             .join("; ");
-        Self::Graphql { errors, summary }
+        Self::Graphql {
+            errors,
+            summary,
+            retry_after,
+        }
     }
 
     pub fn category(&self) -> TrackerErrorCategory {
@@ -65,6 +77,7 @@ impl LinearError {
     pub fn retry_after(&self) -> Option<Duration> {
         match self {
             Self::HttpStatus { retry_after, .. } => *retry_after,
+            Self::Graphql { retry_after, .. } => *retry_after,
             _ => None,
         }
     }
@@ -168,8 +181,17 @@ mod tests {
             message: "issue not found".to_string(),
             code: Some("NOT_FOUND".to_string()),
         }]);
+        let rate_limited = LinearError::from_graphql_errors_with_retry_after(
+            vec![GraphqlError {
+                message: "rate limit exceeded".to_string(),
+                code: Some("RATELIMITED".to_string()),
+            }],
+            Some(Duration::from_secs(2)),
+        );
 
         assert_eq!(forbidden.category(), TrackerErrorCategory::PermissionDenied);
         assert_eq!(not_found.category(), TrackerErrorCategory::NotFound);
+        assert_eq!(rate_limited.category(), TrackerErrorCategory::RateLimited);
+        assert_eq!(rate_limited.retry_after(), Some(Duration::from_secs(2)));
     }
 }

--- a/crates/opensymphony-linear/src/error.rs
+++ b/crates/opensymphony-linear/src/error.rs
@@ -26,6 +26,8 @@ pub enum LinearError {
         errors: Vec<GraphqlError>,
         summary: String,
     },
+    #[error("Linear omitted requested issue IDs from state refresh: {issue_ids:?}")]
+    MissingIssueIds { issue_ids: Vec<String> },
     #[error("Linear API returned an invalid response: {0}")]
     InvalidResponse(String),
 }
@@ -45,6 +47,7 @@ impl LinearError {
 
     pub fn category(&self) -> TrackerErrorCategory {
         match self {
+            Self::MissingIssueIds { .. } => TrackerErrorCategory::NotFound,
             Self::InvalidConfiguration(_) | Self::InvalidResponse(_) => {
                 TrackerErrorCategory::InvalidResponse
             }

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -93,7 +93,6 @@ query IssueStatesByIds($projectSlug: String!, $issueIds: [String!], $first: Int!
       id: { in: $issueIds }
       project: { slugId: { eq: $projectSlug } }
     }
-    includeArchived: true
     first: $first
     after: $after
   ) {

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -2,13 +2,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 pub(super) const ISSUES_BY_STATE_QUERY: &str = r#"
-query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!, $after: String, $relationFirst: Int!) {
+query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchived: Boolean!, $first: Int!, $after: String, $relationFirst: Int!) {
   issues(
     filter: {
       project: { slugId: { eq: $projectSlug } }
       state: { name: { in: $stateNames } }
     }
-    includeArchived: true
+    includeArchived: $includeArchived
     first: $first
     after: $after
   ) {
@@ -136,6 +136,7 @@ pub(super) struct GraphqlErrorExtensions {
 pub(super) struct IssuesByStateVariables {
     pub project_slug: String,
     pub state_names: Vec<String>,
+    pub include_archived: bool,
     pub first: usize,
     pub after: Option<String>,
     pub relation_first: usize,

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -2,12 +2,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 pub(super) const ISSUES_BY_STATE_QUERY: &str = r#"
-query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!, $after: String) {
+query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!, $after: String, $relationFirst: Int!) {
   issues(
     filter: {
       project: { slugId: { eq: $projectSlug } }
       state: { name: { in: $stateNames } }
     }
+    includeArchived: true
     first: $first
     after: $after
   ) {
@@ -30,7 +31,7 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!,
           name
         }
       }
-      inverseRelations(first: 100) {
+      inverseRelations(first: $relationFirst) {
         nodes {
           type
           issue {
@@ -89,6 +90,7 @@ pub(super) const ISSUE_STATES_BY_IDS_QUERY: &str = r#"
 query IssueStatesByIds($issueIds: [String!], $first: Int!, $after: String) {
   issues(
     filter: { id: { in: $issueIds } }
+    includeArchived: true
     first: $first
     after: $after
   ) {
@@ -134,6 +136,7 @@ pub(super) struct IssuesByStateVariables {
     pub state_names: Vec<String>,
     pub first: usize,
     pub after: Option<String>,
+    pub relation_first: usize,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -14,6 +14,7 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!,
     nodes {
       id
       identifier
+      url
       title
       description
       priority
@@ -186,6 +187,7 @@ pub(super) struct PageInfo {
 pub(super) struct LinearIssueNode {
     pub id: String,
     pub identifier: String,
+    pub url: String,
     pub title: String,
     pub description: Option<String>,
     pub priority: f64,

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -1,0 +1,201 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub(super) const ISSUES_BY_STATE_QUERY: &str = r#"
+query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!, $after: String) {
+  issues(
+    filter: {
+      project: { slugId: { eq: $projectSlug } }
+      state: { name: { in: $stateNames } }
+    }
+    first: $first
+    after: $after
+  ) {
+    nodes {
+      id
+      identifier
+      title
+      description
+      priority
+      createdAt
+      updatedAt
+      state {
+        id
+        name
+        type
+      }
+      labels {
+        nodes {
+          name
+        }
+      }
+      inverseRelations(first: 100) {
+        nodes {
+          type
+          issue {
+            id
+            identifier
+            title
+            state {
+              id
+              name
+              type
+            }
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+"#;
+
+pub(super) const ISSUE_STATES_BY_IDS_QUERY: &str = r#"
+query IssueStatesByIds($issueIds: [String!], $first: Int!, $after: String) {
+  issues(
+    filter: { id: { in: $issueIds } }
+    first: $first
+    after: $after
+  ) {
+    nodes {
+      id
+      identifier
+      updatedAt
+      state {
+        id
+        name
+        type
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GraphqlEnvelope<T> {
+    pub data: Option<T>,
+    pub errors: Option<Vec<GraphqlErrorPayload>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GraphqlErrorPayload {
+    pub message: String,
+    pub extensions: Option<GraphqlErrorExtensions>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GraphqlErrorExtensions {
+    pub code: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssuesByStateVariables {
+    pub project_slug: String,
+    pub state_names: Vec<String>,
+    pub first: usize,
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssueStatesByIdsVariables {
+    pub issue_ids: Vec<String>,
+    pub first: usize,
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssuesByStateData {
+    pub issues: IssuesConnection<LinearIssueNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssueStatesByIdsData {
+    pub issues: IssuesConnection<LinearIssueStateNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssuesConnection<T> {
+    pub nodes: Vec<T>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: PageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    pub has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    pub end_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct LinearIssueNode {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: f64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub state: LinearWorkflowState,
+    pub labels: LinearLabelConnection,
+    pub inverse_relations: LinearRelationConnection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct LinearIssueStateNode {
+    pub id: String,
+    pub identifier: String,
+    pub updated_at: DateTime<Utc>,
+    pub state: LinearWorkflowState,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearWorkflowState {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearLabelConnection {
+    pub nodes: Vec<LinearLabelNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearLabelNode {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct LinearRelationConnection {
+    pub nodes: Vec<LinearRelationNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearRelationNode {
+    #[serde(rename = "type")]
+    pub relation_type: String,
+    pub issue: LinearBlockerNode,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearBlockerNode {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub state: LinearWorkflowState,
+}

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -43,11 +43,42 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $first: Int!,
             }
           }
         }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
     }
     pageInfo {
       hasNextPage
       endCursor
+    }
+  }
+}
+"#;
+
+pub(super) const ISSUE_INVERSE_RELATIONS_QUERY: &str = r#"
+query IssueInverseRelationsPage($issueId: String!, $first: Int!, $after: String) {
+  issue(id: $issueId) {
+    id
+    inverseRelations(first: $first, after: $after) {
+      nodes {
+        type
+        issue {
+          id
+          identifier
+          title
+          state {
+            id
+            name
+            type
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
     }
   }
 }
@@ -112,6 +143,14 @@ pub(super) struct IssueStatesByIdsVariables {
     pub after: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssueInverseRelationsVariables {
+    pub issue_id: String,
+    pub first: usize,
+    pub after: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub(super) struct IssuesByStateData {
     pub issues: IssuesConnection<LinearIssueNode>,
@@ -120,6 +159,11 @@ pub(super) struct IssuesByStateData {
 #[derive(Debug, Deserialize)]
 pub(super) struct IssueStatesByIdsData {
     pub issues: IssuesConnection<LinearIssueStateNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct IssueInverseRelationsData {
+    pub issue: Option<LinearIssueRelationsNode>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -154,6 +198,13 @@ pub(super) struct LinearIssueNode {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(super) struct LinearIssueRelationsNode {
+    pub id: String,
+    pub inverse_relations: LinearRelationConnection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(super) struct LinearIssueStateNode {
     pub id: String,
     pub identifier: String,
@@ -183,6 +234,8 @@ pub(super) struct LinearLabelNode {
 #[serde(rename_all = "camelCase")]
 pub(super) struct LinearRelationConnection {
     pub nodes: Vec<LinearRelationNode>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: PageInfo,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -87,9 +87,12 @@ query IssueInverseRelationsPage($issueId: String!, $first: Int!, $after: String)
 "#;
 
 pub(super) const ISSUE_STATES_BY_IDS_QUERY: &str = r#"
-query IssueStatesByIds($issueIds: [String!], $first: Int!, $after: String) {
+query IssueStatesByIds($projectSlug: String!, $issueIds: [String!], $first: Int!, $after: String) {
   issues(
-    filter: { id: { in: $issueIds } }
+    filter: {
+      id: { in: $issueIds }
+      project: { slugId: { eq: $projectSlug } }
+    }
     includeArchived: true
     first: $first
     after: $after
@@ -142,6 +145,7 @@ pub(super) struct IssuesByStateVariables {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct IssueStatesByIdsVariables {
+    pub project_slug: String,
     pub issue_ids: Vec<String>,
     pub first: usize,
     pub after: Option<String>,

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 pub(super) const ISSUES_BY_STATE_QUERY: &str = r#"
-query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchived: Boolean!, $first: Int!, $after: String, $relationFirst: Int!) {
+query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchived: Boolean!, $first: Int!, $after: String, $relationFirst: Int!, $labelFirst: Int!) {
   issues(
     filter: {
       project: { slugId: { eq: $projectSlug } }
@@ -26,9 +26,13 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchi
         name
         type
       }
-      labels {
+      labels(first: $labelFirst) {
         nodes {
           name
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
       inverseRelations(first: $relationFirst) {
@@ -54,6 +58,23 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchi
     pageInfo {
       hasNextPage
       endCursor
+    }
+  }
+}
+"#;
+
+pub(super) const ISSUE_LABELS_QUERY: &str = r#"
+query IssueLabelsPage($issueId: String!, $first: Int!, $after: String) {
+  issue(id: $issueId) {
+    id
+    labels(first: $first, after: $after) {
+      nodes {
+        name
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
     }
   }
 }
@@ -140,6 +161,7 @@ pub(super) struct IssuesByStateVariables {
     pub first: usize,
     pub after: Option<String>,
     pub relation_first: usize,
+    pub label_first: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -154,6 +176,14 @@ pub(super) struct IssueStatesByIdsVariables {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct IssueInverseRelationsVariables {
+    pub issue_id: String,
+    pub first: usize,
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IssueLabelsVariables {
     pub issue_id: String,
     pub first: usize,
     pub after: Option<String>,
@@ -175,13 +205,18 @@ pub(super) struct IssueInverseRelationsData {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct IssueLabelsData {
+    pub issue: Option<LinearIssueLabelsNode>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct IssuesConnection<T> {
     pub nodes: Vec<T>,
     #[serde(rename = "pageInfo")]
     pub page_info: PageInfo,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub(super) struct PageInfo {
     #[serde(rename = "hasNextPage")]
     pub has_next_page: bool,
@@ -214,6 +249,13 @@ pub(super) struct LinearIssueRelationsNode {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(super) struct LinearIssueLabelsNode {
+    pub id: String,
+    pub labels: LinearLabelConnection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(super) struct LinearIssueStateNode {
     pub id: String,
     pub identifier: String,
@@ -232,6 +274,8 @@ pub(super) struct LinearWorkflowState {
 #[derive(Debug, Deserialize)]
 pub(super) struct LinearLabelConnection {
     pub nodes: Vec<LinearLabelNode>,
+    #[serde(default, rename = "pageInfo")]
+    pub page_info: PageInfo,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/opensymphony-linear/src/lib.rs
+++ b/crates/opensymphony-linear/src/lib.rs
@@ -1,1 +1,7 @@
-pub const CRATE_NAME: &str = "opensymphony-linear";
+mod client;
+mod error;
+mod graphql;
+mod normalize;
+
+pub use client::{LinearClient, LinearConfig, RetryPolicy};
+pub use error::{GraphqlError, LinearError};

--- a/crates/opensymphony-linear/src/normalize.rs
+++ b/crates/opensymphony-linear/src/normalize.rs
@@ -38,6 +38,7 @@ fn normalize_state(state: LinearWorkflowState) -> TrackerIssueState {
     TrackerIssueState {
         id: state.id,
         name: state.name,
+        tracker_type: state.kind.clone(),
         kind: TrackerIssueStateKind::from_tracker_type(state.kind),
     }
 }

--- a/crates/opensymphony-linear/src/normalize.rs
+++ b/crates/opensymphony-linear/src/normalize.rs
@@ -1,0 +1,113 @@
+use opensymphony_domain::{
+    TrackerIssue, TrackerIssueBlocker, TrackerIssueState, TrackerIssueStateKind,
+    TrackerIssueStateSnapshot,
+};
+
+use crate::error::LinearError;
+use crate::graphql::{
+    LinearBlockerNode, LinearIssueNode, LinearIssueStateNode, LinearLabelNode, LinearRelationNode,
+    LinearWorkflowState,
+};
+
+pub(super) fn normalize_issue(node: LinearIssueNode) -> Result<TrackerIssue, LinearError> {
+    Ok(TrackerIssue {
+        id: node.id,
+        identifier: node.identifier,
+        title: node.title,
+        description: node.description,
+        priority: normalize_priority(node.priority)?,
+        state: normalize_state(node.state),
+        labels: normalize_labels(node.labels.nodes),
+        blocked_by: normalize_blockers(node.inverse_relations.nodes),
+        created_at: node.created_at,
+        updated_at: node.updated_at,
+    })
+}
+
+pub(super) fn normalize_issue_state(node: LinearIssueStateNode) -> TrackerIssueStateSnapshot {
+    TrackerIssueStateSnapshot {
+        id: node.id,
+        identifier: node.identifier,
+        state: normalize_state(node.state),
+        updated_at: node.updated_at,
+    }
+}
+
+fn normalize_state(state: LinearWorkflowState) -> TrackerIssueState {
+    TrackerIssueState {
+        id: state.id,
+        name: state.name,
+        kind: TrackerIssueStateKind::from_tracker_type(state.kind),
+    }
+}
+
+fn normalize_labels(labels: Vec<LinearLabelNode>) -> Vec<String> {
+    let mut labels = labels
+        .into_iter()
+        .map(|label| label.name)
+        .collect::<Vec<_>>();
+    labels.sort_unstable();
+    labels.dedup();
+    labels
+}
+
+fn normalize_blockers(relations: Vec<LinearRelationNode>) -> Vec<TrackerIssueBlocker> {
+    let mut blockers = relations
+        .into_iter()
+        .filter(|relation| relation.relation_type == "blocks")
+        .map(|relation| normalize_blocker(relation.issue))
+        .collect::<Vec<_>>();
+    blockers.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+    blockers.dedup_by(|left, right| left.id == right.id);
+    blockers
+}
+
+fn normalize_blocker(blocker: LinearBlockerNode) -> TrackerIssueBlocker {
+    TrackerIssueBlocker {
+        id: blocker.id,
+        identifier: blocker.identifier,
+        title: blocker.title,
+        state: normalize_state(blocker.state),
+    }
+}
+
+fn normalize_priority(priority: f64) -> Result<Option<u8>, LinearError> {
+    if !priority.is_finite() || priority < 0.0 {
+        return Err(LinearError::InvalidResponse(format!(
+            "Linear priority must be a finite non-negative number, got {priority}"
+        )));
+    }
+
+    let rounded = priority.trunc();
+    if (priority - rounded).abs() > f64::EPSILON {
+        return Err(LinearError::InvalidResponse(format!(
+            "Linear priority must be an integer value, got {priority}"
+        )));
+    }
+
+    match rounded as u64 {
+        0 => Ok(None),
+        value if value <= u8::MAX as u64 => Ok(Some(value as u8)),
+        value => Err(LinearError::InvalidResponse(format!(
+            "Linear priority exceeds u8 range: {value}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::normalize::normalize_priority;
+
+    #[test]
+    fn priority_zero_becomes_none() {
+        assert_eq!(
+            normalize_priority(0.0).expect("priority should normalize"),
+            None
+        );
+    }
+
+    #[test]
+    fn fractional_priority_is_rejected() {
+        assert!(normalize_priority(1.5).is_err());
+    }
+}

--- a/crates/opensymphony-linear/src/normalize.rs
+++ b/crates/opensymphony-linear/src/normalize.rs
@@ -13,6 +13,7 @@ pub(super) fn normalize_issue(node: LinearIssueNode) -> Result<TrackerIssue, Lin
     Ok(TrackerIssue {
         id: node.id,
         identifier: node.identifier,
+        url: node.url,
         title: node.title,
         description: node.description,
         priority: normalize_priority(node.priority)?,
@@ -71,6 +72,8 @@ fn normalize_blocker(blocker: LinearBlockerNode) -> TrackerIssueBlocker {
     }
 }
 
+const LINEAR_PRIORITY_LOWEST_URGENCY: u64 = 4;
+
 fn normalize_priority(priority: f64) -> Result<Option<u8>, LinearError> {
     if !priority.is_finite() || priority < 0.0 {
         return Err(LinearError::InvalidResponse(format!(
@@ -87,9 +90,11 @@ fn normalize_priority(priority: f64) -> Result<Option<u8>, LinearError> {
 
     match rounded as u64 {
         0 => Ok(None),
-        value if value <= u8::MAX as u64 => Ok(Some(value as u8)),
+        value if value <= LINEAR_PRIORITY_LOWEST_URGENCY => {
+            Ok(Some((LINEAR_PRIORITY_LOWEST_URGENCY + 1 - value) as u8))
+        }
         value => Err(LinearError::InvalidResponse(format!(
-            "Linear priority exceeds u8 range: {value}"
+            "Linear priority must be between 0 and {LINEAR_PRIORITY_LOWEST_URGENCY}, got {value}"
         ))),
     }
 }
@@ -109,5 +114,22 @@ mod tests {
     #[test]
     fn fractional_priority_is_rejected() {
         assert!(normalize_priority(1.5).is_err());
+    }
+
+    #[test]
+    fn linear_priority_is_inverted_for_scheduler_ordering() {
+        assert_eq!(
+            normalize_priority(1.0).expect("priority should normalize"),
+            Some(4)
+        );
+        assert_eq!(
+            normalize_priority(4.0).expect("priority should normalize"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn undocumented_linear_priority_values_are_rejected() {
+        assert!(normalize_priority(5.0).is_err());
     }
 }

--- a/crates/opensymphony-linear/src/normalize.rs
+++ b/crates/opensymphony-linear/src/normalize.rs
@@ -17,7 +17,7 @@ pub(super) fn normalize_issue(node: LinearIssueNode) -> Result<TrackerIssue, Lin
         title: node.title,
         description: node.description,
         priority: normalize_priority(node.priority)?,
-        state: normalize_state(node.state),
+        state: node.state.name,
         labels: normalize_labels(node.labels.nodes),
         blocked_by: normalize_blockers(node.inverse_relations.nodes),
         created_at: node.created_at,
@@ -72,7 +72,7 @@ fn normalize_blocker(blocker: LinearBlockerNode) -> TrackerIssueBlocker {
     }
 }
 
-const LINEAR_PRIORITY_LOWEST_URGENCY: u64 = 4;
+const LINEAR_MAX_PRIORITY: u64 = 4;
 
 fn normalize_priority(priority: f64) -> Result<Option<u8>, LinearError> {
     if !priority.is_finite() || priority < 0.0 {
@@ -90,11 +90,9 @@ fn normalize_priority(priority: f64) -> Result<Option<u8>, LinearError> {
 
     match rounded as u64 {
         0 => Ok(None),
-        value if value <= LINEAR_PRIORITY_LOWEST_URGENCY => {
-            Ok(Some((LINEAR_PRIORITY_LOWEST_URGENCY + 1 - value) as u8))
-        }
+        value if value <= LINEAR_MAX_PRIORITY => Ok(Some(value as u8)),
         value => Err(LinearError::InvalidResponse(format!(
-            "Linear priority must be between 0 and {LINEAR_PRIORITY_LOWEST_URGENCY}, got {value}"
+            "Linear priority must be between 0 and {LINEAR_MAX_PRIORITY}, got {value}"
         ))),
     }
 }
@@ -117,14 +115,14 @@ mod tests {
     }
 
     #[test]
-    fn linear_priority_is_inverted_for_scheduler_ordering() {
+    fn linear_priority_is_preserved_for_prompt_consumers() {
         assert_eq!(
             normalize_priority(1.0).expect("priority should normalize"),
-            Some(4)
+            Some(1)
         );
         assert_eq!(
             normalize_priority(4.0).expect("priority should normalize"),
-            Some(1)
+            Some(4)
         );
     }
 

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
@@ -5,6 +5,7 @@
         {
           "id": "issue-260",
           "identifier": "COE-260",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine",
           "title": "Domain model and orchestrator state machine",
           "description": "Implement the shared orchestrator state machine.",
           "priority": 1.0,
@@ -60,6 +61,7 @@
         {
           "id": "issue-264",
           "identifier": "COE-264",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-264/linear-read-adapter-and-issue-normalization",
           "title": "Linear read adapter and issue normalization",
           "description": null,
           "priority": 0.0,

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
@@ -1,0 +1,110 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-260",
+          "identifier": "COE-260",
+          "title": "Domain model and orchestrator state machine",
+          "description": "Implement the shared orchestrator state machine.",
+          "priority": 1.0,
+          "createdAt": "2026-03-20T10:00:00Z",
+          "updatedAt": "2026-03-21T12:00:00Z",
+          "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+          },
+          "labels": {
+            "nodes": [
+              { "name": "urgent" },
+              { "name": "backend" },
+              { "name": "backend" }
+            ]
+          },
+          "inverseRelations": {
+            "nodes": [
+              {
+                "type": "blocks",
+                "issue": {
+                  "id": "issue-258",
+                  "identifier": "COE-258",
+                  "title": "Bootstrap workspace and crate boundaries",
+                  "state": {
+                    "id": "state-done",
+                    "name": "Done",
+                    "type": "completed"
+                  }
+                }
+              },
+              {
+                "type": "related",
+                "issue": {
+                  "id": "issue-999",
+                  "identifier": "COE-999",
+                  "title": "Ignore this relation",
+                  "state": {
+                    "id": "state-todo",
+                    "name": "Todo",
+                    "type": "unstarted"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id": "issue-264",
+          "identifier": "COE-264",
+          "title": "Linear read adapter and issue normalization",
+          "description": null,
+          "priority": 0.0,
+          "createdAt": "2026-03-21T11:00:00Z",
+          "updatedAt": "2026-03-21T12:30:00Z",
+          "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+          },
+          "labels": {
+            "nodes": []
+          },
+          "inverseRelations": {
+            "nodes": [
+              {
+                "type": "blocks",
+                "issue": {
+                  "id": "issue-261",
+                  "identifier": "COE-261",
+                  "title": "Current blocker",
+                  "state": {
+                    "id": "state-started",
+                    "name": "In Progress",
+                    "type": "started"
+                  }
+                }
+              },
+              {
+                "type": "blocks",
+                "issue": {
+                  "id": "issue-261",
+                  "identifier": "COE-261",
+                  "title": "Current blocker",
+                  "state": {
+                    "id": "state-started",
+                    "name": "In Progress",
+                    "type": "started"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
@@ -50,7 +50,11 @@
                   }
                 }
               }
-            ]
+            ],
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
           }
         },
         {
@@ -97,7 +101,11 @@
                   }
                 }
               }
-            ]
+            ],
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
           }
         }
       ],

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_with_label_paging.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_with_label_paging.json
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-260",
+          "identifier": "COE-260",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine",
+          "title": "Domain model and orchestrator state machine",
+          "description": "Implement the shared orchestrator state machine.",
+          "priority": 1.0,
+          "createdAt": "2026-03-20T10:00:00Z",
+          "updatedAt": "2026-03-21T12:00:00Z",
+          "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+          },
+          "labels": {
+            "nodes": [
+              { "name": "backend" }
+            ],
+            "pageInfo": {
+              "hasNextPage": true,
+              "endCursor": "labels-cursor-1"
+            }
+          },
+          "inverseRelations": {
+            "nodes": [],
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_with_relation_paging.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_with_relation_paging.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-264",
+          "identifier": "COE-264",
+          "title": "Linear read adapter and issue normalization",
+          "description": null,
+          "priority": 0.0,
+          "createdAt": "2026-03-21T11:00:00Z",
+          "updatedAt": "2026-03-21T12:30:00Z",
+          "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+          },
+          "labels": {
+            "nodes": []
+          },
+          "inverseRelations": {
+            "nodes": [
+              {
+                "type": "related",
+                "issue": {
+                  "id": "issue-999",
+                  "identifier": "COE-999",
+                  "title": "Unrelated relation on the first page",
+                  "state": {
+                    "id": "state-todo",
+                    "name": "Todo",
+                    "type": "unstarted"
+                  }
+                }
+              }
+            ],
+            "pageInfo": {
+              "hasNextPage": true,
+              "endCursor": "relations-cursor-1"
+            }
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_with_relation_paging.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_with_relation_paging.json
@@ -5,6 +5,7 @@
         {
           "id": "issue-264",
           "identifier": "COE-264",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-264/linear-read-adapter-and-issue-normalization",
           "title": "Linear read adapter and issue normalization",
           "description": null,
           "priority": 0.0,

--- a/crates/opensymphony-linear/tests/fixtures/issue_inverse_relations_page_2.json
+++ b/crates/opensymphony-linear/tests/fixtures/issue_inverse_relations_page_2.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "issue": {
+      "id": "issue-264",
+      "inverseRelations": {
+        "nodes": [
+          {
+            "type": "blocks",
+            "issue": {
+              "id": "issue-258",
+              "identifier": "COE-258",
+              "title": "Bootstrap workspace and crate boundaries",
+              "state": {
+                "id": "state-done",
+                "name": "Done",
+                "type": "completed"
+              }
+            }
+          }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "endCursor": null
+        }
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/issue_labels_page_2.json
+++ b/crates/opensymphony-linear/tests/fixtures/issue_labels_page_2.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "issue": {
+      "id": "issue-260",
+      "labels": {
+        "nodes": [
+          { "name": "urgent" },
+          { "name": "backend" }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "endCursor": null
+        }
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/issue_states_missing_id.json
+++ b/crates/opensymphony-linear/tests/fixtures/issue_states_missing_id.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-260",
+          "identifier": "COE-260",
+          "updatedAt": "2026-03-21T16:00:00Z",
+          "state": {
+            "id": "state-done",
+            "name": "Done",
+            "type": "completed"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/issue_states_page.json
+++ b/crates/opensymphony-linear/tests/fixtures/issue_states_page.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-260",
+          "identifier": "COE-260",
+          "updatedAt": "2026-03-21T16:00:00Z",
+          "state": {
+            "id": "state-done",
+            "name": "Done",
+            "type": "completed"
+          }
+        },
+        {
+          "id": "issue-264",
+          "identifier": "COE-264",
+          "updatedAt": "2026-03-21T17:00:00Z",
+          "state": {
+            "id": "state-canceled",
+            "name": "Canceled",
+            "type": "canceled"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/issues_page_1.json
+++ b/crates/opensymphony-linear/tests/fixtures/issues_page_1.json
@@ -5,6 +5,7 @@
         {
           "id": "issue-260",
           "identifier": "COE-260",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine",
           "title": "Domain model and orchestrator state machine",
           "description": "Implement the state machine.",
           "priority": 1.0,
@@ -29,6 +30,7 @@
         {
           "id": "issue-263",
           "identifier": "COE-263",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-263/workspace-manager-and-lifecycle-hooks",
           "title": "Workspace manager and lifecycle hooks",
           "description": "Implement workspace hooks.",
           "priority": 2.0,

--- a/crates/opensymphony-linear/tests/fixtures/issues_page_1.json
+++ b/crates/opensymphony-linear/tests/fixtures/issues_page_1.json
@@ -1,0 +1,52 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-260",
+          "identifier": "COE-260",
+          "title": "Domain model and orchestrator state machine",
+          "description": "Implement the state machine.",
+          "priority": 1.0,
+          "createdAt": "2026-03-20T10:00:00Z",
+          "updatedAt": "2026-03-21T12:00:00Z",
+          "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+          },
+          "labels": {
+            "nodes": [{ "name": "backend" }]
+          },
+          "inverseRelations": {
+            "nodes": []
+          }
+        },
+        {
+          "id": "issue-263",
+          "identifier": "COE-263",
+          "title": "Workspace manager and lifecycle hooks",
+          "description": "Implement workspace hooks.",
+          "priority": 2.0,
+          "createdAt": "2026-03-20T11:00:00Z",
+          "updatedAt": "2026-03-21T13:00:00Z",
+          "state": {
+            "id": "state-todo",
+            "name": "Todo",
+            "type": "unstarted"
+          },
+          "labels": {
+            "nodes": [{ "name": "workspace" }]
+          },
+          "inverseRelations": {
+            "nodes": []
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "cursor-1"
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/fixtures/issues_page_1.json
+++ b/crates/opensymphony-linear/tests/fixtures/issues_page_1.json
@@ -19,7 +19,11 @@
             "nodes": [{ "name": "backend" }]
           },
           "inverseRelations": {
-            "nodes": []
+            "nodes": [],
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
           }
         },
         {
@@ -39,7 +43,11 @@
             "nodes": [{ "name": "workspace" }]
           },
           "inverseRelations": {
-            "nodes": []
+            "nodes": [],
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
           }
         }
       ],

--- a/crates/opensymphony-linear/tests/fixtures/issues_page_2.json
+++ b/crates/opensymphony-linear/tests/fixtures/issues_page_2.json
@@ -19,7 +19,11 @@
             "nodes": [{ "name": "tracker" }]
           },
           "inverseRelations": {
-            "nodes": []
+            "nodes": [],
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            }
           }
         }
       ],

--- a/crates/opensymphony-linear/tests/fixtures/issues_page_2.json
+++ b/crates/opensymphony-linear/tests/fixtures/issues_page_2.json
@@ -5,6 +5,7 @@
         {
           "id": "issue-264",
           "identifier": "COE-264",
+          "url": "https://linear.app/trilogy-ai-coe/issue/COE-264/linear-read-adapter-and-issue-normalization",
           "title": "Linear read adapter and issue normalization",
           "description": "Implement Linear reads.",
           "priority": 1.0,

--- a/crates/opensymphony-linear/tests/fixtures/issues_page_2.json
+++ b/crates/opensymphony-linear/tests/fixtures/issues_page_2.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "issue-264",
+          "identifier": "COE-264",
+          "title": "Linear read adapter and issue normalization",
+          "description": "Implement Linear reads.",
+          "priority": 1.0,
+          "createdAt": "2026-03-21T11:00:00Z",
+          "updatedAt": "2026-03-21T14:00:00Z",
+          "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+          },
+          "labels": {
+            "nodes": [{ "name": "tracker" }]
+          },
+          "inverseRelations": {
+            "nodes": []
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -8,7 +8,7 @@ use axum::{
     Json, Router,
 };
 use opensymphony_domain::{TrackerErrorCategory, TrackerIssueStateKind};
-use opensymphony_linear::{LinearClient, LinearConfig, RetryPolicy};
+use opensymphony_linear::{LinearClient, LinearConfig, LinearError, RetryPolicy};
 use serde_json::Value;
 use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
 
@@ -200,6 +200,10 @@ async fn issue_states_by_ids_return_normalized_snapshots() {
         requests[0].body["variables"]["issueIds"],
         serde_json::json!(["issue-260", "issue-264"])
     );
+    assert_eq!(
+        requests[0].body["variables"]["projectSlug"],
+        Value::String("e7b957855cb7".to_string())
+    );
 }
 
 #[tokio::test]
@@ -218,6 +222,43 @@ async fn issue_states_by_ids_fail_when_linear_omits_requested_ids() {
 
     assert_eq!(error.category(), TrackerErrorCategory::NotFound);
     assert!(error.to_string().contains("issue-264"));
+}
+
+#[test]
+fn client_configuration_requires_active_states() {
+    let mut config = LinearConfig::new("test-token", "e7b957855cb7");
+    config.terminal_states = vec!["Done".to_string()];
+
+    let error = match LinearClient::new(config) {
+        Ok(_) => panic!("missing active states should fail"),
+        Err(error) => error,
+    };
+
+    match error {
+        LinearError::InvalidConfiguration(message) => {
+            assert!(message.contains("tracker.active_states"));
+        }
+        other => panic!("expected invalid configuration error, got {other:?}"),
+    }
+}
+
+#[test]
+fn client_configuration_requires_terminal_states() {
+    let mut config = LinearConfig::new("test-token", "e7b957855cb7");
+    config.active_states = vec!["In Progress".to_string()];
+    config.terminal_states = vec![" ".to_string()];
+
+    let error = match LinearClient::new(config) {
+        Ok(_) => panic!("blank terminal states should fail"),
+        Err(error) => error,
+    };
+
+    match error {
+        LinearError::InvalidConfiguration(message) => {
+            assert!(message.contains("tracker.terminal_states"));
+        }
+        other => panic!("expected invalid configuration error, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -43,6 +43,7 @@ async fn candidate_issues_normalize_fixture_payloads() {
     assert_eq!(first.labels, vec!["backend", "urgent"]);
     assert_eq!(first.blocked_by.len(), 1);
     assert!(first.blocked_by[0].is_terminal());
+    assert_eq!(first.blocked_by[0].state.tracker_type, "completed");
 
     let second = &issues[1];
     assert_eq!(second.identifier, "COE-264");
@@ -58,6 +59,7 @@ async fn candidate_issues_normalize_fixture_payloads() {
         second.blocked_by[0].state.kind,
         TrackerIssueStateKind::Started
     );
+    assert_eq!(second.blocked_by[0].state.tracker_type, "started");
 
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 1);
@@ -184,8 +186,10 @@ async fn issue_states_by_ids_return_normalized_snapshots() {
     assert_eq!(snapshots.len(), 2);
     assert_eq!(snapshots[0].identifier, "COE-260");
     assert_eq!(snapshots[0].state.kind, TrackerIssueStateKind::Completed);
+    assert_eq!(snapshots[0].state.tracker_type, "completed");
     assert_eq!(snapshots[1].identifier, "COE-264");
     assert_eq!(snapshots[1].state.kind, TrackerIssueStateKind::Canceled);
+    assert_eq!(snapshots[1].state.tracker_type, "canceled");
 
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 1);

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -30,13 +30,21 @@ async fn candidate_issues_normalize_fixture_payloads() {
 
     let first = &issues[0];
     assert_eq!(first.identifier, "COE-260");
-    assert_eq!(first.priority, Some(1));
+    assert_eq!(
+        first.url,
+        "https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine"
+    );
+    assert_eq!(first.priority, Some(4));
     assert_eq!(first.labels, vec!["backend", "urgent"]);
     assert_eq!(first.blocked_by.len(), 1);
     assert!(first.blocked_by[0].is_terminal());
 
     let second = &issues[1];
     assert_eq!(second.identifier, "COE-264");
+    assert_eq!(
+        second.url,
+        "https://linear.app/trilogy-ai-coe/issue/COE-264/linear-read-adapter-and-issue-normalization"
+    );
     assert_eq!(second.priority, None);
     assert_eq!(second.blocked_by.len(), 1);
     assert_eq!(second.blocked_by[0].identifier, "COE-261");
@@ -118,7 +126,10 @@ async fn issues_by_state_walk_pagination() {
 
     assert_eq!(issues.len(), 3);
     assert_eq!(issues[0].identifier, "COE-260");
+    assert_eq!(issues[0].priority, Some(4));
+    assert_eq!(issues[1].priority, Some(3));
     assert_eq!(issues[2].identifier, "COE-264");
+    assert_eq!(issues[2].priority, Some(4));
 
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 2);

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -34,7 +34,8 @@ async fn candidate_issues_normalize_fixture_payloads() {
         first.url,
         "https://linear.app/trilogy-ai-coe/issue/COE-260/domain-model-and-orchestrator-state-machine"
     );
-    assert_eq!(first.priority, Some(4));
+    assert_eq!(first.priority, Some(1));
+    assert_eq!(first.state, "In Progress");
     assert_eq!(first.labels, vec!["backend", "urgent"]);
     assert_eq!(first.blocked_by.len(), 1);
     assert!(first.blocked_by[0].is_terminal());
@@ -46,6 +47,7 @@ async fn candidate_issues_normalize_fixture_payloads() {
         "https://linear.app/trilogy-ai-coe/issue/COE-264/linear-read-adapter-and-issue-normalization"
     );
     assert_eq!(second.priority, None);
+    assert_eq!(second.state, "In Progress");
     assert_eq!(second.blocked_by.len(), 1);
     assert_eq!(second.blocked_by[0].identifier, "COE-261");
     assert_eq!(
@@ -126,10 +128,10 @@ async fn issues_by_state_walk_pagination() {
 
     assert_eq!(issues.len(), 3);
     assert_eq!(issues[0].identifier, "COE-260");
-    assert_eq!(issues[0].priority, Some(4));
-    assert_eq!(issues[1].priority, Some(3));
+    assert_eq!(issues[0].priority, Some(1));
+    assert_eq!(issues[1].priority, Some(2));
     assert_eq!(issues[2].identifier, "COE-264");
-    assert_eq!(issues[2].priority, Some(4));
+    assert_eq!(issues[2].priority, Some(1));
 
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 2);

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -88,6 +88,10 @@ async fn candidate_issues_normalize_fixture_payloads() {
         .as_str()
         .expect("query should be a string")
         .contains("includeArchived: $includeArchived"));
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("labels(first: $labelFirst)"));
 }
 
 #[tokio::test]
@@ -135,6 +139,10 @@ async fn candidate_issues_fetch_all_inverse_relation_pages() {
         requests[0].body["variables"]["labelFirst"],
         serde_json::json!(10)
     );
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("labels(first: $labelFirst)"));
 }
 
 #[tokio::test]
@@ -219,6 +227,10 @@ async fn issues_by_state_walk_pagination() {
         .as_str()
         .expect("query should be a string")
         .contains("includeArchived: $includeArchived"));
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("labels(first: $labelFirst)"));
     assert_eq!(requests[0].body["variables"]["after"], Value::Null);
     assert_eq!(
         requests[1].body["variables"]["after"],
@@ -252,10 +264,18 @@ async fn terminal_issues_include_archived_for_cleanup() {
         requests[0].body["variables"]["includeArchived"],
         Value::Bool(true)
     );
+    assert_eq!(
+        requests[0].body["variables"]["labelFirst"],
+        serde_json::json!(10)
+    );
     assert!(requests[0].body["query"]
         .as_str()
         .expect("query should be a string")
         .contains("includeArchived: $includeArchived"));
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("labels(first: $labelFirst)"));
 }
 
 #[tokio::test]
@@ -497,6 +517,29 @@ async fn graphql_rate_limited_bad_request_retries_using_reset_header() {
         start.elapsed() < Duration::from_secs(1),
         "retry should use the reset header instead of the exponential backoff"
     );
+}
+
+#[tokio::test]
+async fn graphql_internal_server_error_retries_even_with_graphql_envelope() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::BAD_GATEWAY,
+            r#"{"errors":[{"message":"temporary upstream failure","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}"#,
+        )
+        .with_header("content-type", "application/json"),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("5xx GraphQL envelopes should stay retryable");
+
+    assert_eq!(issues.len(), 2);
+    assert_eq!(server.recorded_requests().await.len(), 2);
 }
 
 #[tokio::test]

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -76,10 +76,14 @@ async fn candidate_issues_normalize_fixture_payloads() {
         requests[0].body["variables"]["relationFirst"],
         serde_json::json!(10)
     );
+    assert_eq!(
+        requests[0].body["variables"]["includeArchived"],
+        Value::Bool(false)
+    );
     assert!(requests[0].body["query"]
         .as_str()
         .expect("query should be a string")
-        .contains("includeArchived: true"));
+        .contains("includeArchived: $includeArchived"));
 }
 
 #[tokio::test]
@@ -158,15 +162,51 @@ async fn issues_by_state_walk_pagination() {
         requests[0].body["variables"]["relationFirst"],
         serde_json::json!(2)
     );
+    assert_eq!(
+        requests[0].body["variables"]["includeArchived"],
+        Value::Bool(false)
+    );
     assert!(requests[0].body["query"]
         .as_str()
         .expect("query should be a string")
-        .contains("includeArchived: true"));
+        .contains("includeArchived: $includeArchived"));
     assert_eq!(requests[0].body["variables"]["after"], Value::Null);
     assert_eq!(
         requests[1].body["variables"]["after"],
         Value::String("cursor-1".to_string())
     );
+}
+
+#[tokio::test]
+async fn terminal_issues_include_archived_for_cleanup() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(include_str!(
+        "fixtures/candidate_issues_page.json"
+    ))])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .terminal_issues()
+        .await
+        .expect("terminal cleanup query should succeed");
+
+    assert_eq!(issues.len(), 2);
+
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].body["variables"]["stateNames"],
+        serde_json::json!(["Done", "Canceled"])
+    );
+    assert_eq!(
+        requests[0].body["variables"]["includeArchived"],
+        Value::Bool(true)
+    );
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("includeArchived: $includeArchived"));
 }
 
 #[tokio::test]

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -1,0 +1,299 @@
+use std::{collections::VecDeque, sync::Arc, time::Duration};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderMap, Response, StatusCode},
+    routing::post,
+    Json, Router,
+};
+use opensymphony_domain::{TrackerErrorCategory, TrackerIssueStateKind};
+use opensymphony_linear::{LinearClient, LinearConfig, RetryPolicy};
+use serde_json::Value;
+use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
+
+#[tokio::test]
+async fn candidate_issues_normalize_fixture_payloads() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(include_str!(
+        "fixtures/candidate_issues_page.json"
+    ))])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("candidate query should succeed");
+
+    assert_eq!(issues.len(), 2);
+
+    let first = &issues[0];
+    assert_eq!(first.identifier, "COE-260");
+    assert_eq!(first.priority, Some(1));
+    assert_eq!(first.labels, vec!["backend", "urgent"]);
+    assert_eq!(first.blocked_by.len(), 1);
+    assert!(first.blocked_by[0].is_terminal());
+
+    let second = &issues[1];
+    assert_eq!(second.identifier, "COE-264");
+    assert_eq!(second.priority, None);
+    assert_eq!(second.blocked_by.len(), 1);
+    assert_eq!(second.blocked_by[0].identifier, "COE-261");
+    assert_eq!(
+        second.blocked_by[0].state.kind,
+        TrackerIssueStateKind::Started
+    );
+
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer test-token")
+    );
+    assert_eq!(
+        requests[0].body["variables"]["projectSlug"],
+        Value::String("e7b957855cb7".to_string())
+    );
+    assert_eq!(
+        requests[0].body["variables"]["stateNames"],
+        serde_json::json!(["In Progress"])
+    );
+}
+
+#[tokio::test]
+async fn issues_by_state_walk_pagination() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(include_str!("fixtures/issues_page_1.json")),
+        QueuedResponse::json(include_str!("fixtures/issues_page_2.json")),
+    ])
+    .await;
+    let mut config = test_config(server.base_url());
+    config.page_size = 2;
+    let client = LinearClient::new(config).expect("client configuration should be valid");
+
+    let issues = client
+        .issues_by_state_names(&["Todo".to_string(), "In Progress".to_string()])
+        .await
+        .expect("pagination query should succeed");
+
+    assert_eq!(issues.len(), 3);
+    assert_eq!(issues[0].identifier, "COE-260");
+    assert_eq!(issues[2].identifier, "COE-264");
+
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("query IssuesByState"));
+    assert_eq!(requests[0].body["variables"]["after"], Value::Null);
+    assert_eq!(
+        requests[1].body["variables"]["after"],
+        Value::String("cursor-1".to_string())
+    );
+}
+
+#[tokio::test]
+async fn issue_states_by_ids_return_normalized_snapshots() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(include_str!(
+        "fixtures/issue_states_page.json"
+    ))])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let snapshots = client
+        .issue_states_by_ids(&["issue-260".to_string(), "issue-264".to_string()])
+        .await
+        .expect("issue state query should succeed");
+
+    assert_eq!(snapshots.len(), 2);
+    assert_eq!(snapshots[0].identifier, "COE-260");
+    assert_eq!(snapshots[0].state.kind, TrackerIssueStateKind::Completed);
+    assert_eq!(snapshots[1].identifier, "COE-264");
+    assert_eq!(snapshots[1].state.kind, TrackerIssueStateKind::Canceled);
+
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("query IssueStatesByIds"));
+    assert_eq!(
+        requests[0].body["variables"]["issueIds"],
+        serde_json::json!(["issue-260", "issue-264"])
+    );
+}
+
+#[tokio::test]
+async fn rate_limited_requests_retry_using_retry_after() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::TOO_MANY_REQUESTS,
+            "{\"error\":\"rate limited\"}",
+        )
+        .with_header("retry-after", "0"),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("client should retry the rate-limited request");
+
+    assert_eq!(issues.len(), 2);
+    assert_eq!(server.recorded_requests().await.len(), 2);
+}
+
+#[tokio::test]
+async fn permission_denied_maps_to_tracker_error_category() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::new(
+        StatusCode::FORBIDDEN,
+        "{\"error\":\"forbidden\"}",
+    )])
+    .await;
+    let mut config = test_config(server.base_url());
+    config.retry_policy.max_attempts = 1;
+    let client = LinearClient::new(config).expect("client configuration should be valid");
+
+    let error = client
+        .candidate_issues()
+        .await
+        .expect_err("permission denied response should fail");
+
+    assert_eq!(error.category(), TrackerErrorCategory::PermissionDenied);
+}
+
+fn test_config(base_url: &str) -> LinearConfig {
+    let mut config = LinearConfig::new("test-token", "e7b957855cb7");
+    config.base_url = base_url.to_string();
+    config.active_states = vec!["In Progress".to_string()];
+    config.terminal_states = vec!["Done".to_string(), "Canceled".to_string()];
+    config.request_timeout = Duration::from_secs(2);
+    config.retry_policy = RetryPolicy {
+        max_attempts: 2,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(1),
+    };
+    config
+}
+
+#[derive(Debug, Clone)]
+struct CapturedRequest {
+    authorization: Option<String>,
+    body: Value,
+}
+
+#[derive(Clone)]
+struct AppState {
+    responses: Arc<Mutex<VecDeque<QueuedResponse>>>,
+    requests: Arc<Mutex<Vec<CapturedRequest>>>,
+}
+
+struct MockGraphqlServer {
+    base_url: String,
+    state: AppState,
+    task: JoinHandle<()>,
+}
+
+impl MockGraphqlServer {
+    async fn start(responses: Vec<QueuedResponse>) -> Self {
+        let state = AppState {
+            responses: Arc::new(Mutex::new(VecDeque::from(responses))),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        };
+        let app = Router::new()
+            .route("/graphql", post(handle_graphql))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should expose an address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("mock server should stay up");
+        });
+
+        Self {
+            base_url: format!("http://{address}/graphql"),
+            state,
+            task,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    async fn recorded_requests(&self) -> Vec<CapturedRequest> {
+        self.state.requests.lock().await.clone()
+    }
+}
+
+impl Drop for MockGraphqlServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn handle_graphql(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response<Body> {
+    let request = CapturedRequest {
+        authorization: headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned),
+        body,
+    };
+    state.requests.lock().await.push(request);
+
+    let response = state
+        .responses
+        .lock()
+        .await
+        .pop_front()
+        .expect("test did not queue enough responses");
+
+    let mut builder = Response::builder().status(response.status);
+    for (name, value) in response.headers {
+        builder = builder.header(name, value);
+    }
+    builder
+        .body(Body::from(response.body))
+        .expect("response should be valid")
+}
+
+struct QueuedResponse {
+    status: StatusCode,
+    body: String,
+    headers: Vec<(String, String)>,
+}
+
+impl QueuedResponse {
+    fn json(body: &str) -> Self {
+        Self::new(StatusCode::OK, body).with_header("content-type", "application/json")
+    }
+
+    fn new(status: StatusCode, body: &str) -> Self {
+        Self {
+            status,
+            body: body.to_string(),
+            headers: Vec::new(),
+        }
+    }
+
+    fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.to_string(), value.to_string()));
+        self
+    }
+}

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -193,7 +193,7 @@ async fn issue_states_by_ids_return_normalized_snapshots() {
         .as_str()
         .expect("query should be a string")
         .contains("query IssueStatesByIds"));
-    assert!(requests[0].body["query"]
+    assert!(!requests[0].body["query"]
         .as_str()
         .expect("query should be a string")
         .contains("includeArchived: true"));

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -57,10 +57,7 @@ async fn candidate_issues_normalize_fixture_payloads() {
 
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 1);
-    assert_eq!(
-        requests[0].authorization.as_deref(),
-        Some("Bearer test-token")
-    );
+    assert_eq!(requests[0].authorization.as_deref(), Some("test-token"));
     assert_eq!(
         requests[0].body["variables"]["projectSlug"],
         Value::String("e7b957855cb7".to_string())
@@ -256,6 +253,25 @@ fn client_configuration_requires_terminal_states() {
     match error {
         LinearError::InvalidConfiguration(message) => {
             assert!(message.contains("tracker.terminal_states"));
+        }
+        other => panic!("expected invalid configuration error, got {other:?}"),
+    }
+}
+
+#[test]
+fn client_configuration_requires_project_slug() {
+    let mut config = LinearConfig::new("test-token", "   ");
+    config.active_states = vec!["In Progress".to_string()];
+    config.terminal_states = vec!["Done".to_string()];
+
+    let error = match LinearClient::new(config) {
+        Ok(_) => panic!("blank project slug should fail"),
+        Err(error) => error,
+    };
+
+    match error {
+        LinearError::InvalidConfiguration(message) => {
+            assert!(message.contains("tracker.project_slug"));
         }
         other => panic!("expected invalid configuration error, got {other:?}"),
     }

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -69,6 +69,14 @@ async fn candidate_issues_normalize_fixture_payloads() {
         requests[0].body["variables"]["stateNames"],
         serde_json::json!(["In Progress"])
     );
+    assert_eq!(
+        requests[0].body["variables"]["relationFirst"],
+        serde_json::json!(10)
+    );
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("includeArchived: true"));
 }
 
 #[tokio::test]
@@ -108,6 +116,10 @@ async fn candidate_issues_fetch_all_inverse_relation_pages() {
         requests[1].body["variables"]["after"],
         Value::String("relations-cursor-1".to_string())
     );
+    assert_eq!(
+        requests[0].body["variables"]["relationFirst"],
+        serde_json::json!(10)
+    );
 }
 
 #[tokio::test]
@@ -139,6 +151,14 @@ async fn issues_by_state_walk_pagination() {
         .as_str()
         .expect("query should be a string")
         .contains("query IssuesByState"));
+    assert_eq!(
+        requests[0].body["variables"]["relationFirst"],
+        serde_json::json!(2)
+    );
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("includeArchived: true"));
     assert_eq!(requests[0].body["variables"]["after"], Value::Null);
     assert_eq!(
         requests[1].body["variables"]["after"],
@@ -172,6 +192,10 @@ async fn issue_states_by_ids_return_normalized_snapshots() {
         .as_str()
         .expect("query should be a string")
         .contains("query IssueStatesByIds"));
+    assert!(requests[0].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("includeArchived: true"));
     assert_eq!(
         requests[0].body["variables"]["issueIds"],
         serde_json::json!(["issue-260", "issue-264"])
@@ -214,6 +238,30 @@ async fn rate_limited_requests_retry_using_retry_after() {
         .candidate_issues()
         .await
         .expect("client should retry the rate-limited request");
+
+    assert_eq!(issues.len(), 2);
+    assert_eq!(server.recorded_requests().await.len(), 2);
+}
+
+#[tokio::test]
+async fn graphql_rate_limited_bad_request_retries() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::BAD_REQUEST,
+            r#"{"errors":[{"message":"rate limit exceeded","extensions":{"code":"RATELIMITED"}}]}"#,
+        )
+        .with_header("content-type", "application/json")
+        .with_header("retry-after", "0"),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("GraphQL rate-limited requests should retry");
 
     assert_eq!(issues.len(), 2);
     assert_eq!(server.recorded_requests().await.len(), 2);

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -62,6 +62,45 @@ async fn candidate_issues_normalize_fixture_payloads() {
 }
 
 #[tokio::test]
+async fn candidate_issues_fetch_all_inverse_relation_pages() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(include_str!(
+            "fixtures/candidate_issues_with_relation_paging.json"
+        )),
+        QueuedResponse::json(include_str!("fixtures/issue_inverse_relations_page_2.json")),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("candidate query should succeed");
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "COE-264");
+    assert_eq!(issues[0].blocked_by.len(), 1);
+    assert_eq!(issues[0].blocked_by[0].identifier, "COE-258");
+    assert!(issues[0].blocked_by[0].is_terminal());
+
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 2);
+    assert!(requests[1].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("query IssueInverseRelationsPage"));
+    assert_eq!(
+        requests[1].body["variables"]["issueId"],
+        Value::String("issue-264".to_string())
+    );
+    assert_eq!(
+        requests[1].body["variables"]["after"],
+        Value::String("relations-cursor-1".to_string())
+    );
+}
+
+#[tokio::test]
 async fn issues_by_state_walk_pagination() {
     let server = MockGraphqlServer::start(vec![
         QueuedResponse::json(include_str!("fixtures/issues_page_1.json")),
@@ -124,6 +163,24 @@ async fn issue_states_by_ids_return_normalized_snapshots() {
         requests[0].body["variables"]["issueIds"],
         serde_json::json!(["issue-260", "issue-264"])
     );
+}
+
+#[tokio::test]
+async fn issue_states_by_ids_fail_when_linear_omits_requested_ids() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(include_str!(
+        "fixtures/issue_states_missing_id.json"
+    ))])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let error = client
+        .issue_states_by_ids(&["issue-260".to_string(), "issue-264".to_string()])
+        .await
+        .expect_err("missing issue ids should fail reconciliation");
+
+    assert_eq!(error.category(), TrackerErrorCategory::NotFound);
+    assert!(error.to_string().contains("issue-264"));
 }
 
 #[tokio::test]

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -77,6 +77,10 @@ async fn candidate_issues_normalize_fixture_payloads() {
         serde_json::json!(10)
     );
     assert_eq!(
+        requests[0].body["variables"]["labelFirst"],
+        serde_json::json!(10)
+    );
+    assert_eq!(
         requests[0].body["variables"]["includeArchived"],
         Value::Bool(false)
     );
@@ -127,6 +131,47 @@ async fn candidate_issues_fetch_all_inverse_relation_pages() {
         requests[0].body["variables"]["relationFirst"],
         serde_json::json!(10)
     );
+    assert_eq!(
+        requests[0].body["variables"]["labelFirst"],
+        serde_json::json!(10)
+    );
+}
+
+#[tokio::test]
+async fn candidate_issues_fetch_all_label_pages() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(include_str!(
+            "fixtures/candidate_issues_with_label_paging.json"
+        )),
+        QueuedResponse::json(include_str!("fixtures/issue_labels_page_2.json")),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("candidate query should succeed");
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "COE-260");
+    assert_eq!(issues[0].labels, vec!["backend", "urgent"]);
+
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 2);
+    assert!(requests[1].body["query"]
+        .as_str()
+        .expect("query should be a string")
+        .contains("query IssueLabelsPage"));
+    assert_eq!(
+        requests[1].body["variables"]["issueId"],
+        Value::String("issue-260".to_string())
+    );
+    assert_eq!(
+        requests[1].body["variables"]["after"],
+        Value::String("labels-cursor-1".to_string())
+    );
 }
 
 #[tokio::test]
@@ -160,6 +205,10 @@ async fn issues_by_state_walk_pagination() {
         .contains("query IssuesByState"));
     assert_eq!(
         requests[0].body["variables"]["relationFirst"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        requests[0].body["variables"]["labelFirst"],
         serde_json::json!(2)
     );
     assert_eq!(
@@ -386,6 +435,29 @@ async fn graphql_rate_limited_bad_request_retries() {
         .candidate_issues()
         .await
         .expect("GraphQL rate-limited requests should retry");
+
+    assert_eq!(issues.len(), 2);
+    assert_eq!(server.recorded_requests().await.len(), 2);
+}
+
+#[tokio::test]
+async fn graphql_server_error_envelope_retries() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            r#"{"errors":[{"message":"temporary upstream failure"}]}"#,
+        )
+        .with_header("content-type", "application/json"),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issues()
+        .await
+        .expect("5xx GraphQL envelopes should stay retryable");
 
     assert_eq!(issues.len(), 2);
     assert_eq!(server.recorded_requests().await.len(), 2);

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -40,6 +40,7 @@ Normalize tracker payloads into a stable issue model with fields such as:
 
 - `id`
 - `identifier`
+- `url`
 - `title`
 - `description`
 - `priority`
@@ -55,6 +56,7 @@ Implementation note:
 
 - blocker normalization should derive `blocked_by` from `inverseRelations` entries where relation `type == "blocks"`
 - issue state normalization should retain both the state name and the Linear `WorkflowState.type` string so terminal blockers remain detectable
+- issue normalization should retain the Linear issue URL because `WORKFLOW.md` renders `{{ issue.url }}` under strict template validation
 
 ## 3. Candidate sorting and eligibility
 
@@ -65,6 +67,10 @@ Recommended sort order:
 1. higher priority first
 2. older creation time first
 3. identifier tie-breaker
+
+Implementation note:
+
+- Linear's raw priority scale is urgency-inverted (`1` is most urgent, `0` is unprioritized), so the adapter should normalize it before returning scheduler-facing issues
 
 Eligibility reminders:
 
@@ -174,9 +180,10 @@ The Linear MCP tools should complement this, not duplicate the whole tracker dat
 struct Issue {
     id: String,
     identifier: String,
+    url: String,
     title: String,
     description: Option<String>,
-    priority: Option<i64>,
+    priority: Option<u8>,
     state: String,
     labels: Vec<String>,
     blocked_by: Vec<IssueBlocker>,

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -69,7 +69,7 @@ Implementation note:
 - blocker and state-refresh normalization should retain both the state name and the raw Linear `WorkflowState.type` string, while also exposing a normalized `kind`, so terminal blockers remain detectable without losing the tracker's exact type value
 - issue normalization should retain the Linear issue URL because `WORKFLOW.md` renders `{{ issue.url }}` under strict template validation
 - issue normalization should preserve the raw Linear priority because prompt/UI consumers render `{{ issue.priority }}` directly
-- top-level issue pages should request only a small initial `inverseRelations` slice and page the rest per issue so nested connection complexity stays under Linear's query cap
+- top-level issue pages should request only small initial `labels` and `inverseRelations` slices and page the rest per issue so connection-heavy issue metadata stays complete without blowing past Linear's query cap
 
 ## 3. Candidate sorting and eligibility
 
@@ -108,6 +108,7 @@ Current adapter contract:
 - reject blank `LINEAR_API_KEY` values during client construction so startup misconfiguration fails fast instead of repeated auth failures at poll time
 - decode GraphQL error envelopes before falling back to raw HTTP classification because Linear rate limits can arrive as HTTP 400 with GraphQL code `RATELIMITED`
 - prefer Linear's `X-RateLimit-*-Reset` headers when calculating retry delays for rate-limited responses, falling back to `Retry-After` and then local exponential backoff only when no reset window is advertised
+- keep transient HTTP 5xx responses on the retryable HTTP-status path even when the body decodes as a GraphQL error envelope
 - keep GraphQL query and response structs private to `opensymphony-linear`
 - return only normalized domain models to orchestrator-facing callers
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -31,6 +31,10 @@ Implementation note:
 
 Fetch current states for all running issues during reconciliation.
 
+Implementation note:
+
+- by-ID reconciliation should keep the same `project_slug` filter as candidate reads so issues moved out of the tracked project fall out of orchestration instead of staying alive
+
 ## 2.3 Terminal-state fetch for startup cleanup
 
 Fetch issues in terminal states when sweeping existing workspaces on startup.
@@ -108,6 +112,10 @@ Required:
 - workflow `tracker.project_slug` (the Linear `Project.slugId` value)
 - workflow `tracker.active_states`
 - workflow `tracker.terminal_states`
+
+Implementation note:
+
+- the adapter should reject blank or missing `tracker.active_states` / `tracker.terminal_states` lists at client construction time so workflow misconfiguration fails fast instead of returning empty candidate/cleanup results
 
 Optional:
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -25,7 +25,7 @@ Fetch issues that:
 Implementation note:
 
 - the GraphQL adapter filters by Linear `Project.slugId`, so workflow `tracker.project_slug` should store that stable slug value
-- paginated `issues(...)` reads should pass `includeArchived: true` so cleanup and reconciliation can still observe archived terminal work
+- candidate and terminal-state `issues(...)` reads should pass `includeArchived: true` so cleanup can still observe archived terminal work
 
 ## 2.2 State refresh by IDs
 
@@ -34,6 +34,7 @@ Fetch current states for all running issues during reconciliation.
 Implementation note:
 
 - by-ID reconciliation should keep the same `project_slug` filter as candidate reads so issues moved out of the tracked project fall out of orchestration instead of staying alive
+- by-ID reconciliation should exclude archived issues so operators can archive live work to release it from orchestration immediately
 
 ## 2.3 Terminal-state fetch for startup cleanup
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -62,7 +62,7 @@ Implementation note:
 
 - blocker normalization should derive `blocked_by` from `inverseRelations` entries where relation `type == "blocks"`
 - `TrackerIssue.state` should remain the workflow-facing state name string consumed by `WORKFLOW.md` and `WORKFLOW.example.md`
-- blocker and state-refresh normalization should retain both the state name and the Linear `WorkflowState.type` string so terminal blockers remain detectable without hardcoding active-state semantics
+- blocker and state-refresh normalization should retain both the state name and the raw Linear `WorkflowState.type` string, while also exposing a normalized `kind`, so terminal blockers remain detectable without losing the tracker's exact type value
 - issue normalization should retain the Linear issue URL because `WORKFLOW.md` renders `{{ issue.url }}` under strict template validation
 - issue normalization should preserve the raw Linear priority because prompt/UI consumers render `{{ issue.priority }}` directly
 - top-level issue pages should request only a small initial `inverseRelations` slice and page the rest per issue so nested connection complexity stays under Linear's query cap

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -99,7 +99,7 @@ Eligibility reminders:
 
 Current adapter contract:
 
-- send GraphQL requests to the configured endpoint with `Authorization: Bearer <LINEAR_API_KEY>`
+- send GraphQL requests to the configured endpoint with `Authorization: <LINEAR_API_KEY>` because the local MVP uses personal Linear API keys rather than OAuth access tokens
 - decode GraphQL error envelopes before falling back to raw HTTP classification because Linear rate limits can arrive as HTTP 400 with GraphQL code `RATELIMITED`
 - keep GraphQL query and response structs private to `opensymphony-linear`
 - return only normalized domain models to orchestrator-facing callers
@@ -115,6 +115,7 @@ Required:
 
 Implementation note:
 
+- the adapter should reject blank `tracker.project_slug` values at client construction time so candidate/cleanup reads fail fast instead of silently querying `slugId == ""`
 - the adapter should reject blank or missing `tracker.active_states` / `tracker.terminal_states` lists at client construction time so workflow misconfiguration fails fast instead of returning empty candidate/cleanup results
 
 Optional:

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -25,7 +25,7 @@ Fetch issues that:
 Implementation note:
 
 - the GraphQL adapter filters by Linear `Project.slugId`, so workflow `tracker.project_slug` should store that stable slug value
-- candidate and terminal-state `issues(...)` reads should pass `includeArchived: true` so cleanup can still observe archived terminal work
+- candidate issue polling should exclude archived issues so archiving an active ticket releases it instead of redispatching it on the next poll
 
 ## 2.2 State refresh by IDs
 
@@ -39,6 +39,10 @@ Implementation note:
 ## 2.3 Terminal-state fetch for startup cleanup
 
 Fetch issues in terminal states when sweeping existing workspaces on startup.
+
+Implementation note:
+
+- terminal-state cleanup reads should pass `includeArchived: true` so archived terminal work remains visible during startup cleanup
 
 ## 2.4 Normalization
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -25,6 +25,7 @@ Fetch issues that:
 Implementation note:
 
 - the GraphQL adapter filters by Linear `Project.slugId`, so workflow `tracker.project_slug` should store that stable slug value
+- paginated `issues(...)` reads should pass `includeArchived: true` so cleanup and reconciliation can still observe archived terminal work
 
 ## 2.2 State refresh by IDs
 
@@ -59,6 +60,7 @@ Implementation note:
 - blocker and state-refresh normalization should retain both the state name and the Linear `WorkflowState.type` string so terminal blockers remain detectable without hardcoding active-state semantics
 - issue normalization should retain the Linear issue URL because `WORKFLOW.md` renders `{{ issue.url }}` under strict template validation
 - issue normalization should preserve the raw Linear priority because prompt/UI consumers render `{{ issue.priority }}` directly
+- top-level issue pages should request only a small initial `inverseRelations` slice and page the rest per issue so nested connection complexity stays under Linear's query cap
 
 ## 3. Candidate sorting and eligibility
 
@@ -94,6 +96,7 @@ Eligibility reminders:
 Current adapter contract:
 
 - send GraphQL requests to the configured endpoint with `Authorization: Bearer <LINEAR_API_KEY>`
+- decode GraphQL error envelopes before falling back to raw HTTP classification because Linear rate limits can arrive as HTTP 400 with GraphQL code `RATELIMITED`
 - keep GraphQL query and response structs private to `opensymphony-linear`
 - return only normalized domain models to orchestrator-facing callers
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -55,8 +55,10 @@ Keep the orchestrator independent of raw GraphQL response shape.
 Implementation note:
 
 - blocker normalization should derive `blocked_by` from `inverseRelations` entries where relation `type == "blocks"`
-- issue state normalization should retain both the state name and the Linear `WorkflowState.type` string so terminal blockers remain detectable
+- `TrackerIssue.state` should remain the workflow-facing state name string consumed by `WORKFLOW.md` and `WORKFLOW.example.md`
+- blocker and state-refresh normalization should retain both the state name and the Linear `WorkflowState.type` string so terminal blockers remain detectable without hardcoding active-state semantics
 - issue normalization should retain the Linear issue URL because `WORKFLOW.md` renders `{{ issue.url }}` under strict template validation
+- issue normalization should preserve the raw Linear priority because prompt/UI consumers render `{{ issue.priority }}` directly
 
 ## 3. Candidate sorting and eligibility
 
@@ -64,13 +66,13 @@ The orchestrator should receive normalized issues and apply Symphony sorting and
 
 Recommended sort order:
 
-1. higher priority first
+1. higher urgency first using raw Linear priority (`1` before `2`; `0` remains unprioritized)
 2. older creation time first
 3. identifier tie-breaker
 
 Implementation note:
 
-- Linear's raw priority scale is urgency-inverted (`1` is most urgent, `0` is unprioritized), so the adapter should normalize it before returning scheduler-facing issues
+- Linear's raw priority scale is urgency-inverted (`1` is most urgent, `0` is unprioritized), so the scheduler should derive its sort key from the raw value instead of rewriting the shared issue model
 
 Eligibility reminders:
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -106,7 +106,7 @@ Current adapter contract:
 
 - send GraphQL requests to the configured endpoint with `Authorization: <LINEAR_API_KEY>` because the local MVP uses personal Linear API keys rather than OAuth access tokens
 - reject blank `LINEAR_API_KEY` values during client construction so startup misconfiguration fails fast instead of repeated auth failures at poll time
-- decode GraphQL error envelopes before falling back to raw HTTP classification because Linear rate limits can arrive as HTTP 400 with GraphQL code `RATELIMITED`
+- decode GraphQL error envelopes before falling back to raw HTTP classification because Linear rate limits can arrive as HTTP 400 with GraphQL code `RATELIMITED`, but keep transient HTTP 5xx responses retryable even when the body is a GraphQL error envelope
 - prefer Linear's `X-RateLimit-*-Reset` headers when calculating retry delays for rate-limited responses, falling back to `Retry-After` and then local exponential backoff only when no reset window is advertised
 - keep transient HTTP 5xx responses on the retryable HTTP-status path even when the body decodes as a GraphQL error envelope
 - keep GraphQL query and response structs private to `opensymphony-linear`

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -22,6 +22,10 @@ Fetch issues that:
 - are in configured active states
 - include enough fields to normalize issue data and eligibility
 
+Implementation note:
+
+- the GraphQL adapter filters by Linear `Project.slugId`, so workflow `tracker.project_slug` should store that stable slug value
+
 ## 2.2 State refresh by IDs
 
 Fetch current states for all running issues during reconciliation.
@@ -46,6 +50,11 @@ Normalize tracker payloads into a stable issue model with fields such as:
 - `updated_at`
 
 Keep the orchestrator independent of raw GraphQL response shape.
+
+Implementation note:
+
+- blocker normalization should derive `blocked_by` from `inverseRelations` entries where relation `type == "blocks"`
+- issue state normalization should retain both the state name and the Linear `WorkflowState.type` string so terminal blockers remain detectable
 
 ## 3. Candidate sorting and eligibility
 
@@ -74,12 +83,18 @@ Eligibility reminders:
 - structured error classification
 - redaction of tokens in logs
 
+Current adapter contract:
+
+- send GraphQL requests to the configured endpoint with `Authorization: Bearer <LINEAR_API_KEY>`
+- keep GraphQL query and response structs private to `opensymphony-linear`
+- return only normalized domain models to orchestrator-facing callers
+
 ## 4.2 Configuration inputs
 
 Required:
 
 - `LINEAR_API_KEY`
-- workflow `tracker.project_slug`
+- workflow `tracker.project_slug` (the Linear `Project.slugId` value)
 - workflow `tracker.active_states`
 - workflow `tracker.terminal_states`
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, issue URL/raw-priority preservation, archived-query pagination flags, GraphQL 400/429 rate-limit retries, by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, required-state-list configuration validation, issue URL/raw-priority preservation, archived-query pagination flags, GraphQL 400/429 rate-limit retries, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, required-state-list configuration validation, issue URL/raw-priority preservation, archived-query pagination flags, GraphQL 400/429 rate-limit retries, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required project/state configuration validation, issue URL/raw-priority preservation, archived-query pagination flags, GraphQL 400/429 rate-limit retries, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, issue URL/raw-priority preservation, pagination, by-ID state refresh, retry-after handling, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, issue URL/raw-priority preservation, archived-query pagination flags, GraphQL 400/429 rate-limit retries, by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, raw workflow-state type preservation alongside normalized kinds, archived-query pagination flags for candidate/terminal reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,6 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, pagination, by-ID state refresh, retry-after handling, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, issue URL and priority normalization, pagination, by-ID state refresh, retry-after handling, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, issue URL/raw-priority preservation, pagination, by-ID state refresh, retry-after handling, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, archived-query pagination flags for candidate/terminal reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, raw workflow-state type preservation alongside normalized kinds, archived-query pagination flags for candidate/terminal reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, archived-query pagination flags, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, archived-query pagination flags for candidate/terminal reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,7 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, pagination, by-ID state refresh, retry-after handling, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, issue URL and priority normalization, pagination, by-ID state refresh, retry-after handling, and tracker error mapping against a local stub server
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`


### PR DESCRIPTION
## Summary
- add normalized tracker issue/state types in `opensymphony-domain`
- implement the Linear GraphQL read client with private query models, pagination, retries, and error mapping
- add fixture-backed tests for normalization, pagination, by-id state refresh, and rate-limit handling

## Validation
- cargo test -p opensymphony-domain
- cargo test -p opensymphony-linear
- cargo fmt --check
- cargo clippy -p opensymphony-linear -p opensymphony-domain --all-targets -- -D warnings