### PR TITLE
COE-262: Harden OpenHands REST client contract

### DIFF
--- a/crates/opensymphony-openhands/src/client.rs
+++ b/crates/opensymphony-openhands/src/client.rs
@@ -1,37 +1,178 @@
 use std::time::Duration;
 
 use futures_util::StreamExt;
-use reqwest::StatusCode;
-use serde::de::DeserializeOwned;
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE},
+    RequestBuilder,
+};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use tokio::time::{timeout_at, Instant};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, Message},
+};
 use tracing::debug;
 use url::Url;
 use uuid::Uuid;
 
 use crate::events::{ConversationStateMirror, EventCache, KnownEvent};
 use crate::models::{
-    Conversation, ConversationCreateRequest, EventEnvelope, SearchConversationEventsResponse,
-    SendMessageRequest,
+    AcceptedResponse, Conversation, ConversationCreateRequest, ConversationRunRequest,
+    EventEnvelope, SearchConversationEventsResponse, SendMessageRequest,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiKeyAuth {
+    name: String,
+    value: String,
+}
+
+impl ApiKeyAuth {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpAuth {
+    None,
+    QueryParam(ApiKeyAuth),
+    Header(ApiKeyAuth),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebSocketAuth {
+    None,
+    QueryParam(ApiKeyAuth),
+    Header(ApiKeyAuth),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthConfig {
+    pub http: HttpAuth,
+    pub websocket: WebSocketAuth,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+impl AuthConfig {
+    pub fn none() -> Self {
+        Self {
+            http: HttpAuth::None,
+            websocket: WebSocketAuth::None,
+        }
+    }
+
+    pub fn query_param_api_key(name: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = ApiKeyAuth::new(name, value);
+        Self {
+            http: HttpAuth::QueryParam(key.clone()),
+            websocket: WebSocketAuth::QueryParam(key),
+        }
+    }
+
+    pub fn header_api_key(name: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = ApiKeyAuth::new(name, value);
+        Self {
+            http: HttpAuth::Header(key.clone()),
+            websocket: WebSocketAuth::Header(key),
+        }
+    }
+
+    pub fn header_api_key_with_websocket_query_fallback(
+        header_name: impl Into<String>,
+        websocket_query_param: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        let value = value.into();
+        Self {
+            http: HttpAuth::Header(ApiKeyAuth::new(header_name, value.clone())),
+            websocket: WebSocketAuth::QueryParam(ApiKeyAuth::new(websocket_query_param, value)),
+        }
+    }
+
+    fn apply_http_query(&self, url: &mut Url) {
+        if let HttpAuth::QueryParam(key) = &self.http {
+            url.query_pairs_mut().append_pair(key.name(), key.value());
+        }
+    }
+
+    fn apply_websocket_query(&self, url: &mut Url) {
+        if let WebSocketAuth::QueryParam(key) = &self.websocket {
+            url.query_pairs_mut().append_pair(key.name(), key.value());
+        }
+    }
+
+    fn apply_http_headers(
+        &self,
+        request: RequestBuilder,
+    ) -> Result<RequestBuilder, OpenHandsError> {
+        match &self.http {
+            HttpAuth::Header(key) => Ok(request.header(
+                parse_header_name(key.name())?,
+                parse_header_value(key.value())?,
+            )),
+            _ => Ok(request),
+        }
+    }
+
+    fn apply_websocket_headers(&self, headers: &mut HeaderMap) -> Result<(), OpenHandsError> {
+        if let WebSocketAuth::Header(key) = &self.websocket {
+            headers.insert(
+                parse_header_name(key.name())?,
+                parse_header_value(key.value())?,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransportConfig {
-    pub base_url: String,
-    pub session_api_key: Option<String>,
+    base_url: String,
+    auth: AuthConfig,
 }
 
 impl TransportConfig {
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
-            session_api_key: None,
+            auth: AuthConfig::default(),
         }
     }
 
+    pub fn with_auth(mut self, auth: AuthConfig) -> Self {
+        self.auth = auth;
+        self
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn auth(&self) -> &AuthConfig {
+        &self.auth
+    }
+
     fn endpoint(&self, suffix: &str) -> Result<Url, OpenHandsError> {
-        let mut url = Url::parse(&self.base_url)?;
+        let mut url = self.parsed_base_url()?;
         let base_path = url.path().trim_end_matches('/');
         let path = format!("{base_path}{suffix}");
         let normalized = if path.is_empty() {
@@ -40,22 +181,29 @@ impl TransportConfig {
             path
         };
         url.set_path(&normalized);
-        if let Some(session_api_key) = &self.session_api_key {
-            url.query_pairs_mut()
-                .append_pair("session_api_key", session_api_key);
-        }
+        self.auth.apply_http_query(&mut url);
         Ok(url)
     }
 
-    fn ws_url(&self, conversation_id: Uuid) -> Result<Url, OpenHandsError> {
-        let mut url = Url::parse(&self.base_url)?;
+    fn websocket_request(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<tokio_tungstenite::tungstenite::http::Request<()>, OpenHandsError> {
+        let mut url = self.parsed_base_url()?;
         let scheme = match url.scheme() {
             "http" => "ws",
             "https" => "wss",
-            other => return Err(OpenHandsError::UnsupportedScheme(other.to_string())),
+            other => {
+                return Err(OpenHandsError::invalid_configuration(format!(
+                    "unsupported base URL scheme `{other}`"
+                )));
+            }
         };
-        url.set_scheme(scheme)
-            .map_err(|_| OpenHandsError::UnsupportedScheme(scheme.to_string()))?;
+        url.set_scheme(scheme).map_err(|_| {
+            OpenHandsError::invalid_configuration(format!(
+                "failed to apply websocket scheme `{scheme}`"
+            ))
+        })?;
 
         let base_path = url.path().trim_end_matches('/');
         let path = if base_path.is_empty() {
@@ -64,32 +212,58 @@ impl TransportConfig {
             format!("{base_path}/sockets/events/{conversation_id}")
         };
         url.set_path(&path);
-        if let Some(session_api_key) = &self.session_api_key {
-            url.query_pairs_mut()
-                .append_pair("session_api_key", session_api_key);
-        }
-        Ok(url)
+        self.auth.apply_websocket_query(&mut url);
+
+        let mut request = url.as_str().into_client_request().map_err(|error| {
+            OpenHandsError::invalid_configuration(format!(
+                "invalid websocket request `{url}`: {error}"
+            ))
+        })?;
+        self.auth.apply_websocket_headers(request.headers_mut())?;
+        Ok(request)
+    }
+
+    fn apply_http_auth(&self, request: RequestBuilder) -> Result<RequestBuilder, OpenHandsError> {
+        self.auth.apply_http_headers(request)
+    }
+
+    fn parsed_base_url(&self) -> Result<Url, OpenHandsError> {
+        Url::parse(&self.base_url).map_err(|error| {
+            OpenHandsError::invalid_configuration(format!(
+                "invalid base URL `{}`: {error}",
+                self.base_url
+            ))
+        })
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum OpenHandsError {
-    #[error("request failed: {0}")]
-    Request(Box<reqwest::Error>),
-    #[error("websocket failed: {0}")]
-    WebSocket(Box<tokio_tungstenite::tungstenite::Error>),
-    #[error("url parsing failed: {0}")]
-    Url(Box<url::ParseError>),
-    #[error("json decoding failed: {0}")]
-    Json(Box<serde_json::Error>),
-    #[error("websocket event decoding failed: {error}; payload prefix: {snippet}")]
-    MalformedWebSocketEvent {
-        #[source]
-        error: Box<serde_json::Error>,
-        snippet: String,
+    #[error("invalid transport configuration: {detail}")]
+    InvalidConfiguration { detail: String },
+    #[error("{operation} transport failed: {detail}")]
+    Transport {
+        operation: &'static str,
+        detail: String,
     },
-    #[error("unexpected HTTP status {status}: {body}")]
-    HttpStatus { status: StatusCode, body: String },
+    #[error("{operation} returned HTTP {status_code}: {body}")]
+    HttpStatus {
+        operation: &'static str,
+        status_code: u16,
+        body: String,
+    },
+    #[error("{operation} protocol error: {detail}")]
+    Protocol {
+        operation: &'static str,
+        detail: String,
+    },
+    #[error("{operation} websocket failed: {detail}")]
+    WebSocketTransport {
+        operation: &'static str,
+        detail: String,
+    },
+    #[error("websocket event decoding failed: {detail}; payload prefix: {snippet}")]
+    MalformedWebSocketEvent { detail: String, snippet: String },
     #[error("websocket readiness timed out after {0:?}")]
     ReadinessTimeout(Duration),
     #[error("probe run activity was not observed after {0:?}")]
@@ -98,31 +272,34 @@ pub enum OpenHandsError {
     ProbeRunUnhealthy(String),
     #[error("websocket closed before readiness")]
     WebSocketClosed,
-    #[error("unsupported base URL scheme: {0}")]
-    UnsupportedScheme(String),
 }
 
-impl From<reqwest::Error> for OpenHandsError {
-    fn from(error: reqwest::Error) -> Self {
-        Self::Request(Box::new(error))
+impl OpenHandsError {
+    fn invalid_configuration(detail: impl Into<String>) -> Self {
+        Self::InvalidConfiguration {
+            detail: detail.into(),
+        }
     }
-}
 
-impl From<tokio_tungstenite::tungstenite::Error> for OpenHandsError {
-    fn from(error: tokio_tungstenite::tungstenite::Error) -> Self {
-        Self::WebSocket(Box::new(error))
+    fn transport(operation: &'static str, error: impl std::fmt::Display) -> Self {
+        Self::Transport {
+            operation,
+            detail: error.to_string(),
+        }
     }
-}
 
-impl From<url::ParseError> for OpenHandsError {
-    fn from(error: url::ParseError) -> Self {
-        Self::Url(Box::new(error))
+    fn protocol(operation: &'static str, error: impl std::fmt::Display) -> Self {
+        Self::Protocol {
+            operation,
+            detail: error.to_string(),
+        }
     }
-}
 
-impl From<serde_json::Error> for OpenHandsError {
-    fn from(error: serde_json::Error) -> Self {
-        Self::Json(Box::new(error))
+    fn websocket_transport(operation: &'static str, error: impl std::fmt::Display) -> Self {
+        Self::WebSocketTransport {
+            operation,
+            detail: error.to_string(),
+        }
     }
 }
 
@@ -149,70 +326,71 @@ impl OpenHandsClient {
     }
 
     pub async fn openapi_probe(&self) -> Result<(), OpenHandsError> {
-        let response = self
-            .http
-            .get(self.transport.endpoint("/openapi.json")?)
-            .send()
-            .await?;
-        ensure_success(response).await.map(|_| ())
+        let response = send(self.get_request("/openapi.json")?, "probe OpenAPI").await?;
+        read_success_body(response, "probe OpenAPI")
+            .await
+            .map(|_| ())
     }
 
     pub async fn create_conversation(
         &self,
         request: &ConversationCreateRequest,
     ) -> Result<Conversation, OpenHandsError> {
-        let response = self
-            .http
-            .post(self.transport.endpoint("/api/conversations")?)
-            .json(request)
-            .send()
-            .await?;
-        decode_json(response).await
+        let response = send(
+            self.json_request(
+                self.post_request("/api/conversations")?,
+                "create conversation",
+                request,
+            )?,
+            "create conversation",
+        )
+        .await?;
+        decode_json(response, "create conversation").await
     }
 
     pub async fn get_conversation(
         &self,
         conversation_id: Uuid,
     ) -> Result<Conversation, OpenHandsError> {
-        let response = self
-            .http
-            .get(
-                self.transport
-                    .endpoint(&format!("/api/conversations/{conversation_id}"))?,
-            )
-            .send()
-            .await?;
-        decode_json(response).await
+        let response = send(
+            self.get_request(&format!("/api/conversations/{conversation_id}"))?,
+            "fetch conversation",
+        )
+        .await?;
+        decode_json(response, "fetch conversation").await
     }
 
     pub async fn send_message(
         &self,
         conversation_id: Uuid,
         request: &SendMessageRequest,
-    ) -> Result<(), OpenHandsError> {
-        let response = self
-            .http
-            .post(
-                self.transport
-                    .endpoint(&format!("/api/conversations/{conversation_id}/events"))?,
-            )
-            .json(request)
-            .send()
-            .await?;
-        ensure_success(response).await.map(|_| ())
+    ) -> Result<AcceptedResponse, OpenHandsError> {
+        let response = send(
+            self.json_request(
+                self.post_request(&format!("/api/conversations/{conversation_id}/events"))?,
+                "send conversation event",
+                request,
+            )?,
+            "send conversation event",
+        )
+        .await?;
+        decode_accepted(response, "send conversation event").await
     }
 
-    pub async fn run_conversation(&self, conversation_id: Uuid) -> Result<(), OpenHandsError> {
-        let response = self
-            .http
-            .post(
-                self.transport
-                    .endpoint(&format!("/api/conversations/{conversation_id}/run"))?,
-            )
-            .json(&serde_json::json!({}))
-            .send()
-            .await?;
-        ensure_success(response).await.map(|_| ())
+    pub async fn run_conversation(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<AcceptedResponse, OpenHandsError> {
+        let response = send(
+            self.json_request(
+                self.post_request(&format!("/api/conversations/{conversation_id}/run"))?,
+                "trigger conversation run",
+                &ConversationRunRequest::default(),
+            )?,
+            "trigger conversation run",
+        )
+        .await?;
+        decode_accepted(response, "trigger conversation run").await
     }
 
     pub async fn search_events_page(
@@ -227,8 +405,12 @@ impl OpenHandsClient {
             url.query_pairs_mut().append_pair("page_id", page_id);
         }
 
-        let response = self.http.get(url).send().await?;
-        decode_json(response).await
+        let response = send(
+            self.transport.apply_http_auth(self.http.get(url))?,
+            "search conversation events",
+        )
+        .await?;
+        decode_json(response, "search conversation events").await
     }
 
     pub async fn search_all_events(
@@ -254,8 +436,10 @@ impl OpenHandsClient {
         conversation_id: Uuid,
         wait_timeout: Duration,
     ) -> Result<EventEnvelope, OpenHandsError> {
-        let ws_url = self.transport.ws_url(conversation_id)?;
-        let (mut stream, _) = connect_async(ws_url.as_str()).await?;
+        let ws_request = self.transport.websocket_request(conversation_id)?;
+        let (mut stream, _) = connect_async(ws_request)
+            .await
+            .map_err(|error| OpenHandsError::websocket_transport("wait for readiness", error))?;
         let deadline = Instant::now() + wait_timeout;
 
         loop {
@@ -303,7 +487,12 @@ impl OpenHandsClient {
                     debug!("ignoring raw websocket frame before readiness");
                 }
                 Some(Ok(Message::Close(_))) | None => return Err(OpenHandsError::WebSocketClosed),
-                Some(Err(error)) => return Err(OpenHandsError::WebSocket(Box::new(error))),
+                Some(Err(error)) => {
+                    return Err(OpenHandsError::websocket_transport(
+                        "wait for readiness",
+                        error,
+                    ));
+                }
             }
         }
     }
@@ -369,6 +558,30 @@ impl OpenHandsClient {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
+
+    fn get_request(&self, suffix: &str) -> Result<RequestBuilder, OpenHandsError> {
+        let url = self.transport.endpoint(suffix)?;
+        self.transport.apply_http_auth(self.http.get(url))
+    }
+
+    fn post_request(&self, suffix: &str) -> Result<RequestBuilder, OpenHandsError> {
+        let url = self.transport.endpoint(suffix)?;
+        self.transport.apply_http_auth(self.http.post(url))
+    }
+
+    fn json_request<T>(
+        &self,
+        request: RequestBuilder,
+        operation: &'static str,
+        payload: &T,
+    ) -> Result<RequestBuilder, OpenHandsError>
+    where
+        T: Serialize,
+    {
+        let body = serde_json::to_vec(payload)
+            .map_err(|error| OpenHandsError::protocol(operation, error))?;
+        Ok(request.header(CONTENT_TYPE, "application/json").body(body))
+    }
 }
 
 enum ProbeActivity {
@@ -377,35 +590,98 @@ enum ProbeActivity {
     Unhealthy(String),
 }
 
-async fn ensure_success(response: reqwest::Response) -> Result<Value, OpenHandsError> {
-    let status = response.status();
-    let body = response.text().await?;
-    if !status.is_success() {
-        return Err(OpenHandsError::HttpStatus { status, body });
-    }
-
-    serde_json::from_str(&body).map_err(OpenHandsError::from)
+async fn send(
+    request: RequestBuilder,
+    operation: &'static str,
+) -> Result<reqwest::Response, OpenHandsError> {
+    request
+        .send()
+        .await
+        .map_err(|error| OpenHandsError::transport(operation, error))
 }
 
-async fn decode_json<T>(response: reqwest::Response) -> Result<T, OpenHandsError>
+async fn read_success_body(
+    response: reqwest::Response,
+    operation: &'static str,
+) -> Result<Option<Value>, OpenHandsError> {
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|error| OpenHandsError::transport(operation, error))?;
+    if !status.is_success() {
+        return Err(OpenHandsError::HttpStatus {
+            operation,
+            status_code: status.as_u16(),
+            body,
+        });
+    }
+
+    if body.trim().is_empty() {
+        return Ok(None);
+    }
+
+    serde_json::from_str(&body)
+        .map(Some)
+        .map_err(|error| OpenHandsError::protocol(operation, error))
+}
+
+async fn decode_json<T>(
+    response: reqwest::Response,
+    operation: &'static str,
+) -> Result<T, OpenHandsError>
 where
     T: DeserializeOwned,
 {
-    let value = ensure_success(response).await?;
-    serde_json::from_value(value).map_err(OpenHandsError::from)
+    let value = read_success_body(response, operation)
+        .await?
+        .ok_or_else(|| OpenHandsError::protocol(operation, "expected JSON response body"))?;
+    serde_json::from_value(value).map_err(|error| OpenHandsError::protocol(operation, error))
+}
+
+async fn decode_accepted(
+    response: reqwest::Response,
+    operation: &'static str,
+) -> Result<AcceptedResponse, OpenHandsError> {
+    let Some(value) = read_success_body(response, operation).await? else {
+        return Ok(AcceptedResponse::accepted());
+    };
+
+    let accepted: AcceptedResponse = serde_json::from_value(value)
+        .map_err(|error| OpenHandsError::protocol(operation, error))?;
+    if accepted.success {
+        Ok(accepted)
+    } else {
+        Err(OpenHandsError::protocol(
+            operation,
+            "response reported `success=false`",
+        ))
+    }
 }
 
 fn parse_text_event(payload: &str) -> Result<EventEnvelope, OpenHandsError> {
     serde_json::from_str(payload).map_err(|error| OpenHandsError::MalformedWebSocketEvent {
-        error: Box::new(error),
+        detail: error.to_string(),
         snippet: payload.chars().take(160).collect(),
     })
 }
 
 fn parse_binary_event(payload: &[u8]) -> Result<EventEnvelope, OpenHandsError> {
     serde_json::from_slice(payload).map_err(|error| OpenHandsError::MalformedWebSocketEvent {
-        error: Box::new(error),
+        detail: error.to_string(),
         snippet: String::from_utf8_lossy(payload).chars().take(160).collect(),
+    })
+}
+
+fn parse_header_name(name: &str) -> Result<HeaderName, OpenHandsError> {
+    HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+        OpenHandsError::invalid_configuration(format!("invalid auth header name `{name}`: {error}"))
+    })
+}
+
+fn parse_header_value(value: &str) -> Result<HeaderValue, OpenHandsError> {
+    HeaderValue::from_str(value).map_err(|error| {
+        OpenHandsError::invalid_configuration(format!("invalid auth header value: {error}"))
     })
 }
 

--- a/crates/opensymphony-openhands/src/lib.rs
+++ b/crates/opensymphony-openhands/src/lib.rs
@@ -2,10 +2,13 @@ mod client;
 mod events;
 mod models;
 
-pub use client::{OpenHandsClient, OpenHandsError, OpenHandsProbeResult, TransportConfig};
+pub use client::{
+    ApiKeyAuth, AuthConfig, HttpAuth, OpenHandsClient, OpenHandsError, OpenHandsProbeResult,
+    TransportConfig, WebSocketAuth,
+};
 pub use events::{ConversationStateMirror, EventCache, KnownEvent};
 pub use models::{
-    AgentConfig, ConfirmationPolicy, Conversation, ConversationCreateRequest,
-    ConversationStateUpdatePayload, EventEnvelope, LlmConfig, SearchConversationEventsResponse,
-    SendMessageRequest, TextContent, WorkspaceConfig,
+    AcceptedResponse, AgentConfig, ConfirmationPolicy, Conversation, ConversationCreateRequest,
+    ConversationRunRequest, ConversationStateUpdatePayload, EventEnvelope, LlmConfig,
+    SearchConversationEventsResponse, SendMessageRequest, TextContent, WorkspaceConfig,
 };

--- a/crates/opensymphony-openhands/src/models.rs
+++ b/crates/opensymphony-openhands/src/models.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceConfig {
     pub working_dir: String,
@@ -115,6 +119,21 @@ impl SendMessageRequest {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConversationRunRequest {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AcceptedResponse {
+    #[serde(default = "default_true")]
+    pub success: bool,
+}
+
+impl AcceptedResponse {
+    pub fn accepted() -> Self {
+        Self { success: true }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConversationStateUpdatePayload {
     #[serde(default)]
@@ -209,4 +228,69 @@ pub struct SearchConversationEventsResponse {
     pub events: Vec<EventEnvelope>,
     #[serde(default)]
     pub next_page_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn conversation_create_request_serializes_minimal_contract() {
+        let request = ConversationCreateRequest {
+            conversation_id: Uuid::parse_str("11111111-2222-3333-4444-555555555555")
+                .expect("uuid should parse"),
+            workspace: WorkspaceConfig {
+                working_dir: "/tmp/workspace".to_string(),
+                kind: "LocalWorkspace".to_string(),
+            },
+            persistence_dir: "/tmp/workspace/.opensymphony/openhands".to_string(),
+            max_iterations: 7,
+            stuck_detection: true,
+            confirmation_policy: ConfirmationPolicy {
+                kind: "NeverConfirm".to_string(),
+            },
+            agent: AgentConfig {
+                kind: "Agent".to_string(),
+                llm: Some(LlmConfig {
+                    model: "fake-model".to_string(),
+                    api_key: Some("fake-key".to_string()),
+                }),
+            },
+        };
+
+        let value = serde_json::to_value(&request).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "conversation_id": "11111111-2222-3333-4444-555555555555",
+                "workspace": {
+                    "working_dir": "/tmp/workspace",
+                    "kind": "LocalWorkspace",
+                },
+                "persistence_dir": "/tmp/workspace/.opensymphony/openhands",
+                "max_iterations": 7,
+                "stuck_detection": true,
+                "confirmation_policy": {
+                    "kind": "NeverConfirm",
+                },
+                "agent": {
+                    "kind": "Agent",
+                    "llm": {
+                        "model": "fake-model",
+                        "api_key": "fake-key",
+                    },
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn conversation_run_request_serializes_to_empty_object() {
+        let value = serde_json::to_value(ConversationRunRequest::default())
+            .expect("request should serialize");
+
+        assert_eq!(value, json!({}));
+    }
 }

--- a/crates/opensymphony-openhands/tests/client_resilience.rs
+++ b/crates/opensymphony-openhands/tests/client_resilience.rs
@@ -1,22 +1,20 @@
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
         Path, Query, State,
     },
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
 use chrono::Utc;
 use opensymphony_openhands::{
-    Conversation, ConversationCreateRequest, EventEnvelope, OpenHandsClient,
-    SearchConversationEventsResponse, SendMessageRequest, TransportConfig,
+    AuthConfig, Conversation, ConversationCreateRequest, EventEnvelope, OpenHandsClient,
+    OpenHandsError, SearchConversationEventsResponse, SendMessageRequest, TransportConfig,
 };
-use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
 use uuid::Uuid;
@@ -33,11 +31,21 @@ async fn wait_for_readiness_ignores_non_state_frames_before_ready_event() {
 }
 
 #[tokio::test]
-async fn session_api_key_authenticates_rest_operations() {
-    let server = TestServer::start(auth_router("secret-token")).await;
-    let mut transport = TransportConfig::new(server.base_url());
-    transport.session_api_key = Some("secret-token".to_string());
-    let client = OpenHandsClient::new(transport);
+async fn query_param_api_key_authenticates_rest_and_websocket_operations() {
+    let server = TestServer::start(auth_router(AuthExpectations {
+        rest: ExpectedAuth::QueryParam {
+            name: "session_api_key".to_string(),
+            value: "secret-token".to_string(),
+        },
+        websocket: ExpectedAuth::QueryParam {
+            name: "session_api_key".to_string(),
+            value: "secret-token".to_string(),
+        },
+    }))
+    .await;
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()).with_auth(
+        AuthConfig::query_param_api_key("session_api_key", "secret-token"),
+    ));
     let request = ConversationCreateRequest::doctor_probe(
         "/tmp/workspace",
         "/tmp/workspace/.opensymphony/openhands",
@@ -68,6 +76,121 @@ async fn session_api_key_authenticates_rest_operations() {
         .search_all_events(conversation.conversation_id)
         .await
         .expect("search should carry auth");
+    client
+        .wait_for_readiness(conversation.conversation_id, Duration::from_secs(2))
+        .await
+        .expect("websocket readiness should carry query auth");
+}
+
+#[tokio::test]
+async fn header_api_key_with_websocket_query_fallback_authenticates_operations() {
+    let server = TestServer::start(auth_router(AuthExpectations {
+        rest: ExpectedAuth::Header {
+            name: "x-session-api-key".to_string(),
+            value: "secret-token".to_string(),
+        },
+        websocket: ExpectedAuth::QueryParam {
+            name: "session_api_key".to_string(),
+            value: "secret-token".to_string(),
+        },
+    }))
+    .await;
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()).with_auth(
+        AuthConfig::header_api_key_with_websocket_query_fallback(
+            "x-session-api-key",
+            "session_api_key",
+            "secret-token",
+        ),
+    ));
+    let request = ConversationCreateRequest::doctor_probe(
+        "/tmp/workspace",
+        "/tmp/workspace/.opensymphony/openhands",
+        None,
+        None,
+    );
+
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("create should carry header auth");
+    client
+        .wait_for_readiness(conversation.conversation_id, Duration::from_secs(2))
+        .await
+        .expect("websocket readiness should use query fallback");
+    client
+        .send_message(
+            conversation.conversation_id,
+            &SendMessageRequest::user_text("hello"),
+        )
+        .await
+        .expect("send_message should carry header auth");
+    client
+        .run_conversation(conversation.conversation_id)
+        .await
+        .expect("run should carry header auth");
+}
+
+#[tokio::test]
+async fn auth_failure_maps_to_stable_http_status_error() {
+    let server = TestServer::start(auth_router(AuthExpectations {
+        rest: ExpectedAuth::QueryParam {
+            name: "session_api_key".to_string(),
+            value: "secret-token".to_string(),
+        },
+        websocket: ExpectedAuth::QueryParam {
+            name: "session_api_key".to_string(),
+            value: "secret-token".to_string(),
+        },
+    }))
+    .await;
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let request = ConversationCreateRequest::doctor_probe(
+        "/tmp/workspace",
+        "/tmp/workspace/.opensymphony/openhands",
+        None,
+        None,
+    );
+
+    let error = client
+        .create_conversation(&request)
+        .await
+        .expect_err("missing auth should fail");
+
+    match error {
+        OpenHandsError::HttpStatus {
+            operation,
+            status_code,
+            ..
+        } => {
+            assert_eq!(operation, "create conversation");
+            assert_eq!(status_code, 401);
+        }
+        other => panic!("expected stable HTTP status error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn malformed_payload_maps_to_stable_protocol_error() {
+    let server = TestServer::start(malformed_payload_router()).await;
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let request = ConversationCreateRequest::doctor_probe(
+        "/tmp/workspace",
+        "/tmp/workspace/.opensymphony/openhands",
+        None,
+        None,
+    );
+
+    let error = client
+        .create_conversation(&request)
+        .await
+        .expect_err("invalid JSON should fail");
+
+    match error {
+        OpenHandsError::Protocol { operation, .. } => {
+            assert_eq!(operation, "create conversation");
+        }
+        other => panic!("expected stable protocol error, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -188,14 +311,26 @@ async fn handle_readiness_socket(mut socket: WebSocket) {
 
 #[derive(Clone)]
 struct AuthState {
-    expected_key: String,
+    expectations: AuthExpectations,
     conversation: Arc<Mutex<Option<Conversation>>>,
     ready_events: Arc<Mutex<Vec<EventEnvelope>>>,
 }
 
-fn auth_router(expected_key: &str) -> Router {
+#[derive(Clone)]
+struct AuthExpectations {
+    rest: ExpectedAuth,
+    websocket: ExpectedAuth,
+}
+
+#[derive(Clone)]
+enum ExpectedAuth {
+    QueryParam { name: String, value: String },
+    Header { name: String, value: String },
+}
+
+fn auth_router(expectations: AuthExpectations) -> Router {
     let state = AuthState {
-        expected_key: expected_key.to_string(),
+        expectations,
         conversation: Arc::new(Mutex::new(None)),
         ready_events: Arc::new(Mutex::new(vec![EventEnvelope::state_update(
             "evt-ready",
@@ -218,7 +353,150 @@ fn auth_router(expected_key: &str) -> Router {
             "/api/conversations/:conversation_id/events/search",
             get(search_events),
         )
+        .route(
+            "/sockets/events/:conversation_id",
+            get(authenticated_readiness_socket),
+        )
         .with_state(state)
+}
+
+async fn create_conversation(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Json(request): Json<ConversationCreateRequest>,
+) -> Result<Json<Conversation>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    let conversation = Conversation {
+        conversation_id: request.conversation_id,
+        workspace: request.workspace,
+        persistence_dir: request.persistence_dir,
+        max_iterations: request.max_iterations,
+        stuck_detection: request.stuck_detection,
+        execution_status: "idle".to_string(),
+        confirmation_policy: request.confirmation_policy,
+        agent: request.agent,
+    };
+    *state.conversation.lock().await = Some(conversation.clone());
+    Ok(Json(conversation))
+}
+
+async fn get_conversation(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+) -> Result<Json<Conversation>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    let conversation = state
+        .conversation
+        .lock()
+        .await
+        .clone()
+        .ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Json(conversation))
+}
+
+async fn send_message(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+    Json(_request): Json<SendMessageRequest>,
+) -> Result<Json<Value>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    Ok(Json(json!({ "success": true })))
+}
+
+async fn run_conversation(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+) -> Result<Json<Value>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    Ok(Json(json!({ "success": true })))
+}
+
+async fn search_events(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+) -> Result<Json<SearchConversationEventsResponse>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    let offset = query
+        .get("page_id")
+        .map(String::as_str)
+        .unwrap_or("0")
+        .parse::<usize>()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    let events = state.ready_events.lock().await;
+    let page = events
+        .iter()
+        .skip(offset)
+        .take(1)
+        .cloned()
+        .collect::<Vec<_>>();
+    let next_page_id = (offset + page.len() < events.len()).then(|| (offset + 1).to_string());
+    Ok(Json(SearchConversationEventsResponse {
+        events: page,
+        next_page_id,
+    }))
+}
+
+async fn authenticated_readiness_socket(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+    websocket: WebSocketUpgrade,
+) -> Result<impl IntoResponse, StatusCode> {
+    ensure_expected_auth(&state.expectations.websocket, &headers, &query)?;
+    let ready_events = state.ready_events.lock().await.clone();
+
+    Ok(websocket.on_upgrade(async move |mut socket| {
+        for event in ready_events {
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&event).expect("event should serialize"),
+                ))
+                .await
+                .expect("ready event should send");
+        }
+    }))
+}
+
+fn ensure_expected_auth(
+    expected: &ExpectedAuth,
+    headers: &HeaderMap,
+    query: &HashMap<String, String>,
+) -> Result<(), StatusCode> {
+    match expected {
+        ExpectedAuth::QueryParam { name, value } => match query.get(name) {
+            Some(actual) if actual == value => Ok(()),
+            _ => Err(StatusCode::UNAUTHORIZED),
+        },
+        ExpectedAuth::Header { name, value } => match headers.get(name) {
+            Some(actual)
+                if actual
+                    .to_str()
+                    .map(|candidate| candidate == value)
+                    .unwrap_or(false) =>
+            {
+                Ok(())
+            }
+            _ => Err(StatusCode::UNAUTHORIZED),
+        },
+    }
+}
+
+fn malformed_payload_router() -> Router {
+    Router::new().route("/api/conversations", post(malformed_create_conversation))
+}
+
+async fn malformed_create_conversation() -> impl IntoResponse {
+    (StatusCode::OK, "not-json")
 }
 
 #[derive(Clone, Default)]
@@ -273,99 +551,6 @@ fn failed_probe_router(state: ProbeState) -> Router {
         )
         .route("/sockets/events/:conversation_id", get(probe_events_socket))
         .with_state(state)
-}
-
-#[derive(Debug, Deserialize, Default)]
-struct AuthQuery {
-    session_api_key: Option<String>,
-    page_id: Option<String>,
-}
-
-async fn create_conversation(
-    State(state): State<AuthState>,
-    Query(query): Query<AuthQuery>,
-    Json(request): Json<ConversationCreateRequest>,
-) -> Result<Json<Conversation>, StatusCode> {
-    ensure_auth(&state, &query)?;
-    let conversation = Conversation {
-        conversation_id: request.conversation_id,
-        workspace: request.workspace,
-        persistence_dir: request.persistence_dir,
-        max_iterations: request.max_iterations,
-        stuck_detection: request.stuck_detection,
-        execution_status: "idle".to_string(),
-        confirmation_policy: request.confirmation_policy,
-        agent: request.agent,
-    };
-    *state.conversation.lock().await = Some(conversation.clone());
-    Ok(Json(conversation))
-}
-
-async fn get_conversation(
-    State(state): State<AuthState>,
-    Query(query): Query<AuthQuery>,
-    Path(_conversation_id): Path<Uuid>,
-) -> Result<Json<Conversation>, StatusCode> {
-    ensure_auth(&state, &query)?;
-    let conversation = state
-        .conversation
-        .lock()
-        .await
-        .clone()
-        .ok_or(StatusCode::NOT_FOUND)?;
-    Ok(Json(conversation))
-}
-
-async fn send_message(
-    State(state): State<AuthState>,
-    Query(query): Query<AuthQuery>,
-    Path(_conversation_id): Path<Uuid>,
-    Json(_request): Json<SendMessageRequest>,
-) -> Result<Json<Value>, StatusCode> {
-    ensure_auth(&state, &query)?;
-    Ok(Json(json!({ "success": true })))
-}
-
-async fn run_conversation(
-    State(state): State<AuthState>,
-    Query(query): Query<AuthQuery>,
-    Path(_conversation_id): Path<Uuid>,
-) -> Result<Json<Value>, StatusCode> {
-    ensure_auth(&state, &query)?;
-    Ok(Json(json!({ "success": true })))
-}
-
-async fn search_events(
-    State(state): State<AuthState>,
-    Query(query): Query<AuthQuery>,
-    Path(_conversation_id): Path<Uuid>,
-) -> Result<Json<SearchConversationEventsResponse>, StatusCode> {
-    ensure_auth(&state, &query)?;
-    let offset = query
-        .page_id
-        .as_deref()
-        .unwrap_or("0")
-        .parse::<usize>()
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    let events = state.ready_events.lock().await;
-    let page = events
-        .iter()
-        .skip(offset)
-        .take(1)
-        .cloned()
-        .collect::<Vec<_>>();
-    let next_page_id = (offset + page.len() < events.len()).then(|| (offset + 1).to_string());
-    Ok(Json(SearchConversationEventsResponse {
-        events: page,
-        next_page_id,
-    }))
-}
-
-fn ensure_auth(state: &AuthState, query: &AuthQuery) -> Result<(), StatusCode> {
-    match query.session_api_key.as_deref() {
-        Some(value) if value == state.expected_key => Ok(()),
-        _ => Err(StatusCode::UNAUTHORIZED),
-    }
 }
 
 async fn probe_create_conversation(

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -237,6 +237,12 @@ Implementation rule:
 - keep the orchestrator core independent of the raw OpenHands JSON model
 - all payload shaping belongs in `opensymphony-openhands`
 
+Current repository implementation:
+
+- `ConversationCreateRequest` carries the minimal create payload subset, including `conversation_id`, `workspace.working_dir`, and `persistence_dir`
+- `ConversationRunRequest` serializes the empty `{}` body used by `POST /api/conversations/{conversation_id}/run`
+- `AcceptedResponse` tolerates either an explicit JSON success body or an empty successful response for `POST /events` and `POST /run`
+
 ## 9. Authentication
 
 ## 9.1 Local MVP
@@ -257,8 +263,10 @@ The Rust client should still support:
 
 Current repository implementation:
 
-- `TransportConfig.session_api_key` is appended to REST endpoint URLs as well as the WebSocket URL so one auth knob covers create, get, send-message, run, search, and attach flows
-- `crates/opensymphony-openhands/tests/client_resilience.rs` covers both authenticated REST operations and the readiness path when non-readiness frames arrive before the first state update
+- `TransportConfig` now carries an `AuthConfig` with explicit no-auth, query-param API key, header API key, and header-plus-WebSocket-query-fallback modes
+- REST auth is applied independently from WebSocket auth so remote/header deployments do not force the local query-param shape
+- `OpenHandsError` now maps invalid config, transport failures, HTTP status failures, protocol failures, and WebSocket failures into stable runtime categories without exposing `reqwest::Error` or `http::StatusCode`
+- `crates/opensymphony-openhands/tests/client_resilience.rs` covers authenticated REST operations, WebSocket readiness auth, auth failure mapping, malformed payload handling, and non-readiness frames before the first state update
 - the doctor probe now exercises a real `POST /events` plus `POST /run` path and only reports the runtime healthy after a successful terminal `execution_status` of `finished`
 - failure-only probe streams such as `ConversationErrorEvent` or terminal `execution_status` values like `error` and `stuck` are treated as unhealthy instead of silently passing
 


### PR DESCRIPTION
## Summary
- replace the public OpenHands transport auth surface with explicit auth modes for local and remote deployments
- map REST, protocol, and websocket failures into stable runtime error categories and add typed run/ack models
- extend contract coverage for serialization, auth success/failure, malformed payloads, and readiness auth paths

## Validation
- cargo test -p opensymphony-openhands
- cargo test -p opensymphony-openhands --test client_resilience
- cargo test -p opensymphony-openhands --test fake_server_contract
- cargo clippy -p opensymphony-openhands --all-targets -- -D warnings