### PR TITLE
COE-263: Implement workspace manager and lifecycle hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ name = "opensymphony-workspace"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,14 @@ version = "0.1.0"
 [[package]]
 name = "opensymphony-workspace"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ axum = { version = "0.7", features = ["macros", "ws"] }
 chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 futures-util = "0.3"
+libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["fs", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
-

--- a/crates/opensymphony-workspace/Cargo.toml
+++ b/crates/opensymphony-workspace/Cargo.toml
@@ -8,3 +8,12 @@ repository.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[dependencies]
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/opensymphony-workspace/Cargo.toml
+++ b/crates/opensymphony-workspace/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 chrono.workspace = true
+libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -45,7 +45,7 @@ pub enum WorkspaceError {
     PathEscape { root: PathBuf, path: PathBuf },
     #[error("issue workspace path may not be a symlink: {path}")]
     WorkspacePathSymlink { path: PathBuf },
-    #[error("OpenSymphony-managed metadata path may not be a symlink: {path}")]
+    #[error("OpenSymphony-managed path may not be a symlink: {path}")]
     ManagedPathSymlink { path: PathBuf },
     #[error("failed to create directory {path}: {source}")]
     CreateDirectory { path: PathBuf, source: io::Error },

--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -43,6 +43,8 @@ pub enum WorkspaceError {
     },
     #[error("path {path} escapes configured root {root}")]
     PathEscape { root: PathBuf, path: PathBuf },
+    #[error("issue workspace path may not be a symlink: {path}")]
+    WorkspacePathSymlink { path: PathBuf },
     #[error("OpenSymphony-managed metadata path may not be a symlink: {path}")]
     ManagedPathSymlink { path: PathBuf },
     #[error("failed to create directory {path}: {source}")]

--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -4,6 +4,31 @@ use serde_json::Error as JsonError;
 
 use crate::HookKind;
 
+#[derive(Debug)]
+pub struct WorkspaceOwnershipConflictDetails {
+    pub workspace: PathBuf,
+    pub workspace_key: String,
+    pub existing_issue_id: String,
+    pub existing_identifier: String,
+    pub requested_issue_id: String,
+    pub requested_identifier: String,
+}
+
+impl std::fmt::Display for WorkspaceOwnershipConflictDetails {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "workspace {} with sanitized key {} is already owned by issue {} ({}), cannot reuse it for {} ({})",
+            self.workspace.display(),
+            self.workspace_key,
+            self.existing_identifier,
+            self.existing_issue_id,
+            self.requested_identifier,
+            self.requested_issue_id
+        )
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum WorkspaceError {
     #[error("workspace root must be absolute: {path}")]
@@ -12,8 +37,14 @@ pub enum WorkspaceError {
     EmptyIdentifier,
     #[error("sanitized workspace key is invalid or reserved: {key}")]
     InvalidWorkspaceKey { key: String },
+    #[error("{details}")]
+    WorkspaceOwnershipConflict {
+        details: Box<WorkspaceOwnershipConflictDetails>,
+    },
     #[error("path {path} escapes configured root {root}")]
     PathEscape { root: PathBuf, path: PathBuf },
+    #[error("OpenSymphony-managed metadata path may not be a symlink: {path}")]
+    ManagedPathSymlink { path: PathBuf },
     #[error("failed to create directory {path}: {source}")]
     CreateDirectory { path: PathBuf, source: io::Error },
     #[error("failed to canonicalize {path}: {source}")]

--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -1,0 +1,57 @@
+use std::{io, path::PathBuf, time::Duration};
+
+use serde_json::Error as JsonError;
+
+use crate::HookKind;
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceError {
+    #[error("workspace root must be absolute: {path}")]
+    RootNotAbsolute { path: PathBuf },
+    #[error("issue identifier cannot be empty")]
+    EmptyIdentifier,
+    #[error("sanitized workspace key is invalid or reserved: {key}")]
+    InvalidWorkspaceKey { key: String },
+    #[error("path {path} escapes configured root {root}")]
+    PathEscape { root: PathBuf, path: PathBuf },
+    #[error("failed to create directory {path}: {source}")]
+    CreateDirectory { path: PathBuf, source: io::Error },
+    #[error("failed to canonicalize {path}: {source}")]
+    Canonicalize { path: PathBuf, source: io::Error },
+    #[error("failed to read manifest {path}: {source}")]
+    ReadManifest { path: PathBuf, source: io::Error },
+    #[error("failed to decode manifest {path}: {source}")]
+    DecodeManifest { path: PathBuf, source: JsonError },
+    #[error("failed to encode manifest {path}: {source}")]
+    EncodeManifest { path: PathBuf, source: JsonError },
+    #[error("failed to write manifest {path}: {source}")]
+    WriteManifest { path: PathBuf, source: io::Error },
+    #[error("failed to launch hook `{hook}` in {cwd}: {source}")]
+    LaunchHook {
+        hook: HookKind,
+        cwd: PathBuf,
+        source: io::Error,
+    },
+    #[error("hook `{hook}` cwd {cwd} escapes workspace {workspace}")]
+    HookPathEscape {
+        hook: HookKind,
+        workspace: PathBuf,
+        cwd: PathBuf,
+    },
+    #[error("hook `{hook}` timed out after {timeout:?}: {command}")]
+    HookTimedOut {
+        hook: HookKind,
+        command: String,
+        timeout: Duration,
+    },
+    #[error("hook `{hook}` failed with exit code {exit_code:?}: {command}")]
+    HookFailed {
+        hook: HookKind,
+        command: String,
+        exit_code: Option<i32>,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("failed to remove workspace {path}: {source}")]
+    RemoveWorkspace { path: PathBuf, source: io::Error },
+}

--- a/crates/opensymphony-workspace/src/lib.rs
+++ b/crates/opensymphony-workspace/src/lib.rs
@@ -1,1 +1,14 @@
-pub const CRATE_NAME: &str = "opensymphony-workspace";
+mod error;
+mod manager;
+mod models;
+mod paths;
+
+pub use error::WorkspaceError;
+pub use manager::WorkspaceManager;
+pub use models::{
+    CleanupConfig, CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookConfig,
+    HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind, IssueDescriptor,
+    IssueLifecycleState, IssueManifest, RunDescriptor, RunManifest, RunStatus, WorkspaceHandle,
+    WorkspaceManagerConfig,
+};
+pub use paths::{resolve_path_within_root, sanitize_workspace_key, workspace_path_for_root};

--- a/crates/opensymphony-workspace/src/lib.rs
+++ b/crates/opensymphony-workspace/src/lib.rs
@@ -3,7 +3,7 @@ mod manager;
 mod models;
 mod paths;
 
-pub use error::WorkspaceError;
+pub use error::{WorkspaceError, WorkspaceOwnershipConflictDetails};
 pub use manager::WorkspaceManager;
 pub use models::{
     CleanupConfig, CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookConfig,

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -58,7 +58,11 @@ impl WorkspaceManager {
         let workspace_key = sanitize_workspace_key(&issue.identifier)?;
         let workspace_path = crate::workspace_path_for_root(&canonical_root, &issue.identifier)?;
 
+        self.reject_symlinked_workspace_root(&workspace_path)
+            .await?;
         self.create_directory(&workspace_path).await?;
+        self.reject_symlinked_workspace_root(&workspace_path)
+            .await?;
         let canonical_workspace = self.canonicalize_path(&workspace_path).await?;
         ensure_descendant(&canonical_root, &canonical_workspace)?;
 
@@ -331,13 +335,7 @@ impl WorkspaceManager {
             Ok(manifest) => Ok(classify_issue_manifest_ownership(
                 issue, workspace, manifest,
             )),
-            Err(_) if !self.bootstrap_layout_exists(workspace).await? => {
-                Ok(ExistingIssueManifestState::ForeignArtifact)
-            }
-            Err(error) => Err(WorkspaceError::DecodeManifest {
-                path,
-                source: error,
-            }),
+            Err(_) => Ok(ExistingIssueManifestState::ForeignArtifact),
         }
     }
 
@@ -557,40 +555,11 @@ impl WorkspaceManager {
         &self,
         workspace: &WorkspaceHandle,
     ) -> Result<(), WorkspaceError> {
+        self.reject_symlinked_workspace_root(workspace.workspace_path())
+            .await?;
         let canonical_root = self.canonicalize_path(&self.config.root).await?;
         let canonical_workspace = self.canonicalize_path(workspace.workspace_path()).await?;
         ensure_descendant(&canonical_root, &canonical_workspace)
-    }
-
-    async fn bootstrap_layout_exists(
-        &self,
-        workspace: &WorkspaceHandle,
-    ) -> Result<bool, WorkspaceError> {
-        for directory in [
-            workspace.metadata_dir(),
-            workspace.logs_dir(),
-            workspace.generated_dir(),
-            workspace.openhands_dir(),
-            workspace.prompts_dir(),
-            workspace.runs_dir(),
-        ] {
-            let path = self
-                .validate_managed_metadata_path(workspace, &directory)
-                .await?;
-            match fs::metadata(&path).await {
-                Ok(metadata) if metadata.is_dir() => {}
-                Ok(_) => return Ok(false),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-                Err(error) => {
-                    return Err(WorkspaceError::Canonicalize {
-                        path,
-                        source: error,
-                    });
-                }
-            }
-        }
-
-        Ok(true)
     }
 
     async fn create_directory(&self, path: &Path) -> Result<(), WorkspaceError> {
@@ -621,6 +590,22 @@ impl WorkspaceManager {
                 path: path.to_path_buf(),
                 source: error,
             })
+    }
+
+    async fn reject_symlinked_workspace_root(&self, path: &Path) -> Result<(), WorkspaceError> {
+        match fs::symlink_metadata(path).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                Err(WorkspaceError::WorkspacePathSymlink {
+                    path: path.to_path_buf(),
+                })
+            }
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(WorkspaceError::Canonicalize {
+                path: path.to_path_buf(),
+                source: error,
+            }),
+        }
     }
 
     async fn load_manifest<T>(

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -331,7 +331,7 @@ impl WorkspaceManager {
             Ok(manifest) => Ok(classify_issue_manifest_ownership(
                 issue, workspace, manifest,
             )),
-            Err(error) if !self.bootstrap_layout_exists(workspace).await? => {
+            Err(_) if !self.bootstrap_layout_exists(workspace).await? => {
                 Ok(ExistingIssueManifestState::ForeignArtifact)
             }
             Err(error) => Err(WorkspaceError::DecodeManifest {

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -1,0 +1,538 @@
+use std::{path::Path, process::Stdio};
+
+use chrono::Utc;
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::{
+    fs,
+    process::Command,
+    time::{timeout, Instant},
+};
+
+use crate::{
+    paths::{normalize_absolute_path, resolve_path_within_root, sanitize_workspace_key},
+    CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookDefinition, HookExecutionRecord,
+    HookExecutionStatus, HookKind, IssueDescriptor, IssueLifecycleState, IssueManifest,
+    RunDescriptor, RunManifest, RunStatus, WorkspaceError, WorkspaceHandle, WorkspaceManagerConfig,
+};
+
+pub struct WorkspaceManager {
+    config: WorkspaceManagerConfig,
+}
+
+struct HookFailure {
+    error: WorkspaceError,
+    record: HookExecutionRecord,
+}
+
+impl WorkspaceManager {
+    pub fn new(mut config: WorkspaceManagerConfig) -> Result<Self, WorkspaceError> {
+        config.root = normalize_absolute_path(&config.root)?;
+        Ok(Self { config })
+    }
+
+    pub fn config(&self) -> &WorkspaceManagerConfig {
+        &self.config
+    }
+
+    pub fn workspace_path_for(
+        &self,
+        issue_identifier: &str,
+    ) -> Result<std::path::PathBuf, WorkspaceError> {
+        crate::workspace_path_for_root(&self.config.root, issue_identifier)
+    }
+
+    pub async fn ensure(
+        &self,
+        issue: &IssueDescriptor,
+    ) -> Result<EnsureWorkspaceResult, WorkspaceError> {
+        self.create_directory(&self.config.root).await?;
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let workspace_key = sanitize_workspace_key(&issue.identifier)?;
+        let workspace_path = crate::workspace_path_for_root(&canonical_root, &issue.identifier)?;
+        let created = !path_exists(&workspace_path).await?;
+
+        self.create_directory(&workspace_path).await?;
+        let canonical_workspace = self.canonicalize_path(&workspace_path).await?;
+        ensure_descendant(&canonical_root, &canonical_workspace)?;
+
+        let handle = WorkspaceHandle::new(
+            issue.issue_id.clone(),
+            issue.identifier.clone(),
+            workspace_key,
+            canonical_workspace,
+        );
+        self.bootstrap_workspace_layout(&handle).await?;
+        let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
+        let after_create = if created {
+            match self.execute_hook(HookKind::AfterCreate, &handle).await {
+                Ok(record) => record,
+                Err(failure) => return Err(failure.error),
+            }
+        } else {
+            None
+        };
+
+        Ok(EnsureWorkspaceResult {
+            handle,
+            issue_manifest,
+            created,
+            after_create,
+        })
+    }
+
+    pub async fn start_run(
+        &self,
+        workspace: &WorkspaceHandle,
+        run: &RunDescriptor,
+    ) -> Result<RunManifest, WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+
+        let mut manifest = RunManifest::new(workspace, run);
+        self.write_run_manifest(workspace, &manifest).await?;
+
+        match self.execute_hook(HookKind::BeforeRun, workspace).await {
+            Ok(Some(record)) => manifest.hooks.push(record),
+            Ok(None) => {}
+            Err(failure) => {
+                manifest.status = RunStatus::PreparationFailed;
+                manifest.status_detail = Some(failure.error.to_string());
+                manifest.updated_at = Utc::now();
+                manifest.hooks.push(failure.record);
+                self.write_run_manifest(workspace, &manifest).await?;
+                return Err(failure.error);
+            }
+        }
+
+        manifest.status = RunStatus::Prepared;
+        manifest.updated_at = Utc::now();
+        self.write_run_manifest(workspace, &manifest).await?;
+        Ok(manifest)
+    }
+
+    pub async fn finish_run(
+        &self,
+        workspace: &WorkspaceHandle,
+        run_manifest: &mut RunManifest,
+        status: RunStatus,
+    ) -> Result<(), WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+
+        run_manifest.status = status;
+        run_manifest.updated_at = Utc::now();
+        self.write_run_manifest(workspace, run_manifest).await?;
+
+        match self.execute_hook(HookKind::AfterRun, workspace).await {
+            Ok(Some(record)) => run_manifest.hooks.push(record),
+            Ok(None) => {}
+            Err(failure) => run_manifest.hooks.push(failure.record),
+        }
+
+        run_manifest.updated_at = Utc::now();
+        self.write_run_manifest(workspace, run_manifest).await
+    }
+
+    pub fn cleanup_decision(&self, state: IssueLifecycleState) -> CleanupDecision {
+        match (state, self.config.cleanup.remove_terminal_workspaces) {
+            (IssueLifecycleState::Terminal, true) => CleanupDecision::Remove,
+            _ => CleanupDecision::Retain,
+        }
+    }
+
+    pub async fn cleanup(
+        &self,
+        workspace: &WorkspaceHandle,
+        state: IssueLifecycleState,
+    ) -> Result<CleanupOutcome, WorkspaceError> {
+        if !path_exists(workspace.workspace_path()).await? {
+            return Ok(CleanupOutcome {
+                decision: self.cleanup_decision(state),
+                before_remove: None,
+            });
+        }
+
+        self.validate_workspace_handle(workspace).await?;
+        if state != IssueLifecycleState::Terminal {
+            return Ok(CleanupOutcome {
+                decision: CleanupDecision::Retain,
+                before_remove: None,
+            });
+        }
+
+        let before_remove = match self.execute_hook(HookKind::BeforeRemove, workspace).await {
+            Ok(record) => record,
+            Err(failure) => Some(failure.record),
+        };
+        let decision = self.cleanup_decision(state);
+
+        if decision == CleanupDecision::Remove {
+            match fs::remove_dir_all(workspace.workspace_path()).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(WorkspaceError::RemoveWorkspace {
+                        path: workspace.workspace_path().to_path_buf(),
+                        source: error,
+                    });
+                }
+            }
+        }
+
+        Ok(CleanupOutcome {
+            decision,
+            before_remove,
+        })
+    }
+
+    pub async fn load_issue_manifest(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<Option<IssueManifest>, WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.load_manifest(&workspace.issue_manifest_path()).await
+    }
+
+    pub async fn write_issue_manifest(
+        &self,
+        workspace: &WorkspaceHandle,
+        manifest: &IssueManifest,
+    ) -> Result<(), WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.write_manifest(&workspace.issue_manifest_path(), manifest)
+            .await
+    }
+
+    pub async fn load_run_manifest(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<Option<RunManifest>, WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.load_manifest(&workspace.run_manifest_path()).await
+    }
+
+    pub async fn write_run_manifest(
+        &self,
+        workspace: &WorkspaceHandle,
+        manifest: &RunManifest,
+    ) -> Result<(), WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.write_manifest(&workspace.run_manifest_path(), manifest)
+            .await
+    }
+
+    async fn upsert_issue_manifest(
+        &self,
+        issue: &IssueDescriptor,
+        workspace: &WorkspaceHandle,
+    ) -> Result<IssueManifest, WorkspaceError> {
+        let existing = self
+            .load_manifest::<IssueManifest>(&workspace.issue_manifest_path())
+            .await?;
+        let now = Utc::now();
+        let manifest = IssueManifest {
+            issue_id: issue.issue_id.clone(),
+            identifier: issue.identifier.clone(),
+            title: issue.title.clone(),
+            current_state: issue.current_state.clone(),
+            sanitized_workspace_key: workspace.workspace_key().to_string(),
+            workspace_path: workspace.workspace_path().to_path_buf(),
+            created_at: existing
+                .as_ref()
+                .map(|manifest| manifest.created_at)
+                .unwrap_or(now),
+            updated_at: now,
+            last_seen_tracker_refresh_at: issue.last_seen_tracker_refresh_at,
+        };
+
+        self.write_manifest(&workspace.issue_manifest_path(), &manifest)
+            .await?;
+        Ok(manifest)
+    }
+
+    async fn bootstrap_workspace_layout(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<(), WorkspaceError> {
+        for directory in [
+            workspace.metadata_dir(),
+            workspace.logs_dir(),
+            workspace.generated_dir(),
+            workspace.openhands_dir(),
+            workspace.prompts_dir(),
+            workspace.runs_dir(),
+        ] {
+            self.create_directory(&directory).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn execute_hook(
+        &self,
+        kind: HookKind,
+        workspace: &WorkspaceHandle,
+    ) -> Result<Option<HookExecutionRecord>, Box<HookFailure>> {
+        let Some(hook) = self.hook_definition(kind) else {
+            return Ok(None);
+        };
+        let cwd = self.resolve_hook_cwd(workspace, kind, hook)?;
+        let mut command = build_shell_command(&hook.command);
+        command
+            .current_dir(&cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let started_at = Utc::now();
+        let started = Instant::now();
+        let output = timeout(self.config.hooks.timeout, command.output()).await;
+        let finished_at = Utc::now();
+        let duration_ms = started.elapsed().as_millis() as u64;
+
+        match output {
+            Ok(Ok(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                let exit_code = output.status.code();
+
+                if output.status.success() {
+                    Ok(Some(HookExecutionRecord {
+                        kind,
+                        command: hook.command.clone(),
+                        cwd,
+                        best_effort: !kind.is_required(),
+                        status: HookExecutionStatus::Succeeded,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        exit_code,
+                        stdout,
+                        stderr,
+                    }))
+                } else {
+                    let record = HookExecutionRecord {
+                        kind,
+                        command: hook.command.clone(),
+                        cwd,
+                        best_effort: !kind.is_required(),
+                        status: HookExecutionStatus::Failed,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        exit_code,
+                        stdout: stdout.clone(),
+                        stderr: stderr.clone(),
+                    };
+                    Err(Box::new(HookFailure {
+                        error: WorkspaceError::HookFailed {
+                            hook: kind,
+                            command: hook.command.clone(),
+                            exit_code,
+                            stdout,
+                            stderr,
+                        },
+                        record,
+                    }))
+                }
+            }
+            Ok(Err(error)) => Err(Box::new(HookFailure {
+                error: WorkspaceError::LaunchHook {
+                    hook: kind,
+                    cwd: cwd.clone(),
+                    source: error,
+                },
+                record: HookExecutionRecord {
+                    kind,
+                    command: hook.command.clone(),
+                    cwd,
+                    best_effort: !kind.is_required(),
+                    status: HookExecutionStatus::Failed,
+                    started_at,
+                    finished_at,
+                    duration_ms,
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                },
+            })),
+            Err(_) => Err(Box::new(HookFailure {
+                error: WorkspaceError::HookTimedOut {
+                    hook: kind,
+                    command: hook.command.clone(),
+                    timeout: self.config.hooks.timeout,
+                },
+                record: HookExecutionRecord {
+                    kind,
+                    command: hook.command.clone(),
+                    cwd,
+                    best_effort: !kind.is_required(),
+                    status: HookExecutionStatus::TimedOut,
+                    started_at,
+                    finished_at,
+                    duration_ms,
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                },
+            })),
+        }
+    }
+
+    fn hook_definition(&self, kind: HookKind) -> Option<&HookDefinition> {
+        match kind {
+            HookKind::AfterCreate => self.config.hooks.after_create.as_ref(),
+            HookKind::BeforeRun => self.config.hooks.before_run.as_ref(),
+            HookKind::AfterRun => self.config.hooks.after_run.as_ref(),
+            HookKind::BeforeRemove => self.config.hooks.before_remove.as_ref(),
+        }
+    }
+
+    fn resolve_hook_cwd(
+        &self,
+        workspace: &WorkspaceHandle,
+        kind: HookKind,
+        hook: &HookDefinition,
+    ) -> Result<std::path::PathBuf, Box<HookFailure>> {
+        let workspace_path = workspace.workspace_path().to_path_buf();
+        let cwd = match hook.cwd.as_ref() {
+            Some(cwd) => resolve_path_within_root(&workspace_path, cwd).map_err(|error| {
+                let escaped = match &error {
+                    WorkspaceError::PathEscape { path, .. } => path.clone(),
+                    _ => cwd.clone(),
+                };
+
+                Box::new(HookFailure {
+                    error: WorkspaceError::HookPathEscape {
+                        hook: kind,
+                        workspace: workspace_path.clone(),
+                        cwd: escaped.clone(),
+                    },
+                    record: HookExecutionRecord {
+                        kind,
+                        command: hook.command.clone(),
+                        cwd: escaped,
+                        best_effort: !kind.is_required(),
+                        status: HookExecutionStatus::Failed,
+                        started_at: Utc::now(),
+                        finished_at: Utc::now(),
+                        duration_ms: 0,
+                        exit_code: None,
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    },
+                })
+            })?,
+            None => workspace_path,
+        };
+
+        Ok(cwd)
+    }
+
+    async fn validate_workspace_handle(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<(), WorkspaceError> {
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let canonical_workspace = self.canonicalize_path(workspace.workspace_path()).await?;
+        ensure_descendant(&canonical_root, &canonical_workspace)
+    }
+
+    async fn create_directory(&self, path: &Path) -> Result<(), WorkspaceError> {
+        fs::create_dir_all(path)
+            .await
+            .map_err(|error| WorkspaceError::CreateDirectory {
+                path: path.to_path_buf(),
+                source: error,
+            })
+    }
+
+    async fn canonicalize_path(&self, path: &Path) -> Result<std::path::PathBuf, WorkspaceError> {
+        fs::canonicalize(path)
+            .await
+            .map_err(|error| WorkspaceError::Canonicalize {
+                path: path.to_path_buf(),
+                source: error,
+            })
+    }
+
+    async fn load_manifest<T>(&self, path: &Path) -> Result<Option<T>, WorkspaceError>
+    where
+        T: DeserializeOwned,
+    {
+        let raw = match fs::read_to_string(path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(WorkspaceError::ReadManifest {
+                    path: path.to_path_buf(),
+                    source: error,
+                });
+            }
+        };
+
+        serde_json::from_str(&raw)
+            .map(Some)
+            .map_err(|error| WorkspaceError::DecodeManifest {
+                path: path.to_path_buf(),
+                source: error,
+            })
+    }
+
+    async fn write_manifest<T>(&self, path: &Path, manifest: &T) -> Result<(), WorkspaceError>
+    where
+        T: Serialize,
+    {
+        if let Some(parent) = path.parent() {
+            self.create_directory(parent).await?;
+        }
+
+        let payload = serde_json::to_vec_pretty(manifest).map_err(|error| {
+            WorkspaceError::EncodeManifest {
+                path: path.to_path_buf(),
+                source: error,
+            }
+        })?;
+
+        fs::write(path, payload)
+            .await
+            .map_err(|error| WorkspaceError::WriteManifest {
+                path: path.to_path_buf(),
+                source: error,
+            })
+    }
+}
+
+fn ensure_descendant(root: &Path, candidate: &Path) -> Result<(), WorkspaceError> {
+    if candidate.starts_with(root) {
+        Ok(())
+    } else {
+        Err(WorkspaceError::PathEscape {
+            root: root.to_path_buf(),
+            path: candidate.to_path_buf(),
+        })
+    }
+}
+
+async fn path_exists(path: &Path) -> Result<bool, WorkspaceError> {
+    match fs::metadata(path).await {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(WorkspaceError::Canonicalize {
+            path: path.to_path_buf(),
+            source: error,
+        }),
+    }
+}
+
+#[cfg(unix)]
+fn build_shell_command(command: &str) -> Command {
+    let mut process = Command::new("sh");
+    process.arg("-lc").arg(command);
+    process
+}
+
+#[cfg(windows)]
+fn build_shell_command(command: &str) -> Command {
+    let mut process = Command::new("cmd");
+    process.arg("/C").arg(command);
+    process
+}

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -49,7 +49,6 @@ impl WorkspaceManager {
         let canonical_root = self.canonicalize_path(&self.config.root).await?;
         let workspace_key = sanitize_workspace_key(&issue.identifier)?;
         let workspace_path = crate::workspace_path_for_root(&canonical_root, &issue.identifier)?;
-        let created = !path_exists(&workspace_path).await?;
 
         self.create_directory(&workspace_path).await?;
         let canonical_workspace = self.canonicalize_path(&workspace_path).await?;
@@ -61,8 +60,7 @@ impl WorkspaceManager {
             workspace_key,
             canonical_workspace,
         );
-        self.bootstrap_workspace_layout(&handle).await?;
-        let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
+        let created = !path_exists(&handle.issue_manifest_path()).await?;
         let after_create = if created {
             match self.execute_hook(HookKind::AfterCreate, &handle).await {
                 Ok(record) => record,
@@ -71,6 +69,8 @@ impl WorkspaceManager {
         } else {
             None
         };
+        self.bootstrap_workspace_layout(&handle).await?;
+        let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
 
         Ok(EnsureWorkspaceResult {
             handle,
@@ -274,7 +274,7 @@ impl WorkspaceManager {
         let Some(hook) = self.hook_definition(kind) else {
             return Ok(None);
         };
-        let cwd = self.resolve_hook_cwd(workspace, kind, hook)?;
+        let cwd = self.resolve_hook_cwd(workspace, kind, hook).await?;
         let mut command = build_shell_command(&hook.command);
         command
             .current_dir(&cwd)
@@ -386,7 +386,7 @@ impl WorkspaceManager {
         }
     }
 
-    fn resolve_hook_cwd(
+    async fn resolve_hook_cwd(
         &self,
         workspace: &WorkspaceHandle,
         kind: HookKind,
@@ -394,33 +394,84 @@ impl WorkspaceManager {
     ) -> Result<std::path::PathBuf, Box<HookFailure>> {
         let workspace_path = workspace.workspace_path().to_path_buf();
         let cwd = match hook.cwd.as_ref() {
-            Some(cwd) => resolve_path_within_root(&workspace_path, cwd).map_err(|error| {
-                let escaped = match &error {
-                    WorkspaceError::PathEscape { path, .. } => path.clone(),
-                    _ => cwd.clone(),
-                };
+            Some(cwd) => {
+                let lexical_cwd =
+                    resolve_path_within_root(&workspace_path, cwd).map_err(|error| {
+                        let escaped = match &error {
+                            WorkspaceError::PathEscape { path, .. } => path.clone(),
+                            _ => cwd.clone(),
+                        };
 
-                Box::new(HookFailure {
-                    error: WorkspaceError::HookPathEscape {
-                        hook: kind,
-                        workspace: workspace_path.clone(),
-                        cwd: escaped.clone(),
-                    },
-                    record: HookExecutionRecord {
-                        kind,
-                        command: hook.command.clone(),
-                        cwd: escaped,
-                        best_effort: !kind.is_required(),
-                        status: HookExecutionStatus::Failed,
-                        started_at: Utc::now(),
-                        finished_at: Utc::now(),
-                        duration_ms: 0,
-                        exit_code: None,
-                        stdout: String::new(),
-                        stderr: String::new(),
-                    },
-                })
-            })?,
+                        Box::new(HookFailure {
+                            error: WorkspaceError::HookPathEscape {
+                                hook: kind,
+                                workspace: workspace_path.clone(),
+                                cwd: escaped.clone(),
+                            },
+                            record: HookExecutionRecord {
+                                kind,
+                                command: hook.command.clone(),
+                                cwd: escaped,
+                                best_effort: !kind.is_required(),
+                                status: HookExecutionStatus::Failed,
+                                started_at: Utc::now(),
+                                finished_at: Utc::now(),
+                                duration_ms: 0,
+                                exit_code: None,
+                                stdout: String::new(),
+                                stderr: String::new(),
+                            },
+                        })
+                    })?;
+
+                let canonical_cwd = fs::canonicalize(&lexical_cwd).await.map_err(|error| {
+                    Box::new(HookFailure {
+                        error: WorkspaceError::LaunchHook {
+                            hook: kind,
+                            cwd: lexical_cwd.clone(),
+                            source: error,
+                        },
+                        record: HookExecutionRecord {
+                            kind,
+                            command: hook.command.clone(),
+                            cwd: lexical_cwd.clone(),
+                            best_effort: !kind.is_required(),
+                            status: HookExecutionStatus::Failed,
+                            started_at: Utc::now(),
+                            finished_at: Utc::now(),
+                            duration_ms: 0,
+                            exit_code: None,
+                            stdout: String::new(),
+                            stderr: String::new(),
+                        },
+                    })
+                })?;
+
+                ensure_descendant(&workspace_path, &canonical_cwd).map_err(|_| {
+                    Box::new(HookFailure {
+                        error: WorkspaceError::HookPathEscape {
+                            hook: kind,
+                            workspace: workspace_path.clone(),
+                            cwd: canonical_cwd.clone(),
+                        },
+                        record: HookExecutionRecord {
+                            kind,
+                            command: hook.command.clone(),
+                            cwd: canonical_cwd.clone(),
+                            best_effort: !kind.is_required(),
+                            status: HookExecutionStatus::Failed,
+                            started_at: Utc::now(),
+                            finished_at: Utc::now(),
+                            duration_ms: 0,
+                            exit_code: None,
+                            stdout: String::new(),
+                            stderr: String::new(),
+                        },
+                    })
+                })?;
+
+                canonical_cwd
+            }
             None => workspace_path,
         };
 

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -13,6 +13,7 @@ use crate::{
     CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookDefinition, HookExecutionRecord,
     HookExecutionStatus, HookKind, IssueDescriptor, IssueLifecycleState, IssueManifest,
     RunDescriptor, RunManifest, RunStatus, WorkspaceError, WorkspaceHandle, WorkspaceManagerConfig,
+    WorkspaceOwnershipConflictDetails,
 };
 
 pub struct WorkspaceManager {
@@ -22,6 +23,13 @@ pub struct WorkspaceManager {
 struct HookFailure {
     error: WorkspaceError,
     record: HookExecutionRecord,
+}
+
+enum ExistingIssueManifestState {
+    Missing,
+    Owned(IssueManifest),
+    ForeignArtifact,
+    Conflict(IssueManifest),
 }
 
 impl WorkspaceManager {
@@ -60,7 +68,21 @@ impl WorkspaceManager {
             workspace_key,
             canonical_workspace,
         );
-        let created = !path_exists(&handle.issue_manifest_path()).await?;
+        let existing_manifest = self.inspect_issue_manifest_state(issue, &handle).await?;
+        if let ExistingIssueManifestState::Conflict(manifest) = &existing_manifest {
+            return Err(WorkspaceError::WorkspaceOwnershipConflict {
+                details: Box::new(WorkspaceOwnershipConflictDetails {
+                    workspace: handle.workspace_path().to_path_buf(),
+                    workspace_key: handle.workspace_key().to_string(),
+                    existing_issue_id: manifest.issue_id.clone(),
+                    existing_identifier: manifest.identifier.clone(),
+                    requested_issue_id: issue.issue_id.clone(),
+                    requested_identifier: issue.identifier.clone(),
+                }),
+            });
+        }
+
+        let created = !matches!(existing_manifest, ExistingIssueManifestState::Owned(_));
         let after_create = if created {
             match self.execute_hook(HookKind::AfterCreate, &handle).await {
                 Ok(record) => record,
@@ -188,7 +210,8 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
     ) -> Result<Option<IssueManifest>, WorkspaceError> {
         self.validate_workspace_handle(workspace).await?;
-        self.load_manifest(&workspace.issue_manifest_path()).await
+        self.load_manifest(workspace, &workspace.issue_manifest_path())
+            .await
     }
 
     pub async fn write_issue_manifest(
@@ -197,7 +220,7 @@ impl WorkspaceManager {
         manifest: &IssueManifest,
     ) -> Result<(), WorkspaceError> {
         self.validate_workspace_handle(workspace).await?;
-        self.write_manifest(&workspace.issue_manifest_path(), manifest)
+        self.write_manifest(workspace, &workspace.issue_manifest_path(), manifest)
             .await
     }
 
@@ -206,7 +229,8 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
     ) -> Result<Option<RunManifest>, WorkspaceError> {
         self.validate_workspace_handle(workspace).await?;
-        self.load_manifest(&workspace.run_manifest_path()).await
+        self.load_manifest(workspace, &workspace.run_manifest_path())
+            .await
     }
 
     pub async fn write_run_manifest(
@@ -215,7 +239,7 @@ impl WorkspaceManager {
         manifest: &RunManifest,
     ) -> Result<(), WorkspaceError> {
         self.validate_workspace_handle(workspace).await?;
-        self.write_manifest(&workspace.run_manifest_path(), manifest)
+        self.write_manifest(workspace, &workspace.run_manifest_path(), manifest)
             .await
     }
 
@@ -224,9 +248,24 @@ impl WorkspaceManager {
         issue: &IssueDescriptor,
         workspace: &WorkspaceHandle,
     ) -> Result<IssueManifest, WorkspaceError> {
-        let existing = self
-            .load_manifest::<IssueManifest>(&workspace.issue_manifest_path())
-            .await?;
+        let existing = match self.inspect_issue_manifest_state(issue, workspace).await? {
+            ExistingIssueManifestState::Owned(manifest) => Some(manifest),
+            ExistingIssueManifestState::Conflict(manifest) => {
+                return Err(WorkspaceError::WorkspaceOwnershipConflict {
+                    details: Box::new(WorkspaceOwnershipConflictDetails {
+                        workspace: workspace.workspace_path().to_path_buf(),
+                        workspace_key: workspace.workspace_key().to_string(),
+                        existing_issue_id: manifest.issue_id,
+                        existing_identifier: manifest.identifier,
+                        requested_issue_id: issue.issue_id.clone(),
+                        requested_identifier: issue.identifier.clone(),
+                    }),
+                });
+            }
+            ExistingIssueManifestState::Missing | ExistingIssueManifestState::ForeignArtifact => {
+                None
+            }
+        };
         let now = Utc::now();
         let manifest = IssueManifest {
             issue_id: issue.issue_id.clone(),
@@ -243,7 +282,7 @@ impl WorkspaceManager {
             last_seen_tracker_refresh_at: issue.last_seen_tracker_refresh_at,
         };
 
-        self.write_manifest(&workspace.issue_manifest_path(), &manifest)
+        self.write_manifest(workspace, &workspace.issue_manifest_path(), &manifest)
             .await?;
         Ok(manifest)
     }
@@ -260,10 +299,46 @@ impl WorkspaceManager {
             workspace.prompts_dir(),
             workspace.runs_dir(),
         ] {
-            self.create_directory(&directory).await?;
+            self.create_managed_directory(workspace, &directory).await?;
         }
 
         Ok(())
+    }
+
+    async fn inspect_issue_manifest_state(
+        &self,
+        issue: &IssueDescriptor,
+        workspace: &WorkspaceHandle,
+    ) -> Result<ExistingIssueManifestState, WorkspaceError> {
+        let path = workspace.issue_manifest_path();
+        let path = self
+            .validate_managed_metadata_path(workspace, &path)
+            .await?;
+        let raw = match fs::read_to_string(&path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ExistingIssueManifestState::Missing);
+            }
+            Err(error) => {
+                return Err(WorkspaceError::ReadManifest {
+                    path,
+                    source: error,
+                });
+            }
+        };
+
+        match serde_json::from_str::<IssueManifest>(&raw) {
+            Ok(manifest) => Ok(classify_issue_manifest_ownership(
+                issue, workspace, manifest,
+            )),
+            Err(error) if !self.bootstrap_layout_exists(workspace).await? => {
+                Ok(ExistingIssueManifestState::ForeignArtifact)
+            }
+            Err(error) => Err(WorkspaceError::DecodeManifest {
+                path,
+                source: error,
+            }),
+        }
     }
 
     async fn execute_hook(
@@ -487,6 +562,37 @@ impl WorkspaceManager {
         ensure_descendant(&canonical_root, &canonical_workspace)
     }
 
+    async fn bootstrap_layout_exists(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<bool, WorkspaceError> {
+        for directory in [
+            workspace.metadata_dir(),
+            workspace.logs_dir(),
+            workspace.generated_dir(),
+            workspace.openhands_dir(),
+            workspace.prompts_dir(),
+            workspace.runs_dir(),
+        ] {
+            let path = self
+                .validate_managed_metadata_path(workspace, &directory)
+                .await?;
+            match fs::metadata(&path).await {
+                Ok(metadata) if metadata.is_dir() => {}
+                Ok(_) => return Ok(false),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                Err(error) => {
+                    return Err(WorkspaceError::Canonicalize {
+                        path,
+                        source: error,
+                    });
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
     async fn create_directory(&self, path: &Path) -> Result<(), WorkspaceError> {
         fs::create_dir_all(path)
             .await
@@ -494,6 +600,18 @@ impl WorkspaceManager {
                 path: path.to_path_buf(),
                 source: error,
             })
+    }
+
+    async fn create_managed_directory(
+        &self,
+        workspace: &WorkspaceHandle,
+        path: &Path,
+    ) -> Result<(), WorkspaceError> {
+        let path = self.validate_managed_metadata_path(workspace, path).await?;
+        self.create_directory(&path).await?;
+        self.validate_managed_metadata_path(workspace, &path)
+            .await?;
+        Ok(())
     }
 
     async fn canonicalize_path(&self, path: &Path) -> Result<std::path::PathBuf, WorkspaceError> {
@@ -505,11 +623,16 @@ impl WorkspaceManager {
             })
     }
 
-    async fn load_manifest<T>(&self, path: &Path) -> Result<Option<T>, WorkspaceError>
+    async fn load_manifest<T>(
+        &self,
+        workspace: &WorkspaceHandle,
+        path: &Path,
+    ) -> Result<Option<T>, WorkspaceError>
     where
         T: DeserializeOwned,
     {
-        let raw = match fs::read_to_string(path).await {
+        let path = self.validate_managed_metadata_path(workspace, path).await?;
+        let raw = match fs::read_to_string(&path).await {
             Ok(raw) => raw,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => {
@@ -528,27 +651,96 @@ impl WorkspaceManager {
             })
     }
 
-    async fn write_manifest<T>(&self, path: &Path, manifest: &T) -> Result<(), WorkspaceError>
+    async fn write_manifest<T>(
+        &self,
+        workspace: &WorkspaceHandle,
+        path: &Path,
+        manifest: &T,
+    ) -> Result<(), WorkspaceError>
     where
         T: Serialize,
     {
         if let Some(parent) = path.parent() {
-            self.create_directory(parent).await?;
+            self.create_managed_directory(workspace, parent).await?;
         }
+        let path = self.validate_managed_metadata_path(workspace, path).await?;
 
         let payload = serde_json::to_vec_pretty(manifest).map_err(|error| {
             WorkspaceError::EncodeManifest {
-                path: path.to_path_buf(),
+                path: path.clone(),
                 source: error,
             }
         })?;
 
-        fs::write(path, payload)
+        fs::write(&path, payload)
             .await
             .map_err(|error| WorkspaceError::WriteManifest {
-                path: path.to_path_buf(),
+                path,
                 source: error,
             })
+    }
+
+    async fn validate_managed_metadata_path(
+        &self,
+        workspace: &WorkspaceHandle,
+        path: &Path,
+    ) -> Result<std::path::PathBuf, WorkspaceError> {
+        let normalized = normalize_absolute_path(path)?;
+        ensure_descendant(workspace.workspace_path(), &normalized)?;
+
+        let relative = normalized
+            .strip_prefix(workspace.workspace_path())
+            .expect("managed metadata paths should remain within the workspace");
+        let mut current = workspace.workspace_path().to_path_buf();
+
+        for component in relative.components() {
+            current.push(component.as_os_str());
+
+            match fs::symlink_metadata(&current).await {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(WorkspaceError::ManagedPathSymlink {
+                        path: current.clone(),
+                    });
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+                Err(error) => {
+                    return Err(WorkspaceError::Canonicalize {
+                        path: current.clone(),
+                        source: error,
+                    });
+                }
+            }
+        }
+
+        Ok(normalized)
+    }
+}
+
+fn classify_issue_manifest_ownership(
+    issue: &IssueDescriptor,
+    workspace: &WorkspaceHandle,
+    manifest: IssueManifest,
+) -> ExistingIssueManifestState {
+    if !issue_manifest_claims_workspace(workspace, &manifest) {
+        return ExistingIssueManifestState::ForeignArtifact;
+    }
+
+    if manifest.issue_id == issue.issue_id && manifest.identifier == issue.identifier {
+        ExistingIssueManifestState::Owned(manifest)
+    } else {
+        ExistingIssueManifestState::Conflict(manifest)
+    }
+}
+
+fn issue_manifest_claims_workspace(workspace: &WorkspaceHandle, manifest: &IssueManifest) -> bool {
+    if manifest.sanitized_workspace_key != workspace.workspace_key() {
+        return false;
+    }
+
+    match normalize_absolute_path(&manifest.workspace_path) {
+        Ok(path) => path == workspace.workspace_path(),
+        Err(_) => false,
     }
 }
 

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -577,7 +577,7 @@ async fn path_exists(path: &Path) -> Result<bool, WorkspaceError> {
 #[cfg(unix)]
 fn build_shell_command(command: &str) -> Command {
     let mut process = Command::new("sh");
-    process.arg("-lc").arg(command);
+    process.arg("-c").arg(command);
     process
 }
 
@@ -586,4 +586,26 @@ fn build_shell_command(command: &str) -> Command {
     let mut process = Command::new("cmd");
     process.arg("/C").arg(command);
     process
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::ffi::OsString;
+
+    use super::build_shell_command;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_hook_commands_use_non_login_shell() {
+        let command = build_shell_command("echo hook");
+        let std_command = command.as_std();
+        let args: Vec<OsString> = std_command.get_args().map(|arg| arg.to_owned()).collect();
+
+        assert_eq!(std_command.get_program(), "sh");
+        assert_eq!(
+            args,
+            vec![OsString::from("-c"), OsString::from("echo hook")]
+        );
+    }
 }

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -1,14 +1,16 @@
-use std::{path::Path, process::Stdio};
+use std::{io, path::Path, process::Stdio};
 
 use chrono::Utc;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{
     fs,
+    io::{AsyncRead, AsyncReadExt},
     process::Command,
     time::{timeout, Instant},
 };
 
 use crate::{
+    models::AfterCreateBootstrapReceipt,
     paths::{normalize_absolute_path, resolve_path_within_root, sanitize_workspace_key},
     CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookDefinition, HookExecutionRecord,
     HookExecutionStatus, HookKind, IssueDescriptor, IssueLifecycleState, IssueManifest,
@@ -30,6 +32,31 @@ enum ExistingIssueManifestState {
     Owned(IssueManifest),
     ForeignArtifact,
     Conflict(IssueManifest),
+}
+
+enum ExistingReceiptState {
+    Missing,
+    Owned,
+    ForeignArtifact,
+    Conflict(AfterCreateBootstrapReceipt),
+}
+
+enum ExistingWorkspaceState {
+    Missing,
+    Owned,
+    AfterCreateCompleted,
+    ForeignArtifact,
+    Conflict(WorkspaceOwnershipClaim),
+}
+
+struct WorkspaceOwnershipClaim {
+    issue_id: String,
+    identifier: String,
+}
+
+enum HookCommandOutput {
+    Completed(std::process::Output),
+    TimedOut { stdout: String, stderr: String },
 }
 
 impl WorkspaceManager {
@@ -72,24 +99,32 @@ impl WorkspaceManager {
             workspace_key,
             canonical_workspace,
         );
-        let existing_manifest = self.inspect_issue_manifest_state(issue, &handle).await?;
-        if let ExistingIssueManifestState::Conflict(manifest) = &existing_manifest {
+        let existing_state = self.inspect_workspace_state(issue, &handle).await?;
+        if let ExistingWorkspaceState::Conflict(claim) = &existing_state {
             return Err(WorkspaceError::WorkspaceOwnershipConflict {
                 details: Box::new(WorkspaceOwnershipConflictDetails {
                     workspace: handle.workspace_path().to_path_buf(),
                     workspace_key: handle.workspace_key().to_string(),
-                    existing_issue_id: manifest.issue_id.clone(),
-                    existing_identifier: manifest.identifier.clone(),
+                    existing_issue_id: claim.issue_id.clone(),
+                    existing_identifier: claim.identifier.clone(),
                     requested_issue_id: issue.issue_id.clone(),
                     requested_identifier: issue.identifier.clone(),
                 }),
             });
         }
 
-        let created = !matches!(existing_manifest, ExistingIssueManifestState::Owned(_));
+        let created = matches!(
+            existing_state,
+            ExistingWorkspaceState::Missing | ExistingWorkspaceState::ForeignArtifact
+        );
         let after_create = if created {
             match self.execute_hook(HookKind::AfterCreate, &handle).await {
-                Ok(record) => record,
+                Ok(record) => {
+                    if record.is_some() {
+                        self.write_after_create_receipt(issue, &handle).await?;
+                    }
+                    record
+                }
                 Err(failure) => return Err(failure.error),
             }
         } else {
@@ -291,6 +326,16 @@ impl WorkspaceManager {
         Ok(manifest)
     }
 
+    async fn write_after_create_receipt(
+        &self,
+        issue: &IssueDescriptor,
+        workspace: &WorkspaceHandle,
+    ) -> Result<(), WorkspaceError> {
+        let receipt = AfterCreateBootstrapReceipt::new(workspace, issue);
+        self.write_manifest(workspace, &workspace.after_create_receipt_path(), &receipt)
+            .await
+    }
+
     async fn bootstrap_workspace_layout(
         &self,
         workspace: &WorkspaceHandle,
@@ -315,9 +360,7 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
     ) -> Result<ExistingIssueManifestState, WorkspaceError> {
         let path = workspace.issue_manifest_path();
-        let path = self
-            .validate_managed_metadata_path(workspace, &path)
-            .await?;
+        let path = self.validate_workspace_owned_path(workspace, &path).await?;
         let raw = match fs::read_to_string(&path).await {
             Ok(raw) => raw,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -339,6 +382,73 @@ impl WorkspaceManager {
         }
     }
 
+    async fn inspect_after_create_receipt_state(
+        &self,
+        issue: &IssueDescriptor,
+        workspace: &WorkspaceHandle,
+    ) -> Result<ExistingReceiptState, WorkspaceError> {
+        let path = workspace.after_create_receipt_path();
+        let path = self.validate_workspace_owned_path(workspace, &path).await?;
+        let raw = match fs::read_to_string(&path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ExistingReceiptState::Missing);
+            }
+            Err(error) => {
+                return Err(WorkspaceError::ReadManifest {
+                    path,
+                    source: error,
+                });
+            }
+        };
+
+        match serde_json::from_str::<AfterCreateBootstrapReceipt>(&raw) {
+            Ok(receipt) => Ok(classify_after_create_receipt_ownership(
+                issue, workspace, receipt,
+            )),
+            Err(_) => Ok(ExistingReceiptState::ForeignArtifact),
+        }
+    }
+
+    async fn inspect_workspace_state(
+        &self,
+        issue: &IssueDescriptor,
+        workspace: &WorkspaceHandle,
+    ) -> Result<ExistingWorkspaceState, WorkspaceError> {
+        let issue_manifest_state = self.inspect_issue_manifest_state(issue, workspace).await?;
+        let issue_manifest_is_foreign = matches!(
+            issue_manifest_state,
+            ExistingIssueManifestState::ForeignArtifact
+        );
+        match issue_manifest_state {
+            ExistingIssueManifestState::Owned(_) => return Ok(ExistingWorkspaceState::Owned),
+            ExistingIssueManifestState::Conflict(manifest) => {
+                return Ok(ExistingWorkspaceState::Conflict(
+                    ownership_claim_from_issue_manifest(manifest),
+                ));
+            }
+            ExistingIssueManifestState::Missing | ExistingIssueManifestState::ForeignArtifact => {}
+        }
+
+        let receipt_state = self
+            .inspect_after_create_receipt_state(issue, workspace)
+            .await?;
+        match receipt_state {
+            ExistingReceiptState::Owned => Ok(ExistingWorkspaceState::AfterCreateCompleted),
+            ExistingReceiptState::Conflict(receipt) => Ok(ExistingWorkspaceState::Conflict(
+                ownership_claim_from_after_create_receipt(receipt),
+            )),
+            ExistingReceiptState::ForeignArtifact => Ok(ExistingWorkspaceState::ForeignArtifact),
+            ExistingReceiptState::Missing => {
+                if issue_manifest_is_foreign {
+                    Ok(ExistingWorkspaceState::ForeignArtifact)
+                } else {
+                    Ok(ExistingWorkspaceState::Missing)
+                }
+            }
+        }
+    }
+
     async fn execute_hook(
         &self,
         kind: HookKind,
@@ -349,6 +459,7 @@ impl WorkspaceManager {
         };
         let cwd = self.resolve_hook_cwd(workspace, kind, hook).await?;
         let mut command = build_shell_command(&hook.command);
+        configure_hook_command(&mut command);
         command
             .current_dir(&cwd)
             .stdout(Stdio::piped())
@@ -357,12 +468,35 @@ impl WorkspaceManager {
 
         let started_at = Utc::now();
         let started = Instant::now();
-        let output = timeout(self.config.hooks.timeout, command.output()).await;
+        let output = run_hook_command(command, self.config.hooks.timeout)
+            .await
+            .map_err(|error| {
+                Box::new(HookFailure {
+                    error: WorkspaceError::LaunchHook {
+                        hook: kind,
+                        cwd: cwd.clone(),
+                        source: error,
+                    },
+                    record: HookExecutionRecord {
+                        kind,
+                        command: hook.command.clone(),
+                        cwd: cwd.clone(),
+                        best_effort: !kind.is_required(),
+                        status: HookExecutionStatus::Failed,
+                        started_at,
+                        finished_at: Utc::now(),
+                        duration_ms: started.elapsed().as_millis() as u64,
+                        exit_code: None,
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    },
+                })
+            })?;
         let finished_at = Utc::now();
         let duration_ms = started.elapsed().as_millis() as u64;
 
         match output {
-            Ok(Ok(output)) => {
+            HookCommandOutput::Completed(output) => {
                 let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
                 let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
                 let exit_code = output.status.code();
@@ -407,27 +541,7 @@ impl WorkspaceManager {
                     }))
                 }
             }
-            Ok(Err(error)) => Err(Box::new(HookFailure {
-                error: WorkspaceError::LaunchHook {
-                    hook: kind,
-                    cwd: cwd.clone(),
-                    source: error,
-                },
-                record: HookExecutionRecord {
-                    kind,
-                    command: hook.command.clone(),
-                    cwd,
-                    best_effort: !kind.is_required(),
-                    status: HookExecutionStatus::Failed,
-                    started_at,
-                    finished_at,
-                    duration_ms,
-                    exit_code: None,
-                    stdout: String::new(),
-                    stderr: String::new(),
-                },
-            })),
-            Err(_) => Err(Box::new(HookFailure {
+            HookCommandOutput::TimedOut { stdout, stderr } => Err(Box::new(HookFailure {
                 error: WorkspaceError::HookTimedOut {
                     hook: kind,
                     command: hook.command.clone(),
@@ -443,8 +557,8 @@ impl WorkspaceManager {
                     finished_at,
                     duration_ms,
                     exit_code: None,
-                    stdout: String::new(),
-                    stderr: String::new(),
+                    stdout,
+                    stderr,
                 },
             })),
         }
@@ -576,10 +690,9 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
         path: &Path,
     ) -> Result<(), WorkspaceError> {
-        let path = self.validate_managed_metadata_path(workspace, path).await?;
+        let path = self.validate_workspace_owned_path(workspace, path).await?;
         self.create_directory(&path).await?;
-        self.validate_managed_metadata_path(workspace, &path)
-            .await?;
+        self.validate_workspace_owned_path(workspace, &path).await?;
         Ok(())
     }
 
@@ -616,7 +729,7 @@ impl WorkspaceManager {
     where
         T: DeserializeOwned,
     {
-        let path = self.validate_managed_metadata_path(workspace, path).await?;
+        let path = self.validate_workspace_owned_path(workspace, path).await?;
         let raw = match fs::read_to_string(&path).await {
             Ok(raw) => raw,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -648,7 +761,7 @@ impl WorkspaceManager {
         if let Some(parent) = path.parent() {
             self.create_managed_directory(workspace, parent).await?;
         }
-        let path = self.validate_managed_metadata_path(workspace, path).await?;
+        let path = self.validate_workspace_owned_path(workspace, path).await?;
 
         let payload = serde_json::to_vec_pretty(manifest).map_err(|error| {
             WorkspaceError::EncodeManifest {
@@ -665,7 +778,7 @@ impl WorkspaceManager {
             })
     }
 
-    async fn validate_managed_metadata_path(
+    async fn validate_workspace_owned_path(
         &self,
         workspace: &WorkspaceHandle,
         path: &Path,
@@ -675,7 +788,7 @@ impl WorkspaceManager {
 
         let relative = normalized
             .strip_prefix(workspace.workspace_path())
-            .expect("managed metadata paths should remain within the workspace");
+            .expect("managed workspace paths should remain within the workspace");
         let mut current = workspace.workspace_path().to_path_buf();
 
         for component in relative.components() {
@@ -702,6 +815,130 @@ impl WorkspaceManager {
     }
 }
 
+async fn run_hook_command(
+    mut command: Command,
+    timeout_duration: std::time::Duration,
+) -> io::Result<HookCommandOutput> {
+    let mut child = command.spawn()?;
+    let process_id = child.id();
+    let stdout_task = tokio::spawn(read_child_pipe(child.stdout.take()));
+    let stderr_task = tokio::spawn(read_child_pipe(child.stderr.take()));
+
+    match timeout(timeout_duration, child.wait()).await {
+        Ok(status) => {
+            let status = status?;
+            let stdout = join_child_pipe(stdout_task).await?;
+            let stderr = join_child_pipe(stderr_task).await?;
+
+            Ok(HookCommandOutput::Completed(std::process::Output {
+                status,
+                stdout,
+                stderr,
+            }))
+        }
+        Err(_) => {
+            terminate_hook_process_tree(&mut child, process_id).await?;
+            let _ = child.wait().await?;
+            let stdout = join_child_pipe(stdout_task).await?;
+            let stderr = join_child_pipe(stderr_task).await?;
+
+            Ok(HookCommandOutput::TimedOut {
+                stdout: String::from_utf8_lossy(&stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&stderr).into_owned(),
+            })
+        }
+    }
+}
+
+async fn read_child_pipe<R>(pipe: Option<R>) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let Some(mut pipe) = pipe else {
+        return Ok(Vec::new());
+    };
+    let mut buffer = Vec::new();
+    pipe.read_to_end(&mut buffer).await?;
+    Ok(buffer)
+}
+
+async fn join_child_pipe(
+    task: tokio::task::JoinHandle<io::Result<Vec<u8>>>,
+) -> io::Result<Vec<u8>> {
+    match task.await {
+        Ok(result) => result,
+        Err(error) => Err(io::Error::other(error)),
+    }
+}
+
+#[cfg(unix)]
+fn configure_hook_command(command: &mut Command) {
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_hook_command(_command: &mut Command) {}
+
+#[cfg(unix)]
+async fn terminate_hook_process_tree(
+    _child: &mut tokio::process::Child,
+    process_id: Option<u32>,
+) -> io::Result<()> {
+    if let Some(process_id) = process_id {
+        let result = unsafe { libc::kill(-(process_id as i32), libc::SIGKILL) };
+        if result != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+async fn terminate_hook_process_tree(
+    child: &mut tokio::process::Child,
+    process_id: Option<u32>,
+) -> io::Result<()> {
+    let Some(process_id) = process_id else {
+        return child.kill().await;
+    };
+
+    let status = Command::new("taskkill")
+        .arg("/T")
+        .arg("/F")
+        .arg("/PID")
+        .arg(process_id.to_string())
+        .status()
+        .await?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "taskkill /T /F /PID {process_id} exited with {status}"
+        )))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+async fn terminate_hook_process_tree(
+    child: &mut tokio::process::Child,
+    _process_id: Option<u32>,
+) -> io::Result<()> {
+    child.kill().await
+}
+
 fn classify_issue_manifest_ownership(
     issue: &IssueDescriptor,
     workspace: &WorkspaceHandle,
@@ -718,14 +955,69 @@ fn classify_issue_manifest_ownership(
     }
 }
 
+fn classify_after_create_receipt_ownership(
+    issue: &IssueDescriptor,
+    workspace: &WorkspaceHandle,
+    receipt: AfterCreateBootstrapReceipt,
+) -> ExistingReceiptState {
+    if !after_create_receipt_claims_workspace(workspace, &receipt) {
+        return ExistingReceiptState::ForeignArtifact;
+    }
+
+    if receipt.issue_id == issue.issue_id && receipt.identifier == issue.identifier {
+        ExistingReceiptState::Owned
+    } else {
+        ExistingReceiptState::Conflict(receipt)
+    }
+}
+
 fn issue_manifest_claims_workspace(workspace: &WorkspaceHandle, manifest: &IssueManifest) -> bool {
-    if manifest.sanitized_workspace_key != workspace.workspace_key() {
+    workspace_path_claim_matches(
+        workspace,
+        &manifest.sanitized_workspace_key,
+        &manifest.workspace_path,
+    )
+}
+
+fn after_create_receipt_claims_workspace(
+    workspace: &WorkspaceHandle,
+    receipt: &AfterCreateBootstrapReceipt,
+) -> bool {
+    workspace_path_claim_matches(
+        workspace,
+        &receipt.sanitized_workspace_key,
+        &receipt.workspace_path,
+    )
+}
+
+fn workspace_path_claim_matches(
+    workspace: &WorkspaceHandle,
+    claimed_workspace_key: &str,
+    claimed_workspace_path: &Path,
+) -> bool {
+    if claimed_workspace_key != workspace.workspace_key() {
         return false;
     }
 
-    match normalize_absolute_path(&manifest.workspace_path) {
+    match normalize_absolute_path(claimed_workspace_path) {
         Ok(path) => path == workspace.workspace_path(),
         Err(_) => false,
+    }
+}
+
+fn ownership_claim_from_issue_manifest(manifest: IssueManifest) -> WorkspaceOwnershipClaim {
+    WorkspaceOwnershipClaim {
+        issue_id: manifest.issue_id,
+        identifier: manifest.identifier,
+    }
+}
+
+fn ownership_claim_from_after_create_receipt(
+    receipt: AfterCreateBootstrapReceipt,
+) -> WorkspaceOwnershipClaim {
+    WorkspaceOwnershipClaim {
+        issue_id: receipt.issue_id,
+        identifier: receipt.identifier,
     }
 }
 

--- a/crates/opensymphony-workspace/src/models.rs
+++ b/crates/opensymphony-workspace/src/models.rs
@@ -127,6 +127,10 @@ impl WorkspaceHandle {
         self.workspace_path.join(".opensymphony")
     }
 
+    pub(crate) fn after_create_receipt_path(&self) -> PathBuf {
+        self.workspace_path.join(".opensymphony.after_create.json")
+    }
+
     pub fn issue_manifest_path(&self) -> PathBuf {
         self.metadata_dir().join("issue.json")
     }
@@ -157,6 +161,27 @@ impl WorkspaceHandle {
 
     pub fn runs_dir(&self) -> PathBuf {
         self.metadata_dir().join("runs")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AfterCreateBootstrapReceipt {
+    pub issue_id: String,
+    pub identifier: String,
+    pub sanitized_workspace_key: String,
+    pub workspace_path: PathBuf,
+    pub completed_at: DateTime<Utc>,
+}
+
+impl AfterCreateBootstrapReceipt {
+    pub(crate) fn new(workspace: &WorkspaceHandle, issue: &IssueDescriptor) -> Self {
+        Self {
+            issue_id: issue.issue_id.clone(),
+            identifier: issue.identifier.clone(),
+            sanitized_workspace_key: workspace.workspace_key().to_string(),
+            workspace_path: workspace.workspace_path().to_path_buf(),
+            completed_at: Utc::now(),
+        }
     }
 }
 

--- a/crates/opensymphony-workspace/src/models.rs
+++ b/crates/opensymphony-workspace/src/models.rs
@@ -1,0 +1,301 @@
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueDescriptor {
+    pub issue_id: String,
+    pub identifier: String,
+    pub title: String,
+    pub current_state: String,
+    pub last_seen_tracker_refresh_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunDescriptor {
+    pub run_id: String,
+    pub attempt: u32,
+}
+
+impl RunDescriptor {
+    pub fn new(run_id: impl Into<String>, attempt: u32) -> Self {
+        Self {
+            run_id: run_id.into(),
+            attempt,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookDefinition {
+    pub command: String,
+    pub cwd: Option<PathBuf>,
+}
+
+impl HookDefinition {
+    pub fn shell(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            cwd: None,
+        }
+    }
+
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookConfig {
+    pub after_create: Option<HookDefinition>,
+    pub before_run: Option<HookDefinition>,
+    pub after_run: Option<HookDefinition>,
+    pub before_remove: Option<HookDefinition>,
+    pub timeout: Duration,
+}
+
+impl Default for HookConfig {
+    fn default() -> Self {
+        Self {
+            after_create: None,
+            before_run: None,
+            after_run: None,
+            before_remove: None,
+            timeout: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CleanupConfig {
+    pub remove_terminal_workspaces: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceManagerConfig {
+    pub root: PathBuf,
+    pub hooks: HookConfig,
+    pub cleanup: CleanupConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceHandle {
+    issue_id: String,
+    identifier: String,
+    workspace_key: String,
+    workspace_path: PathBuf,
+}
+
+impl WorkspaceHandle {
+    pub(crate) fn new(
+        issue_id: impl Into<String>,
+        identifier: impl Into<String>,
+        workspace_key: impl Into<String>,
+        workspace_path: PathBuf,
+    ) -> Self {
+        Self {
+            issue_id: issue_id.into(),
+            identifier: identifier.into(),
+            workspace_key: workspace_key.into(),
+            workspace_path,
+        }
+    }
+
+    pub fn issue_id(&self) -> &str {
+        &self.issue_id
+    }
+
+    pub fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    pub fn workspace_key(&self) -> &str {
+        &self.workspace_key
+    }
+
+    pub fn workspace_path(&self) -> &Path {
+        &self.workspace_path
+    }
+
+    pub fn metadata_dir(&self) -> PathBuf {
+        self.workspace_path.join(".opensymphony")
+    }
+
+    pub fn issue_manifest_path(&self) -> PathBuf {
+        self.metadata_dir().join("issue.json")
+    }
+
+    pub fn run_manifest_path(&self) -> PathBuf {
+        self.metadata_dir().join("run.json")
+    }
+
+    pub fn conversation_manifest_path(&self) -> PathBuf {
+        self.metadata_dir().join("conversation.json")
+    }
+
+    pub fn logs_dir(&self) -> PathBuf {
+        self.metadata_dir().join("logs")
+    }
+
+    pub fn generated_dir(&self) -> PathBuf {
+        self.metadata_dir().join("generated")
+    }
+
+    pub fn openhands_dir(&self) -> PathBuf {
+        self.metadata_dir().join("openhands")
+    }
+
+    pub fn prompts_dir(&self) -> PathBuf {
+        self.metadata_dir().join("prompts")
+    }
+
+    pub fn runs_dir(&self) -> PathBuf {
+        self.metadata_dir().join("runs")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnsureWorkspaceResult {
+    pub handle: WorkspaceHandle,
+    pub issue_manifest: IssueManifest,
+    pub created: bool,
+    pub after_create: Option<HookExecutionRecord>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssueLifecycleState {
+    Active,
+    Inactive,
+    Terminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanupDecision {
+    Retain,
+    Remove,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanupOutcome {
+    pub decision: CleanupDecision,
+    pub before_remove: Option<HookExecutionRecord>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookKind {
+    AfterCreate,
+    BeforeRun,
+    AfterRun,
+    BeforeRemove,
+}
+
+impl HookKind {
+    pub fn is_required(self) -> bool {
+        matches!(self, Self::AfterCreate | Self::BeforeRun)
+    }
+}
+
+impl fmt::Display for HookKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::AfterCreate => "after_create",
+            Self::BeforeRun => "before_run",
+            Self::AfterRun => "after_run",
+            Self::BeforeRemove => "before_remove",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookExecutionStatus {
+    Succeeded,
+    Failed,
+    TimedOut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookExecutionRecord {
+    pub kind: HookKind,
+    pub command: String,
+    pub cwd: PathBuf,
+    pub best_effort: bool,
+    pub status: HookExecutionStatus,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub duration_ms: u64,
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueManifest {
+    pub issue_id: String,
+    pub identifier: String,
+    pub title: String,
+    pub current_state: String,
+    pub sanitized_workspace_key: String,
+    pub workspace_path: PathBuf,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_seen_tracker_refresh_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Preparing,
+    Prepared,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    PreparationFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunManifest {
+    pub run_id: String,
+    pub issue_id: String,
+    pub identifier: String,
+    pub sanitized_workspace_key: String,
+    pub workspace_path: PathBuf,
+    pub attempt: u32,
+    pub status: RunStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_detail: Option<String>,
+    #[serde(default)]
+    pub hooks: Vec<HookExecutionRecord>,
+}
+
+impl RunManifest {
+    pub fn new(workspace: &WorkspaceHandle, run: &RunDescriptor) -> Self {
+        let now = Utc::now();
+        Self {
+            run_id: run.run_id.clone(),
+            issue_id: workspace.issue_id().to_string(),
+            identifier: workspace.identifier().to_string(),
+            sanitized_workspace_key: workspace.workspace_key().to_string(),
+            workspace_path: workspace.workspace_path().to_path_buf(),
+            attempt: run.attempt,
+            status: RunStatus::Preparing,
+            created_at: now,
+            updated_at: now,
+            status_detail: None,
+            hooks: Vec::new(),
+        }
+    }
+}

--- a/crates/opensymphony-workspace/src/paths.rs
+++ b/crates/opensymphony-workspace/src/paths.rs
@@ -1,0 +1,139 @@
+use std::path::{Component, Path, PathBuf};
+
+use crate::WorkspaceError;
+
+pub fn sanitize_workspace_key(identifier: &str) -> Result<String, WorkspaceError> {
+    if identifier.trim().is_empty() {
+        return Err(WorkspaceError::EmptyIdentifier);
+    }
+
+    let key = identifier
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    if key.is_empty()
+        || !matches!(
+            Path::new(&key).components().next(),
+            Some(Component::Normal(_))
+        )
+    {
+        return Err(WorkspaceError::InvalidWorkspaceKey { key });
+    }
+
+    if Path::new(&key).components().nth(1).is_some() {
+        return Err(WorkspaceError::InvalidWorkspaceKey { key });
+    }
+
+    Ok(key)
+}
+
+pub fn workspace_path_for_root(
+    root: impl AsRef<Path>,
+    issue_identifier: &str,
+) -> Result<PathBuf, WorkspaceError> {
+    let root = normalize_absolute_path(root.as_ref())?;
+    let key = sanitize_workspace_key(issue_identifier)?;
+    resolve_path_within_root(root, key)
+}
+
+pub fn resolve_path_within_root(
+    root: impl AsRef<Path>,
+    candidate: impl AsRef<Path>,
+) -> Result<PathBuf, WorkspaceError> {
+    let root = normalize_absolute_path(root.as_ref())?;
+    let candidate = if candidate.as_ref().is_absolute() {
+        normalize_absolute_path(candidate.as_ref())?
+    } else {
+        normalize_absolute_path(&root.join(candidate.as_ref()))?
+    };
+
+    if candidate.starts_with(&root) {
+        Ok(candidate)
+    } else {
+        Err(WorkspaceError::PathEscape {
+            root,
+            path: candidate,
+        })
+    }
+}
+
+pub(crate) fn normalize_absolute_path(path: &Path) -> Result<PathBuf, WorkspaceError> {
+    if !path.is_absolute() {
+        return Err(WorkspaceError::RootNotAbsolute {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR)),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{resolve_path_within_root, sanitize_workspace_key};
+    use crate::WorkspaceError;
+
+    #[test]
+    fn sanitizes_documented_examples() {
+        assert_eq!(sanitize_workspace_key("ABC-123").unwrap(), "ABC-123");
+        assert_eq!(sanitize_workspace_key("feature/42").unwrap(), "feature_42");
+        assert_eq!(
+            sanitize_workspace_key("Bug: weird path").unwrap(),
+            "Bug__weird_path"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_and_reserved_workspace_keys() {
+        assert!(matches!(
+            sanitize_workspace_key(""),
+            Err(WorkspaceError::EmptyIdentifier)
+        ));
+        assert!(matches!(
+            sanitize_workspace_key("."),
+            Err(WorkspaceError::InvalidWorkspaceKey { .. })
+        ));
+        assert!(matches!(
+            sanitize_workspace_key(".."),
+            Err(WorkspaceError::InvalidWorkspaceKey { .. })
+        ));
+    }
+
+    #[test]
+    fn containment_helper_rejects_parent_escape() {
+        let root = std::env::temp_dir().join("opensymphony-workspace-root");
+        let error = resolve_path_within_root(&root, PathBuf::from("../escape")).unwrap_err();
+
+        assert!(matches!(error, WorkspaceError::PathEscape { .. }));
+    }
+
+    #[test]
+    fn containment_helper_allows_descendants() {
+        let root = std::env::temp_dir().join("opensymphony-workspace-root");
+        let candidate = resolve_path_within_root(&root, PathBuf::from("child/.opensymphony"))
+            .expect("descendant path should remain within root");
+
+        assert!(candidate.ends_with(PathBuf::from("child/.opensymphony")));
+    }
+}

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -280,6 +280,75 @@ async fn ensure_retries_after_create_when_foreign_issue_manifest_preexists() {
 }
 
 #[tokio::test]
+async fn ensure_retries_after_create_when_copied_malformed_issue_manifest_preexists() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            after_create: Some(HookDefinition::shell(after_create_retry_command())),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263-malformed-manifest");
+
+    manager
+        .ensure(&issue)
+        .await
+        .expect_err("first ensure should fail its after_create hook");
+
+    let workspace_path = manager
+        .workspace_path_for(&issue.identifier)
+        .expect("workspace path should resolve");
+    let metadata_dir = workspace_path.join(".opensymphony");
+    for directory in [
+        metadata_dir.clone(),
+        metadata_dir.join("logs"),
+        metadata_dir.join("generated"),
+        metadata_dir.join("openhands"),
+        metadata_dir.join("prompts"),
+        metadata_dir.join("runs"),
+    ] {
+        tokio::fs::create_dir_all(&directory)
+            .await
+            .expect("bootstrap directory should exist");
+    }
+    tokio::fs::write(metadata_dir.join("issue.json"), "{")
+        .await
+        .expect("malformed issue manifest should be written");
+
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("second ensure should retry after_create and succeed");
+
+    assert!(ensured.created);
+    assert_eq!(
+        tokio::fs::read_to_string(
+            ensured
+                .handle
+                .workspace_path()
+                .join("after_create_success.txt")
+        )
+        .await
+        .expect("after_create should succeed on retry")
+        .trim(),
+        "success"
+    );
+    assert_eq!(
+        manager
+            .load_issue_manifest(&ensured.handle)
+            .await
+            .expect("issue manifest should load")
+            .expect("issue manifest should exist")
+            .issue_id,
+        issue.issue_id
+    );
+}
+
+#[tokio::test]
 async fn ensure_rejects_workspace_reuse_for_colliding_sanitized_key() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
     let workspace_root = temp_dir.path().join("workspaces");
@@ -606,6 +675,49 @@ async fn hook_cwd_override_cannot_escape_workspace() {
             ..
         }
     ));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn workspace_handle_validation_rejects_symlinked_workspace_roots() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let first = manager
+        .ensure(&sample_issue("COE-263-root-symlink-a"))
+        .await
+        .expect("first workspace should exist");
+    let second = manager
+        .ensure(&sample_issue("COE-263-root-symlink-b"))
+        .await
+        .expect("second workspace should exist");
+
+    tokio::fs::remove_dir_all(first.handle.workspace_path())
+        .await
+        .expect("first workspace should be removable");
+    symlink(
+        second.handle.workspace_path(),
+        first.handle.workspace_path(),
+    )
+    .expect("workspace root symlink should be created");
+
+    let error = manager
+        .start_run(&first.handle, &RunDescriptor::new("run-root-symlink", 1))
+        .await
+        .expect_err("symlinked workspace root should be rejected");
+    assert!(matches!(
+        error,
+        WorkspaceError::WorkspacePathSymlink { ref path }
+            if path == first.handle.workspace_path()
+    ));
+    assert!(!tokio::fs::try_exists(second.handle.run_manifest_path())
+        .await
+        .expect("run manifest lookup should succeed"));
 }
 
 #[cfg(unix)]

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -7,6 +7,9 @@ use opensymphony_workspace::{
 };
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 fn sample_issue(identifier: &str) -> IssueDescriptor {
     IssueDescriptor {
         issue_id: format!("id-{identifier}"),
@@ -69,6 +72,26 @@ fn best_effort_failure_command() -> &'static str {
     "echo after-run 1>&2 && exit /b 9"
 }
 
+#[cfg(unix)]
+fn after_create_requires_empty_workspace_command() -> &'static str {
+    "if [ -e .opensymphony ]; then echo metadata-present 1>&2; exit 17; fi; echo after_create > after_create.txt"
+}
+
+#[cfg(windows)]
+fn after_create_requires_empty_workspace_command() -> &'static str {
+    "if exist .opensymphony\\NUL (echo metadata-present 1>&2 && exit /b 17) else (echo after_create> after_create.txt)"
+}
+
+#[cfg(unix)]
+fn after_create_retry_command() -> &'static str {
+    "if [ ! -f after_create_attempt.txt ]; then echo first > after_create_attempt.txt; echo retry 1>&2; exit 23; fi; echo success > after_create_success.txt"
+}
+
+#[cfg(windows)]
+fn after_create_retry_command() -> &'static str {
+    "if not exist after_create_attempt.txt (echo first> after_create_attempt.txt && echo retry 1>&2 && exit /b 23) else (echo success> after_create_success.txt)"
+}
+
 #[tokio::test]
 async fn ensure_creates_reuses_workspace_and_runs_after_create_once() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
@@ -77,7 +100,7 @@ async fn ensure_creates_reuses_workspace_and_runs_after_create_once() {
         &workspace_root,
         HookConfig {
             after_create: Some(HookDefinition::shell(
-                "echo after_create >> .opensymphony/logs/after_create-count.txt",
+                after_create_requires_empty_workspace_command(),
             )),
             ..HookConfig::default()
         },
@@ -107,13 +130,72 @@ async fn ensure_creates_reuses_workspace_and_runs_after_create_once() {
             .expect("issue manifest should exist")
             .contains("\"sanitized_workspace_key\": \"COE-263\"")
     );
-
-    let after_create_log =
-        tokio::fs::read_to_string(first.handle.logs_dir().join("after_create-count.txt"))
+    assert_eq!(
+        tokio::fs::read_to_string(first.handle.workspace_path().join("after_create.txt"))
             .await
-            .expect("after_create hook should have written a marker");
-    let run_count = after_create_log.lines().count();
-    assert_eq!(run_count, 1);
+            .expect("after_create hook should run before metadata bootstrap")
+            .trim(),
+        "after_create"
+    );
+
+    assert!(!tokio::fs::try_exists(
+        second
+            .handle
+            .workspace_path()
+            .join("after_create_attempt.txt")
+    )
+    .await
+    .expect("attempt marker lookup should succeed"));
+}
+
+#[tokio::test]
+async fn ensure_retries_after_create_after_failed_first_bootstrap() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            after_create: Some(HookDefinition::shell(after_create_retry_command())),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263-retry");
+
+    let first_error = manager
+        .ensure(&issue)
+        .await
+        .expect_err("first ensure should fail its after_create hook");
+    assert!(matches!(
+        first_error,
+        WorkspaceError::HookFailed {
+            hook: HookKind::AfterCreate,
+            ..
+        }
+    ));
+
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("second ensure should retry after_create and succeed");
+
+    assert!(ensured.created);
+    assert_eq!(
+        tokio::fs::read_to_string(
+            ensured
+                .handle
+                .workspace_path()
+                .join("after_create_success.txt")
+        )
+        .await
+        .expect("after_create should succeed on retry")
+        .trim(),
+        "success"
+    );
+    assert!(tokio::fs::try_exists(ensured.handle.issue_manifest_path())
+        .await
+        .expect("issue manifest lookup should succeed"));
 }
 
 #[tokio::test]
@@ -402,6 +484,56 @@ async fn hook_cwd_override_cannot_escape_workspace() {
         .start_run(&ensured.handle, &RunDescriptor::new("run-cwd", 1))
         .await
         .expect_err("escaping cwd should fail");
+
+    assert!(matches!(
+        error,
+        WorkspaceError::HookPathEscape {
+            hook: HookKind::BeforeRun,
+            ..
+        }
+    ));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn hook_cwd_override_cannot_escape_workspace_through_symlink() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-symlink"))
+        .await
+        .expect("workspace should exist");
+
+    let outside_dir = temp_dir.path().join("outside");
+    tokio::fs::create_dir_all(&outside_dir)
+        .await
+        .expect("outside dir should exist");
+    symlink(
+        &outside_dir,
+        ensured.handle.workspace_path().join("link-out"),
+    )
+    .expect("symlink should be created");
+
+    let escaped_manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_run: Some(HookDefinition::shell("pwd").with_cwd("link-out")),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+
+    let error = escaped_manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-symlink", 1))
+        .await
+        .expect_err("symlinked cwd should be rejected");
 
     assert!(matches!(
         error,

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -107,6 +107,24 @@ fn foreign_issue_manifest_json(workspace_path: &std::path::Path, key: &str) -> S
     .expect("foreign issue manifest JSON should serialize")
 }
 
+#[cfg(unix)]
+fn shell_quote(path: &std::path::Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
+}
+
+#[cfg(unix)]
+fn after_create_bootstrap_failure_command(outside_dir: &std::path::Path) -> String {
+    format!(
+        "if [ -f after_create_success.txt ]; then echo reran > after_create_reran.txt; exit 41; fi; echo success > after_create_success.txt; ln -s {} .opensymphony",
+        shell_quote(outside_dir)
+    )
+}
+
+#[cfg(unix)]
+fn timeout_with_background_child_command() -> &'static str {
+    "(sleep 1; echo descendant > .opensymphony/logs/descendant.txt) & echo $! > .opensymphony/logs/descendant.pid; sleep 5"
+}
+
 #[tokio::test]
 async fn ensure_creates_reuses_workspace_and_runs_after_create_once() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
@@ -348,6 +366,71 @@ async fn ensure_retries_after_create_when_copied_malformed_issue_manifest_preexi
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn ensure_does_not_rerun_after_create_after_post_hook_bootstrap_failure() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let outside_dir = temp_dir.path().join("outside");
+    tokio::fs::create_dir_all(&outside_dir)
+        .await
+        .expect("outside dir should exist");
+
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            after_create: Some(HookDefinition::shell(
+                after_create_bootstrap_failure_command(&outside_dir),
+            )),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263-after-create-receipt");
+
+    let first_error = manager
+        .ensure(&issue)
+        .await
+        .expect_err("first ensure should fail after after_create succeeds");
+    assert!(matches!(
+        first_error,
+        WorkspaceError::ManagedPathSymlink { .. }
+    ));
+
+    let workspace_path = manager
+        .workspace_path_for(&issue.identifier)
+        .expect("workspace path should resolve");
+    assert!(
+        tokio::fs::try_exists(workspace_path.join(".opensymphony.after_create.json"))
+            .await
+            .expect("after_create receipt lookup should succeed")
+    );
+
+    tokio::fs::remove_file(workspace_path.join(".opensymphony"))
+        .await
+        .expect("symlinked metadata dir should be removable");
+
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("second ensure should resume bootstrap without rerunning after_create");
+
+    assert!(!ensured.created);
+    assert!(
+        !tokio::fs::try_exists(workspace_path.join("after_create_reran.txt"))
+            .await
+            .expect("rerun marker lookup should succeed")
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(workspace_path.join("after_create_success.txt"))
+            .await
+            .expect("first after_create run marker should exist")
+            .trim(),
+        "success"
+    );
+}
+
 #[tokio::test]
 async fn ensure_rejects_workspace_reuse_for_colliding_sanitized_key() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
@@ -470,6 +553,54 @@ async fn before_run_timeout_is_recorded_and_returned() {
     assert_eq!(persisted.status, RunStatus::PreparationFailed);
     assert_eq!(persisted.hooks.len(), 1);
     assert_eq!(persisted.hooks[0].status, HookExecutionStatus::TimedOut);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn before_run_timeout_kills_spawned_descendants() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_run: Some(HookDefinition::shell(
+                timeout_with_background_child_command(),
+            )),
+            timeout: Duration::from_millis(100),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-timeout-tree"))
+        .await
+        .expect("workspace should exist");
+
+    let error = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-timeout-tree", 1))
+        .await
+        .expect_err("timeout should fail required hook");
+    assert!(matches!(
+        error,
+        WorkspaceError::HookTimedOut {
+            hook: HookKind::BeforeRun,
+            ..
+        }
+    ));
+
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+    assert!(
+        tokio::fs::try_exists(ensured.handle.logs_dir().join("descendant.pid"))
+            .await
+            .expect("descendant pid lookup should succeed")
+    );
+    assert!(
+        !tokio::fs::try_exists(ensured.handle.logs_dir().join("descendant.txt"))
+            .await
+            .expect("descendant marker lookup should succeed")
+    );
 }
 
 #[tokio::test]

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -5,6 +5,7 @@ use opensymphony_workspace::{
     IssueDescriptor, IssueLifecycleState, RunDescriptor, RunStatus, WorkspaceError,
     WorkspaceManager, WorkspaceManagerConfig,
 };
+use serde_json::json;
 use tempfile::TempDir;
 
 #[cfg(unix)]
@@ -90,6 +91,20 @@ fn after_create_retry_command() -> &'static str {
 #[cfg(windows)]
 fn after_create_retry_command() -> &'static str {
     "if not exist after_create_attempt.txt (echo first> after_create_attempt.txt && echo retry 1>&2 && exit /b 23) else (echo success> after_create_success.txt)"
+}
+
+fn foreign_issue_manifest_json(workspace_path: &std::path::Path, key: &str) -> String {
+    serde_json::to_string_pretty(&json!({
+        "issue_id": "foreign-id",
+        "identifier": "foreign-issue",
+        "title": "Foreign issue",
+        "current_state": "In Progress",
+        "sanitized_workspace_key": key,
+        "workspace_path": workspace_path,
+        "created_at": "2026-03-21T00:00:00Z",
+        "updated_at": "2026-03-21T00:00:00Z"
+    }))
+    .expect("foreign issue manifest JSON should serialize")
 }
 
 #[tokio::test]
@@ -196,6 +211,105 @@ async fn ensure_retries_after_create_after_failed_first_bootstrap() {
     assert!(tokio::fs::try_exists(ensured.handle.issue_manifest_path())
         .await
         .expect("issue manifest lookup should succeed"));
+}
+
+#[tokio::test]
+async fn ensure_retries_after_create_when_foreign_issue_manifest_preexists() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            after_create: Some(HookDefinition::shell(after_create_retry_command())),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263-foreign-manifest");
+
+    manager
+        .ensure(&issue)
+        .await
+        .expect_err("first ensure should fail its after_create hook");
+
+    let workspace_path = manager
+        .workspace_path_for(&issue.identifier)
+        .expect("workspace path should resolve");
+    let metadata_dir = workspace_path.join(".opensymphony");
+    tokio::fs::create_dir_all(&metadata_dir)
+        .await
+        .expect("metadata dir should exist");
+    tokio::fs::write(
+        metadata_dir.join("issue.json"),
+        foreign_issue_manifest_json(
+            temp_dir.path().join("elsewhere").as_path(),
+            "COE-263-foreign-manifest",
+        ),
+    )
+    .await
+    .expect("foreign issue manifest should be written");
+
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("second ensure should retry after_create and succeed");
+
+    assert!(ensured.created);
+    assert_eq!(
+        tokio::fs::read_to_string(
+            ensured
+                .handle
+                .workspace_path()
+                .join("after_create_success.txt")
+        )
+        .await
+        .expect("after_create should succeed on retry")
+        .trim(),
+        "success"
+    );
+    assert_eq!(
+        manager
+            .load_issue_manifest(&ensured.handle)
+            .await
+            .expect("issue manifest should load")
+            .expect("issue manifest should exist")
+            .issue_id,
+        issue.issue_id
+    );
+}
+
+#[tokio::test]
+async fn ensure_rejects_workspace_reuse_for_colliding_sanitized_key() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let first_issue = sample_issue("feature/42");
+    let second_issue = sample_issue("feature:42");
+
+    manager
+        .ensure(&first_issue)
+        .await
+        .expect("first workspace should be created");
+
+    let error = manager
+        .ensure(&second_issue)
+        .await
+        .expect_err("colliding sanitized key should be rejected");
+
+    assert!(matches!(
+        error,
+        WorkspaceError::WorkspaceOwnershipConflict {
+            details,
+            ..
+        } if details.existing_issue_id == first_issue.issue_id
+            && details.requested_issue_id == second_issue.issue_id
+    ));
 }
 
 #[tokio::test]
@@ -541,5 +655,75 @@ async fn hook_cwd_override_cannot_escape_workspace_through_symlink() {
             hook: HookKind::BeforeRun,
             ..
         }
+    ));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn managed_manifest_paths_reject_symlinked_reads_and_writes() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-metadata-symlink"))
+        .await
+        .expect("workspace should exist");
+
+    let outside_issue_manifest = temp_dir.path().join("outside-issue.json");
+    tokio::fs::write(&outside_issue_manifest, "{}")
+        .await
+        .expect("outside issue manifest should exist");
+    tokio::fs::remove_file(ensured.handle.issue_manifest_path())
+        .await
+        .expect("managed issue manifest should be removable");
+    symlink(
+        &outside_issue_manifest,
+        ensured.handle.issue_manifest_path(),
+    )
+    .expect("issue manifest symlink should be created");
+
+    let read_error = manager
+        .load_issue_manifest(&ensured.handle)
+        .await
+        .expect_err("symlinked issue manifest should be rejected");
+    assert!(matches!(
+        read_error,
+        WorkspaceError::ManagedPathSymlink { .. }
+    ));
+
+    tokio::fs::remove_file(ensured.handle.issue_manifest_path())
+        .await
+        .expect("issue manifest symlink should be removable");
+    let restored = manager
+        .ensure(&sample_issue("COE-263-metadata-symlink"))
+        .await
+        .expect("workspace should remain reusable");
+    manager
+        .write_issue_manifest(&ensured.handle, &restored.issue_manifest)
+        .await
+        .expect("issue manifest should be writable after restoring direct path");
+
+    let outside_run_manifest = temp_dir.path().join("outside-run.json");
+    tokio::fs::write(&outside_run_manifest, "{}")
+        .await
+        .expect("outside run manifest should exist");
+    symlink(&outside_run_manifest, ensured.handle.run_manifest_path())
+        .expect("run manifest symlink should be created");
+
+    let write_error = manager
+        .start_run(
+            &ensured.handle,
+            &RunDescriptor::new("run-symlinked-manifest", 1),
+        )
+        .await
+        .expect_err("symlinked run manifest should be rejected");
+    assert!(matches!(
+        write_error,
+        WorkspaceError::ManagedPathSymlink { .. }
     ));
 }

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -1,0 +1,413 @@
+use std::time::Duration;
+
+use opensymphony_workspace::{
+    CleanupConfig, CleanupDecision, HookConfig, HookDefinition, HookExecutionStatus, HookKind,
+    IssueDescriptor, IssueLifecycleState, RunDescriptor, RunStatus, WorkspaceError,
+    WorkspaceManager, WorkspaceManagerConfig,
+};
+use tempfile::TempDir;
+
+fn sample_issue(identifier: &str) -> IssueDescriptor {
+    IssueDescriptor {
+        issue_id: format!("id-{identifier}"),
+        identifier: identifier.to_string(),
+        title: format!("Issue {identifier}"),
+        current_state: "In Progress".to_string(),
+        last_seen_tracker_refresh_at: None,
+    }
+}
+
+fn manager_config(
+    root: &std::path::Path,
+    hooks: HookConfig,
+    cleanup: CleanupConfig,
+) -> WorkspaceManagerConfig {
+    WorkspaceManagerConfig {
+        root: root.to_path_buf(),
+        hooks,
+        cleanup,
+    }
+}
+
+#[cfg(unix)]
+fn current_dir_command(output_path: &str) -> String {
+    format!("pwd > {output_path}")
+}
+
+#[cfg(windows)]
+fn current_dir_command(output_path: &str) -> String {
+    format!("cd > {output_path}")
+}
+
+#[cfg(unix)]
+fn timeout_command() -> &'static str {
+    "sleep 1"
+}
+
+#[cfg(windows)]
+fn timeout_command() -> &'static str {
+    "ping 127.0.0.1 -n 2 > NUL"
+}
+
+#[cfg(unix)]
+fn failing_command() -> &'static str {
+    "echo boom 1>&2; exit 7"
+}
+
+#[cfg(windows)]
+fn failing_command() -> &'static str {
+    "echo boom 1>&2 && exit /b 7"
+}
+
+#[cfg(unix)]
+fn best_effort_failure_command() -> &'static str {
+    "echo after-run 1>&2; exit 9"
+}
+
+#[cfg(windows)]
+fn best_effort_failure_command() -> &'static str {
+    "echo after-run 1>&2 && exit /b 9"
+}
+
+#[tokio::test]
+async fn ensure_creates_reuses_workspace_and_runs_after_create_once() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            after_create: Some(HookDefinition::shell(
+                "echo after_create >> .opensymphony/logs/after_create-count.txt",
+            )),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263");
+
+    let first = manager
+        .ensure(&issue)
+        .await
+        .expect("first ensure should succeed");
+    let second = manager
+        .ensure(&issue)
+        .await
+        .expect("second ensure should reuse workspace");
+
+    assert!(first.created);
+    assert!(!second.created);
+    assert_eq!(
+        first.handle.workspace_path(),
+        second.handle.workspace_path()
+    );
+    assert!(
+        tokio::fs::read_to_string(first.handle.issue_manifest_path())
+            .await
+            .expect("issue manifest should exist")
+            .contains("\"sanitized_workspace_key\": \"COE-263\"")
+    );
+
+    let after_create_log =
+        tokio::fs::read_to_string(first.handle.logs_dir().join("after_create-count.txt"))
+            .await
+            .expect("after_create hook should have written a marker");
+    let run_count = after_create_log.lines().count();
+    assert_eq!(run_count, 1);
+}
+
+#[tokio::test]
+async fn start_run_executes_before_run_in_workspace_and_persists_manifest() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_run: Some(HookDefinition::shell(current_dir_command(
+                ".opensymphony/logs/before_run_cwd.txt",
+            ))),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("feature/42");
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("workspace should exist");
+
+    let run_manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-1", 1))
+        .await
+        .expect("before_run hook should succeed");
+
+    assert_eq!(run_manifest.status, RunStatus::Prepared);
+    assert_eq!(run_manifest.hooks.len(), 1);
+    assert_eq!(run_manifest.hooks[0].kind, HookKind::BeforeRun);
+    assert_eq!(run_manifest.hooks[0].status, HookExecutionStatus::Succeeded);
+
+    let cwd = tokio::fs::read_to_string(ensured.handle.logs_dir().join("before_run_cwd.txt"))
+        .await
+        .expect("hook should have written cwd");
+    let normalized = cwd.trim();
+    assert_eq!(
+        std::path::Path::new(normalized),
+        ensured.handle.workspace_path()
+    );
+
+    let persisted = manager
+        .load_run_manifest(&ensured.handle)
+        .await
+        .expect("run manifest read should succeed")
+        .expect("run manifest should exist");
+    assert_eq!(persisted.status, RunStatus::Prepared);
+    assert_eq!(persisted.sanitized_workspace_key, "feature_42");
+}
+
+#[tokio::test]
+async fn before_run_timeout_is_recorded_and_returned() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_run: Some(HookDefinition::shell(timeout_command())),
+            timeout: Duration::from_millis(50),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-timeout"))
+        .await
+        .expect("workspace should exist");
+
+    let error = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-timeout", 1))
+        .await
+        .expect_err("timeout should fail required hook");
+
+    assert!(matches!(
+        error,
+        WorkspaceError::HookTimedOut {
+            hook: HookKind::BeforeRun,
+            ..
+        }
+    ));
+
+    let persisted = manager
+        .load_run_manifest(&ensured.handle)
+        .await
+        .expect("run manifest read should succeed")
+        .expect("run manifest should exist");
+    assert_eq!(persisted.status, RunStatus::PreparationFailed);
+    assert_eq!(persisted.hooks.len(), 1);
+    assert_eq!(persisted.hooks[0].status, HookExecutionStatus::TimedOut);
+}
+
+#[tokio::test]
+async fn before_run_failure_captures_stderr() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_run: Some(HookDefinition::shell(failing_command())),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-failure"))
+        .await
+        .expect("workspace should exist");
+
+    let error = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-failure", 2))
+        .await
+        .expect_err("non-zero exit should fail required hook");
+
+    assert!(matches!(
+        error,
+        WorkspaceError::HookFailed {
+            hook: HookKind::BeforeRun,
+            ..
+        }
+    ));
+
+    let persisted = manager
+        .load_run_manifest(&ensured.handle)
+        .await
+        .expect("run manifest read should succeed")
+        .expect("run manifest should exist");
+    assert_eq!(persisted.status, RunStatus::PreparationFailed);
+    assert_eq!(persisted.hooks[0].stderr.trim(), "boom");
+    assert_eq!(persisted.hooks[0].exit_code, Some(7));
+}
+
+#[tokio::test]
+async fn after_run_failure_is_best_effort_and_persisted() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            after_run: Some(HookDefinition::shell(best_effort_failure_command())),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-after-run"))
+        .await
+        .expect("workspace should exist");
+    let mut run_manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-after", 3))
+        .await
+        .expect("before_run is not configured");
+
+    manager
+        .finish_run(&ensured.handle, &mut run_manifest, RunStatus::Succeeded)
+        .await
+        .expect("after_run should be best effort");
+
+    let persisted = manager
+        .load_run_manifest(&ensured.handle)
+        .await
+        .expect("run manifest read should succeed")
+        .expect("run manifest should exist");
+    assert_eq!(persisted.status, RunStatus::Succeeded);
+    assert_eq!(persisted.hooks.len(), 1);
+    assert_eq!(persisted.hooks[0].kind, HookKind::AfterRun);
+    assert_eq!(persisted.hooks[0].status, HookExecutionStatus::Failed);
+    assert_eq!(persisted.hooks[0].stderr.trim(), "after-run");
+}
+
+#[tokio::test]
+async fn cleanup_retains_non_terminal_workspaces() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig {
+            remove_terminal_workspaces: true,
+        },
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-active"))
+        .await
+        .expect("workspace should exist");
+
+    let outcome = manager
+        .cleanup(&ensured.handle, IssueLifecycleState::Inactive)
+        .await
+        .expect("non-terminal cleanup should succeed");
+
+    assert_eq!(outcome.decision, CleanupDecision::Retain);
+    assert!(tokio::fs::metadata(ensured.handle.workspace_path())
+        .await
+        .is_ok());
+}
+
+#[tokio::test]
+async fn terminal_cleanup_can_run_before_remove_without_deleting_workspace() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_remove: Some(HookDefinition::shell(
+                "echo before_remove > .opensymphony/logs/before_remove.txt",
+            )),
+            ..HookConfig::default()
+        },
+        CleanupConfig {
+            remove_terminal_workspaces: false,
+        },
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-terminal-retain"))
+        .await
+        .expect("workspace should exist");
+
+    let outcome = manager
+        .cleanup(&ensured.handle, IssueLifecycleState::Terminal)
+        .await
+        .expect("terminal cleanup should succeed");
+
+    assert_eq!(outcome.decision, CleanupDecision::Retain);
+    assert_eq!(
+        tokio::fs::read_to_string(ensured.handle.logs_dir().join("before_remove.txt"))
+            .await
+            .expect("before_remove should have written marker")
+            .trim(),
+        "before_remove"
+    );
+}
+
+#[tokio::test]
+async fn terminal_cleanup_can_delete_workspace() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig {
+            remove_terminal_workspaces: true,
+        },
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-terminal-remove"))
+        .await
+        .expect("workspace should exist");
+
+    let outcome = manager
+        .cleanup(&ensured.handle, IssueLifecycleState::Terminal)
+        .await
+        .expect("terminal cleanup should succeed");
+
+    assert_eq!(outcome.decision, CleanupDecision::Remove);
+    assert!(tokio::fs::metadata(ensured.handle.workspace_path())
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn hook_cwd_override_cannot_escape_workspace() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_run: Some(HookDefinition::shell("echo nope").with_cwd("../outside")),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-263-cwd"))
+        .await
+        .expect("workspace should exist");
+
+    let error = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-cwd", 1))
+        .await
+        .expect_err("escaping cwd should fail");
+
+    assert!(matches!(
+        error,
+        WorkspaceError::HookPathEscape {
+            hook: HookKind::BeforeRun,
+            ..
+        }
+    ));
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,7 +132,7 @@ Recommended crate boundaries:
   - workspace mapping
   - sanitization and containment
   - hook runner
-  - issue metadata manifest
+  - issue and run metadata manifests
 - `opensymphony-linear`
   - Linear GraphQL client
   - issue normalization

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,9 +133,11 @@ Recommended crate boundaries:
   - sanitization and containment
   - hook runner
   - issue and run metadata manifests
+  - root-scoped `after_create` bootstrap receipt for post-hook recovery
   - manifest-backed workspace ownership checks for colliding sanitized keys
   - symlink rejection for reused workspace roots
   - managed metadata path safety for `.opensymphony/`
+  - process-tree teardown for timed-out hooks
 - `opensymphony-linear`
   - Linear GraphQL client
   - issue normalization

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,6 +134,7 @@ Recommended crate boundaries:
   - hook runner
   - issue and run metadata manifests
   - manifest-backed workspace ownership checks for colliding sanitized keys
+  - symlink rejection for reused workspace roots
   - managed metadata path safety for `.opensymphony/`
 - `opensymphony-linear`
   - Linear GraphQL client

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,8 @@ Recommended crate boundaries:
   - sanitization and containment
   - hook runner
   - issue and run metadata manifests
+  - manifest-backed workspace ownership checks for colliding sanitized keys
+  - managed metadata path safety for `.opensymphony/`
 - `opensymphony-linear`
   - Linear GraphQL client
   - issue normalization

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -98,10 +98,11 @@ Current implementation:
 - allow fresh `after_create` hooks to bootstrap clone/worktree flows before `.opensymphony/` exists
 - retry failed first-time `after_create` hooks on the next `ensure`
 - reject sanitized-key collisions when an existing current-path issue manifest belongs to another issue
-- ignore foreign or copied `.opensymphony/issue.json` artifacts when deciding whether first bootstrap already completed
+- ignore foreign, copied, or undecodable `.opensymphony/issue.json` artifacts when deciding whether first bootstrap already completed
 - hook timeout
 - hook stderr capture
 - avoid login-shell startup files when launching Unix hooks
+- reject symlinked workspace roots during reused-workspace validation
 - reject symlink-based `cwd` escapes for hooks
 - reject symlinked `.opensymphony` manifest reads and writes
 - cleanup on terminal issue state

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -99,6 +99,7 @@ Current implementation:
 - retry failed first-time `after_create` hooks on the next `ensure`
 - hook timeout
 - hook stderr capture
+- avoid login-shell startup files when launching Unix hooks
 - reject symlink-based `cwd` escapes for hooks
 - cleanup on terminal issue state
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -97,10 +97,13 @@ Current implementation:
 - persist issue and run manifests
 - allow fresh `after_create` hooks to bootstrap clone/worktree flows before `.opensymphony/` exists
 - retry failed first-time `after_create` hooks on the next `ensure`
+- reject sanitized-key collisions when an existing current-path issue manifest belongs to another issue
+- ignore foreign or copied `.opensymphony/issue.json` artifacts when deciding whether first bootstrap already completed
 - hook timeout
 - hook stderr capture
 - avoid login-shell startup files when launching Unix hooks
 - reject symlink-based `cwd` escapes for hooks
+- reject symlinked `.opensymphony` manifest reads and writes
 - cleanup on terminal issue state
 
 ## 3.3 OpenHands adapter

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -97,9 +97,11 @@ Current implementation:
 - persist issue and run manifests
 - allow fresh `after_create` hooks to bootstrap clone/worktree flows before `.opensymphony/` exists
 - retry failed first-time `after_create` hooks on the next `ensure`
+- remember a successful first-time `after_create` before later metadata bootstrap steps so clone/worktree hooks are not rerun after a post-hook bootstrap failure
 - reject sanitized-key collisions when an existing current-path issue manifest belongs to another issue
 - ignore foreign, copied, or undecodable `.opensymphony/issue.json` artifacts when deciding whether first bootstrap already completed
 - hook timeout
+- kill spawned hook descendants when a timeout fires
 - hook stderr capture
 - avoid login-shell startup files when launching Unix hooks
 - reject symlinked workspace roots during reused-workspace validation
@@ -292,6 +294,7 @@ Write logs to:
 Each issue workspace should expose enough local artifacts to debug recovery:
 
 ```text
+<issue_workspace>/.opensymphony.after_create.json
 <issue_workspace>/.opensymphony/
   issue.json
   run.json
@@ -300,7 +303,7 @@ Each issue workspace should expose enough local artifacts to debug recovery:
   logs/
 ```
 
-These files should make restart recovery explainable without scraping daemon memory, and `run.json` should retain the latest hook/status evidence for the worker lifetime.
+These files should make restart recovery explainable without scraping daemon memory. The root-scoped `after_create` receipt explains why a partially bootstrapped workspace will skip rerunning clone/worktree hooks, and `run.json` should retain the latest hook/status evidence for the worker lifetime.
 
 ## 10. Version pinning
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -95,8 +95,11 @@ Current implementation:
 - refuse path escape
 - create and reuse workspace
 - persist issue and run manifests
+- allow fresh `after_create` hooks to bootstrap clone/worktree flows before `.opensymphony/` exists
+- retry failed first-time `after_create` hooks on the next `ensure`
 - hook timeout
 - hook stderr capture
+- reject symlink-based `cwd` escapes for hooks
 - cleanup on terminal issue state
 
 ## 3.3 OpenHands adapter

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -94,6 +94,7 @@ Current implementation:
 - sanitize issue identifiers
 - refuse path escape
 - create and reuse workspace
+- persist issue and run manifests
 - hook timeout
 - hook stderr capture
 - cleanup on terminal issue state
@@ -273,13 +274,13 @@ Each issue workspace should expose enough local artifacts to debug recovery:
 ```text
 <issue_workspace>/.opensymphony/
   issue.json
+  run.json
   conversation.json
-  last-run.json
   prompts/
   logs/
 ```
 
-These files should make restart recovery explainable without scraping daemon memory.
+These files should make restart recovery explainable without scraping daemon memory, and `run.json` should retain the latest hook/status evidence for the worker lifetime.
 
 ## 10. Version pinning
 

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -57,7 +57,7 @@ Recommended layout inside each issue workspace:
 Notes:
 
 - `.opensymphony/` is OpenSymphony-owned metadata.
-- The workspace layer bootstraps `issue.json`, `run.json`, and the supporting metadata directories on first ensure.
+- The workspace layer bootstraps `issue.json`, `run.json`, and the supporting metadata directories after a successful first-time `after_create` hook so clone/worktree hooks still see a fresh workspace directory.
 - `conversation.json` remains reserved for the OpenHands session layer even though the workspace handle exposes its deterministic path.
 - The repository working tree remains otherwise untouched except by normal agent work.
 - OpenSymphony must never overwrite repository-owned `AGENTS.md`.
@@ -83,6 +83,8 @@ Preserve the Symphony hook model.
 
 Runs once after a brand-new issue workspace is created.
 
+On first bootstrap, this hook runs before OpenSymphony creates `.opensymphony/` so repository bootstrap commands such as `git clone <repo> .` or `git worktree add <path>` can target an otherwise empty workspace directory.
+
 Use for:
 
 - cloning the repo
@@ -91,6 +93,8 @@ Use for:
 - creating ignored helper files
 
 Do not rerun it on every worker attempt.
+
+If the first `after_create` attempt fails before bootstrap completes, the next `ensure` attempt should retry `after_create` instead of treating the partially initialized workspace directory as fully reusable.
 
 ## 6.2 `before_run`
 
@@ -128,6 +132,7 @@ Use for:
 
 - Hooks execute inside the issue workspace unless explicitly documented otherwise.
 - Any explicit hook `cwd` override must still resolve inside the same issue workspace.
+- Containment checks for explicit hook `cwd` overrides should use canonicalized paths so symlinked subdirectories cannot escape the workspace.
 - Hook timeouts use the configured `hooks.timeout_ms`.
 - Hook failures are categorized and surfaced with issue context.
 - `after_run` and `before_remove` are best effort by default.
@@ -349,9 +354,12 @@ trait WorkspaceManager {
 - canonical path containment
 - create vs reuse
 - `after_create` only once
+- clone/worktree-compatible fresh bootstrap before `.opensymphony/` exists
+- retry `after_create` after a failed first bootstrap
 - `before_run` every worker lifetime
 - timeout on hook
 - hook stderr capture
+- canonical `cwd` containment for symlinked subdirectories
 - terminal cleanup
 - issue and run metadata file write and reload
 - conversation reset path preserves workspace safety

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -39,6 +39,7 @@ Recommended layout inside each issue workspace:
 
 ```text
 <issue_workspace>/
+  .opensymphony.after_create.json
   .opensymphony/
     issue.json
     run.json
@@ -60,6 +61,7 @@ Recommended layout inside each issue workspace:
 Notes:
 
 - `.opensymphony/` is OpenSymphony-owned metadata.
+- `.opensymphony.after_create.json` is an internal OpenSymphony bootstrap receipt written at the workspace root immediately after a successful first-time `after_create` hook and before `.opensymphony/` metadata bootstrap.
 - The workspace layer bootstraps `issue.json`, `run.json`, and the supporting metadata directories after a successful first-time `after_create` hook so clone/worktree hooks still see a fresh workspace directory.
 - `conversation.json` remains reserved for the OpenHands session layer even though the workspace handle exposes its deterministic path.
 - The repository working tree remains otherwise untouched except by normal agent work.
@@ -99,7 +101,9 @@ Do not rerun it on every worker attempt.
 
 If the first `after_create` attempt fails before bootstrap completes, the next `ensure` attempt should retry `after_create` instead of treating the partially initialized workspace directory as fully reusable.
 
-Bootstrap completion is determined by a decodable OpenSymphony-owned `issue.json` whose workspace path and sanitized key match the current workspace, not by raw file existence. Repository-provided, copied, or undecodable `.opensymphony/issue.json` artifacts must not suppress the retry.
+After a successful first-time `after_create`, OpenSymphony must persist a root-scoped bootstrap receipt before it starts creating `.opensymphony/` metadata. If later bootstrap steps fail, the next `ensure` should resume metadata bootstrap without rerunning `after_create`.
+
+Steady-state workspace ownership is still determined by a decodable OpenSymphony-owned `issue.json` whose workspace path and sanitized key match the current workspace, not by raw file existence. Repository-provided, copied, or undecodable `.opensymphony/issue.json` or `.opensymphony.after_create.json` artifacts must not suppress a required first-bootstrap retry.
 
 ## 6.2 `before_run`
 
@@ -142,6 +146,7 @@ Use for:
 - OpenSymphony-managed metadata paths under `.opensymphony/` must reject symlinked directories or files before any manifest read or write.
 - Unix hook commands should run via a non-login `sh -c` shell so host profile startup files cannot change `cwd` or fail the hook before the configured command runs.
 - Hook timeouts use the configured `hooks.timeout_ms`.
+- When a hook times out, OpenSymphony must terminate the entire spawned process tree rather than only the direct shell wrapper process.
 - Hook failures are categorized and surfaced with issue context.
 - `after_run` and `before_remove` are best effort by default.
 - `after_create` and `before_run` failures fail the current worker attempt.

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -133,6 +133,7 @@ Use for:
 - Hooks execute inside the issue workspace unless explicitly documented otherwise.
 - Any explicit hook `cwd` override must still resolve inside the same issue workspace.
 - Containment checks for explicit hook `cwd` overrides should use canonicalized paths so symlinked subdirectories cannot escape the workspace.
+- Unix hook commands should run via a non-login `sh -c` shell so host profile startup files cannot change `cwd` or fail the hook before the configured command runs.
 - Hook timeouts use the configured `hooks.timeout_ms`.
 - Hook failures are categorized and surfaced with issue context.
 - `after_run` and `before_remove` are best effort by default.

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -23,6 +23,8 @@ Examples:
 - `feature/42` -> `feature_42`
 - `Bug: weird path` -> `Bug__weird_path`
 
+Because this sanitization is not injective, workspace reuse must be gated by the persisted issue manifest for the current path. If an existing current-path manifest claims the same sanitized key for a different issue, OpenSymphony must refuse reuse instead of silently aliasing two issues onto one workspace.
+
 ## 3. Hard safety invariants
 
 - The resolved workspace path must stay under `workspace.root`.
@@ -96,6 +98,8 @@ Do not rerun it on every worker attempt.
 
 If the first `after_create` attempt fails before bootstrap completes, the next `ensure` attempt should retry `after_create` instead of treating the partially initialized workspace directory as fully reusable.
 
+Bootstrap completion is determined by an OpenSymphony-owned `issue.json` whose workspace path and sanitized key match the current workspace, not by raw file existence. Repository-provided or copied `.opensymphony/issue.json` artifacts must not suppress the retry.
+
 ## 6.2 `before_run`
 
 Runs before each worker lifetime.
@@ -133,6 +137,7 @@ Use for:
 - Hooks execute inside the issue workspace unless explicitly documented otherwise.
 - Any explicit hook `cwd` override must still resolve inside the same issue workspace.
 - Containment checks for explicit hook `cwd` overrides should use canonicalized paths so symlinked subdirectories cannot escape the workspace.
+- OpenSymphony-managed metadata paths under `.opensymphony/` must reject symlinked directories or files before any manifest read or write.
 - Unix hook commands should run via a non-login `sh -c` shell so host profile startup files cannot change `cwd` or fail the hook before the configured command runs.
 - Hook timeouts use the configured `hooks.timeout_ms`.
 - Hook failures are categorized and surfaced with issue context.
@@ -160,6 +165,7 @@ Use cases:
 - restart recovery
 - operator debugging
 - workspace introspection
+- authoritative ownership check for non-injective sanitized workspace keys
 
 ## 7.1 Run metadata manifest
 

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -38,8 +38,8 @@ Recommended layout inside each issue workspace:
 <issue_workspace>/
   .opensymphony/
     issue.json
+    run.json
     conversation.json
-    retry.json
     prompts/
       last-full-prompt.md
       last-continuation-prompt.md
@@ -57,6 +57,8 @@ Recommended layout inside each issue workspace:
 Notes:
 
 - `.opensymphony/` is OpenSymphony-owned metadata.
+- The workspace layer bootstraps `issue.json`, `run.json`, and the supporting metadata directories on first ensure.
+- `conversation.json` remains reserved for the OpenHands session layer even though the workspace handle exposes its deterministic path.
 - The repository working tree remains otherwise untouched except by normal agent work.
 - OpenSymphony must never overwrite repository-owned `AGENTS.md`.
 
@@ -125,6 +127,7 @@ Use for:
 ## 6.5 Hook execution rules
 
 - Hooks execute inside the issue workspace unless explicitly documented otherwise.
+- Any explicit hook `cwd` override must still resolve inside the same issue workspace.
 - Hook timeouts use the configured `hooks.timeout_ms`.
 - Hook failures are categorized and surfaced with issue context.
 - `after_run` and `before_remove` are best effort by default.
@@ -151,6 +154,30 @@ Use cases:
 - restart recovery
 - operator debugging
 - workspace introspection
+
+## 7.1 Run metadata manifest
+
+Persist the latest worker-lifetime manifest under `.opensymphony/run.json`.
+
+Suggested fields:
+
+- `run_id`
+- `attempt`
+- `issue_id`
+- `identifier`
+- `sanitized_workspace_key`
+- `workspace_path`
+- `status`
+- `status_detail`
+- `hooks`
+- `created_at`
+- `updated_at`
+
+Use cases:
+
+- capture `before_run` and `after_run` hook outcomes with stdout/stderr for diagnostics
+- explain the latest worker-lifetime state during restart recovery
+- make cleanup and retry decisions inspectable without daemon memory
 
 ## 8. Conversation metadata manifest
 
@@ -286,9 +313,23 @@ A future hosted mode can keep the same workspace ownership model while moving ac
 ```rust
 trait WorkspaceManager {
     fn workspace_path_for(&self, issue_identifier: &str) -> Result<PathBuf>;
-    async fn ensure(&self, issue: &Issue) -> Result<WorkspaceHandle>;
-    async fn run_hook(&self, hook: HookKind, workspace: &WorkspaceHandle) -> Result<()>;
-    async fn remove(&self, workspace: &WorkspaceHandle) -> Result<()>;
+    async fn ensure(&self, issue: &IssueDescriptor) -> Result<EnsureWorkspaceResult>;
+    async fn start_run(
+        &self,
+        workspace: &WorkspaceHandle,
+        run: &RunDescriptor,
+    ) -> Result<RunManifest>;
+    async fn finish_run(
+        &self,
+        workspace: &WorkspaceHandle,
+        run: &mut RunManifest,
+        status: RunStatus,
+    ) -> Result<()>;
+    async fn cleanup(
+        &self,
+        workspace: &WorkspaceHandle,
+        state: IssueLifecycleState,
+    ) -> Result<CleanupOutcome>;
 }
 ```
 
@@ -298,6 +339,8 @@ trait WorkspaceManager {
 - `identifier`
 - `workspace_path`
 - `metadata_dir`
+- `issue_manifest_path`
+- `run_manifest_path`
 - `conversation_manifest_path`
 
 ## 16. Tests required
@@ -308,6 +351,7 @@ trait WorkspaceManager {
 - `after_create` only once
 - `before_run` every worker lifetime
 - timeout on hook
+- hook stderr capture
 - terminal cleanup
-- metadata file write and reload
+- issue and run metadata file write and reload
 - conversation reset path preserves workspace safety

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -28,6 +28,7 @@ Because this sanitization is not injective, workspace reuse must be gated by the
 ## 3. Hard safety invariants
 
 - The resolved workspace path must stay under `workspace.root`.
+- The issue workspace path itself must not be a symlink when OpenSymphony reuses or validates it.
 - `cwd` for all hook commands and all OpenHands runs must equal the resolved issue workspace path unless an explicit per-command `cwd` override inside the same workspace is required.
 - OpenSymphony must never run agent work directly in `workspace.root`.
 - Path checks must operate on canonicalized paths when possible.
@@ -98,7 +99,7 @@ Do not rerun it on every worker attempt.
 
 If the first `after_create` attempt fails before bootstrap completes, the next `ensure` attempt should retry `after_create` instead of treating the partially initialized workspace directory as fully reusable.
 
-Bootstrap completion is determined by an OpenSymphony-owned `issue.json` whose workspace path and sanitized key match the current workspace, not by raw file existence. Repository-provided or copied `.opensymphony/issue.json` artifacts must not suppress the retry.
+Bootstrap completion is determined by a decodable OpenSymphony-owned `issue.json` whose workspace path and sanitized key match the current workspace, not by raw file existence. Repository-provided, copied, or undecodable `.opensymphony/issue.json` artifacts must not suppress the retry.
 
 ## 6.2 `before_run`
 
@@ -135,6 +136,7 @@ Use for:
 ## 6.5 Hook execution rules
 
 - Hooks execute inside the issue workspace unless explicitly documented otherwise.
+- Workspace-handle validation must reject symlinked workspace roots before hook execution, cleanup, or manifest I/O can proceed.
 - Any explicit hook `cwd` override must still resolve inside the same issue workspace.
 - Containment checks for explicit hook `cwd` overrides should use canonicalized paths so symlinked subdirectories cannot escape the workspace.
 - OpenSymphony-managed metadata paths under `.opensymphony/` must reject symlinked directories or files before any manifest read or write.


### PR DESCRIPTION
## Summary
- implement the `opensymphony-workspace` manager with deterministic path sanitization, containment checks, lifecycle hook execution, and terminal cleanup decisions
- persist issue and run manifests under `.opensymphony/` and expose stable handle/config types for future orchestrator/runtime integration
- document the new workspace manifest contract and add tempdir coverage for create/reuse, timeout, stderr capture, and cleanup behavior

## Testing
- cargo test -p opensymphony-workspace
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace