### PR TITLE
COE-270: add deterministic workspace context artifacts

### DIFF
--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -59,6 +59,8 @@ pub enum WorkspaceError {
     EncodeManifest { path: PathBuf, source: JsonError },
     #[error("failed to write manifest {path}: {source}")]
     WriteManifest { path: PathBuf, source: io::Error },
+    #[error("failed to write artifact {path}: {source}")]
+    WriteArtifact { path: PathBuf, source: io::Error },
     #[error("failed to launch hook `{hook}` in {cwd}: {source}")]
     LaunchHook {
         hook: HookKind,

--- a/crates/opensymphony-workspace/src/lib.rs
+++ b/crates/opensymphony-workspace/src/lib.rs
@@ -6,9 +6,10 @@ mod paths;
 pub use error::{WorkspaceError, WorkspaceOwnershipConflictDetails};
 pub use manager::WorkspaceManager;
 pub use models::{
-    CleanupConfig, CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookConfig,
-    HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind, IssueDescriptor,
-    IssueLifecycleState, IssueManifest, RunDescriptor, RunManifest, RunStatus, WorkspaceHandle,
-    WorkspaceManagerConfig,
+    CleanupConfig, CleanupDecision, CleanupOutcome, ConversationManifest, EnsureWorkspaceResult,
+    HookConfig, HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind,
+    IssueContextArtifact, IssueDescriptor, IssueLifecycleState, IssueManifest,
+    PromptCaptureDescriptor, PromptCaptureManifest, PromptKind, RunDescriptor, RunManifest,
+    RunStatus, SessionContextArtifact, WorkspaceHandle, WorkspaceManagerConfig,
 };
 pub use paths::{resolve_path_within_root, sanitize_workspace_key, workspace_path_for_root};

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -10,10 +10,11 @@ use tokio::{
 };
 
 use crate::{
-    CleanupDecision, CleanupOutcome, EnsureWorkspaceResult, HookDefinition, HookExecutionRecord,
-    HookExecutionStatus, HookKind, IssueDescriptor, IssueLifecycleState, IssueManifest,
-    RunDescriptor, RunManifest, RunStatus, WorkspaceError, WorkspaceHandle, WorkspaceManagerConfig,
-    WorkspaceOwnershipConflictDetails,
+    CleanupDecision, CleanupOutcome, ConversationManifest, EnsureWorkspaceResult, HookDefinition,
+    HookExecutionRecord, HookExecutionStatus, HookKind, IssueContextArtifact, IssueDescriptor,
+    IssueLifecycleState, IssueManifest, PromptCaptureDescriptor, PromptCaptureManifest,
+    RunDescriptor, RunManifest, RunStatus, SessionContextArtifact, WorkspaceError, WorkspaceHandle,
+    WorkspaceManagerConfig, WorkspaceOwnershipConflictDetails,
     models::AfterCreateBootstrapReceipt,
     paths::{normalize_absolute_path, resolve_path_within_root, sanitize_workspace_key},
 };
@@ -279,6 +280,84 @@ impl WorkspaceManager {
     ) -> Result<(), WorkspaceError> {
         self.validate_workspace_handle(workspace).await?;
         self.write_manifest(workspace, &workspace.run_manifest_path(), manifest)
+            .await
+    }
+
+    pub async fn load_conversation_manifest(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<Option<ConversationManifest>, WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.load_manifest(workspace, &workspace.conversation_manifest_path())
+            .await
+    }
+
+    pub async fn write_conversation_manifest(
+        &self,
+        workspace: &WorkspaceHandle,
+        manifest: &ConversationManifest,
+    ) -> Result<(), WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.write_manifest(workspace, &workspace.conversation_manifest_path(), manifest)
+            .await
+    }
+
+    pub async fn write_prompt_capture(
+        &self,
+        workspace: &WorkspaceHandle,
+        run: &RunDescriptor,
+        descriptor: PromptCaptureDescriptor,
+        prompt: &str,
+    ) -> Result<PromptCaptureManifest, WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+
+        let manifest = PromptCaptureManifest::new(workspace, run, descriptor, prompt);
+        let archived_manifest_path =
+            workspace.run_prompt_manifest_path(run.attempt, descriptor.kind, descriptor.sequence);
+        let stable_manifest_path = workspace.latest_prompt_manifest_path(descriptor.kind);
+
+        self.write_text_artifact(workspace, &manifest.archived_prompt_path, prompt)
+            .await?;
+        self.write_text_artifact(workspace, &manifest.stable_prompt_path, prompt)
+            .await?;
+        self.write_manifest(workspace, &archived_manifest_path, &manifest)
+            .await?;
+        self.write_manifest(workspace, &stable_manifest_path, &manifest)
+            .await?;
+
+        Ok(manifest)
+    }
+
+    pub async fn write_issue_context(
+        &self,
+        workspace: &WorkspaceHandle,
+        artifact: &IssueContextArtifact,
+    ) -> Result<(), WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.write_text_artifact(
+            workspace,
+            &workspace.issue_context_path(),
+            &artifact.render_markdown(workspace),
+        )
+        .await
+    }
+
+    pub async fn load_session_context(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<Option<SessionContextArtifact>, WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.load_manifest(workspace, &workspace.session_context_path())
+            .await
+    }
+
+    pub async fn write_session_context(
+        &self,
+        workspace: &WorkspaceHandle,
+        artifact: &SessionContextArtifact,
+    ) -> Result<(), WorkspaceError> {
+        self.validate_workspace_handle(workspace).await?;
+        self.write_manifest(workspace, &workspace.session_context_path(), artifact)
             .await
     }
 
@@ -773,6 +852,25 @@ impl WorkspaceManager {
         fs::write(&path, payload)
             .await
             .map_err(|error| WorkspaceError::WriteManifest {
+                path,
+                source: error,
+            })
+    }
+
+    async fn write_text_artifact(
+        &self,
+        workspace: &WorkspaceHandle,
+        path: &Path,
+        content: &str,
+    ) -> Result<(), WorkspaceError> {
+        if let Some(parent) = path.parent() {
+            self.create_managed_directory(workspace, parent).await?;
+        }
+        let path = self.validate_workspace_owned_path(workspace, path).await?;
+
+        fs::write(&path, content)
+            .await
+            .map_err(|error| WorkspaceError::WriteArtifact {
                 path,
                 source: error,
             })

--- a/crates/opensymphony-workspace/src/models.rs
+++ b/crates/opensymphony-workspace/src/models.rs
@@ -162,6 +162,43 @@ impl WorkspaceHandle {
     pub fn runs_dir(&self) -> PathBuf {
         self.metadata_dir().join("runs")
     }
+
+    pub fn latest_prompt_path(&self, kind: PromptKind) -> PathBuf {
+        self.prompts_dir()
+            .join(format!("last-{}-prompt.md", kind.file_stem()))
+    }
+
+    pub fn latest_prompt_manifest_path(&self, kind: PromptKind) -> PathBuf {
+        self.prompts_dir()
+            .join(format!("last-{}-prompt.json", kind.file_stem()))
+    }
+
+    pub fn run_artifacts_dir(&self, attempt: u32) -> PathBuf {
+        self.runs_dir().join(format!("attempt-{attempt:04}"))
+    }
+
+    pub fn run_prompt_path(&self, attempt: u32, kind: PromptKind, sequence: u32) -> PathBuf {
+        self.run_artifacts_dir(attempt)
+            .join(format!("prompt-{}-{sequence:03}.md", kind.file_stem()))
+    }
+
+    pub fn run_prompt_manifest_path(
+        &self,
+        attempt: u32,
+        kind: PromptKind,
+        sequence: u32,
+    ) -> PathBuf {
+        self.run_artifacts_dir(attempt)
+            .join(format!("prompt-{}-{sequence:03}.json", kind.file_stem()))
+    }
+
+    pub fn issue_context_path(&self) -> PathBuf {
+        self.generated_dir().join("issue-context.md")
+    }
+
+    pub fn session_context_path(&self) -> PathBuf {
+        self.generated_dir().join("session-context.json")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -289,6 +326,20 @@ pub enum RunStatus {
     PreparationFailed,
 }
 
+impl fmt::Display for RunStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Preparing => "preparing",
+            Self::Prepared => "prepared",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::PreparationFailed => "preparation_failed",
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunManifest {
     pub run_id: String,
@@ -321,6 +372,283 @@ impl RunManifest {
             updated_at: now,
             status_detail: None,
             hooks: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationManifest {
+    pub issue_id: String,
+    pub identifier: String,
+    pub conversation_id: String,
+    pub server_base_url: String,
+    pub persistence_dir: PathBuf,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attached_at: Option<DateTime<Utc>>,
+    pub fresh_conversation: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_reason: Option<String>,
+    pub runtime_contract_version: String,
+}
+
+impl ConversationManifest {
+    pub fn new(
+        workspace: &WorkspaceHandle,
+        conversation_id: impl Into<String>,
+        server_base_url: impl Into<String>,
+        persistence_dir: impl Into<PathBuf>,
+        runtime_contract_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            issue_id: workspace.issue_id().to_string(),
+            identifier: workspace.identifier().to_string(),
+            conversation_id: conversation_id.into(),
+            server_base_url: server_base_url.into(),
+            persistence_dir: persistence_dir.into(),
+            created_at: Utc::now(),
+            last_attached_at: None,
+            fresh_conversation: true,
+            reset_reason: None,
+            runtime_contract_version: runtime_contract_version.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptKind {
+    Full,
+    Continuation,
+}
+
+impl PromptKind {
+    pub fn file_stem(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Continuation => "continuation",
+        }
+    }
+}
+
+impl fmt::Display for PromptKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Full => "full",
+            Self::Continuation => "continuation",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptCaptureDescriptor {
+    pub kind: PromptKind,
+    pub sequence: u32,
+}
+
+impl PromptCaptureDescriptor {
+    pub fn new(kind: PromptKind, sequence: u32) -> Self {
+        Self { kind, sequence }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromptCaptureManifest {
+    pub issue_id: String,
+    pub identifier: String,
+    pub run_id: String,
+    pub attempt: u32,
+    pub prompt_kind: PromptKind,
+    pub sequence: u32,
+    pub workspace_path: PathBuf,
+    pub archived_prompt_path: PathBuf,
+    pub stable_prompt_path: PathBuf,
+    pub captured_at: DateTime<Utc>,
+    pub prompt_length_bytes: usize,
+}
+
+impl PromptCaptureManifest {
+    pub fn new(
+        workspace: &WorkspaceHandle,
+        run: &RunDescriptor,
+        descriptor: PromptCaptureDescriptor,
+        prompt: &str,
+    ) -> Self {
+        Self {
+            issue_id: workspace.issue_id().to_string(),
+            identifier: workspace.identifier().to_string(),
+            run_id: run.run_id.clone(),
+            attempt: run.attempt,
+            prompt_kind: descriptor.kind,
+            sequence: descriptor.sequence,
+            workspace_path: workspace.workspace_path().to_path_buf(),
+            archived_prompt_path: workspace.run_prompt_path(
+                run.attempt,
+                descriptor.kind,
+                descriptor.sequence,
+            ),
+            stable_prompt_path: workspace.latest_prompt_path(descriptor.kind),
+            captured_at: Utc::now(),
+            prompt_length_bytes: prompt.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueContextArtifact {
+    pub issue_id: String,
+    pub identifier: String,
+    pub title: String,
+    pub current_state: String,
+    pub repo_workflow_path: PathBuf,
+    pub repo_agents_path: Option<PathBuf>,
+    pub repo_skills_dir: Option<PathBuf>,
+    pub last_run_status: Option<RunStatus>,
+    pub important_constraints: Vec<String>,
+    pub known_blockers: Vec<String>,
+}
+
+impl IssueContextArtifact {
+    pub fn render_markdown(&self, workspace: &WorkspaceHandle) -> String {
+        use std::fmt::Write as _;
+
+        let mut output = String::new();
+        let _ = writeln!(output, "# OpenSymphony Issue Context");
+        let _ = writeln!(output);
+        let _ = writeln!(output, "Repository-owned policy remains authoritative.");
+        let _ = writeln!(
+            output,
+            "These generated notes reference repo-owned files without overwriting them."
+        );
+        let _ = writeln!(output);
+        let _ = writeln!(output, "- issue: {}", self.identifier);
+        let _ = writeln!(output, "- issue id: {}", self.issue_id);
+        let _ = writeln!(output, "- title: {}", self.title);
+        let _ = writeln!(output, "- current state: {}", self.current_state);
+        let _ = writeln!(
+            output,
+            "- last run status: {}",
+            self.last_run_status
+                .map(|status| status.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        );
+        let _ = writeln!(output);
+        let _ = writeln!(output, "## Repository Context");
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "- WORKFLOW.md: {}",
+            self.repo_workflow_path.display()
+        );
+        let _ = writeln!(
+            output,
+            "- AGENTS.md: {}",
+            self.repo_agents_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "absent".to_string())
+        );
+        let _ = writeln!(
+            output,
+            "- .agents/skills/: {}",
+            self.repo_skills_dir
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "absent".to_string())
+        );
+        let _ = writeln!(output);
+        let _ = writeln!(output, "## OpenSymphony Artifacts");
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "- issue manifest: {}",
+            workspace.issue_manifest_path().display()
+        );
+        let _ = writeln!(
+            output,
+            "- run manifest: {}",
+            workspace.run_manifest_path().display()
+        );
+        let _ = writeln!(
+            output,
+            "- conversation manifest: {}",
+            workspace.conversation_manifest_path().display()
+        );
+        let _ = writeln!(
+            output,
+            "- latest full prompt: {}",
+            workspace.latest_prompt_path(PromptKind::Full).display()
+        );
+        let _ = writeln!(
+            output,
+            "- latest continuation prompt: {}",
+            workspace
+                .latest_prompt_path(PromptKind::Continuation)
+                .display()
+        );
+        let _ = writeln!(
+            output,
+            "- session context: {}",
+            workspace.session_context_path().display()
+        );
+        if !self.important_constraints.is_empty() {
+            let _ = writeln!(output);
+            let _ = writeln!(output, "## Important Constraints");
+            let _ = writeln!(output);
+            for constraint in &self.important_constraints {
+                let _ = writeln!(output, "- {constraint}");
+            }
+        }
+        if !self.known_blockers.is_empty() {
+            let _ = writeln!(output);
+            let _ = writeln!(output, "## Known Blockers");
+            let _ = writeln!(output);
+            for blocker in &self.known_blockers {
+                let _ = writeln!(output, "- {blocker}");
+            }
+        }
+
+        output
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionContextArtifact {
+    pub issue_id: String,
+    pub identifier: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_status: Option<RunStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_prompt_kind: Option<PromptKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_prompt_path: Option<PathBuf>,
+    #[serde(default)]
+    pub recent_validation_commands: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_retry_reason: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl SessionContextArtifact {
+    pub fn new(workspace: &WorkspaceHandle) -> Self {
+        Self {
+            issue_id: workspace.issue_id().to_string(),
+            identifier: workspace.identifier().to_string(),
+            conversation_id: None,
+            attempt: None,
+            last_run_id: None,
+            last_run_status: None,
+            last_prompt_kind: None,
+            last_prompt_path: None,
+            recent_validation_commands: Vec::new(),
+            last_retry_reason: None,
+            updated_at: Utc::now(),
         }
     }
 }

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
 use opensymphony_workspace::{
-    CleanupConfig, CleanupDecision, HookConfig, HookDefinition, HookExecutionStatus, HookKind,
-    IssueDescriptor, IssueLifecycleState, RunDescriptor, RunStatus, WorkspaceError,
-    WorkspaceManager, WorkspaceManagerConfig,
+    CleanupConfig, CleanupDecision, ConversationManifest, HookConfig, HookDefinition,
+    HookExecutionStatus, HookKind, IssueContextArtifact, IssueDescriptor, IssueLifecycleState,
+    PromptCaptureDescriptor, PromptKind, RunDescriptor, RunStatus, SessionContextArtifact,
+    WorkspaceError, WorkspaceManager, WorkspaceManagerConfig,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -685,6 +686,239 @@ async fn after_run_failure_is_best_effort_and_persisted() {
     assert_eq!(persisted.hooks[0].kind, HookKind::AfterRun);
     assert_eq!(persisted.hooks[0].status, HookExecutionStatus::Failed);
     assert_eq!(persisted.hooks[0].stderr.trim(), "after-run");
+}
+
+#[tokio::test]
+async fn conversation_manifest_and_generated_context_artifacts_are_persisted() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-270-artifacts"))
+        .await
+        .expect("workspace should exist");
+
+    let mut conversation = ConversationManifest::new(
+        &ensured.handle,
+        "conv-270",
+        "http://127.0.0.1:8000",
+        ensured.handle.openhands_dir(),
+        "agent-server-v1",
+    );
+    conversation.last_attached_at = Some(chrono::Utc::now());
+    conversation.fresh_conversation = false;
+    manager
+        .write_conversation_manifest(&ensured.handle, &conversation)
+        .await
+        .expect("conversation manifest should write");
+
+    let loaded = manager
+        .load_conversation_manifest(&ensured.handle)
+        .await
+        .expect("conversation manifest should load")
+        .expect("conversation manifest should exist");
+    assert_eq!(loaded, conversation);
+
+    let issue_context = IssueContextArtifact {
+        issue_id: ensured.handle.issue_id().to_string(),
+        identifier: ensured.handle.identifier().to_string(),
+        title: "Repository harness and generated context artifacts".to_string(),
+        current_state: "In Progress".to_string(),
+        repo_workflow_path: ensured.handle.workspace_path().join("WORKFLOW.md"),
+        repo_agents_path: Some(ensured.handle.workspace_path().join("AGENTS.md")),
+        repo_skills_dir: Some(ensured.handle.workspace_path().join(".agents/skills")),
+        last_run_status: Some(RunStatus::Prepared),
+        important_constraints: vec![
+            "Repo-owned policy remains authoritative.".to_string(),
+            "Generated artifacts stay under .opensymphony/.".to_string(),
+        ],
+        known_blockers: vec!["None".to_string()],
+    };
+    manager
+        .write_issue_context(&ensured.handle, &issue_context)
+        .await
+        .expect("issue context should write");
+
+    let rendered_issue_context = tokio::fs::read_to_string(ensured.handle.issue_context_path())
+        .await
+        .expect("issue context should exist");
+    assert!(rendered_issue_context.contains("Repository-owned policy remains authoritative."));
+    assert!(rendered_issue_context.contains("WORKFLOW.md"));
+    assert!(rendered_issue_context.contains(".agents/skills/"));
+    assert!(rendered_issue_context.contains(".opensymphony/conversation.json"));
+
+    let mut session_context = SessionContextArtifact::new(&ensured.handle);
+    session_context.conversation_id = Some("conv-270".to_string());
+    session_context.attempt = Some(4);
+    session_context.last_run_id = Some("run-4".to_string());
+    session_context.last_run_status = Some(RunStatus::Succeeded);
+    session_context.last_prompt_kind = Some(PromptKind::Continuation);
+    session_context.last_prompt_path =
+        Some(ensured.handle.latest_prompt_path(PromptKind::Continuation));
+    session_context.recent_validation_commands =
+        vec!["cargo test -p opensymphony-workspace".to_string()];
+    manager
+        .write_session_context(&ensured.handle, &session_context)
+        .await
+        .expect("session context should write");
+
+    let loaded_session = manager
+        .load_session_context(&ensured.handle)
+        .await
+        .expect("session context should load")
+        .expect("session context should exist");
+    assert_eq!(loaded_session, session_context);
+}
+
+#[tokio::test]
+async fn prompt_capture_writes_latest_and_per_run_artifacts() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-270-prompts"))
+        .await
+        .expect("workspace should exist");
+    let run = RunDescriptor::new("run-17", 17);
+
+    let first = manager
+        .write_prompt_capture(
+            &ensured.handle,
+            &run,
+            PromptCaptureDescriptor::new(PromptKind::Full, 1),
+            "Initial full prompt",
+        )
+        .await
+        .expect("first prompt capture should write");
+    let second = manager
+        .write_prompt_capture(
+            &ensured.handle,
+            &run,
+            PromptCaptureDescriptor::new(PromptKind::Full, 2),
+            "Updated full prompt",
+        )
+        .await
+        .expect("second prompt capture should write");
+    manager
+        .write_prompt_capture(
+            &ensured.handle,
+            &run,
+            PromptCaptureDescriptor::new(PromptKind::Continuation, 1),
+            "Continuation guidance",
+        )
+        .await
+        .expect("continuation prompt capture should write");
+
+    assert_eq!(
+        tokio::fs::read_to_string(first.archived_prompt_path.clone())
+            .await
+            .expect("archived first prompt should exist"),
+        "Initial full prompt"
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(second.archived_prompt_path.clone())
+            .await
+            .expect("archived second prompt should exist"),
+        "Updated full prompt"
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(ensured.handle.latest_prompt_path(PromptKind::Full))
+            .await
+            .expect("latest full prompt should exist"),
+        "Updated full prompt"
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(ensured.handle.latest_prompt_path(PromptKind::Continuation))
+            .await
+            .expect("latest continuation prompt should exist"),
+        "Continuation guidance"
+    );
+
+    let latest_full_manifest =
+        serde_json::from_str::<opensymphony_workspace::PromptCaptureManifest>(
+            &tokio::fs::read_to_string(
+                ensured.handle.latest_prompt_manifest_path(PromptKind::Full),
+            )
+            .await
+            .expect("latest full prompt manifest should exist"),
+        )
+        .expect("latest full prompt manifest should decode");
+    assert_eq!(latest_full_manifest.sequence, 2);
+    assert_eq!(latest_full_manifest.attempt, 17);
+    assert_eq!(latest_full_manifest.prompt_kind, PromptKind::Full);
+
+    let archived_run_manifest =
+        serde_json::from_str::<opensymphony_workspace::PromptCaptureManifest>(
+            &tokio::fs::read_to_string(ensured.handle.run_prompt_manifest_path(
+                17,
+                PromptKind::Continuation,
+                1,
+            ))
+            .await
+            .expect("archived continuation prompt manifest should exist"),
+        )
+        .expect("archived continuation prompt manifest should decode");
+    assert_eq!(archived_run_manifest.run_id, "run-17");
+    assert_eq!(archived_run_manifest.sequence, 1);
+    assert_eq!(
+        archived_run_manifest.prompt_length_bytes,
+        "Continuation guidance".len()
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn generated_issue_context_rejects_symlinked_output_paths() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-270-generated-symlink"))
+        .await
+        .expect("workspace should exist");
+
+    let outside_issue_context = temp_dir.path().join("outside-issue-context.md");
+    tokio::fs::write(&outside_issue_context, "outside")
+        .await
+        .expect("outside issue context should exist");
+    symlink(&outside_issue_context, ensured.handle.issue_context_path())
+        .expect("issue context symlink should be created");
+
+    let error = manager
+        .write_issue_context(
+            &ensured.handle,
+            &IssueContextArtifact {
+                issue_id: ensured.handle.issue_id().to_string(),
+                identifier: ensured.handle.identifier().to_string(),
+                title: "Symlink rejection".to_string(),
+                current_state: "In Progress".to_string(),
+                repo_workflow_path: ensured.handle.workspace_path().join("WORKFLOW.md"),
+                repo_agents_path: None,
+                repo_skills_dir: None,
+                last_run_status: None,
+                important_constraints: Vec::new(),
+                known_blockers: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("symlinked issue context should be rejected");
+
+    assert!(matches!(error, WorkspaceError::ManagedPathSymlink { .. }));
 }
 
 #[tokio::test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,8 @@ Recommended crate boundaries:
   - workspace mapping
   - sanitization and containment
   - hook runner
-  - issue and run metadata manifests
+  - issue, run, and conversation manifests
+  - prompt capture helpers and generated issue/session context artifacts
   - root-scoped `after_create` bootstrap receipt for post-hook recovery
   - manifest-backed workspace ownership checks for colliding sanitized keys
   - symlink rejection for reused workspace roots

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -207,9 +207,19 @@ The agent already sees:
 - repository files
 - `WORKFLOW.md`
 - repo-root `AGENTS.md` if present in the target repo
+- optional repo-owned `.agents/skills/`
 - OpenSymphony-generated `.opensymphony/generated/issue-context.md`
 
+Recommended precedence:
+
+1. repo-owned `WORKFLOW.md`
+2. repo-owned `AGENTS.md`
+3. repo-owned `.agents/skills/`
+4. additive OpenSymphony-generated `.opensymphony/generated/issue-context.md`
+5. live tracker lookups through Linear MCP tools
+
 The Linear MCP tools should complement this, not duplicate the whole tracker database.
+OpenSymphony-generated files should reference repo-owned policy and latest tracker state without overwriting either one, and example target repos should ignore `.opensymphony/` locally so these artifacts remain workspace-scoped.
 
 ## 8. Suggested issue model in Rust
 

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -183,14 +183,20 @@ Each issue gets a stable `conversation_id` persisted under:
 Suggested persisted fields:
 
 - `issue_id`
-- `issue_identifier`
+- `identifier`
 - `conversation_id`
-- `created_at`
-- `last_attached_at`
 - `server_base_url`
 - `persistence_dir`
-- `conversation_contract_version`
-- `status`
+- `created_at`
+- `last_attached_at`
+- `fresh_conversation`
+- `reset_reason`
+- `runtime_contract_version`
+
+Implementation note:
+
+- `opensymphony-workspace` owns the deterministic `conversation.json` path and serialization helper
+- the OpenHands issue-session runner still decides when to create, reuse, attach, or reset the conversation
 
 ## 6.2 Persistence directory
 

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -162,6 +162,7 @@ examples/
   target-repo/
     WORKFLOW.md
     AGENTS.md
+    .gitignore
     .agents/skills/
   configs/
     local-dev.yaml

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -130,6 +130,9 @@ Current implementation:
 - refuse path escape
 - create and reuse workspace
 - persist issue and run manifests
+- persist conversation manifests
+- persist stable prompt captures plus per-run prompt archives
+- persist generated `issue-context.md` and `session-context.json`
 - allow fresh `after_create` hooks to bootstrap clone/worktree flows before `.opensymphony/` exists
 - retry failed first-time `after_create` hooks on the next `ensure`
 - remember a successful first-time `after_create` before later metadata bootstrap steps so clone/worktree hooks are not rerun after a post-hook bootstrap failure
@@ -399,10 +402,21 @@ Each issue workspace should expose enough local artifacts to debug recovery:
   run.json
   conversation.json
   prompts/
+    last-full-prompt.md
+    last-full-prompt.json
+    last-continuation-prompt.md
+    last-continuation-prompt.json
+  runs/
+    attempt-0001/
+      prompt-full-001.md
+      prompt-full-001.json
   logs/
+  generated/
+    issue-context.md
+    session-context.json
 ```
 
-These files should make restart recovery explainable without scraping daemon memory. The root-scoped `after_create` receipt explains why a partially bootstrapped workspace will skip rerunning clone/worktree hooks, and `run.json` should retain the latest hook/status evidence for the worker lifetime.
+These files should make restart recovery explainable without scraping daemon memory. The root-scoped `after_create` receipt explains why a partially bootstrapped workspace will skip rerunning clone/worktree hooks, `run.json` should retain the latest hook/status evidence for the worker lifetime, and the prompt plus generated-context artifacts should make repo-policy precedence and the last dispatched prompt inspectable without reconstructing daemon state.
 
 ## 10. Version pinning
 

--- a/docs/websocket-runtime.md
+++ b/docs/websocket-runtime.md
@@ -227,6 +227,7 @@ For each turn:
 1. Select prompt shape:
    - full prompt on fresh conversation
    - continuation guidance on resumed conversation or later turns
+   - persist the selected prompt under `.opensymphony/prompts/last-*-prompt.(md|json)` and archive the per-run capture under `.opensymphony/runs/attempt-####/`
 2. `POST /api/conversations/{id}/events`
    - user role
    - prompt content

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -55,7 +55,13 @@ Recommended layout inside each issue workspace:
     conversation.json
     prompts/
       last-full-prompt.md
+      last-full-prompt.json
       last-continuation-prompt.md
+      last-continuation-prompt.json
+    runs/
+      attempt-0001/
+        prompt-full-001.md
+        prompt-full-001.json
     logs/
       worker.log
       hook.log
@@ -72,7 +78,9 @@ Notes:
 - `.opensymphony/` is OpenSymphony-owned metadata.
 - `.opensymphony.after_create.json` is an internal OpenSymphony bootstrap receipt written at the workspace root immediately after a successful first-time `after_create` hook and before `.opensymphony/` metadata bootstrap.
 - The workspace layer bootstraps `issue.json`, `run.json`, and the supporting metadata directories after a successful first-time `after_create` hook so clone/worktree hooks still see a fresh workspace directory.
-- `conversation.json` remains reserved for the OpenHands session layer even though the workspace handle exposes its deterministic path.
+- `conversation.json` now uses workspace-owned path and serialization helpers, but the OpenHands issue-session runner still owns when it is created, reused, or reset.
+- `prompts/` holds the latest prompt of each kind plus JSON metadata that points back to the per-run archive.
+- `runs/attempt-####/` holds immutable per-run prompt captures for auditability without mutating repository-owned policy files.
 - The repository working tree remains otherwise untouched except by normal agent work.
 - OpenSymphony must never overwrite repository-owned `AGENTS.md`.
 
@@ -239,6 +247,7 @@ Human-readable summary for the agent and operator:
 - issue identifier and title
 - current state
 - last worker outcome
+- repository-owned `WORKFLOW.md`, `AGENTS.md`, and optional `.agents/skills/` locations
 - important constraints
 - known blockers
 - location of OpenSymphony metadata files
@@ -249,12 +258,13 @@ Machine-readable runtime summary:
 
 - conversation ID
 - attempt number
-- last worker timestamps
-- last known execution status
+- last run ID and status
+- last prompt kind and path
 - recent validation commands
 - last retry reason if any
 
 These files help continuity without altering the repository's own guidance files.
+They are additive references to repo-owned policy, not replacements for it.
 
 ## 10. Prompt artifacts
 
@@ -267,11 +277,21 @@ Why:
 - comparing full vs continuation prompt logic
 - making live tests and regressions easier to inspect
 
-Store at minimum:
+Store at minimum under `.opensymphony/prompts/`:
 
-- last full prompt
-- last continuation prompt
-- timestamp metadata
+- `last-full-prompt.md`
+- `last-full-prompt.json`
+- `last-continuation-prompt.md`
+- `last-continuation-prompt.json`
+
+Also archive every captured prompt under `.opensymphony/runs/attempt-####/` using deterministic sequence-numbered file names such as:
+
+- `prompt-full-001.md`
+- `prompt-full-001.json`
+- `prompt-continuation-001.md`
+- `prompt-continuation-001.json`
+
+The stable files in `prompts/` should always mirror the latest capture of that kind, while the per-run `runs/` archive remains append-only for that worker attempt.
 
 ## 11. Conversation lifetime policy inside the workspace
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,9 @@ configuration files referenced in `docs/repository-layout.md`.
 
 Bootstrap placeholders live here so later tasks can add concrete fixtures
 without reshaping the repository root.
+
+The bundled `target-repo/` now also demonstrates:
+
+- a repo-owned `AGENTS.md`
+- an optional repo-owned `.agents/skills/` entry
+- a `.gitignore` that keeps local `.opensymphony/` artifacts out of version control

--- a/examples/target-repo/.agents/skills/inspect-opensymphony-artifacts/SKILL.md
+++ b/examples/target-repo/.agents/skills/inspect-opensymphony-artifacts/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: inspect-opensymphony-artifacts
+description: Inspect local OpenSymphony workspace artifacts without changing repo-owned policy files.
+---
+
+# Inspect OpenSymphony Artifacts
+
+Use this skill when you need to confirm what OpenSymphony generated for the current issue workspace.
+
+- Treat `WORKFLOW.md`, `AGENTS.md`, and other checked-in repo files as repo-owned policy.
+- Treat `.opensymphony/` as additive local state and audit output.
+- Prefer reading:
+  - `.opensymphony/issue.json`
+  - `.opensymphony/run.json`
+  - `.opensymphony/conversation.json`
+  - `.opensymphony/generated/issue-context.md`
+  - `.opensymphony/generated/session-context.json`
+  - `.opensymphony/prompts/`
+  - `.opensymphony/runs/`
+- Do not edit or commit `.opensymphony/` unless the task explicitly asks for fixture changes.

--- a/examples/target-repo/.gitignore
+++ b/examples/target-repo/.gitignore
@@ -1,0 +1,2 @@
+.opensymphony/
+.opensymphony.after_create.json

--- a/examples/target-repo/AGENTS.md
+++ b/examples/target-repo/AGENTS.md
@@ -2,6 +2,9 @@
 
 This target repository exists to validate the local OpenSymphony MVP on a trusted machine.
 
+- `WORKFLOW.md`, this `AGENTS.md`, and optional `.agents/skills/` entries are repo-owned policy.
+- `.opensymphony/` and `.opensymphony.after_create.json` are local OpenSymphony artifacts for audit and recovery.
+- Inspect generated OpenSymphony artifacts when needed, but do not rewrite repo-owned policy files to steer the run.
 - Keep commands deterministic.
 - Do not write outside the target workspace.
 - Prefer small edits that are easy to verify during smoke and live validation.

--- a/examples/target-repo/WORKFLOW.md
+++ b/examples/target-repo/WORKFLOW.md
@@ -18,3 +18,10 @@ openhands:
 # Example Workflow
 
 Work the assigned issue inside this repository and keep changes small and reviewable.
+
+Repository context precedence for this example target repo:
+
+1. Follow this `WORKFLOW.md`.
+2. Respect repo-owned `AGENTS.md` and any repo-owned `.agents/skills/`.
+3. Treat `.opensymphony/generated/issue-context.md` and other `.opensymphony/` files as additive context and audit artifacts.
+4. Do not rewrite repo-owned policy files to make the run succeed.


### PR DESCRIPTION
## Summary

Add deterministic `.opensymphony/` context artifact helpers and example target-repo guidance so issue workspaces can persist conversation metadata, prompt captures, and generated context without mutating repo-owned policy files.

## Changes

- add typed `opensymphony-workspace` helpers for `conversation.json`, stable plus per-run prompt captures, and generated `issue-context.md` / `session-context.json`
- extend workspace tests to cover artifact round-trips, deterministic prompt archive paths, and symlink rejection for generated artifacts
- update the required docs plus the bundled example target repo to document repo-context precedence, `.opensymphony/` coexistence rules, and local ignore behavior

## Evidence

### Test output

```text
$ cargo test -p opensymphony-workspace
running 5 tests
...
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 21 tests
...
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo clippy -p opensymphony-workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.34s

$ cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml
[PASS] workflow: resolved examples/configs/../target-repo/WORKFLOW.md -> workspace /Users/magos/code/symphony-workspaces/COE-270/examples/target-repo/var/workspaces, OpenHands http://127.0.0.1:8000, project sample-project, tracker auth resolved
[PASS] workflow-prompt: rendered 464 characters from examples/configs/../target-repo/WORKFLOW.md
[PASS] workspace-root: ready at /Users/magos/code/symphony-workspaces/COE-270/examples/target-repo/var/workspaces
[PASS] openhands-launcher: RUNTIME=process uv run --directory . --locked --extra agent-server --module openhands.agent_server --host 127.0.0.1 --port 8000 [http://127.0.0.1:8000]
[SKIP] linear: Linear checks skipped because `linear.enabled` is false; workflow tracker project sample-project still resolved
[SKIP] openhands-live: live OpenHands checks skipped; rerun with --live-openhands on a prepared machine
```

### Verification

- reproduced the gap by confirming the docs described `conversation.json`, prompt captures, and generated context files while `opensymphony-workspace` only persisted `issue.json` and `run.json`
- verified the new helpers persist deterministic stable and per-run prompt artifacts plus typed conversation/session context files under `.opensymphony/`
- verified the bundled example target repo resolves and renders with the updated repo-context guidance via `opensymphony doctor`

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

- [COE-270](https://linear.app/trilogy-ai-coe/issue/COE-270/repository-harness-and-generated-context-artifacts)

## Additional notes

- Root `AGENTS.md` was not changed because the repo-level operating rules did not change; the example target repo guidance was updated instead.
