### PR TITLE
Harden remote OpenHands agent-server transport auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1834,6 +1835,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -20,7 +20,9 @@ use opensymphony_openhands::{
     ConversationCreateRequest, DoctorProbeConfig, LocalServerSupervisor, LocalServerTooling,
     OpenHandsClient, SupervisedServerConfig, SupervisorConfig, TransportConfig,
 };
-use opensymphony_workflow::{Environment, ResolvedWorkflow, WorkflowDefinition};
+use opensymphony_workflow::{
+    Environment, ProcessEnvironment, ResolvedWorkflow, WorkflowDefinition,
+};
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use thiserror::Error;
@@ -364,9 +366,7 @@ pub async fn run_doctor_command(config_path: PathBuf, live_openhands: bool) -> E
 
             checks.push(check_workspace_root(&runtime.workflow.config.workspace.root).await);
             checks.push(check_tool_dir(&runtime.tool_dir).await);
-            checks.push(check_loopback_base_url(
-                &runtime.workflow.extensions.openhands.transport.base_url,
-            ));
+            checks.push(check_openhands_transport(&runtime.workflow));
             checks.push(check_linear(&config.linear, &runtime.workflow));
             (runtime, rendered_probe_prompt)
         }
@@ -549,6 +549,18 @@ fn effective_openhands_probe_base_url(
     started_supervisor_base_url
         .unwrap_or(configured_base_url)
         .to_string()
+}
+
+fn build_doctor_transport(
+    runtime: &DoctorRuntimeConfig,
+    base_url_override: Option<String>,
+) -> Result<TransportConfig, String> {
+    let transport = TransportConfig::from_workflow(&runtime.workflow, &ProcessEnvironment)
+        .map_err(|error| error.to_string())?;
+    Ok(match base_url_override {
+        Some(base_url) => TransportConfig::new(base_url).with_auth(transport.auth().clone()),
+        None => transport,
+    })
 }
 
 fn resolve_doctor_runtime(
@@ -757,19 +769,40 @@ fn inspect_local_tooling(tool_dir: &Path) -> ToolingInspection {
     }
 }
 
-fn check_loopback_base_url(base_url: &str) -> CheckResult {
+fn check_openhands_transport(workflow: &ResolvedWorkflow) -> CheckResult {
+    let base_url = &workflow.extensions.openhands.transport.base_url;
     match Url::parse(base_url) {
-        Ok(url) => match url.host_str() {
-            Some("127.0.0.1") | Some("localhost") => CheckResult::pass(
-                "bind-scope",
-                format!("OpenHands base URL is loopback: {base_url}"),
-            ),
-            Some(host) => CheckResult::warn(
-                "bind-scope",
-                format!("OpenHands base URL host `{host}` is not loopback in local mode"),
-            ),
-            None => CheckResult::fail("bind-scope", format!("base URL `{base_url}` has no host")),
-        },
+        Ok(url) => {
+            let host = url.host_str().unwrap_or("<missing-host>");
+            let path = if url.path().trim_matches('/').is_empty() {
+                "root path".to_string()
+            } else {
+                format!("path prefix {}", url.path())
+            };
+            let auth_detail = workflow
+                .extensions
+                .openhands
+                .transport
+                .session_api_key_env
+                .as_deref()
+                .map(|env_name| format!("auth env {env_name}"))
+                .unwrap_or_else(|| "no session API key env".to_string());
+            let remote_target = !matches!(host, "127.0.0.1" | "localhost");
+            if remote_target {
+                CheckResult::pass(
+                    "bind-scope",
+                    format!(
+                        "OpenHands remote target {base_url} ({path}, websocket auth {}, {auth_detail})",
+                        workflow.extensions.openhands.websocket.auth_mode
+                    ),
+                )
+            } else {
+                CheckResult::pass(
+                    "bind-scope",
+                    format!("OpenHands loopback target {base_url} ({path}, {auth_detail})"),
+                )
+            }
+        }
         Err(error) => CheckResult::fail(
             "bind-scope",
             format!("invalid base URL `{base_url}`: {error}"),
@@ -831,7 +864,14 @@ async fn run_live_openhands_checks(
     let mut managed_supervisor = None;
     let mut probe_base_url = base_url.clone();
     let mut http_detail = format!("{probe_base_url} responded to /openapi.json");
-    let client = OpenHandsClient::new(TransportConfig::new(probe_base_url.clone()));
+    let mut transport = match build_doctor_transport(runtime, None) {
+        Ok(transport) => transport,
+        Err(error) => {
+            checks.push(CheckResult::fail("openhands-auth", error));
+            return checks;
+        }
+    };
+    let client = OpenHandsClient::new(transport.clone());
     if let Err(error) = client.openapi_probe().await {
         match maybe_start_local_supervisor(runtime, tooling) {
             Ok(Some(mut supervisor)) => {
@@ -856,6 +896,13 @@ async fn run_live_openhands_checks(
                 probe_base_url =
                     effective_openhands_probe_base_url(base_url, Some(&started.base_url));
                 managed_supervisor = Some(supervisor);
+                transport = match build_doctor_transport(runtime, Some(probe_base_url.clone())) {
+                    Ok(transport) => transport,
+                    Err(error) => {
+                        checks.push(CheckResult::fail("openhands-auth", error));
+                        return stop_managed_supervisor(checks, managed_supervisor);
+                    }
+                };
                 http_detail = format!(
                     "started local supervisor and {probe_base_url} responded to /openapi.json"
                 );
@@ -871,7 +918,7 @@ async fn run_live_openhands_checks(
         }
     }
 
-    let client = OpenHandsClient::new(TransportConfig::new(probe_base_url));
+    let client = OpenHandsClient::new(transport);
     match client.openapi_probe().await {
         Ok(()) => checks.push(CheckResult::pass("openhands-http", http_detail)),
         Err(error) => {
@@ -1024,9 +1071,23 @@ fn maybe_start_local_supervisor(
         ));
     }
 
+    if runtime
+        .workflow
+        .extensions
+        .openhands
+        .transport
+        .session_api_key_env
+        .is_some()
+    {
+        return Ok(None);
+    }
+
     let base_url = &runtime.workflow.extensions.openhands.transport.base_url;
     let url = Url::parse(base_url)
         .map_err(|error| format!("invalid OpenHands base URL `{base_url}`: {error}"))?;
+    if url.scheme() != "http" || !url.path().trim_matches('/').is_empty() {
+        return Ok(None);
+    }
     match url.host_str() {
         Some("127.0.0.1") | Some("localhost") => {}
         _ => return Ok(None),
@@ -1116,6 +1177,11 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
                 0
             },
             blocked: false,
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            transport_target: Some("loopback".to_owned()),
+            http_auth_mode: Some("none".to_owned()),
+            websocket_auth_mode: Some("none".to_owned()),
+            websocket_query_param_name: None,
         },
         IssueSnapshot {
             identifier: "OSYM-401".to_owned(),
@@ -1128,6 +1194,11 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             workspace_path_suffix: "OSYM-401".to_owned(),
             retry_count: 0,
             blocked: false,
+            server_base_url: Some("https://agent.example.com/runtime".to_owned()),
+            transport_target: Some("remote".to_owned()),
+            http_auth_mode: Some("header".to_owned()),
+            websocket_auth_mode: Some("query_param".to_owned()),
+            websocket_query_param_name: Some("session_api_key".to_owned()),
         },
         IssueSnapshot {
             identifier: "OSYM-402".to_owned(),
@@ -1148,6 +1219,11 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             workspace_path_suffix: "OSYM-402".to_owned(),
             retry_count: 0,
             blocked: false,
+            server_base_url: Some("https://agent.example.com/runtime".to_owned()),
+            transport_target: Some("remote".to_owned()),
+            http_auth_mode: Some("header".to_owned()),
+            websocket_auth_mode: Some("header".to_owned()),
+            websocket_query_param_name: None,
         },
     ];
     let running_issues = issues

--- a/crates/opensymphony-cli/tests/tui.rs
+++ b/crates/opensymphony-cli/tests/tui.rs
@@ -47,6 +47,11 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             workspace_path_suffix: "workspace-0".to_owned(),
             retry_count: 0,
             blocked: false,
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            transport_target: Some("loopback".to_owned()),
+            http_auth_mode: Some("none".to_owned()),
+            websocket_auth_mode: Some("none".to_owned()),
+            websocket_query_param_name: None,
         }],
         recent_events: vec![RecentEvent {
             happened_at: now,

--- a/crates/opensymphony-control/src/lib.rs
+++ b/crates/opensymphony-control/src/lib.rs
@@ -440,6 +440,11 @@ mod tests {
                 workspace_path_suffix: "COE-255".to_owned(),
                 retry_count: 0,
                 blocked: false,
+                server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+                transport_target: Some("loopback".to_owned()),
+                http_auth_mode: Some("none".to_owned()),
+                websocket_auth_mode: Some("none".to_owned()),
+                websocket_query_param_name: None,
             }],
             recent_events: vec![RecentEvent {
                 happened_at: now,

--- a/crates/opensymphony-control/tests/control_plane.rs
+++ b/crates/opensymphony-control/tests/control_plane.rs
@@ -51,6 +51,11 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             workspace_path_suffix: "COE-255".to_owned(),
             retry_count: 0,
             blocked: false,
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            transport_target: Some("loopback".to_owned()),
+            http_auth_mode: Some("none".to_owned()),
+            websocket_auth_mode: Some("none".to_owned()),
+            websocket_query_param_name: None,
         }],
         recent_events: vec![RecentEvent {
             happened_at: now,

--- a/crates/opensymphony-domain/src/control_plane.rs
+++ b/crates/opensymphony-domain/src/control_plane.rs
@@ -69,6 +69,16 @@ pub struct ControlPlaneIssueSnapshot {
     pub workspace_path_suffix: String,
     pub retry_count: u32,
     pub blocked: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_query_param_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -162,6 +162,10 @@ mod tests {
         ConversationMetadata {
             conversation_id: must(super::ConversationId::new("conv_260")),
             server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            transport_target: Some("loopback".to_owned()),
+            http_auth_mode: Some("none".to_owned()),
+            websocket_auth_mode: Some("none".to_owned()),
+            websocket_query_param_name: None,
             fresh_conversation,
             runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
             stream_state: RuntimeStreamState::Ready,

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -84,6 +84,14 @@ pub enum RuntimeStreamState {
 pub struct ConversationMetadata {
     pub conversation_id: ConversationId,
     pub server_base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_query_param_name: Option<String>,
     pub fresh_conversation: bool,
     pub runtime_contract_version: Option<String>,
     pub stream_state: RuntimeStreamState,

--- a/crates/opensymphony-domain/tests/snapshot_serialization.rs
+++ b/crates/opensymphony-domain/tests/snapshot_serialization.rs
@@ -47,6 +47,11 @@ fn fixture() -> SnapshotEnvelope {
                 workspace_path_suffix: "COE-269".to_owned(),
                 retry_count: 1,
                 blocked: false,
+                server_base_url: Some("https://agent.example.com/runtime".to_owned()),
+                transport_target: Some("remote".to_owned()),
+                http_auth_mode: Some("header".to_owned()),
+                websocket_auth_mode: Some("query_param".to_owned()),
+                websocket_query_param_name: Some("session_api_key".to_owned()),
             }],
             recent_events: vec![RecentEvent {
                 happened_at: now,
@@ -72,6 +77,11 @@ fn snapshot_envelope_round_trips_through_json() {
         encoded["snapshot"]["issues"][0]["last_outcome"],
         "continued"
     );
+    assert_eq!(
+        encoded["snapshot"]["issues"][0]["transport_target"],
+        "remote"
+    );
+    assert_eq!(encoded["snapshot"]["issues"][0]["http_auth_mode"], "header");
     assert_eq!(
         encoded["snapshot"]["recent_events"][0]["kind"],
         "snapshot_published"

--- a/crates/opensymphony-openhands/Cargo.toml
+++ b/crates/opensymphony-openhands/Cargo.toml
@@ -11,7 +11,7 @@ futures-util.workspace = true
 opensymphony-domain = { path = "../opensymphony-domain" }
 opensymphony-workflow = { path = "../opensymphony-workflow" }
 opensymphony-workspace = { path = "../opensymphony-workspace" }
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/opensymphony-openhands/src/client.rs
+++ b/crates/opensymphony-openhands/src/client.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, collections::VecDeque, time::Duration};
 
 use futures_util::StreamExt;
+use opensymphony_workflow::{Environment, ResolvedWorkflow};
 use reqwest::{
     RequestBuilder,
     header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue},
@@ -17,7 +18,7 @@ use tokio_tungstenite::{
     tungstenite::{Message, client::IntoClientRequest},
 };
 use tracing::debug;
-use url::Url;
+use url::{Host, Url};
 use uuid::Uuid;
 
 use crate::events::{ConversationStateMirror, EventCache, KnownEvent, TerminalExecutionStatus};
@@ -25,6 +26,69 @@ use crate::models::{
     AcceptedResponse, Conversation, ConversationCreateRequest, ConversationRunRequest,
     EventEnvelope, SearchConversationEventsResponse, SendMessageRequest,
 };
+
+const SESSION_API_KEY_HEADER_NAME: &str = "x-session-api-key";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportTargetKind {
+    Loopback,
+    Remote,
+}
+
+impl TransportTargetKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Loopback => "loopback",
+            Self::Remote => "remote",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportAuthKind {
+    None,
+    Header,
+    QueryParam,
+}
+
+impl TransportAuthKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Header => "header",
+            Self::QueryParam => "query_param",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportDiagnostics {
+    pub target_kind: TransportTargetKind,
+    pub http_auth_kind: TransportAuthKind,
+    pub websocket_auth_kind: TransportAuthKind,
+    pub websocket_query_param_name: Option<String>,
+    pub managed_local_server_candidate: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkflowWebSocketAuthMode {
+    Auto,
+    Header,
+    QueryParam,
+}
+
+impl WorkflowWebSocketAuthMode {
+    fn parse(mode: &str) -> Result<Self, OpenHandsError> {
+        match mode.trim().to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "header" => Ok(Self::Header),
+            "query_param" => Ok(Self::QueryParam),
+            other => Err(OpenHandsError::invalid_configuration(format!(
+                "unsupported websocket auth mode `{other}`"
+            ))),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiKeyAuth {
@@ -146,6 +210,29 @@ impl AuthConfig {
 
         Ok(())
     }
+
+    fn http_auth_kind(&self) -> TransportAuthKind {
+        match self.http {
+            HttpAuth::None => TransportAuthKind::None,
+            HttpAuth::Header(_) => TransportAuthKind::Header,
+            HttpAuth::QueryParam(_) => TransportAuthKind::QueryParam,
+        }
+    }
+
+    fn websocket_auth_kind(&self) -> TransportAuthKind {
+        match self.websocket {
+            WebSocketAuth::None => TransportAuthKind::None,
+            WebSocketAuth::Header(_) => TransportAuthKind::Header,
+            WebSocketAuth::QueryParam(_) => TransportAuthKind::QueryParam,
+        }
+    }
+
+    fn websocket_query_param_name(&self) -> Option<&str> {
+        match &self.websocket {
+            WebSocketAuth::QueryParam(key) => Some(key.name()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,6 +249,23 @@ impl TransportConfig {
         }
     }
 
+    pub fn from_workflow<E: Environment>(
+        workflow: &ResolvedWorkflow,
+        env: &E,
+    ) -> Result<Self, OpenHandsError> {
+        let transport = &workflow.extensions.openhands.transport;
+        let websocket = &workflow.extensions.openhands.websocket;
+        let auth = build_workflow_auth_config(
+            transport.session_api_key_env.as_deref(),
+            websocket.auth_mode.as_str(),
+            websocket.query_param_name.as_str(),
+            env,
+        )?;
+        let config = Self::new(transport.base_url.clone()).with_auth(auth);
+        config.parsed_base_url()?;
+        Ok(config)
+    }
+
     pub fn with_auth(mut self, auth: AuthConfig) -> Self {
         self.auth = auth;
         self
@@ -173,6 +277,30 @@ impl TransportConfig {
 
     pub fn auth(&self) -> &AuthConfig {
         &self.auth
+    }
+
+    pub fn diagnostics(&self) -> Result<TransportDiagnostics, OpenHandsError> {
+        let url = self.parsed_base_url()?;
+        let target_kind = if is_loopback_host(url.host()) {
+            TransportTargetKind::Loopback
+        } else {
+            TransportTargetKind::Remote
+        };
+
+        Ok(TransportDiagnostics {
+            target_kind,
+            http_auth_kind: self.auth.http_auth_kind(),
+            websocket_auth_kind: self.auth.websocket_auth_kind(),
+            websocket_query_param_name: self
+                .auth
+                .websocket_query_param_name()
+                .map(ToOwned::to_owned),
+            managed_local_server_candidate: target_kind == TransportTargetKind::Loopback
+                && url.scheme() == "http"
+                && base_url_path_is_root(&url)
+                && self.auth.http_auth_kind() == TransportAuthKind::None
+                && self.auth.websocket_auth_kind() == TransportAuthKind::None,
+        })
     }
 
     fn endpoint(&self, suffix: &str) -> Result<Url, OpenHandsError> {
@@ -232,12 +360,44 @@ impl TransportConfig {
     }
 
     fn parsed_base_url(&self) -> Result<Url, OpenHandsError> {
-        Url::parse(&self.base_url).map_err(|error| {
+        let url = Url::parse(&self.base_url).map_err(|error| {
             OpenHandsError::invalid_configuration(format!(
                 "invalid base URL `{}`: {error}",
                 self.base_url
             ))
-        })
+        })?;
+
+        match url.scheme() {
+            "http" | "https" => {}
+            other => {
+                return Err(OpenHandsError::invalid_configuration(format!(
+                    "unsupported base URL scheme `{other}`"
+                )));
+            }
+        }
+
+        if url.host().is_none() {
+            return Err(OpenHandsError::invalid_configuration(format!(
+                "base URL `{}` must include a host",
+                self.base_url
+            )));
+        }
+
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(OpenHandsError::invalid_configuration(format!(
+                "base URL `{}` must not embed credentials",
+                self.base_url
+            )));
+        }
+
+        if url.query().is_some() || url.fragment().is_some() {
+            return Err(OpenHandsError::invalid_configuration(format!(
+                "base URL `{}` must not include query or fragment suffixes",
+                self.base_url
+            )));
+        }
+
+        Ok(url)
     }
 }
 
@@ -749,6 +909,10 @@ impl OpenHandsClient {
         self.transport.base_url()
     }
 
+    pub fn transport_diagnostics(&self) -> Result<TransportDiagnostics, OpenHandsError> {
+        self.transport.diagnostics()
+    }
+
     pub async fn openapi_probe(&self) -> Result<(), OpenHandsError> {
         let response = send(self.get_request("/openapi.json")?, "probe OpenAPI").await?;
         read_success_body(response, "probe OpenAPI")
@@ -963,6 +1127,73 @@ impl OpenHandsClient {
             OpenHandsError::websocket_transport("connect runtime stream", error)
         })?;
         Ok(stream)
+    }
+}
+
+fn build_workflow_auth_config<E: Environment>(
+    session_api_key_env: Option<&str>,
+    websocket_auth_mode: &str,
+    websocket_query_param_name: &str,
+    env: &E,
+) -> Result<AuthConfig, OpenHandsError> {
+    let websocket_auth_mode = WorkflowWebSocketAuthMode::parse(websocket_auth_mode)?;
+    let Some(session_api_key_env) = session_api_key_env else {
+        return match websocket_auth_mode {
+            WorkflowWebSocketAuthMode::Auto => Ok(AuthConfig::none()),
+            WorkflowWebSocketAuthMode::Header | WorkflowWebSocketAuthMode::QueryParam => {
+                Err(OpenHandsError::invalid_configuration(format!(
+                    "websocket auth mode `{}` requires a configured session API key env",
+                    websocket_auth_mode_label(websocket_auth_mode)
+                )))
+            }
+        };
+    };
+
+    let session_api_key = env
+        .get(session_api_key_env)
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            OpenHandsError::invalid_configuration(format!(
+                "session API key env `{session_api_key_env}` is not set or is blank"
+            ))
+        })?;
+
+    let http = HttpAuth::Header(ApiKeyAuth::new(
+        SESSION_API_KEY_HEADER_NAME,
+        session_api_key.clone(),
+    ));
+    let websocket = match websocket_auth_mode {
+        WorkflowWebSocketAuthMode::Auto | WorkflowWebSocketAuthMode::QueryParam => {
+            WebSocketAuth::QueryParam(ApiKeyAuth::new(websocket_query_param_name, session_api_key))
+        }
+        WorkflowWebSocketAuthMode::Header => WebSocketAuth::Header(ApiKeyAuth::new(
+            SESSION_API_KEY_HEADER_NAME,
+            session_api_key,
+        )),
+    };
+
+    Ok(AuthConfig { http, websocket })
+}
+
+fn websocket_auth_mode_label(mode: WorkflowWebSocketAuthMode) -> &'static str {
+    match mode {
+        WorkflowWebSocketAuthMode::Auto => "auto",
+        WorkflowWebSocketAuthMode::Header => "header",
+        WorkflowWebSocketAuthMode::QueryParam => "query_param",
+    }
+}
+
+fn base_url_path_is_root(url: &Url) -> bool {
+    url.path().trim_matches('/').is_empty()
+}
+
+fn is_loopback_host(host: Option<Host<&str>>) -> bool {
+    match host {
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        None => false,
     }
 }
 

--- a/crates/opensymphony-openhands/src/lib.rs
+++ b/crates/opensymphony-openhands/src/lib.rs
@@ -7,7 +7,8 @@ mod tooling;
 
 pub use client::{
     ApiKeyAuth, AuthConfig, HttpAuth, OpenHandsClient, OpenHandsError, OpenHandsProbeResult,
-    RuntimeEventStream, RuntimeStreamConfig, TransportConfig, WebSocketAuth,
+    RuntimeEventStream, RuntimeStreamConfig, TransportAuthKind, TransportConfig,
+    TransportDiagnostics, TransportTargetKind, WebSocketAuth,
 };
 pub use events::{
     ConversationErrorEvent, ConversationStateMirror, EventCache, KnownEvent, LlmCompletionLogEvent,

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -91,6 +91,14 @@ pub struct IssueConversationManifest {
     pub identifier: IssueIdentifier,
     pub conversation_id: ConversationId,
     pub server_base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_query_param_name: Option<String>,
     pub persistence_dir: PathBuf,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -133,6 +141,10 @@ impl IssueConversationManifest {
             identifier,
             conversation_id,
             server_base_url: None,
+            transport_target: None,
+            http_auth_mode: None,
+            websocket_auth_mode: None,
+            websocket_query_param_name: None,
             persistence_dir,
             created_at: attached_at,
             updated_at: attached_at,
@@ -195,10 +207,30 @@ impl IssueConversationManifest {
         self.updated_at = Utc::now();
     }
 
+    fn apply_transport_diagnostics(
+        &mut self,
+        diagnostics: Option<&crate::TransportDiagnostics>,
+        server_base_url: &str,
+    ) {
+        self.server_base_url = Some(server_base_url.to_string());
+        self.transport_target =
+            diagnostics.map(|diagnostics| diagnostics.target_kind.as_str().to_string());
+        self.http_auth_mode =
+            diagnostics.map(|diagnostics| diagnostics.http_auth_kind.as_str().to_string());
+        self.websocket_auth_mode =
+            diagnostics.map(|diagnostics| diagnostics.websocket_auth_kind.as_str().to_string());
+        self.websocket_query_param_name =
+            diagnostics.and_then(|diagnostics| diagnostics.websocket_query_param_name.clone());
+    }
+
     fn to_domain_metadata(&self, stream_state: RuntimeStreamState) -> ConversationMetadata {
         ConversationMetadata {
             conversation_id: self.conversation_id.clone(),
             server_base_url: self.server_base_url.clone(),
+            transport_target: self.transport_target.clone(),
+            http_auth_mode: self.http_auth_mode.clone(),
+            websocket_auth_mode: self.websocket_auth_mode.clone(),
+            websocket_query_param_name: self.websocket_query_param_name.clone(),
             fresh_conversation: self.fresh_conversation,
             runtime_contract_version: self.runtime_contract_version.clone(),
             stream_state,
@@ -228,6 +260,14 @@ pub struct IssueSessionContext {
     pub fresh_conversation: bool,
     pub workflow_prompt_seeded: bool,
     pub server_base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_query_param_name: Option<String>,
     pub persistence_dir: PathBuf,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_execution_status: Option<String>,
@@ -675,7 +715,9 @@ impl IssueSessionRunner {
 
         let attached_at = Utc::now();
         manifest.fresh_conversation = false;
-        manifest.server_base_url = Some(self.client.base_url().to_string());
+        let transport_diagnostics = self.client.transport_diagnostics().ok();
+        manifest
+            .apply_transport_diagnostics(transport_diagnostics.as_ref(), self.client.base_url());
         manifest.runtime_contract_version = Some(RUNTIME_CONTRACT_VERSION.to_string());
         manifest.last_attached_at = attached_at;
         manifest.updated_at = attached_at;
@@ -789,6 +831,8 @@ impl IssueSessionRunner {
                             &conversation,
                             true,
                             RuntimeStreamState::Failed,
+                            self.client.transport_diagnostics().ok().as_ref(),
+                            self.client.base_url(),
                         )),
                         NormalizedOutcome {
                             kind: WorkerOutcomeKind::Failed,
@@ -813,7 +857,9 @@ impl IssueSessionRunner {
             attached_at,
             reset_reason,
         );
-        manifest.server_base_url = Some(self.client.base_url().to_string());
+        let transport_diagnostics = self.client.transport_diagnostics().ok();
+        manifest
+            .apply_transport_diagnostics(transport_diagnostics.as_ref(), self.client.base_url());
         manifest.apply_runtime_snapshot(&stream);
         workspace_manager
             .write_json_artifact(
@@ -1171,6 +1217,10 @@ fn build_session_context(
         fresh_conversation: manifest.fresh_conversation,
         workflow_prompt_seeded: manifest.workflow_prompt_seeded,
         server_base_url: manifest.server_base_url.clone(),
+        transport_target: manifest.transport_target.clone(),
+        http_auth_mode: manifest.http_auth_mode.clone(),
+        websocket_auth_mode: manifest.websocket_auth_mode.clone(),
+        websocket_query_param_name: manifest.websocket_query_param_name.clone(),
         persistence_dir: manifest.persistence_dir.clone(),
         last_execution_status: manifest.last_execution_status.clone(),
         last_event_id: manifest.last_event_id.clone(),
@@ -1194,11 +1244,21 @@ fn build_summary_metadata(
     conversation: &Conversation,
     fresh_conversation: bool,
     stream_state: RuntimeStreamState,
+    diagnostics: Option<&crate::TransportDiagnostics>,
+    server_base_url: &str,
 ) -> ConversationMetadata {
     ConversationMetadata {
         conversation_id: ConversationId::new(conversation.conversation_id.to_string())
             .expect("UUID-backed conversation ID should not be empty"),
-        server_base_url: None,
+        server_base_url: Some(server_base_url.to_string()),
+        transport_target: diagnostics
+            .map(|diagnostics| diagnostics.target_kind.as_str().to_string()),
+        http_auth_mode: diagnostics
+            .map(|diagnostics| diagnostics.http_auth_kind.as_str().to_string()),
+        websocket_auth_mode: diagnostics
+            .map(|diagnostics| diagnostics.websocket_auth_kind.as_str().to_string()),
+        websocket_query_param_name: diagnostics
+            .and_then(|diagnostics| diagnostics.websocket_query_param_name.clone()),
         fresh_conversation,
         runtime_contract_version: Some(RUNTIME_CONTRACT_VERSION.to_string()),
         stream_state,

--- a/crates/opensymphony-openhands/src/supervisor.rs
+++ b/crates/opensymphony-openhands/src/supervisor.rs
@@ -7,7 +7,9 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
+use reqwest::{blocking::Client, redirect::Policy};
 use thiserror::Error;
+use url::Url;
 
 use crate::tooling::{LocalServerTooling, LocalToolingError, ResolvedLaunch};
 
@@ -176,7 +178,7 @@ impl LocalServerSupervisor {
 
         match &self.config {
             SupervisorConfig::External(config) => {
-                if probe_ready(&config.base_url, &config.probe)? {
+                if probe_external_ready(&config.base_url, &config.probe)? {
                     Ok(ServerStatus {
                         mode: ServerMode::External,
                         ownership: LaunchOwnership::External,
@@ -229,7 +231,7 @@ impl LocalServerSupervisor {
                         });
                     }
 
-                    if probe_ready(&launch.base_url, &config.probe)? {
+                    if probe_local_ready(&launch.base_url, &config.probe)? {
                         let pid = child.id();
                         self.launched = Some(LaunchedProcess {
                             child,
@@ -298,7 +300,7 @@ impl LocalServerSupervisor {
         self.reap_exited_child()?;
 
         if let Some(launched) = self.launched.as_mut() {
-            let ready = probe_ready(&launched.launch.base_url, self.config.probe())?;
+            let ready = probe_local_ready(&launched.launch.base_url, self.config.probe())?;
             return Ok(ServerStatus {
                 mode: ServerMode::Supervised,
                 ownership: LaunchOwnership::Launched,
@@ -328,7 +330,14 @@ impl LocalServerSupervisor {
             });
         }
 
-        let ready = probe_ready(&self.config.base_url(), self.config.probe())?;
+        let ready = match &self.config {
+            SupervisorConfig::Supervised(_) => {
+                probe_local_ready(&self.config.base_url(), self.config.probe())?
+            }
+            SupervisorConfig::External(_) => {
+                probe_external_ready(&self.config.base_url(), self.config.probe())?
+            }
+        };
         Ok(ServerStatus {
             mode: self.config.mode(),
             ownership: match self.config {
@@ -398,6 +407,10 @@ pub enum SupervisorError {
     Tooling(#[from] LocalToolingError),
     #[error("OpenHands base URL must use http://host:port with no path, found `{base_url}`")]
     InvalidBaseUrl { base_url: String },
+    #[error(
+        "OpenHands external base URL must be an absolute http or https URL without query or fragment, found `{base_url}`"
+    )]
+    InvalidExternalBaseUrl { base_url: String },
     #[error("failed to resolve socket address for `{base_url}`: {source}")]
     ResolveAddress {
         base_url: String,
@@ -448,6 +461,13 @@ pub enum SupervisorError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed readiness probe against {base_url}{path}: {source}")]
+    ProbeHttp {
+        base_url: String,
+        path: String,
+        #[source]
+        source: reqwest::Error,
+    },
 }
 
 fn kill_child(child: &mut Child) -> Result<(), SupervisorError> {
@@ -468,7 +488,7 @@ fn kill_child(child: &mut Child) -> Result<(), SupervisorError> {
     Ok(())
 }
 
-fn probe_ready(base_url: &str, probe: &ProbeConfig) -> Result<bool, SupervisorError> {
+fn probe_local_ready(base_url: &str, probe: &ProbeConfig) -> Result<bool, SupervisorError> {
     let endpoint = HttpEndpoint::parse(base_url)?;
     let addresses = endpoint.socket_addresses(base_url)?;
     probe_resolved_addresses(
@@ -478,6 +498,67 @@ fn probe_ready(base_url: &str, probe: &ProbeConfig) -> Result<bool, SupervisorEr
         &addresses,
         probe.connect_timeout,
     )
+}
+
+fn probe_external_ready(base_url: &str, probe: &ProbeConfig) -> Result<bool, SupervisorError> {
+    let endpoint = external_probe_url(base_url, &probe.path)?;
+    let client = Client::builder()
+        .no_proxy()
+        .redirect(Policy::none())
+        .timeout(probe.connect_timeout)
+        .build()
+        .map_err(|source| SupervisorError::ProbeHttp {
+            base_url: base_url.to_string(),
+            path: endpoint.path().to_string(),
+            source,
+        })?;
+
+    match client.get(endpoint.clone()).send() {
+        Ok(response) => Ok(response.status().is_success()),
+        Err(source) if source.is_timeout() => Ok(false),
+        Err(source) if source.is_connect() => Ok(false),
+        Err(source) => Err(SupervisorError::ProbeHttp {
+            base_url: base_url.to_string(),
+            path: endpoint.path().to_string(),
+            source,
+        }),
+    }
+}
+
+fn external_probe_url(base_url: &str, probe_path: &str) -> Result<Url, SupervisorError> {
+    let mut url = Url::parse(base_url).map_err(|_| SupervisorError::InvalidExternalBaseUrl {
+        base_url: base_url.to_string(),
+    })?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => {
+            return Err(SupervisorError::InvalidExternalBaseUrl {
+                base_url: base_url.to_string(),
+            });
+        }
+    }
+
+    if url.host().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(SupervisorError::InvalidExternalBaseUrl {
+            base_url: base_url.to_string(),
+        });
+    }
+
+    let base_path = url.path().trim_end_matches('/');
+    let probe_path = normalized_probe_path(probe_path);
+    let path = if base_path.is_empty() {
+        probe_path.to_string()
+    } else {
+        format!("{base_path}{probe_path}")
+    };
+    url.set_path(&path);
+    Ok(url)
 }
 
 fn probe_resolved_addresses(

--- a/crates/opensymphony-openhands/tests/client_resilience.rs
+++ b/crates/opensymphony-openhands/tests/client_resilience.rs
@@ -149,6 +149,52 @@ async fn header_api_key_with_websocket_query_fallback_authenticates_operations()
 }
 
 #[tokio::test]
+async fn path_prefixed_base_urls_preserve_rest_and_websocket_authentication() {
+    let server = TestServer::start(Router::new().nest(
+        "/runtime",
+        auth_router(AuthExpectations {
+            rest: ExpectedAuth::Header {
+                name: "x-session-api-key".to_string(),
+                value: "secret-token".to_string(),
+            },
+            websocket: ExpectedAuth::QueryParam {
+                name: "session_api_key".to_string(),
+                value: "secret-token".to_string(),
+            },
+        }),
+    ))
+    .await;
+    let client = OpenHandsClient::new(
+        TransportConfig::new(format!("{}/runtime", server.base_url())).with_auth(
+            AuthConfig::header_api_key_with_websocket_query_fallback(
+                "x-session-api-key",
+                "session_api_key",
+                "secret-token",
+            ),
+        ),
+    );
+    let request = ConversationCreateRequest::doctor_probe(
+        "/tmp/workspace",
+        "/tmp/workspace/.opensymphony/openhands",
+        None,
+        None,
+    );
+
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("create should preserve the path prefix");
+    client
+        .wait_for_readiness(conversation.conversation_id, Duration::from_secs(2))
+        .await
+        .expect("websocket readiness should preserve the path prefix");
+    client
+        .run_conversation(conversation.conversation_id)
+        .await
+        .expect("run should preserve the path prefix");
+}
+
+#[tokio::test]
 async fn auth_failure_maps_to_stable_http_status_error() {
     let server = TestServer::start(auth_router(AuthExpectations {
         rest: ExpectedAuth::QueryParam {

--- a/crates/opensymphony-openhands/tests/issue_session_runner.rs
+++ b/crates/opensymphony-openhands/tests/issue_session_runner.rs
@@ -214,6 +214,33 @@ async fn issue_session_runner_reuses_conversation_and_switches_to_continuation_p
             .expect("conversation metadata should exist")
             .fresh_conversation
     );
+    assert_eq!(
+        first_result
+            .conversation
+            .as_ref()
+            .expect("conversation metadata should exist")
+            .transport_target
+            .as_deref(),
+        Some("loopback")
+    );
+    assert_eq!(
+        first_result
+            .conversation
+            .as_ref()
+            .expect("conversation metadata should exist")
+            .http_auth_mode
+            .as_deref(),
+        Some("none")
+    );
+    assert_eq!(
+        first_result
+            .conversation
+            .as_ref()
+            .expect("conversation metadata should exist")
+            .websocket_auth_mode
+            .as_deref(),
+        Some("none")
+    );
 
     let first_conversation = read_conversation_manifest(&manager, &ensured.handle).await;
     assert!(first_conversation.workflow_prompt_seeded);
@@ -339,6 +366,12 @@ async fn issue_session_runner_reuses_conversation_and_switches_to_continuation_p
         session_context.prompt_kind,
         IssueSessionPromptKind::Continuation
     );
+    assert_eq!(
+        session_context.transport_target.as_deref(),
+        Some("loopback")
+    );
+    assert_eq!(session_context.http_auth_mode.as_deref(), Some("none"));
+    assert_eq!(session_context.websocket_auth_mode.as_deref(), Some("none"));
     assert_eq!(
         session_context
             .worker_outcome

--- a/crates/opensymphony-openhands/tests/live_pinned_server.rs
+++ b/crates/opensymphony-openhands/tests/live_pinned_server.rs
@@ -1,0 +1,234 @@
+use std::{
+    env,
+    net::TcpListener,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+
+use opensymphony_openhands::{
+    ApiKeyAuth, AuthConfig, ConversationCreateRequest, HttpAuth, OpenHandsClient, OpenHandsError,
+    RuntimeStreamConfig, TransportConfig, WebSocketAuth,
+};
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+const LIVE_GATE_ENV: &str = "OPENSYMPHONY_LIVE_OPENHANDS";
+const SESSION_API_KEY: &str = "live-secret-token";
+const SESSION_API_KEY_HEADER: &str = "x-session-api-key";
+const SESSION_API_KEY_QUERY_PARAM: &str = "session_api_key";
+
+#[tokio::test]
+async fn live_pinned_server_authenticates_external_http_and_websocket_paths() {
+    if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {
+        eprintln!("skipping live pinned-server test; set {LIVE_GATE_ENV}=1 to enable it");
+        return;
+    }
+
+    let server = PinnedServer::start(SESSION_API_KEY).await;
+    let workspace = TempDir::new().expect("workspace temp dir should be created");
+    let request = doctor_probe_request(workspace.path());
+
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()).with_auth(
+        AuthConfig::header_api_key_with_websocket_query_fallback(
+            SESSION_API_KEY_HEADER,
+            SESSION_API_KEY_QUERY_PARAM,
+            SESSION_API_KEY,
+        ),
+    ));
+
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("create conversation should authenticate");
+    let attached = client
+        .get_conversation(conversation.conversation_id)
+        .await
+        .expect("get conversation should authenticate");
+    assert_eq!(attached.conversation_id, conversation.conversation_id);
+
+    let stream = client
+        .attach_runtime_stream(
+            conversation.conversation_id,
+            RuntimeStreamConfig {
+                readiness_timeout: Duration::from_secs(5),
+                reconnect_initial_backoff: Duration::from_millis(100),
+                reconnect_max_backoff: Duration::from_millis(250),
+                max_reconnect_attempts: 1,
+            },
+        )
+        .await
+        .expect("websocket readiness should authenticate");
+
+    assert_eq!(
+        stream.conversation().conversation_id,
+        conversation.conversation_id
+    );
+    assert_eq!(
+        stream.state_mirror().execution_status(),
+        Some("idle"),
+        "new conversations should attach in the idle state"
+    );
+}
+
+#[tokio::test]
+async fn live_pinned_server_rejects_missing_http_auth_and_wrong_websocket_auth() {
+    if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {
+        eprintln!("skipping live pinned-server test; set {LIVE_GATE_ENV}=1 to enable it");
+        return;
+    }
+
+    let server = PinnedServer::start(SESSION_API_KEY).await;
+    let workspace = TempDir::new().expect("workspace temp dir should be created");
+    let request = doctor_probe_request(workspace.path());
+
+    let authenticated = OpenHandsClient::new(TransportConfig::new(server.base_url()).with_auth(
+        AuthConfig::header_api_key_with_websocket_query_fallback(
+            SESSION_API_KEY_HEADER,
+            SESSION_API_KEY_QUERY_PARAM,
+            SESSION_API_KEY,
+        ),
+    ));
+    let conversation = authenticated
+        .create_conversation(&request)
+        .await
+        .expect("setup conversation should authenticate");
+
+    let missing_http_auth = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let error = missing_http_auth
+        .create_conversation(&request)
+        .await
+        .expect_err("missing HTTP auth should be rejected");
+    assert!(
+        matches!(
+            error,
+            OpenHandsError::HttpStatus {
+                status_code: 401,
+                ..
+            }
+        ),
+        "expected stable HTTP 401 mapping, got {error:?}"
+    );
+
+    let wrong_websocket_auth = OpenHandsClient::new(
+        TransportConfig::new(server.base_url()).with_auth(AuthConfig {
+            http: HttpAuth::Header(ApiKeyAuth::new(SESSION_API_KEY_HEADER, SESSION_API_KEY)),
+            websocket: WebSocketAuth::QueryParam(ApiKeyAuth::new(
+                SESSION_API_KEY_QUERY_PARAM,
+                "wrong-secret-token",
+            )),
+        }),
+    );
+    let error = match wrong_websocket_auth
+        .attach_runtime_stream(
+            conversation.conversation_id,
+            RuntimeStreamConfig {
+                readiness_timeout: Duration::from_secs(5),
+                reconnect_initial_backoff: Duration::from_millis(100),
+                reconnect_max_backoff: Duration::from_millis(250),
+                max_reconnect_attempts: 1,
+            },
+        )
+        .await
+    {
+        Ok(_) => panic!("wrong websocket auth should fail the attach handshake"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(error, OpenHandsError::WebSocketTransport { .. }),
+        "expected stable websocket transport mapping, got {error:?}"
+    );
+}
+
+struct PinnedServer {
+    child: Child,
+    base_url: String,
+}
+
+impl PinnedServer {
+    async fn start(session_api_key: &str) -> Self {
+        let port = free_port();
+        let base_url = format!("http://127.0.0.1:{port}");
+        let repo_root = workspace_root();
+        let mut child = Command::new(repo_root.join("tools/openhands-server/run-local.sh"))
+            .current_dir(&repo_root)
+            .env("OPENHANDS_SERVER_PORT", port.to_string())
+            .env("SESSION_API_KEY", session_api_key)
+            .env("OPENHANDS_SUPPRESS_BANNER", "1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("pinned OpenHands server should start");
+
+        wait_for_ready(&base_url, session_api_key, &mut child).await;
+
+        Self { child, base_url }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for PinnedServer {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir should have workspace parent")
+        .parent()
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind free port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+fn doctor_probe_request(workspace_root: &std::path::Path) -> ConversationCreateRequest {
+    let working_dir = workspace_root.join("repo");
+    let persistence_dir = working_dir.join(".opensymphony/openhands");
+    std::fs::create_dir_all(&persistence_dir).expect("probe directories should be created");
+    ConversationCreateRequest::doctor_probe(
+        working_dir.display().to_string(),
+        persistence_dir.display().to_string(),
+        Some("gpt-4.1-mini".to_string()),
+        None,
+    )
+}
+
+async fn wait_for_ready(base_url: &str, session_api_key: &str, child: &mut Child) {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(250))
+        .build()
+        .expect("probe client should build");
+
+    for _ in 0..120 {
+        if let Some(status) = child.try_wait().expect("child status should be readable") {
+            panic!("pinned OpenHands server exited before readiness: status={status:?}");
+        }
+
+        match client
+            .get(format!("{base_url}/openapi.json"))
+            .header(SESSION_API_KEY_HEADER, session_api_key)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => return,
+            Ok(_) | Err(_) => sleep(Duration::from_millis(100)).await,
+        }
+    }
+
+    panic!("pinned OpenHands server did not become ready at {base_url}");
+}

--- a/crates/opensymphony-openhands/tests/supervisor.rs
+++ b/crates/opensymphony-openhands/tests/supervisor.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::{Read, Write},
     net::TcpListener,
     path::Path,
     process::{Child, Command, Stdio},
@@ -154,6 +155,56 @@ fn stopping_external_mode_never_kills_the_server() {
 
     child.kill().expect("kill child");
     child.wait().expect("wait child");
+}
+
+#[test]
+fn external_mode_supports_path_prefixed_base_urls() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("listener address should resolve");
+    let server = thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().expect("request should connect");
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 256];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let bytes_read = stream.read(&mut chunk).expect("request should read");
+                if bytes_read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..bytes_read]);
+            }
+
+            let request = String::from_utf8(request).expect("request should be valid UTF-8");
+            assert!(
+                request.starts_with("GET /runtime/openapi.json HTTP/1.1\r\n"),
+                "unexpected request: {request:?}"
+            );
+
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+            )
+            .expect("response should write");
+            stream.flush().expect("response should flush");
+        }
+    });
+
+    let mut supervisor = LocalServerSupervisor::new(SupervisorConfig::External(
+        ExternalServerConfig::new(format!("http://{address}/runtime")),
+    ));
+
+    let started = supervisor
+        .start()
+        .expect("path-prefixed external server should be reachable");
+    assert_eq!(started.state, ServerState::Ready);
+    assert_eq!(started.ownership, LaunchOwnership::External);
+
+    let status = supervisor.status().expect("status should work");
+    assert_eq!(status.state, ServerState::Ready);
+
+    server.join().expect("server thread should finish");
 }
 
 struct FakeToolingFixture {

--- a/crates/opensymphony-openhands/tests/transport_config.rs
+++ b/crates/opensymphony-openhands/tests/transport_config.rs
@@ -1,0 +1,187 @@
+use std::{collections::BTreeMap, path::Path};
+
+use opensymphony_openhands::{
+    HttpAuth, TransportAuthKind, TransportConfig, TransportTargetKind, WebSocketAuth,
+};
+use opensymphony_workflow::{ResolvedWorkflow, WorkflowDefinition};
+
+fn resolve_workflow(source: &str, env: BTreeMap<String, String>) -> ResolvedWorkflow {
+    let workflow = WorkflowDefinition::parse(source).expect("workflow should parse");
+    workflow
+        .resolve(Path::new("/repo"), &env)
+        .expect("workflow should resolve")
+}
+
+#[test]
+fn workflow_transport_config_uses_pinned_auto_auth_shape() {
+    let workflow = resolve_workflow(
+        r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    base_url: https://agent.example.com/runtime
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
+---
+{{ issue.identifier }}
+"#,
+        BTreeMap::from([
+            ("LINEAR_API_KEY".to_string(), "linear-token".to_string()),
+            (
+                "OPENHANDS_SESSION_API_KEY".to_string(),
+                "secret-token".to_string(),
+            ),
+        ]),
+    );
+
+    let transport = TransportConfig::from_workflow(
+        &workflow,
+        &BTreeMap::from([(
+            "OPENHANDS_SESSION_API_KEY".to_string(),
+            "secret-token".to_string(),
+        )]),
+    )
+    .expect("transport should resolve");
+
+    match &transport.auth().http {
+        HttpAuth::Header(key) => {
+            assert_eq!(key.name(), "x-session-api-key");
+            assert_eq!(key.value(), "secret-token");
+        }
+        other => panic!("expected header HTTP auth, got {other:?}"),
+    }
+
+    match &transport.auth().websocket {
+        WebSocketAuth::QueryParam(key) => {
+            assert_eq!(key.name(), "session_api_key");
+            assert_eq!(key.value(), "secret-token");
+        }
+        other => panic!("expected websocket query-param auth, got {other:?}"),
+    }
+
+    let diagnostics = transport.diagnostics().expect("diagnostics should resolve");
+    assert_eq!(diagnostics.target_kind, TransportTargetKind::Remote);
+    assert_eq!(diagnostics.http_auth_kind, TransportAuthKind::Header);
+    assert_eq!(
+        diagnostics.websocket_auth_kind,
+        TransportAuthKind::QueryParam
+    );
+    assert_eq!(
+        diagnostics.websocket_query_param_name.as_deref(),
+        Some("session_api_key")
+    );
+    assert!(!diagnostics.managed_local_server_candidate);
+}
+
+#[test]
+fn loopback_transport_without_auth_stays_a_managed_local_server_candidate() {
+    let workflow = resolve_workflow(
+        r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    base_url: http://127.0.0.1:8000
+---
+{{ issue.identifier }}
+"#,
+        BTreeMap::from([("LINEAR_API_KEY".to_string(), "linear-token".to_string())]),
+    );
+
+    let transport = TransportConfig::from_workflow(&workflow, &BTreeMap::<String, String>::new())
+        .expect("transport should resolve");
+    let diagnostics = transport.diagnostics().expect("diagnostics should resolve");
+
+    assert_eq!(diagnostics.target_kind, TransportTargetKind::Loopback);
+    assert_eq!(diagnostics.http_auth_kind, TransportAuthKind::None);
+    assert_eq!(diagnostics.websocket_auth_kind, TransportAuthKind::None);
+    assert!(diagnostics.managed_local_server_candidate);
+}
+
+#[test]
+fn path_prefixed_or_authenticated_loopback_transports_do_not_autostart_local_supervision() {
+    let workflow = resolve_workflow(
+        r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    base_url: http://127.0.0.1:8000/runtime
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
+  websocket:
+    auth_mode: header
+---
+{{ issue.identifier }}
+"#,
+        BTreeMap::from([
+            ("LINEAR_API_KEY".to_string(), "linear-token".to_string()),
+            (
+                "OPENHANDS_SESSION_API_KEY".to_string(),
+                "secret-token".to_string(),
+            ),
+        ]),
+    );
+
+    let transport = TransportConfig::from_workflow(
+        &workflow,
+        &BTreeMap::from([(
+            "OPENHANDS_SESSION_API_KEY".to_string(),
+            "secret-token".to_string(),
+        )]),
+    )
+    .expect("transport should resolve");
+    let diagnostics = transport.diagnostics().expect("diagnostics should resolve");
+
+    assert_eq!(diagnostics.target_kind, TransportTargetKind::Loopback);
+    assert_eq!(diagnostics.http_auth_kind, TransportAuthKind::Header);
+    assert_eq!(diagnostics.websocket_auth_kind, TransportAuthKind::Header);
+    assert!(!diagnostics.managed_local_server_candidate);
+}
+
+#[test]
+fn workflow_transport_config_requires_a_non_blank_session_key_when_auth_is_enabled() {
+    let workflow = resolve_workflow(
+        r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    base_url: https://agent.example.com/runtime
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
+---
+{{ issue.identifier }}
+"#,
+        BTreeMap::from([("LINEAR_API_KEY".to_string(), "linear-token".to_string())]),
+    );
+
+    let error = TransportConfig::from_workflow(
+        &workflow,
+        &BTreeMap::from([("OPENHANDS_SESSION_API_KEY".to_string(), "   ".to_string())]),
+    )
+    .expect_err("blank session key env should fail");
+
+    assert!(
+        error.to_string().contains("OPENHANDS_SESSION_API_KEY"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -81,6 +81,10 @@ mod tests {
             Some(ConversationMetadata {
                 conversation_id: must(ConversationId::new("conv_260")),
                 server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+                transport_target: Some("loopback".to_owned()),
+                http_auth_mode: Some("none".to_owned()),
+                websocket_auth_mode: Some("none".to_owned()),
+                websocket_query_param_name: None,
                 fresh_conversation: true,
                 runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_owned()),
                 stream_state: RuntimeStreamState::Ready,

--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -1215,6 +1215,11 @@ mod tests {
                         workspace_path_suffix: format!("workspace-{index}"),
                         retry_count: index as u32,
                         blocked: false,
+                        server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+                        transport_target: Some("loopback".to_owned()),
+                        http_auth_mode: Some("none".to_owned()),
+                        websocket_auth_mode: Some("none".to_owned()),
+                        websocket_query_param_name: None,
                     })
                     .collect(),
                 recent_events: vec![RecentEvent {

--- a/crates/opensymphony-tui/tests/reducer.rs
+++ b/crates/opensymphony-tui/tests/reducer.rs
@@ -59,6 +59,11 @@ fn fixture_with_identifiers(sequence: u64, identifiers: &[String]) -> SnapshotEn
                     workspace_path_suffix: format!("workspace-{index}"),
                     retry_count: index as u32,
                     blocked: false,
+                    server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+                    transport_target: Some("loopback".to_owned()),
+                    http_auth_mode: Some("none".to_owned()),
+                    websocket_auth_mode: Some("none".to_owned()),
+                    websocket_query_param_name: None,
                 })
                 .collect(),
             recent_events: vec![RecentEvent {
@@ -87,6 +92,11 @@ fn reordered_fixture(sequence: u64, identifiers: &[&str]) -> SnapshotEnvelope {
             workspace_path_suffix: format!("workspace-{index}"),
             retry_count: index as u32,
             blocked: false,
+            server_base_url: Some("http://127.0.0.1:3000".to_owned()),
+            transport_target: Some("loopback".to_owned()),
+            http_auth_mode: Some("none".to_owned()),
+            websocket_auth_mode: Some("none".to_owned()),
+            websocket_query_param_name: None,
         })
         .collect();
     snapshot

--- a/crates/opensymphony-workflow/src/lib.rs
+++ b/crates/opensymphony-workflow/src/lib.rs
@@ -738,14 +738,10 @@ openhands:
         for invalid_base_url in [
             "localhost:8000",
             "ws://127.0.0.1:8000",
-            "http://127.0.0.1:8000/",
-            "https://127.0.0.1:8000",
-            "https://example.com/runtime",
-            "http://127.0.0.1:8000/api",
-            "https://example.com/runtime/api/",
             "http://[::1]:8000",
             "http://127.0.0.1:8000?session=abc",
             "http://127.0.0.1:8000#fragment",
+            "https://user:pass@example.com/runtime",
         ] {
             let workflow = WorkflowDefinition::parse(&format!(
                 r#"---
@@ -820,7 +816,7 @@ openhands:
     }
 
     #[test]
-    fn rejects_unsupported_https_openhands_transport_base_url() {
+    fn rejects_non_loopback_http_openhands_transport_base_url() {
         let workflow = WorkflowDefinition::parse(
             r#"---
 tracker:
@@ -832,7 +828,8 @@ tracker:
     - Done
 openhands:
   transport:
-    base_url: https://127.0.0.1:8000
+    base_url: http://agent.example.com:8000
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
 ---
 {{ issue.identifier }}
 "#,
@@ -842,12 +839,110 @@ openhands:
 
         let error = workflow
             .resolve(Path::new("/repo"), &env)
-            .expect_err("https OpenHands origins should fail during resolution");
+            .expect_err("non-loopback http OpenHands origins should fail during resolution");
 
         assert!(matches!(
             error,
             WorkflowConfigError::InvalidField {
                 field: "openhands.transport.base_url",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resolves_remote_https_openhands_transport_with_path_and_auth() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    base_url: https://agent.example.com/runtime/api/
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
+  websocket:
+    ready_timeout_ms: 45000
+    reconnect_initial_ms: 1500
+    reconnect_max_ms: 45000
+    auth_mode: header
+    query_param_name: openhands_token
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let resolved = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect("remote https transport should resolve");
+
+        assert_eq!(
+            resolved.extensions.openhands.transport.base_url,
+            "https://agent.example.com/runtime/api/"
+        );
+        assert_eq!(
+            resolved
+                .extensions
+                .openhands
+                .transport
+                .session_api_key_env
+                .as_deref(),
+            Some("OPENHANDS_SESSION_API_KEY")
+        );
+        assert_eq!(
+            resolved.extensions.openhands.websocket.ready_timeout_ms,
+            45000
+        );
+        assert_eq!(
+            resolved.extensions.openhands.websocket.reconnect_initial_ms,
+            1500
+        );
+        assert_eq!(
+            resolved.extensions.openhands.websocket.reconnect_max_ms,
+            45000
+        );
+        assert_eq!(resolved.extensions.openhands.websocket.auth_mode, "header");
+        assert_eq!(
+            resolved.extensions.openhands.websocket.query_param_name,
+            "openhands_token"
+        );
+    }
+
+    #[test]
+    fn rejects_remote_https_openhands_transport_without_auth_env() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    base_url: https://agent.example.com/runtime/api/
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let error = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect_err("remote https transport should require auth");
+
+        assert!(matches!(
+            error,
+            WorkflowConfigError::InvalidField {
+                field: "openhands.transport.session_api_key_env",
                 ..
             }
         ));
@@ -1131,7 +1226,7 @@ openhands:
     }
 
     #[test]
-    fn rejects_unsupported_openhands_transport_session_api_key_env() {
+    fn resolves_openhands_transport_session_api_key_env() {
         let workflow = WorkflowDefinition::parse(
             r#"---
 tracker:
@@ -1151,21 +1246,23 @@ openhands:
         .expect("workflow should parse");
         let env = env([("LINEAR_API_KEY", "linear-token")]);
 
-        let error = workflow
+        let resolved = workflow
             .resolve(Path::new("/repo"), &env)
-            .expect_err("transport auth overrides should fail during resolution");
+            .expect("transport auth env should resolve");
 
-        assert!(matches!(
-            error,
-            WorkflowConfigError::InvalidField {
-                field: "openhands.transport.session_api_key_env",
-                ..
-            }
-        ));
+        assert_eq!(
+            resolved
+                .extensions
+                .openhands
+                .transport
+                .session_api_key_env
+                .as_deref(),
+            Some("OPENHANDS_SESSION_API_KEY")
+        );
     }
 
     #[test]
-    fn rejects_unsupported_openhands_websocket_auth_mode_override() {
+    fn resolves_openhands_websocket_auth_mode_override() {
         let workflow = WorkflowDefinition::parse(
             r#"---
 tracker:
@@ -1176,6 +1273,8 @@ tracker:
   terminal_states:
     - Done
 openhands:
+  transport:
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
   websocket:
     auth_mode: header
 ---
@@ -1185,41 +1284,17 @@ openhands:
         .expect("workflow should parse");
         let env = env([("LINEAR_API_KEY", "linear-token")]);
 
-        let error = workflow
+        let resolved = workflow
             .resolve(Path::new("/repo"), &env)
-            .expect_err("websocket auth mode overrides should fail during resolution");
+            .expect("websocket auth mode should resolve");
 
-        assert!(matches!(
-            error,
-            WorkflowConfigError::InvalidField {
-                field: "openhands.websocket.auth_mode",
-                ..
-            }
-        ));
+        assert_eq!(resolved.extensions.openhands.websocket.auth_mode, "header");
     }
 
     #[test]
-    fn rejects_unsupported_openhands_websocket_runtime_overrides() {
-        for (workflow_source, field) in [
-            (
-                r#"---
-tracker:
-  kind: linear
-  project_slug: sample-project
-  active_states:
-    - Todo
-  terminal_states:
-    - Done
-openhands:
-  websocket:
-    enabled: false
----
-{{ issue.identifier }}
-"#,
-                "openhands.websocket.enabled",
-            ),
-            (
-                r#"---
+    fn resolves_openhands_websocket_runtime_overrides() {
+        for workflow_source in [
+            r#"---
 tracker:
   kind: linear
   project_slug: sample-project
@@ -1233,10 +1308,7 @@ openhands:
 ---
 {{ issue.identifier }}
 "#,
-                "openhands.websocket.ready_timeout_ms",
-            ),
-            (
-                r#"---
+            r#"---
 tracker:
   kind: linear
   project_slug: sample-project
@@ -1250,10 +1322,7 @@ openhands:
 ---
 {{ issue.identifier }}
 "#,
-                "openhands.websocket.reconnect_initial_ms",
-            ),
-            (
-                r#"---
+            r#"---
 tracker:
   kind: linear
   project_slug: sample-project
@@ -1267,26 +1336,19 @@ openhands:
 ---
 {{ issue.identifier }}
 "#,
-                "openhands.websocket.reconnect_max_ms",
-            ),
         ] {
             let workflow =
                 WorkflowDefinition::parse(workflow_source).expect("workflow should parse");
             let env = env([("LINEAR_API_KEY", "linear-token")]);
 
-            let error = workflow.resolve(Path::new("/repo"), &env).expect_err(
-                "unsupported websocket runtime overrides should fail during resolution",
-            );
-
-            assert!(matches!(
-                error,
-                WorkflowConfigError::InvalidField { field: actual, .. } if actual == field
-            ));
+            workflow
+                .resolve(Path::new("/repo"), &env)
+                .expect("websocket runtime overrides should resolve when supported");
         }
     }
 
     #[test]
-    fn rejects_unsupported_openhands_websocket_query_param_override() {
+    fn rejects_unsupported_openhands_websocket_enabled_override() {
         let workflow = WorkflowDefinition::parse(
             r#"---
 tracker:
@@ -1298,7 +1360,7 @@ tracker:
     - Done
 openhands:
   websocket:
-    query_param_name: openhands_token
+    enabled: false
 ---
 {{ issue.identifier }}
 "#,
@@ -1308,12 +1370,81 @@ openhands:
 
         let error = workflow
             .resolve(Path::new("/repo"), &env)
-            .expect_err("websocket query-param overrides should fail during resolution");
+            .expect_err("workflow-owned websocket enablement should still fail");
 
         assert!(matches!(
             error,
             WorkflowConfigError::InvalidField {
-                field: "openhands.websocket.query_param_name",
+                field: "openhands.websocket.enabled",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resolves_openhands_websocket_query_param_override() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
+  websocket:
+    query_param_name: openhands_token
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let resolved = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect("websocket query-param overrides should resolve");
+
+        assert_eq!(
+            resolved.extensions.openhands.websocket.query_param_name,
+            "openhands_token"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_openhands_websocket_auth_mode_override() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  transport:
+    session_api_key_env: OPENHANDS_SESSION_API_KEY
+  websocket:
+    auth_mode: browser_magic
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let error = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect_err("invalid websocket auth mode should fail during resolution");
+
+        assert!(matches!(
+            error,
+            WorkflowConfigError::InvalidField {
+                field: "openhands.websocket.auth_mode",
                 ..
             }
         ));

--- a/crates/opensymphony-workflow/src/resolve.rs
+++ b/crates/opensymphony-workflow/src/resolve.rs
@@ -22,10 +22,10 @@ use crate::{
         OpenHandsConversationConfig, OpenHandsConversationFrontMatter, OpenHandsFrontMatter,
         OpenHandsLlmConfig, OpenHandsLlmFrontMatter, OpenHandsLocalServerConfig,
         OpenHandsLocalServerFrontMatter, OpenHandsMcpConfig, OpenHandsMcpFrontMatter,
-        OpenHandsTransportConfig, OpenHandsTransportFrontMatter, OpenHandsWebSocketConfig,
-        OpenHandsWebSocketFrontMatter, PollingConfig, PollingFrontMatter, ResolvedWorkflow,
-        TrackerConfig, TrackerFrontMatter, TrackerKind, WorkflowConfig, WorkflowDefinition,
-        WorkflowExtensions, WorkspaceConfig, WorkspaceFrontMatter,
+        OpenHandsTransportConfig, OpenHandsWebSocketConfig, OpenHandsWebSocketFrontMatter,
+        PollingConfig, PollingFrontMatter, ResolvedWorkflow, TrackerConfig, TrackerFrontMatter,
+        TrackerKind, WorkflowConfig, WorkflowDefinition, WorkflowExtensions, WorkspaceConfig,
+        WorkspaceFrontMatter,
     },
 };
 
@@ -231,17 +231,56 @@ fn resolve_openhands<E: Environment>(
     _base_dir: &Path,
     env: &E,
 ) -> Result<OpenHandsConfig, WorkflowConfigError> {
-    reject_unsupported_openhands_transport_auth(&openhands.transport)?;
     reject_unsupported_openhands_local_server_overrides(&openhands.local_server)?;
     reject_unsupported_openhands_websocket_overrides(&openhands.websocket)?;
     reject_unsupported_openhands_mcp(&openhands.mcp)?;
 
+    let transport_base_url =
+        resolve_openhands_base_url(openhands.transport.base_url.as_deref(), env)?;
+    let session_api_key_env = normalize_optional_literal(&openhands.transport.session_api_key_env);
+    let websocket_auth_mode = resolve_string_or_default(
+        openhands.websocket.auth_mode.as_deref(),
+        env,
+        "openhands.websocket.auth_mode",
+        DEFAULT_OPENHANDS_AUTH_MODE,
+    )?;
+    validate_openhands_websocket_auth_mode(&websocket_auth_mode)?;
+    let websocket_query_param_name = resolve_string_or_default(
+        openhands.websocket.query_param_name.as_deref(),
+        env,
+        "openhands.websocket.query_param_name",
+        DEFAULT_OPENHANDS_QUERY_PARAM_NAME,
+    )?;
+    let websocket = OpenHandsWebSocketConfig {
+        enabled: openhands.websocket.enabled.unwrap_or(true),
+        ready_timeout_ms: resolve_positive_u64(
+            openhands.websocket.ready_timeout_ms.as_ref(),
+            "openhands.websocket.ready_timeout_ms",
+            DEFAULT_OPENHANDS_READY_TIMEOUT_MS,
+        )?,
+        reconnect_initial_ms: resolve_positive_u64(
+            openhands.websocket.reconnect_initial_ms.as_ref(),
+            "openhands.websocket.reconnect_initial_ms",
+            DEFAULT_OPENHANDS_RECONNECT_INITIAL_MS,
+        )?,
+        reconnect_max_ms: resolve_positive_u64(
+            openhands.websocket.reconnect_max_ms.as_ref(),
+            "openhands.websocket.reconnect_max_ms",
+            DEFAULT_OPENHANDS_RECONNECT_MAX_MS,
+        )?,
+        auth_mode: websocket_auth_mode,
+        query_param_name: websocket_query_param_name,
+    };
+    validate_remote_openhands_transport_requirements(
+        &transport_base_url,
+        session_api_key_env.as_deref(),
+        &websocket,
+    )?;
+
     Ok(OpenHandsConfig {
         transport: OpenHandsTransportConfig {
-            base_url: resolve_openhands_base_url(openhands.transport.base_url.as_deref(), env)?,
-            session_api_key_env: normalize_optional_literal(
-                &openhands.transport.session_api_key_env,
-            ),
+            base_url: transport_base_url,
+            session_api_key_env,
         },
         local_server: OpenHandsLocalServerConfig {
             enabled: openhands.local_server.enabled.unwrap_or(true),
@@ -275,55 +314,11 @@ fn resolve_openhands<E: Environment>(
             )?,
         },
         conversation: resolve_openhands_conversation(&openhands.conversation, env)?,
-        websocket: OpenHandsWebSocketConfig {
-            enabled: openhands.websocket.enabled.unwrap_or(true),
-            ready_timeout_ms: resolve_positive_u64(
-                openhands.websocket.ready_timeout_ms.as_ref(),
-                "openhands.websocket.ready_timeout_ms",
-                DEFAULT_OPENHANDS_READY_TIMEOUT_MS,
-            )?,
-            reconnect_initial_ms: resolve_positive_u64(
-                openhands.websocket.reconnect_initial_ms.as_ref(),
-                "openhands.websocket.reconnect_initial_ms",
-                DEFAULT_OPENHANDS_RECONNECT_INITIAL_MS,
-            )?,
-            reconnect_max_ms: resolve_positive_u64(
-                openhands.websocket.reconnect_max_ms.as_ref(),
-                "openhands.websocket.reconnect_max_ms",
-                DEFAULT_OPENHANDS_RECONNECT_MAX_MS,
-            )?,
-            auth_mode: resolve_string_or_default(
-                openhands.websocket.auth_mode.as_deref(),
-                env,
-                "openhands.websocket.auth_mode",
-                DEFAULT_OPENHANDS_AUTH_MODE,
-            )?,
-            query_param_name: resolve_string_or_default(
-                openhands.websocket.query_param_name.as_deref(),
-                env,
-                "openhands.websocket.query_param_name",
-                DEFAULT_OPENHANDS_QUERY_PARAM_NAME,
-            )?,
-        },
+        websocket,
         mcp: OpenHandsMcpConfig {
             stdio_servers: Vec::new(),
         },
     })
-}
-
-fn reject_unsupported_openhands_transport_auth(
-    transport: &OpenHandsTransportFrontMatter,
-) -> Result<(), WorkflowConfigError> {
-    if transport.session_api_key_env.is_some() {
-        return Err(WorkflowConfigError::InvalidField {
-            field: "openhands.transport.session_api_key_env",
-            message:
-                "is not supported until the runtime transport layer wires workflow auth into AuthConfig"
-                    .to_owned(),
-        });
-    }
-
-    Ok(())
 }
 
 fn reject_unsupported_openhands_local_server_overrides(
@@ -389,51 +384,6 @@ fn reject_unsupported_openhands_websocket_overrides(
         });
     }
 
-    if websocket.ready_timeout_ms.is_some() {
-        return Err(WorkflowConfigError::InvalidField {
-            field: "openhands.websocket.ready_timeout_ms",
-            message:
-                "is not supported until the runtime readiness path consumes workflow-owned websocket timeouts"
-                    .to_owned(),
-        });
-    }
-
-    if websocket.reconnect_initial_ms.is_some() {
-        return Err(WorkflowConfigError::InvalidField {
-            field: "openhands.websocket.reconnect_initial_ms",
-            message:
-                "is not supported until the runtime reconnect path consumes workflow-owned websocket backoff settings"
-                    .to_owned(),
-        });
-    }
-
-    if websocket.reconnect_max_ms.is_some() {
-        return Err(WorkflowConfigError::InvalidField {
-            field: "openhands.websocket.reconnect_max_ms",
-            message:
-                "is not supported until the runtime reconnect path consumes workflow-owned websocket backoff settings"
-                    .to_owned(),
-        });
-    }
-
-    if websocket.auth_mode.is_some() {
-        return Err(WorkflowConfigError::InvalidField {
-            field: "openhands.websocket.auth_mode",
-            message:
-                "is not supported until the runtime transport layer wires workflow auth into AuthConfig"
-                    .to_owned(),
-        });
-    }
-
-    if websocket.query_param_name.is_some() {
-        return Err(WorkflowConfigError::InvalidField {
-            field: "openhands.websocket.query_param_name",
-            message:
-                "is not supported until the runtime transport layer wires workflow auth into AuthConfig"
-                    .to_owned(),
-        });
-    }
-
     Ok(())
 }
 
@@ -469,17 +419,15 @@ fn resolve_openhands_base_url<E: Environment>(
 fn validate_openhands_base_url(base_url: &str) -> Result<(), WorkflowConfigError> {
     let parsed = Url::parse(base_url).map_err(|error| WorkflowConfigError::InvalidField {
         field: "openhands.transport.base_url",
-        message: format!("must be an absolute http URL: {error}"),
+        message: format!("must be an absolute http or https URL: {error}"),
     })?;
 
     match parsed.scheme() {
-        "http" => {}
+        "http" | "https" => {}
         _ => {
             return Err(WorkflowConfigError::InvalidField {
                 field: "openhands.transport.base_url",
-                message:
-                    "must use the http scheme until supervisor readiness probes support TLS endpoints"
-                        .to_owned(),
+                message: "must use the http or https scheme".to_owned(),
             });
         }
     }
@@ -502,33 +450,68 @@ fn validate_openhands_base_url(base_url: &str) -> Result<(), WorkflowConfigError
         }
     }
 
-    let without_scheme =
-        base_url
-            .strip_prefix("http://")
-            .ok_or_else(|| {
-                WorkflowConfigError::InvalidField {
-            field: "openhands.transport.base_url",
-            message:
-                "must use the http scheme until supervisor readiness probes support TLS endpoints"
-                    .to_owned(),
-        }
-            })?;
-
-    if without_scheme.contains('/') {
+    if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(WorkflowConfigError::InvalidField {
             field: "openhands.transport.base_url",
-            message:
-                "must not include a path until supervisor readiness probes support prefixed base URLs"
-                    .to_owned(),
+            message: "must not embed credentials".to_owned(),
         });
     }
 
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err(WorkflowConfigError::InvalidField {
             field: "openhands.transport.base_url",
-            message:
-                "must not include query or fragment suffixes until supervisor readiness probes support origin-only base URLs"
-                    .to_owned(),
+            message: "must not include query or fragment suffixes".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_openhands_websocket_auth_mode(auth_mode: &str) -> Result<(), WorkflowConfigError> {
+    match auth_mode.trim().to_ascii_lowercase().as_str() {
+        "auto" | "header" | "query_param" => Ok(()),
+        _ => Err(WorkflowConfigError::InvalidField {
+            field: "openhands.websocket.auth_mode",
+            message: "must be one of `auto`, `header`, or `query_param`".to_owned(),
+        }),
+    }
+}
+
+fn validate_remote_openhands_transport_requirements(
+    base_url: &str,
+    session_api_key_env: Option<&str>,
+    websocket: &OpenHandsWebSocketConfig,
+) -> Result<(), WorkflowConfigError> {
+    let parsed = Url::parse(base_url).map_err(|error| WorkflowConfigError::InvalidField {
+        field: "openhands.transport.base_url",
+        message: format!("must be an absolute http or https URL: {error}"),
+    })?;
+
+    let loopback_target = match parsed.host() {
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        None => false,
+    };
+
+    if !loopback_target && parsed.scheme() != "https" {
+        return Err(WorkflowConfigError::InvalidField {
+            field: "openhands.transport.base_url",
+            message: "must use https for non-loopback remote agent-server targets".to_owned(),
+        });
+    }
+
+    if !loopback_target && session_api_key_env.is_none() {
+        return Err(WorkflowConfigError::InvalidField {
+            field: "openhands.transport.session_api_key_env",
+            message: "is required for non-loopback remote agent-server targets".to_owned(),
+        });
+    }
+
+    if session_api_key_env.is_none() && websocket.auth_mode != DEFAULT_OPENHANDS_AUTH_MODE {
+        return Err(WorkflowConfigError::InvalidField {
+            field: "openhands.websocket.auth_mode",
+            message: "requires `openhands.transport.session_api_key_env`".to_owned(),
         });
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,15 +224,17 @@ Local MVP process graph:
 
 The current local supervisor implementation resolves its launch metadata from
 `tools/openhands-server/`, probes readiness with `GET /openapi.json`, and only
-terminates a process that it launched itself. The runtime attach loop also still
-uses runtime-owned WebSocket readiness and reconnect budgets. Until those paths
-consume workflow-owned launch env, readiness-probe-path, startup-timeout, and
-websocket enablement/timing overrides, workflow resolution rejects explicit
-`local_server.env`, `local_server.readiness_probe_path`,
-`local_server.startup_timeout_ms`, `websocket.enabled`,
-`websocket.ready_timeout_ms`, `websocket.reconnect_initial_ms`, and
-`websocket.reconnect_max_ms` settings, as well as `https://`, path-bearing,
-query-bearing, fragment-bearing, and bracketed-IPv6 OpenHands origins.
+terminates a process that it launched itself. Workflow resolution now accepts
+absolute `http://` and `https://` OpenHands origins with optional path
+prefixes, rejects embedded credentials plus query/fragment suffixes, and still
+rejects bracketed IPv6 until the local readiness probe grows that support.
+Non-loopback targets must use `https://` and configure
+`openhands.transport.session_api_key_env`. The runtime attach loop now consumes
+workflow-owned WebSocket readiness and reconnect budgets. Until the local
+supervisor creation path consumes workflow-owned launcher overrides,
+disablement, env, readiness-probe-path, and startup-timeout settings, those
+fields and explicit `websocket.enabled` remain rejected during workflow
+resolution.
 
 ## 5. Worker and conversation model
 
@@ -308,6 +310,7 @@ The control plane exposes a summarized runtime snapshot derived from:
 - aggregated token and usage totals
 - recent OpenHands event summaries
 - local agent-server health
+- per-issue OpenHands server base URL plus transport and auth diagnostics
 
 The snapshot is not just a projection of OpenHands state. It is a Symphony-specific view.
 
@@ -317,7 +320,9 @@ The current repository implements the first read-only control-plane and FrankenT
 
 - `opensymphony-domain`
   - `SnapshotEnvelope`
-  - daemon, issue, metrics, and recent-event serialization models
+  - daemon, issue, metrics, and recent-event serialization models, including
+    `server_base_url`, `transport_target`, `http_auth_mode`,
+    `websocket_auth_mode`, and `websocket_query_param_name`
 - `opensymphony-control`
   - in-memory snapshot store
   - `GET /healthz`

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -86,6 +86,8 @@ Examples:
 - do not attempt to stop the external server on daemon exit
 - still create issue-scoped `working_dir` values
 - still apply the same REST plus WebSocket client contract
+- allow absolute `http://` or `https://` base URLs with optional path prefixes
+- keep authenticated loopback targets in external mode instead of auto-starting the local supervisor
 - health probing is allowed, but termination remains a no-op unless the daemon
   owns the launched child process
 
@@ -182,15 +184,18 @@ Defaults:
 Defaults:
 
 - explicit base URL required
+- path prefixes supported
 - auth configurable
 - TLS optional but supported if present
+- doctor and the runtime treat authenticated or path-prefixed loopback targets as external rather than supervisor-owned
 
 ## 7.3 Hosted remote
 
 Requirements:
 
 - TLS required
-- auth required
+- `openhands.transport.session_api_key_env` required
+- current default auth shape is HTTP header plus WebSocket query-param fallback, with explicit WebSocket header mode available when the pinned server supports it
 - version pinning required
 - structured audit logging required
 
@@ -221,6 +226,6 @@ Support external local server mode for debugging and CI.
 
 ### Phase 3
 
-Add hosted remote mode with hardened auth and stronger workspace isolation.
+Harden hosted remote mode beyond the current transport/auth support, including stronger workspace isolation and broader hosted-operations concerns.
 
 This sequencing gives the project the fastest path to a working developer-focused MVP while preserving the right long-term boundaries.

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -110,7 +110,7 @@ Current repository implementation:
 - explicit `openhands.local_server.enabled: false` overrides are currently rejected during workflow resolution until the runtime supervisor can honor workflow-owned local-server disablement instead of still deciding launch behavior from the localhost base URL plus pinned tooling readiness
 - explicit `openhands.local_server.env` overrides are currently rejected during workflow resolution until the runtime supervisor creation path forwards workflow-owned launcher environment variables into `extra_env`
 - explicit `openhands.local_server.startup_timeout_ms` overrides are currently rejected during workflow resolution until the runtime supervisor creation path consumes workflow-owned startup timeout settings instead of always using the supervisor default
-- workflow resolution rejects malformed, non-`http://`, path-bearing, query-bearing, fragment-bearing, or bracketed-IPv6 `openhands.transport.base_url` values before the daemon reaches runtime transport setup because the current readiness probes still require a bare IPv4-or-hostname `http://host:port` origin
+- workflow resolution now accepts absolute `http://` and `https://` `openhands.transport.base_url` values with optional path prefixes, rejects embedded credentials plus query/fragment suffixes, still rejects bracketed IPv6 until the local readiness probe supports it, and requires `https://` plus `openhands.transport.session_api_key_env` for non-loopback targets
 
 ## 4.2 Startup contract
 
@@ -140,10 +140,10 @@ Current implementation detail:
   regressions fail before a real issue runner lands
 - the current doctor and live-validation path uses `GET /openapi.json` as the
   conservative readiness probe and will temporarily start a supervised local
-  server when the configured loopback base URL is down but the repo-owned pin is
-  valid; once it starts, doctor follows the launched supervisor's resolved base
-  URL for the rest of the probe instead of reusing the original config alias or
-  path prefix
+  server only when the configured target is an unauthenticated loopback
+  `http://` root origin and the repo-owned pin is valid; authenticated,
+  path-prefixed, or non-loopback targets stay in external mode and are probed in
+  place
 - live-only doctor overrides such as `probe_model` and `probe_api_key_env` are
   resolved lazily when `--live-openhands` is requested, so shared configs can
   leave those `${VAR}` placeholders unset during the static preflight path
@@ -194,6 +194,10 @@ Suggested persisted fields:
 - `updated_at`
 - `last_attached_at`
 - `server_base_url`
+- `transport_target`
+- `http_auth_mode`
+- `websocket_auth_mode`
+- `websocket_query_param_name`
 - `persistence_dir`
 - `fresh_conversation`
 - `workflow_prompt_seeded`
@@ -295,9 +299,12 @@ Current workflow defaulting:
 - `agent.kind` defaults to `Agent` when omitted
 - non-default `openhands.conversation.reuse_policy` values are rejected during workflow resolution until the orchestrator/runtime path can honor alternate conversation reuse behavior
 - `max_iterations` must fit the downstream OpenHands `u32` request range
+- `openhands.transport.session_api_key_env` is accepted and required for non-loopback remote targets
 - workflow-owned `local_server.readiness_probe_path` overrides are rejected during workflow resolution until the runtime supervisor launch path consumes them
 - workflow-owned `local_server.startup_timeout_ms` overrides are rejected during workflow resolution until the runtime supervisor creation path consumes them
-- workflow-owned `websocket.enabled`, `websocket.ready_timeout_ms`, `websocket.reconnect_initial_ms`, and `websocket.reconnect_max_ms` overrides are rejected during workflow resolution until the runtime readiness/reconnect path consumes them
+- `openhands.websocket.auth_mode` defaults to `auto` and `openhands.websocket.query_param_name` defaults to `session_api_key`
+- workflow-owned `websocket.enabled` overrides are rejected during workflow resolution until the runtime readiness path can honor disabling the socket entirely
+- workflow-owned `websocket.ready_timeout_ms`, `websocket.reconnect_initial_ms`, and `websocket.reconnect_max_ms` overrides now resolve into the runtime stream attach and reconnect budgets
 - `agent.llm.model` is required whenever an `llm` block is present
 - workflow-owned LLM option keys are rejected during workflow resolution until the current request subset can actually forward them
 - workflow-owned agent options such as `log_completions` and extra agent keys are rejected during workflow resolution until the current request subset can actually forward them
@@ -314,9 +321,10 @@ Current repository implementation:
 - `ConversationCreateRequest` carries the minimal create payload subset, including `conversation_id`, `workspace.working_dir`, and `persistence_dir`
 - the current request model still serializes `agent` as only `{ kind, llm }`, and `llm` itself as only `{ model, api_key }`, so workflow-owned agent extras plus arbitrary LLM option keys are rejected before runtime launch
 - the current orchestrator/runtime path still uses fixed per-issue conversation reuse, so workflow-owned `reuse_policy` overrides are rejected before runtime launch
-- the current supervisor readiness probe still parses only bare `http://host:port` origins, always uses its default `/openapi.json` probe path, and the CLI still constructs `SupervisedServerConfig::new(tooling)` without applying workflow-owned startup timeouts, so `https://` base URLs plus explicit `local_server.readiness_probe_path` and `local_server.startup_timeout_ms` overrides are rejected before runtime launch
+- the current transport layer preserves base-path prefixes across REST endpoints and `/sockets/events/{conversation_id}`, so the same client can target reverse-proxied external servers without code changes outside config
+- the current supervisor readiness probe still owns the local launch path and always uses `/openapi.json`, so explicit `local_server.readiness_probe_path` and `local_server.startup_timeout_ms` overrides are still rejected before runtime launch
 - the current supervisor launch path still uses runtime-owned launcher environment variables (`OPENHANDS_SERVER_PORT` and `RUNTIME=process`), so explicit workflow-owned `local_server.env` overrides are rejected before runtime launch
-- the current runtime still always opens the readiness socket and uses runtime-owned readiness/reconnect budgets, so explicit workflow-owned `websocket.enabled`, `websocket.ready_timeout_ms`, `websocket.reconnect_initial_ms`, and `websocket.reconnect_max_ms` overrides are rejected before runtime launch
+- the current runtime now consumes workflow-owned `websocket.ready_timeout_ms`, `websocket.reconnect_initial_ms`, and `websocket.reconnect_max_ms` values, but still always opens the readiness socket so explicit `websocket.enabled` overrides remain rejected before runtime launch
 - the current request model does not yet serialize `mcp_config`, so workflow-owned MCP stdio server declarations are rejected before runtime launch
 - `ConversationRunRequest` serializes the empty `{}` body used by `POST /api/conversations/{conversation_id}/run`
 - `AcceptedResponse` tolerates either an explicit JSON success body or an empty successful response for `POST /events` and `POST /run`
@@ -342,11 +350,13 @@ The Rust client should still support:
 
 Current repository implementation:
 
-- `TransportConfig` now carries an `AuthConfig` with explicit no-auth, query-param API key, header API key, and header-plus-WebSocket-query-fallback modes
-- REST auth is applied independently from WebSocket auth so remote/header deployments do not force the local query-param shape
-- workflow-owned auth knobs such as `openhands.transport.session_api_key_env`, `openhands.websocket.auth_mode`, and `openhands.websocket.query_param_name` are currently rejected during workflow resolution until a runtime adapter wires them into `AuthConfig`
+- `TransportConfig::from_workflow` now resolves `openhands.transport.session_api_key_env`, `openhands.websocket.auth_mode`, and `openhands.websocket.query_param_name` into `AuthConfig`
+- when a session API key is configured, REST always uses the pinned `x-session-api-key` header shape while WebSocket auth follows the workflow mode: `auto` and `query_param` use the configured query parameter name, and `header` sends the same header on the socket handshake
+- REST auth is applied independently from WebSocket auth so remote/header deployments do not force the local query-param shape, while the default `auto` mode matches the pinned 1.14.0 SDK behavior
+- non-loopback remote targets must use `https://` and provide `openhands.transport.session_api_key_env` during workflow resolution
+- `IssueSessionRunner` persists `server_base_url`, `transport_target`, `http_auth_mode`, `websocket_auth_mode`, and `websocket_query_param_name` into `conversation.json`, generated session context, and control-plane snapshots for remote troubleshooting
 - `OpenHandsError` now maps invalid config, transport failures, HTTP status failures, protocol failures, and WebSocket failures into stable runtime categories without exposing `reqwest::Error` or `http::StatusCode`
-- `crates/opensymphony-openhands/tests/client_resilience.rs` covers authenticated REST operations, WebSocket readiness auth, auth failure mapping, malformed payload handling, forward-compatible readiness envelopes, ready-state freshness after attach, ready-barrier persistence across later stale cache rebuilds, attach-backlog versus buffered-live ordering, explicit-close shutdown semantics, reused-conversation restart freshness over stale terminal REST state, terminal REST fallback when reconnect exhausts after completion, next-turn probe error delivery after `finished`, and non-readiness frames before the first state update
+- `crates/opensymphony-openhands/tests/client_resilience.rs`, `crates/opensymphony-openhands/tests/transport_config.rs`, `crates/opensymphony-openhands/tests/supervisor.rs`, and the opt-in `crates/opensymphony-openhands/tests/live_pinned_server.rs` suite cover authenticated REST operations, WebSocket readiness auth, auth failure mapping, path-prefixed external targets, local-supervisor eligibility rules, external-server no-op stop behavior, and pinned-server HTTP/WebSocket auth success and failure paths
 - the doctor probe now runs through `RuntimeEventStream`, exercises a real `POST /events` plus `POST /run` path, and only reports the runtime healthy after the attached stream reaches a successful terminal `execution_status` of `finished` with no queued `ConversationErrorEvent` still pending ahead of completion or arriving on the next scheduler-turn buffered drain
 - failure-only probe streams such as `ConversationErrorEvent` or terminal `execution_status` values like `error` and `stuck` are treated as unhealthy instead of silently passing
 - once the attached stream has already observed a healthy terminal outcome, the doctor probe reuses the last successful stream-backed conversation snapshot instead of requiring one more `GET /api/conversations/{id}` that could fail during server shutdown

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -87,7 +87,7 @@ Use release notes to track:
 
 ### Pinned OpenHands version notes
 
-As of 2026-03-21, this repository pins:
+As of 2026-03-22, this repository pins:
 
 - `openhands-agent-server==1.14.0`
 - `openhands-sdk==1.14.0`
@@ -109,6 +109,11 @@ The current local supervisor assumptions validated against this pin are:
 - the CLI still accepts `--host` and `--port`
 - the default bind host remains broader than loopback, so OpenSymphony keeps the
   loopback-only wrapper
+- REST auth uses the `X-Session-API-Key` header when session API keys are configured
+- the SDK remote client still defaults WebSocket auth to the `session_api_key`
+  query parameter when an API key is present
+- the server also accepts WebSocket header auth, with query-param auth taking
+  precedence when both are present
 
 When bumping this version, re-validate the launch surface, readiness probe, HTTP
 contract assumptions, and WebSocket notes before changing the repo pin.

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -80,6 +80,7 @@ Current implementation:
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`
 - `crates/opensymphony-openhands/tests/client_resilience.rs` and `crates/opensymphony-openhands/tests/fake_server_contract.rs` now cover readiness, attach, initial snapshot replay, attach-backlog versus buffered-live ordering, ready-barrier persistence across later stale rebuilds, explicit-close shutdown semantics, reconcile, out-of-order delivery, reused-conversation restart freshness, and reconnect recovery for the runtime stream
+- `crates/opensymphony-openhands/tests/live_pinned_server.rs` provides an opt-in live integration check against the pinned `openhands-agent-server==1.14.0` surface for external-mode auth success and failure
 
 ## 3. Minimum required test coverage by subsystem
 
@@ -108,9 +109,14 @@ Current implementation:
 - resolve the bundled `examples/target-repo/WORKFLOW.md` file end-to-end, not just parse it
 - treat a leading unmatched `---` as prompt body text instead of failing front-matter parsing
 - treat leading thematic-break-delimited non-mapping blocks as prompt body text instead of silently dropping prompt content
-- fail on malformed, non-`http://`, path-bearing, query-bearing, fragment-bearing, or bracketed-IPv6 `openhands.transport.base_url` values during workflow resolution
-- fail when explicit `openhands.websocket.enabled`, `ready_timeout_ms`, `reconnect_initial_ms`, or `reconnect_max_ms` values are configured before the runtime readiness/reconnect path consumes them
-- fail when `openhands.transport.session_api_key_env` or explicit OpenHands WebSocket auth knobs are configured before the runtime transport layer consumes them
+- fail on malformed, non-`http://`/`https://`, credential-bearing, query-bearing, fragment-bearing, or bracketed-IPv6 `openhands.transport.base_url` values during workflow resolution
+- allow `https://` and path-prefixed OpenHands transport base URLs during workflow resolution
+- fail when a non-loopback OpenHands transport base URL uses `http://`
+- fail when a non-loopback OpenHands transport base URL omits `openhands.transport.session_api_key_env`
+- resolve `openhands.transport.session_api_key_env`, `openhands.websocket.auth_mode`, and `openhands.websocket.query_param_name` into the runtime transport config
+- fail when `openhands.websocket.auth_mode` is invalid or requires a missing session API key env
+- fail when explicit `openhands.websocket.enabled` is configured before the runtime readiness path can honor disabling the socket
+- resolve `openhands.websocket.ready_timeout_ms`, `reconnect_initial_ms`, and `reconnect_max_ms` into the runtime readiness and reconnect budgets
 - fail when `openhands.mcp.stdio_servers` is configured before the runtime conversation-create adapter can forward `mcp_config`
 - fail when non-default `openhands.conversation.reuse_policy` values are configured before the orchestrator/runtime path can honor alternate conversation reuse behavior
 - default required OpenHands conversation request fields such as `confirmation_policy` and `agent`, including `confirmation_policy.kind` when the block is present without an explicit kind
@@ -151,6 +157,7 @@ Current implementation:
 
 - supervised server startup and shutdown
 - HTTP client auth modes
+- external server path-prefix probes
 - conversation creation
 - initial REST sync
 - WebSocket readiness barrier
@@ -159,6 +166,7 @@ Current implementation:
 - out-of-order event insertion
 - terminal state detection
 - conversation reuse
+- pinned-server auth success and failure paths
 
 ## 3.4 Orchestrator
 
@@ -307,6 +315,7 @@ Current command set in this repository:
 - `cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:4010/ --exit-after-ms 1200`
 - `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`
 - `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands`
+- `OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_pinned_server -- --nocapture`
 - `cargo run -p opensymphony-cli -- linear-mcp`
 - `./scripts/smoke_local.sh`
 - `OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh`
@@ -400,12 +409,13 @@ Current implementation notes:
 - checkout-relative doctor defaults are derived from the config and tooling paths rather than the caller `cwd`, so running `opensymphony doctor` outside the repo root still validates the intended checkout and bundled `examples/target-repo`
 - the live doctor path additionally probes `GET /openapi.json`, creates a temp conversation using workflow-derived OpenHands conversation settings, attaches `RuntimeEventStream`, waits through non-readiness WebSocket traffic until the readiness barrier is observed, sends a doctor message that includes the rendered workflow prompt, triggers `/run`, and waits for a healthy terminal `execution_status` of `finished` after post-ready reconcile and reconnect-aware streaming, including terminal REST refresh fallback when a post-completion WebSocket reattach exhausts and one final scheduler-turn buffered drain before success is accepted
 - once that live doctor path has already observed terminal success on the attached stream, it reuses the last successful stream-backed conversation snapshot instead of requiring a final `GET /api/conversations/{id}` that can flap during agent-server shutdown
-- when the configured workflow loopback base URL is down but the repo-owned tooling pin is ready, the live doctor path temporarily starts the local supervised server on that port, switches follow-up probes to the launched supervisor base URL, uses it for the probe, then stops it again
+- when the configured workflow loopback base URL is down but the repo-owned tooling pin is ready, the live doctor path temporarily starts the local supervised server only for unauthenticated loopback root-path targets, switches follow-up probes to the launched supervisor base URL, uses it for the probe, then stops it again
 - failure-only runtime events such as `ConversationErrorEvent` and terminal `execution_status` values like `error` or `stuck` fail the live doctor probe instead of counting as generic post-run activity, even when a later mirrored `finished` status is already present in the same drained batch
 - missing `${VAR}` tokens in required or enabled-path config values now fail doctor during config expansion instead of silently validating the config directory as an empty fallback path
 - optional live-only placeholders such as `openhands.probe_model` and `openhands.probe_api_key_env` are treated as unset when their env-backed overrides are absent, so shared configs can keep those overrides empty during the static doctor pass
 - `crates/opensymphony-openhands/tests/client_resilience.rs` locks in the runtime adapter regressions for pre-readiness WebSocket frames, authenticated REST/WebSocket requests, forward-compatible readiness envelopes, ready-state freshness after attach, ready-barrier persistence across later stale state rebuilds, buffered live frames outranking later attach replay items, explicit-close suppression of replay and reconnect, reused-conversation restart freshness over stale terminal REST state, forward-compatible `state_delta` mirror refresh, stale readiness snapshots not regressing newer probe state after reconnect, undecodable later persisted state updates not suppressing a usable ready barrier, terminal REST fallback after reconnect exhaustion, deferred reconnect after buffered delivery, non-replay of reconnect-only readiness barriers, next-turn probe error delivery after `finished`, and post-terminal probe success when a final REST refresh would fail
 - `crates/opensymphony-openhands/tests/fake_server_contract.rs` locks in attach, initial snapshot replay, reconcile, out-of-order insertion, and reconnect recovery against `opensymphony-testkit`
+- `crates/opensymphony-openhands/tests/live_pinned_server.rs` locks in external-mode auth success plus HTTP 401 and WebSocket 403 failure mapping against the pinned `openhands-agent-server==1.14.0` process
 - `crates/opensymphony-cli/tests/doctor.rs` locks in the doctor default target-repo fallback outside the repo `cwd`, required-env placeholder failures, optional live-only placeholder tolerance during static runs, workflow-driven runtime inputs, and the pinned launcher `cwd` behavior
 - `crates/opensymphony-cli/tests/linear_mcp.rs` drives the real `opensymphony linear-mcp` child process through MCP initialization, tool listing, and comment/transition/link/state-list calls against a local fake Linear GraphQL server
 - the current example configs carry machine-local tool/probe settings only; the repo-owned workflow now supplies the workspace root and OpenHands base URL that doctor validates

--- a/docs/websocket-runtime.md
+++ b/docs/websocket-runtime.md
@@ -42,11 +42,17 @@ If the host contains a base path, preserve it.
 
 ## 2.3 Auth modes
 
-Support these modes in the Rust client:
+Support these workflow-controlled modes in the Rust client:
 
-- none
-- query-param session API key fallback
-- optional header-based auth for versions that support it
+- `auto`
+  - no auth when `openhands.transport.session_api_key_env` is unset
+  - otherwise use the pinned 1.14.0 shape: HTTP header `x-session-api-key`
+    plus WebSocket query param `session_api_key`
+- `header`
+  - keep the same HTTP header and send that header on the WebSocket handshake
+- `query_param`
+  - keep the same HTTP header and send the configured query parameter on the
+    WebSocket handshake
 
 Default local MVP behavior: none.
 
@@ -153,11 +159,12 @@ Current repository implementation:
 
 - `opensymphony-openhands::OpenHandsClient::wait_for_readiness` loops until an event envelope with kind `ConversationStateUpdateEvent` arrives from `/sockets/events/{conversation_id}`, while tolerating control frames and unrelated or undecodable frames before readiness
 - `opensymphony-openhands::OpenHandsClient::attach_runtime_stream` performs the full attach sequence: initial REST sync, WebSocket connect, readiness barrier, and post-ready reconcile before returning a live `RuntimeEventStream`
+- `TransportConfig` preserves base-path prefixes and applies REST versus WebSocket auth independently, so reverse-proxied external targets keep their `/runtime/...` style prefixes while still matching the pinned auth contract
 - the readiness frame is retained on `RuntimeEventStream::ready_event` as an attach barrier and diagnostic snapshot, refreshes the in-memory state mirror only when it is newer than the reconciled state, stays authoritative across later mirror rebuilds until reconcile or REST refresh surfaces an equal or newer decodable state update, can salvage a forward-compatible `state_delta` even when the full payload shape no longer deserializes cleanly, can clear stale terminal REST fallback when a reused conversation has already restarted into an active `queued` or `running` state, and is not replayed through `next_event()` unless `/events/search` independently contains the same event ID
 - `RuntimeEventStream::next_event` now drains any immediately available live socket frames into the same ordered pending queue before yielding a later attach-backlog item, so direct consumers still observe timestamp order while replaying persisted history without relying on a fixed read-ahead delay
-- workflow-owned `openhands.websocket.enabled`, `ready_timeout_ms`, `reconnect_initial_ms`, and `reconnect_max_ms` overrides are currently rejected during workflow resolution until the runtime attach/reconnect path consumes them; the live runtime still always opens the readiness socket and uses runtime-owned budgets
+- workflow-owned `openhands.websocket.ready_timeout_ms`, `reconnect_initial_ms`, and `reconnect_max_ms` overrides are now consumed by the runtime attach/reconnect path; explicit `openhands.websocket.enabled` still remains rejected because the live runtime always opens the readiness socket
 - `opensymphony-testkit` sends a state-update event immediately on WebSocket attach so readiness behavior is deterministic in CI
-- `crates/opensymphony-openhands/tests/fake_server_contract.rs`, `crates/opensymphony-openhands/tests/client_resilience.rs`, and `crates/opensymphony-cli/tests/doctor.rs` cover the readiness, attach, and reconcile path
+- `crates/opensymphony-openhands/tests/fake_server_contract.rs`, `crates/opensymphony-openhands/tests/client_resilience.rs`, `crates/opensymphony-openhands/tests/live_pinned_server.rs`, and `crates/opensymphony-cli/tests/doctor.rs` cover the readiness, attach, auth, and reconcile path
 
 ## 6. Event cache and reconciliation
 

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -37,6 +37,8 @@ Because this sanitization is not injective, workspace reuse must be gated by the
 - The issue workspace path itself must not be a symlink when OpenSymphony reuses or validates it.
 - `cwd` for all hook commands and all OpenHands runs must equal the resolved issue workspace path unless an explicit per-command `cwd` override inside the same workspace is required.
 - When `openhands.local_server.command` is omitted, the runtime-owned local tooling layer must resolve the pinned launcher from the OpenSymphony checkout before that `cwd` switch happens. Workflow resolution must not bake a compile-time checkout path into config defaults.
+- Non-loopback remote `openhands.transport.base_url` targets must use `https://` and set `openhands.transport.session_api_key_env`.
+- Only unauthenticated loopback `http://` root origins are eligible for daemon-managed local supervision. Authenticated or path-prefixed loopback targets must be treated as external connections even when they still point at `127.0.0.1` or `localhost`.
 - Explicit workflow-owned `openhands.local_server.command` overrides are currently rejected until the runtime supervisor can honor them instead of always launching the pinned repo-local server wrapper.
 - Explicit workflow-owned `openhands.local_server.enabled: false` overrides are currently rejected until the runtime supervisor can honor workflow-owned local-server disablement instead of still deciding launch behavior from the localhost base URL plus pinned tooling readiness.
 - Explicit workflow-owned `openhands.local_server.env` overrides are currently rejected until the runtime supervisor creation path forwards them into the actual launcher environment instead of still using runtime-owned defaults.
@@ -229,6 +231,10 @@ Suggested fields:
 - `identifier`
 - `conversation_id`
 - `server_base_url`
+- `transport_target`
+- `http_auth_mode`
+- `websocket_auth_mode`
+- `websocket_query_param_name`
 - `persistence_dir`
 - `created_at`
 - `updated_at`
@@ -271,6 +277,7 @@ Human-readable summary for the agent and operator:
 Machine-readable runtime summary:
 
 - conversation ID
+- server base URL plus transport/auth diagnostics
 - run ID
 - attempt number
 - worker ID


### PR DESCRIPTION
## Summary

Add remote OpenHands agent-server transport/auth support without requiring code changes outside workflow config, and surface the resulting transport diagnostics through persisted session metadata and the control plane.

## Changes

- accept remote `https://` OpenHands origins, `session_api_key_env`, websocket auth mode, websocket query param name, and websocket timing overrides during workflow resolution while keeping unsupported local-server overrides rejected
- build workflow-driven HTTP/WebSocket auth into `TransportConfig`, preserve path-prefixed external targets, harden external readiness probing, and keep auto-start limited to unauthenticated loopback root-path targets
- propagate `server_base_url`, `transport_target`, `http_auth_mode`, `websocket_auth_mode`, and `websocket_query_param_name` through conversation manifests, generated session context, domain metadata, CLI samples, and control-plane snapshots
- add transport/auth tests, path-prefixed external supervisor coverage, and an opt-in live pinned-server integration suite against `openhands-agent-server==1.14.0`
- update the runtime, deployment, workspace, testing, and sources docs for remote-mode transport/auth behavior

## Evidence

### Test output

```text
$ cargo test -p opensymphony-workflow -p opensymphony-openhands -p opensymphony-domain -p opensymphony-control -p opensymphony-cli
... test result: ok. 56 passed ... opensymphony-workflow
... test result: ok. 24 passed ... client_resilience
... test result: ok. 6 passed ... supervisor
... test result: ok. 4 passed ... transport_config
... test result: ok. 2 passed ... live_pinned_server (gated skip in normal run)

$ cargo clippy -p opensymphony-workflow -p opensymphony-openhands -p opensymphony-domain -p opensymphony-control -p opensymphony-cli --tests -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.60s

$ OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_pinned_server
running 2 tests
...
test live_pinned_server_rejects_missing_http_auth_and_wrong_websocket_auth ... ok
...
test live_pinned_server_authenticates_external_http_and_websocket_paths ... ok

test result: ok. 2 passed; 0 failed
```

### Verification

- Reproduced the pre-change failure in `opensymphony-workflow`: remote/auth knobs and `https://` OpenHands origins were rejected during resolution.
- Confirmed the shipped transport config now resolves remote auth and path-prefixed external targets while leaving local supervised mode restricted to the local-safe topology.
- Verified the pinned 1.14.0 server contract in the live integration suite: HTTP auth succeeds/fails with the expected 201/401 behavior and websocket auth succeeds/fails with the expected attach/403 behavior.
- Verified remote troubleshooting metadata is serialized through conversation manifests and control-plane snapshots.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

- COE-275

## Additional notes

- The Linear issue still lists `COE-262`, `COE-265`, `COE-266`, and `COE-269` as blockers, but all four are already `Done` in Linear.
- The live pinned-server test includes a dummy `agent.llm.model` because `openhands-agent-server==1.14.0` requires `agent.llm` at conversation creation time even for auth-only attach validation.
