### PR TITLE
Implement hierarchy-aware task selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,8 +1469,12 @@ dependencies = [
 name = "opensymphony-orchestrator"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "opensymphony-domain",
+ "opensymphony-linear",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
 name = "opensymphony-orchestrator"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "opensymphony-domain",
 ]
 

--- a/crates/opensymphony-domain/src/issue.rs
+++ b/crates/opensymphony-domain/src/issue.rs
@@ -27,6 +27,13 @@ pub struct BlockerRef {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueRef {
+    pub id: IssueId,
+    pub identifier: IssueIdentifier,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedIssue {
     pub id: IssueId,
     pub identifier: IssueIdentifier,
@@ -37,7 +44,11 @@ pub struct NormalizedIssue {
     pub branch_name: Option<String>,
     pub url: Option<String>,
     pub labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<IssueId>,
     pub blocked_by: Vec<BlockerRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sub_issues: Vec<IssueRef>,
     pub created_at: Option<TimestampMs>,
     pub updated_at: Option<TimestampMs>,
 }

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -19,7 +19,7 @@ pub use identifiers::{
     ConversationId, IdentifierError, IssueId, IssueIdentifier, TrackerStateId, WorkerId,
     WorkspaceKey,
 };
-pub use issue::{BlockerRef, IssueState, IssueStateCategory, NormalizedIssue};
+pub use issue::{BlockerRef, IssueRef, IssueState, IssueStateCategory, NormalizedIssue};
 pub use runtime::{
     ConversationMetadata, ReleaseReason, RetryAttempt, RetryCalculationError, RetryEntry,
     RetryPolicy, RetryReason, RunAttempt, RuntimeStreamState, StallMetadata, WorkerOutcomeKind,
@@ -34,7 +34,7 @@ pub use state_machine::{
 };
 pub use time::{DurationMs, TimestampMs};
 pub use tracker::{
-    TrackerErrorCategory, TrackerIssue, TrackerIssueBlocker, TrackerIssueState,
+    TrackerErrorCategory, TrackerIssue, TrackerIssueBlocker, TrackerIssueRef, TrackerIssueState,
     TrackerIssueStateKind, TrackerIssueStateSnapshot,
 };
 
@@ -53,7 +53,7 @@ mod tests {
 
     use super::{
         ComponentHealthSnapshot, ConversationMetadata, HealthStatus, IssueExecution, IssueId,
-        IssueIdentifier, IssueSnapshot, IssueState, IssueStateCategory, NormalizedIssue,
+        IssueIdentifier, IssueRef, IssueSnapshot, IssueState, IssueStateCategory, NormalizedIssue,
         OrchestratorSnapshot, ReleaseReason, RetryAttempt, RetryEntry, RetryPolicy, RetryReason,
         RunAttempt, RuntimeStreamState, RuntimeUsageTotals, SchedulerStatus, StateTransitionError,
         TimestampMs, WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey,
@@ -124,7 +124,13 @@ mod tests {
                     .to_owned(),
             ),
             labels: vec!["foundation".to_owned(), "contracts".to_owned()],
+            parent_id: None,
             blocked_by: Vec::new(),
+            sub_issues: vec![IssueRef {
+                id: must(IssueId::new("lin_261")),
+                identifier: must(IssueIdentifier::new("COE-261")),
+                state: "Done".to_owned(),
+            }],
             created_at: Some(ts(10)),
             updated_at: Some(ts(20)),
         }

--- a/crates/opensymphony-domain/src/tracker.rs
+++ b/crates/opensymphony-domain/src/tracker.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +13,11 @@ pub struct TrackerIssue {
     pub priority: Option<u8>,
     pub state: String,
     pub labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
     pub blocked_by: Vec<TrackerIssueBlocker>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sub_issues: Vec<TrackerIssueRef>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -50,6 +56,22 @@ pub struct TrackerIssueBlocker {
 impl TrackerIssueBlocker {
     pub fn is_terminal(&self) -> bool {
         self.state.is_terminal()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerIssueRef {
+    pub id: String,
+    pub identifier: String,
+    pub state: String,
+}
+
+impl TrackerIssueRef {
+    pub fn is_terminal(&self, terminal_states: &HashSet<String>) -> bool {
+        let state = self.state.trim();
+        terminal_states
+            .iter()
+            .any(|terminal_state| terminal_state.trim().eq_ignore_ascii_case(state))
     }
 }
 
@@ -98,7 +120,9 @@ pub enum TrackerErrorCategory {
 
 #[cfg(test)]
 mod tests {
-    use super::{TrackerErrorCategory, TrackerIssueState, TrackerIssueStateKind};
+    use std::collections::HashSet;
+
+    use super::{TrackerErrorCategory, TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind};
 
     #[test]
     fn tracker_state_kind_maps_known_linear_types() {
@@ -172,5 +196,17 @@ mod tests {
         ];
 
         assert_eq!(categories.len(), 8);
+    }
+
+    #[test]
+    fn tracker_issue_ref_matches_terminal_states_case_insensitively() {
+        let issue = TrackerIssueRef {
+            id: "issue-1".to_string(),
+            identifier: "COE-1".to_string(),
+            state: "done".to_string(),
+        };
+        let terminal_states = HashSet::from([String::from("Done"), String::from("Canceled")]);
+
+        assert!(issue.is_terminal(&terminal_states));
     }
 }

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -26,6 +26,18 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchi
         name
         type
       }
+      parent {
+        id
+      }
+      children(first: 50) {
+        nodes {
+          id
+          identifier
+          state {
+            name
+          }
+        }
+      }
       labels(first: $labelFirst) {
         nodes {
           name
@@ -236,6 +248,10 @@ pub(super) struct LinearIssueNode {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub state: LinearWorkflowState,
+    #[serde(default)]
+    pub parent: Option<LinearParentNode>,
+    #[serde(default)]
+    pub children: LinearChildConnection,
     pub labels: LinearLabelConnection,
     pub inverse_relations: LinearRelationConnection,
 }
@@ -269,6 +285,28 @@ pub(super) struct LinearWorkflowState {
     pub name: String,
     #[serde(rename = "type")]
     pub kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearParentNode {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct LinearChildConnection {
+    pub nodes: Vec<LinearChildNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearChildNode {
+    pub id: String,
+    pub identifier: String,
+    pub state: LinearIssueRefState,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LinearIssueRefState {
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/opensymphony-linear/src/normalize.rs
+++ b/crates/opensymphony-linear/src/normalize.rs
@@ -1,12 +1,12 @@
 use opensymphony_domain::{
-    TrackerIssue, TrackerIssueBlocker, TrackerIssueState, TrackerIssueStateKind,
+    TrackerIssue, TrackerIssueBlocker, TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind,
     TrackerIssueStateSnapshot,
 };
 
 use crate::error::LinearError;
 use crate::graphql::{
-    LinearBlockerNode, LinearIssueNode, LinearIssueStateNode, LinearLabelNode, LinearRelationNode,
-    LinearWorkflowState,
+    LinearBlockerNode, LinearChildNode, LinearIssueNode, LinearIssueStateNode, LinearLabelNode,
+    LinearParentNode, LinearRelationNode, LinearWorkflowState,
 };
 
 pub(super) fn normalize_issue(node: LinearIssueNode) -> Result<TrackerIssue, LinearError> {
@@ -19,7 +19,9 @@ pub(super) fn normalize_issue(node: LinearIssueNode) -> Result<TrackerIssue, Lin
         priority: normalize_priority(node.priority)?,
         state: node.state.name,
         labels: normalize_labels(node.labels.nodes),
+        parent_id: normalize_parent_id(node.parent),
         blocked_by: normalize_blockers(node.inverse_relations.nodes),
+        sub_issues: normalize_sub_issues(node.children.nodes),
         created_at: node.created_at,
         updated_at: node.updated_at,
     })
@@ -71,6 +73,24 @@ fn normalize_blocker(blocker: LinearBlockerNode) -> TrackerIssueBlocker {
         title: blocker.title,
         state: normalize_state(blocker.state),
     }
+}
+
+fn normalize_parent_id(parent: Option<LinearParentNode>) -> Option<String> {
+    parent.map(|parent| parent.id)
+}
+
+fn normalize_sub_issues(children: Vec<LinearChildNode>) -> Vec<TrackerIssueRef> {
+    let mut sub_issues = children
+        .into_iter()
+        .map(|child| TrackerIssueRef {
+            id: child.id,
+            identifier: child.identifier,
+            state: child.state.name,
+        })
+        .collect::<Vec<_>>();
+    sub_issues.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+    sub_issues.dedup_by(|left, right| left.id == right.id);
+    sub_issues
 }
 
 const LINEAR_MAX_PRIORITY: u64 = 4;

--- a/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
+++ b/crates/opensymphony-linear/tests/fixtures/candidate_issues_page.json
@@ -16,6 +16,10 @@
             "name": "In Progress",
             "type": "started"
           },
+          "parent": null,
+          "children": {
+            "nodes": []
+          },
           "labels": {
             "nodes": [
               { "name": "urgent" },
@@ -71,6 +75,34 @@
             "id": "state-started",
             "name": "In Progress",
             "type": "started"
+          },
+          "parent": {
+            "id": "issue-254"
+          },
+          "children": {
+            "nodes": [
+              {
+                "id": "issue-277",
+                "identifier": "COE-277",
+                "state": {
+                  "name": "Todo"
+                }
+              },
+              {
+                "id": "issue-266",
+                "identifier": "COE-266",
+                "state": {
+                  "name": "Done"
+                }
+              },
+              {
+                "id": "issue-277",
+                "identifier": "COE-277",
+                "state": {
+                  "name": "Todo"
+                }
+              }
+            ]
           },
           "labels": {
             "nodes": []

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -41,6 +41,8 @@ async fn candidate_issues_normalize_fixture_payloads() {
     assert_eq!(first.priority, Some(1));
     assert_eq!(first.state, "In Progress");
     assert_eq!(first.labels, vec!["backend", "urgent"]);
+    assert_eq!(first.parent_id, None);
+    assert!(first.sub_issues.is_empty());
     assert_eq!(first.blocked_by.len(), 1);
     assert!(first.blocked_by[0].is_terminal());
     assert_eq!(first.blocked_by[0].state.tracker_type, "completed");
@@ -53,6 +55,12 @@ async fn candidate_issues_normalize_fixture_payloads() {
     );
     assert_eq!(second.priority, None);
     assert_eq!(second.state, "In Progress");
+    assert_eq!(second.parent_id.as_deref(), Some("issue-254"));
+    assert_eq!(second.sub_issues.len(), 2);
+    assert_eq!(second.sub_issues[0].identifier, "COE-266");
+    assert_eq!(second.sub_issues[0].state, "Done");
+    assert_eq!(second.sub_issues[1].identifier, "COE-277");
+    assert_eq!(second.sub_issues[1].state, "Todo");
     assert_eq!(second.blocked_by.len(), 1);
     assert_eq!(second.blocked_by[0].identifier, "COE-261");
     assert_eq!(
@@ -95,6 +103,18 @@ async fn candidate_issues_normalize_fixture_payloads() {
             .as_str()
             .expect("query should be a string")
             .contains("labels(first: $labelFirst)")
+    );
+    assert!(
+        requests[0].body["query"]
+            .as_str()
+            .expect("query should be a string")
+            .contains("children(first: 50)")
+    );
+    assert!(
+        requests[0].body["query"]
+            .as_str()
+            .expect("query should be a string")
+            .contains("parent {")
     );
 }
 

--- a/crates/opensymphony-openhands/tests/issue_session_runner.rs
+++ b/crates/opensymphony-openhands/tests/issue_session_runner.rs
@@ -33,7 +33,9 @@ fn sample_issue(identifier: &str) -> NormalizedIssue {
         branch_name: None,
         url: None,
         labels: vec!["runtime".to_string()],
+        parent_id: None,
         blocked_by: Vec::new(),
+        sub_issues: Vec::new(),
         created_at: Some(TimestampMs::new(1)),
         updated_at: Some(TimestampMs::new(2)),
     }

--- a/crates/opensymphony-orchestrator/Cargo.toml
+++ b/crates/opensymphony-orchestrator/Cargo.toml
@@ -12,4 +12,8 @@ path = "src/lib.rs"
 opensymphony-domain = { path = "../opensymphony-domain" }
 
 [dev-dependencies]
+axum = { workspace = true }
 chrono = { workspace = true }
+opensymphony-linear = { path = "../opensymphony-linear" }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/opensymphony-orchestrator/Cargo.toml
+++ b/crates/opensymphony-orchestrator/Cargo.toml
@@ -10,3 +10,6 @@ path = "src/lib.rs"
 
 [dependencies]
 opensymphony-domain = { path = "../opensymphony-domain" }
+
+[dev-dependencies]
+chrono = { workspace = true }

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -1,13 +1,21 @@
+mod selection;
+
 pub const CRATE_NAME: &str = "opensymphony-orchestrator";
 
 pub use opensymphony_domain::{
     ComponentHealthSnapshot, ConversationId, ConversationMetadata, DaemonSnapshot, DurationMs,
-    HealthStatus, IdentifierError, IssueExecution, IssueId, IssueIdentifier, IssueSnapshot,
-    IssueState, IssueStateCategory, NormalizedIssue, OrchestratorSnapshot, ReleaseReason,
-    RetryAttempt, RetryCalculationError, RetryEntry, RetryPolicy, RetryReason, RunAttempt,
-    RuntimeStreamState, RuntimeUsageTotals, SchedulerState, SchedulerStatus, StallMetadata,
-    StateTransitionError, TimestampMs, TrackerStateId, TransitionAction, WorkerAttemptSnapshot,
-    WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
+    HealthStatus, IdentifierError, IssueExecution, IssueId, IssueIdentifier, IssueRef,
+    IssueSnapshot, IssueState, IssueStateCategory, NormalizedIssue, OrchestratorSnapshot,
+    ReleaseReason, RetryAttempt, RetryCalculationError, RetryEntry, RetryPolicy, RetryReason,
+    RunAttempt, RuntimeStreamState, RuntimeUsageTotals, SchedulerState, SchedulerStatus,
+    StallMetadata, StateTransitionError, TimestampMs, TrackerIssue, TrackerIssueBlocker,
+    TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind, TrackerIssueStateSnapshot,
+    TrackerStateId, TransitionAction, WorkerAttemptSnapshot, WorkerId, WorkerOutcomeKind,
+    WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
+};
+pub use selection::{
+    filter_issues_for_dispatch, issue_blocked_by_non_terminal_blockers,
+    parent_issue_blocked_by_incomplete_children, should_dispatch_issue, sort_issues_for_dispatch,
 };
 
 pub fn boundary_summary() -> &'static str {
@@ -20,7 +28,7 @@ mod tests {
 
     use super::{
         ConversationId, ConversationMetadata, DurationMs, IssueExecution, IssueId, IssueIdentifier,
-        IssueState, IssueStateCategory, NormalizedIssue, ReleaseReason, RunAttempt,
+        IssueRef, IssueState, IssueStateCategory, NormalizedIssue, ReleaseReason, RunAttempt,
         RuntimeStreamState, SchedulerStatus, TimestampMs, WorkerId, WorkspaceKey, WorkspaceRecord,
         boundary_summary,
     };
@@ -48,7 +56,13 @@ mod tests {
             branch_name: None,
             url: None,
             labels: Vec::new(),
+            parent_id: None,
             blocked_by: Vec::new(),
+            sub_issues: vec![IssueRef {
+                id: must(IssueId::new("lin_261")),
+                identifier: must(IssueIdentifier::new("COE-261")),
+                state: "Done".to_owned(),
+            }],
             created_at: None,
             updated_at: None,
         };

--- a/crates/opensymphony-orchestrator/src/selection.rs
+++ b/crates/opensymphony-orchestrator/src/selection.rs
@@ -1,0 +1,295 @@
+use std::collections::HashSet;
+
+use opensymphony_domain::TrackerIssue;
+
+pub fn issue_blocked_by_non_terminal_blockers(issue: &TrackerIssue) -> bool {
+    issue
+        .blocked_by
+        .iter()
+        .any(|blocker| !blocker.is_terminal())
+}
+
+pub fn parent_issue_blocked_by_incomplete_children(
+    issue: &TrackerIssue,
+    terminal_states: &HashSet<String>,
+) -> bool {
+    !issue.sub_issues.is_empty()
+        && issue
+            .sub_issues
+            .iter()
+            .any(|sub_issue| !sub_issue.is_terminal(terminal_states))
+}
+
+pub fn should_dispatch_issue(issue: &TrackerIssue, terminal_states: &HashSet<String>) -> bool {
+    !issue_blocked_by_non_terminal_blockers(issue)
+        && !parent_issue_blocked_by_incomplete_children(issue, terminal_states)
+}
+
+pub fn filter_issues_for_dispatch<I>(
+    issues: I,
+    terminal_states: &HashSet<String>,
+) -> Vec<TrackerIssue>
+where
+    I: IntoIterator<Item = TrackerIssue>,
+{
+    let mut filtered = issues
+        .into_iter()
+        .filter(|issue| should_dispatch_issue(issue, terminal_states))
+        .collect::<Vec<_>>();
+    sort_issues_for_dispatch(&mut filtered);
+    filtered
+}
+
+pub fn sort_issues_for_dispatch(issues: &mut [TrackerIssue]) {
+    issues.sort_by(|left, right| {
+        priority_rank(left)
+            .cmp(&priority_rank(right))
+            .then_with(|| left.sub_issues.len().cmp(&right.sub_issues.len()))
+            .then_with(|| left.created_at.cmp(&right.created_at))
+            .then_with(|| left.identifier.cmp(&right.identifier))
+    });
+}
+
+fn priority_rank(issue: &TrackerIssue) -> u8 {
+    issue.priority.unwrap_or(u8::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use chrono::{DateTime, Utc};
+    use opensymphony_domain::{
+        TrackerIssue, TrackerIssueBlocker, TrackerIssueRef, TrackerIssueState,
+        TrackerIssueStateKind,
+    };
+
+    use super::{
+        filter_issues_for_dispatch, issue_blocked_by_non_terminal_blockers,
+        parent_issue_blocked_by_incomplete_children, should_dispatch_issue,
+        sort_issues_for_dispatch,
+    };
+
+    fn ts(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .expect("timestamp should parse")
+            .with_timezone(&Utc)
+    }
+
+    fn terminal_states() -> HashSet<String> {
+        HashSet::from([String::from("Done"), String::from("Canceled")])
+    }
+
+    fn state(name: &str, kind: TrackerIssueStateKind) -> TrackerIssueState {
+        TrackerIssueState {
+            id: format!("state-{}", name.to_ascii_lowercase().replace(' ', "-")),
+            name: name.to_string(),
+            tracker_type: match &kind {
+                TrackerIssueStateKind::Completed => "completed",
+                TrackerIssueStateKind::Canceled => "canceled",
+                TrackerIssueStateKind::Started => "started",
+                TrackerIssueStateKind::Unstarted => "unstarted",
+                TrackerIssueStateKind::Backlog => "backlog",
+                TrackerIssueStateKind::Triage => "triage",
+                TrackerIssueStateKind::Unknown(_) => "unknown",
+            }
+            .to_string(),
+            kind,
+        }
+    }
+
+    fn blocker(identifier: &str, state: TrackerIssueState) -> TrackerIssueBlocker {
+        TrackerIssueBlocker {
+            id: format!("issue-{}", identifier.to_ascii_lowercase()),
+            identifier: identifier.to_string(),
+            title: format!("Issue {identifier}"),
+            state,
+        }
+    }
+
+    fn child(identifier: &str, state: &str) -> TrackerIssueRef {
+        TrackerIssueRef {
+            id: format!("issue-{}", identifier.to_ascii_lowercase()),
+            identifier: identifier.to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    fn issue(
+        identifier: &str,
+        priority: Option<u8>,
+        created_at: &str,
+        blocked_by: Vec<TrackerIssueBlocker>,
+        sub_issues: Vec<TrackerIssueRef>,
+    ) -> TrackerIssue {
+        TrackerIssue {
+            id: format!("issue-{}", identifier.to_ascii_lowercase()),
+            identifier: identifier.to_string(),
+            url: format!("https://linear.app/example/{identifier}"),
+            title: format!("Issue {identifier}"),
+            description: None,
+            priority,
+            state: "In Progress".to_string(),
+            labels: Vec::new(),
+            parent_id: None,
+            blocked_by,
+            sub_issues,
+            created_at: ts(created_at),
+            updated_at: ts(created_at),
+        }
+    }
+
+    #[test]
+    fn parent_issue_is_blocked_when_any_child_is_non_terminal() {
+        let issue = issue(
+            "COE-277",
+            Some(1),
+            "2026-03-22T00:00:00Z",
+            Vec::new(),
+            vec![child("COE-278", "In Progress"), child("COE-279", "Done")],
+        );
+
+        assert!(parent_issue_blocked_by_incomplete_children(
+            &issue,
+            &terminal_states()
+        ));
+    }
+
+    #[test]
+    fn parent_issue_is_ready_when_all_children_are_terminal() {
+        let issue = issue(
+            "COE-277",
+            Some(1),
+            "2026-03-22T00:00:00Z",
+            Vec::new(),
+            vec![child("COE-278", "Done"), child("COE-279", "Canceled")],
+        );
+
+        assert!(!parent_issue_blocked_by_incomplete_children(
+            &issue,
+            &terminal_states()
+        ));
+    }
+
+    #[test]
+    fn blocker_check_composes_with_hierarchy_check() {
+        let issue = issue(
+            "COE-277",
+            Some(1),
+            "2026-03-22T00:00:00Z",
+            vec![blocker(
+                "COE-260",
+                state("In Progress", TrackerIssueStateKind::Started),
+            )],
+            vec![child("COE-278", "Done")],
+        );
+
+        assert!(issue_blocked_by_non_terminal_blockers(&issue));
+        assert!(!should_dispatch_issue(&issue, &terminal_states()));
+    }
+
+    #[test]
+    fn sort_prefers_leaf_issues_before_parents_when_priorities_match() {
+        let mut issues = vec![
+            issue(
+                "COE-277",
+                Some(1),
+                "2026-03-20T00:00:00Z",
+                Vec::new(),
+                vec![child("COE-278", "Done")],
+            ),
+            issue(
+                "COE-278",
+                Some(1),
+                "2026-03-21T00:00:00Z",
+                Vec::new(),
+                Vec::new(),
+            ),
+        ];
+
+        sort_issues_for_dispatch(&mut issues);
+
+        assert_eq!(
+            issues
+                .iter()
+                .map(|issue| issue.identifier.as_str())
+                .collect::<Vec<_>>(),
+            vec!["COE-278", "COE-277"]
+        );
+    }
+
+    #[test]
+    fn filter_skips_parent_until_children_finish() {
+        let issues = vec![
+            issue(
+                "COE-277",
+                Some(1),
+                "2026-03-20T00:00:00Z",
+                Vec::new(),
+                vec![child("COE-278", "In Progress")],
+            ),
+            issue(
+                "COE-278",
+                Some(1),
+                "2026-03-21T00:00:00Z",
+                Vec::new(),
+                Vec::new(),
+            ),
+        ];
+
+        let filtered = filter_issues_for_dispatch(issues, &terminal_states());
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].identifier, "COE-278");
+    }
+
+    #[test]
+    fn nested_hierarchy_dispatches_only_the_leaf_issue() {
+        let issues = vec![
+            issue(
+                "COE-P1",
+                Some(1),
+                "2026-03-20T00:00:00Z",
+                Vec::new(),
+                vec![child("COE-S1", "In Progress")],
+            ),
+            issue(
+                "COE-S1",
+                Some(1),
+                "2026-03-21T00:00:00Z",
+                Vec::new(),
+                vec![child("COE-SS1", "In Progress")],
+            ),
+            issue(
+                "COE-SS1",
+                Some(1),
+                "2026-03-22T00:00:00Z",
+                Vec::new(),
+                Vec::new(),
+            ),
+        ];
+
+        let filtered = filter_issues_for_dispatch(issues, &terminal_states());
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].identifier, "COE-SS1");
+    }
+
+    #[test]
+    fn adding_a_new_child_reblocks_the_parent_on_the_next_snapshot() {
+        let terminal_states = terminal_states();
+        let mut parent = issue(
+            "COE-277",
+            Some(1),
+            "2026-03-20T00:00:00Z",
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert!(should_dispatch_issue(&parent, &terminal_states));
+
+        parent.sub_issues.push(child("COE-278", "Todo"));
+
+        assert!(!should_dispatch_issue(&parent, &terminal_states));
+    }
+}

--- a/crates/opensymphony-orchestrator/tests/hierarchy_selection.rs
+++ b/crates/opensymphony-orchestrator/tests/hierarchy_selection.rs
@@ -1,0 +1,304 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::State,
+    http::{Response, StatusCode},
+    routing::post,
+};
+use opensymphony_linear::{LinearClient, LinearConfig, RetryPolicy};
+use opensymphony_orchestrator::filter_issues_for_dispatch;
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
+
+#[tokio::test]
+async fn fake_linear_hierarchy_keeps_parent_blocked_until_child_completes() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(&candidate_issues_payload(vec![
+            active_parent_with_children(
+                "issue-p1",
+                "COE-277",
+                &[child_ref("issue-s1", "COE-278", "In Progress")],
+            ),
+            active_leaf_issue("issue-s1", "COE-278", Some("issue-p1")),
+        ])),
+        QueuedResponse::json(&candidate_issues_payload(vec![
+            active_parent_with_children(
+                "issue-p1",
+                "COE-277",
+                &[child_ref("issue-s1", "COE-278", "Done")],
+            ),
+        ])),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+    let terminal_states = terminal_states();
+
+    let first_snapshot = client
+        .candidate_issues()
+        .await
+        .expect("candidate query should succeed");
+    let first_dispatchable = filter_issues_for_dispatch(first_snapshot, &terminal_states);
+    assert_eq!(
+        first_dispatchable
+            .iter()
+            .map(|issue| issue.identifier.as_str())
+            .collect::<Vec<_>>(),
+        vec!["COE-278"]
+    );
+
+    let second_snapshot = client
+        .candidate_issues()
+        .await
+        .expect("follow-up candidate query should succeed");
+    let second_dispatchable = filter_issues_for_dispatch(second_snapshot, &terminal_states);
+    assert_eq!(
+        second_dispatchable
+            .iter()
+            .map(|issue| issue.identifier.as_str())
+            .collect::<Vec<_>>(),
+        vec!["COE-277"]
+    );
+}
+
+#[tokio::test]
+async fn fake_linear_hierarchy_reblocks_parent_when_new_child_is_added() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(&candidate_issues_payload(vec![
+            active_parent_with_children("issue-p1", "COE-277", &[]),
+        ])),
+        QueuedResponse::json(&candidate_issues_payload(vec![
+            active_parent_with_children(
+                "issue-p1",
+                "COE-277",
+                &[child_ref("issue-s1", "COE-278", "Todo")],
+            ),
+        ])),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+    let terminal_states = terminal_states();
+
+    let first_snapshot = client
+        .candidate_issues()
+        .await
+        .expect("candidate query should succeed");
+    let first_dispatchable = filter_issues_for_dispatch(first_snapshot, &terminal_states);
+    assert_eq!(
+        first_dispatchable
+            .iter()
+            .map(|issue| issue.identifier.as_str())
+            .collect::<Vec<_>>(),
+        vec!["COE-277"]
+    );
+
+    let second_snapshot = client
+        .candidate_issues()
+        .await
+        .expect("follow-up candidate query should succeed");
+    let second_dispatchable = filter_issues_for_dispatch(second_snapshot, &terminal_states);
+    assert!(second_dispatchable.is_empty());
+}
+
+fn terminal_states() -> HashSet<String> {
+    HashSet::from([String::from("Done"), String::from("Canceled")])
+}
+
+fn test_config(base_url: &str) -> LinearConfig {
+    let mut config = LinearConfig::new("test-token", "e7b957855cb7");
+    config.base_url = base_url.to_string();
+    config.active_states = vec!["In Progress".to_string()];
+    config.terminal_states = vec!["Done".to_string(), "Canceled".to_string()];
+    config.request_timeout = Duration::from_secs(2);
+    config.retry_policy = RetryPolicy {
+        max_attempts: 2,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(1),
+    };
+    config
+}
+
+fn candidate_issues_payload(nodes: Vec<Value>) -> String {
+    json!({
+        "data": {
+            "issues": {
+                "nodes": nodes,
+                "pageInfo": {
+                    "hasNextPage": false,
+                    "endCursor": null
+                }
+            }
+        }
+    })
+    .to_string()
+}
+
+fn active_parent_with_children(id: &str, identifier: &str, children: &[Value]) -> Value {
+    json!({
+        "id": id,
+        "identifier": identifier,
+        "url": format!("https://linear.app/trilogy-ai-coe/issue/{identifier}/parent"),
+        "title": format!("Issue {identifier}"),
+        "description": null,
+        "priority": 1.0,
+        "createdAt": "2026-03-22T00:00:00Z",
+        "updatedAt": "2026-03-22T00:00:00Z",
+        "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+        },
+        "parent": null,
+        "children": {
+            "nodes": children
+        },
+        "labels": {
+            "nodes": []
+        },
+        "inverseRelations": {
+            "nodes": [],
+            "pageInfo": {
+                "hasNextPage": false,
+                "endCursor": null
+            }
+        }
+    })
+}
+
+fn active_leaf_issue(id: &str, identifier: &str, parent_id: Option<&str>) -> Value {
+    json!({
+        "id": id,
+        "identifier": identifier,
+        "url": format!("https://linear.app/trilogy-ai-coe/issue/{identifier}/leaf"),
+        "title": format!("Issue {identifier}"),
+        "description": null,
+        "priority": 1.0,
+        "createdAt": "2026-03-23T00:00:00Z",
+        "updatedAt": "2026-03-23T00:00:00Z",
+        "state": {
+            "id": "state-started",
+            "name": "In Progress",
+            "type": "started"
+        },
+        "parent": parent_id.map(|value| json!({ "id": value })),
+        "children": {
+            "nodes": []
+        },
+        "labels": {
+            "nodes": []
+        },
+        "inverseRelations": {
+            "nodes": [],
+            "pageInfo": {
+                "hasNextPage": false,
+                "endCursor": null
+            }
+        }
+    })
+}
+
+fn child_ref(id: &str, identifier: &str, state: &str) -> Value {
+    json!({
+        "id": id,
+        "identifier": identifier,
+        "state": {
+            "name": state
+        }
+    })
+}
+
+#[derive(Clone)]
+struct AppState {
+    responses: Arc<Mutex<VecDeque<QueuedResponse>>>,
+}
+
+struct MockGraphqlServer {
+    base_url: String,
+    task: JoinHandle<()>,
+}
+
+impl MockGraphqlServer {
+    async fn start(responses: Vec<QueuedResponse>) -> Self {
+        let state = AppState {
+            responses: Arc::new(Mutex::new(VecDeque::from(responses))),
+        };
+        let app = Router::new()
+            .route("/graphql", post(handle_graphql))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should expose an address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("mock server should stay up");
+        });
+
+        Self {
+            base_url: format!("http://{address}/graphql"),
+            task,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for MockGraphqlServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn handle_graphql(State(state): State<AppState>, Json(_body): Json<Value>) -> Response<Body> {
+    let response = state
+        .responses
+        .lock()
+        .await
+        .pop_front()
+        .expect("test did not queue enough responses");
+
+    let mut builder = Response::builder().status(response.status);
+    for (name, value) in response.headers {
+        builder = builder.header(name, value);
+    }
+    builder
+        .body(Body::from(response.body))
+        .expect("response should be valid")
+}
+
+struct QueuedResponse {
+    status: StatusCode,
+    body: String,
+    headers: Vec<(String, String)>,
+}
+
+impl QueuedResponse {
+    fn json(body: &str) -> Self {
+        Self::new(StatusCode::OK, body).with_header("content-type", "application/json")
+    }
+
+    fn new(status: StatusCode, body: &str) -> Self {
+        Self {
+            status,
+            body: body.to_string(),
+            headers: Vec::new(),
+        }
+    }
+
+    fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.to_string(), value.to_string()));
+        self
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,8 @@ The Rust daemon owns all scheduler semantics that Symphony specifies:
 
 OpenHands conversation state is informative, not authoritative for scheduling.
 
+Hierarchy-aware task selection is part of issue eligibility. Parent issues stay blocked until every child issue in the latest tracker snapshot is terminal, and ready leaf issues sort ahead of ready parents within the same priority bucket.
+
 ### 3.2 OpenHands agent-server is an execution adapter
 
 OpenHands is used as the agent execution backend because it exposes:
@@ -189,6 +191,7 @@ The repository now exposes three stable foundation contracts that later mileston
 - `opensymphony-domain`
   - normalized tracker issue model
   - blocker references
+  - parent/sub-issue references for hierarchy-aware dispatch
   - run-attempt, retry-entry, runtime-session, and worker-outcome models
   - serialized orchestrator snapshot types
 - `opensymphony-workflow`
@@ -196,7 +199,9 @@ The repository now exposes three stable foundation contracts that later mileston
   - typed config resolution with fail-fast unknown nested workflow keys plus fail-fast unknown top-level keys outside the supported opaque `codex` namespace, defaults, env indirection, path normalization, required Linear tracker credentials via either explicit `tracker.api_key` or process-level `LINEAR_API_KEY`, explicit env-backed workspace roots, and strict `openhands` extension validation
   - strict prompt rendering over `{issue, attempt}`
 - `opensymphony-orchestrator`
-  - deterministic candidate sorting, claim logic, and claimed-to-running enforcement
+  - deterministic candidate sorting with leaf-before-parent ordering
+  - blocker-aware and hierarchy-aware dispatch eligibility helpers
+  - claim logic and claimed-to-running enforcement
   - explicit `Claimed` / `Running` / `RetryQueued` / `Released` transitions
   - fixed continuation retry, exponential failure backoff, stall detection, retry-start validation for `due_at`, `attempt`, latest dispatch eligibility, and bounded global/per-state capacity using the reservation's current state, reconciliation of running, retry-queued, and claimed-only issues including a claim-to-start grace window that remains independent from disabled stall detection before stale claimed-only release, freshest global rate-limit retention, and restart recovery
 

--- a/docs/elixir-hierarchy-changes.md
+++ b/docs/elixir-hierarchy-changes.md
@@ -59,7 +59,7 @@ Update the type spec:
 
 ### 2. `lib/symphony_elixir/linear/client.ex`
 
-Extend the GraphQL query to fetch sub-issues:
+Extend the GraphQL query to fetch child issues:
 
 ```elixir
 @query """
@@ -87,7 +87,7 @@ query SymphonyLinearPoll($projectSlug: String!, $stateNames: [String!]!, $first:
       parent {
         id
       }
-      subIssues(first: 50) {
+      children(first: 50) {
         nodes {
           id
           identifier
@@ -123,7 +123,7 @@ query SymphonyLinearPoll($projectSlug: String!, $stateNames: [String!]!, $first:
 Add extraction functions:
 
 ```elixir
-defp extract_sub_issues(%{"subIssues" => %{"nodes" => sub_issues}})
+defp extract_sub_issues(%{"children" => %{"nodes" => sub_issues}})
      when is_list(sub_issues) do
   sub_issues
   |> Enum.map(fn issue ->
@@ -245,7 +245,7 @@ test "normalize_issue extracts sub-issues" do
     "id" => "issue-1",
     "identifier" => "TEAM-1",
     "title" => "Parent Issue",
-    "subIssues" => %{
+    "children" => %{
       "nodes" => [
         %{
           "id" => "sub-1",

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -56,7 +56,9 @@ Normalize tracker payloads into a stable issue model with fields such as:
 - `priority`
 - `state`
 - `labels`
+- `parent_id`
 - `blocked_by`
+- `sub_issues`
 - `created_at`
 - `updated_at`
 
@@ -65,8 +67,10 @@ Keep the orchestrator independent of raw GraphQL response shape.
 Implementation note:
 
 - blocker normalization should derive `blocked_by` from `inverseRelations` entries where relation `type == "blocks"`
+- hierarchy normalization should derive `parent_id` from `parent.id` and `sub_issues` from `children.nodes`
 - `TrackerIssue.state` should remain the workflow-facing state name string consumed by `WORKFLOW.md` and `WORKFLOW.example.md`
 - blocker and state-refresh normalization should retain both the state name and the raw Linear `WorkflowState.type` string, while also exposing a normalized `kind`, so terminal blockers remain detectable without losing the tracker's exact type value
+- sub-issue normalization only needs the child `id`, `identifier`, and state `name` because hierarchy gating compares child state names against the workflow-configured terminal-state names
 - issue normalization should retain the Linear issue URL because `WORKFLOW.md` renders `{{ issue.url }}` under strict template validation
 - issue normalization should preserve the raw Linear priority because prompt/UI consumers render `{{ issue.priority }}` directly
 - top-level issue pages should request only small initial `labels` and `inverseRelations` slices and page the rest per issue so connection-heavy issue metadata stays complete without blowing past Linear's query cap
@@ -78,12 +82,14 @@ The orchestrator should receive normalized issues and apply Symphony sorting and
 Recommended sort order:
 
 1. higher urgency first using raw Linear priority (`1` before `2`; `0` remains unprioritized)
-2. older creation time first
-3. identifier tie-breaker
+2. leaf issues before parents when both are otherwise dispatchable
+3. older creation time first
+4. identifier tie-breaker
 
 Implementation note:
 
 - Linear's raw priority scale is urgency-inverted (`1` is most urgent, `0` is unprioritized), so the scheduler should derive its sort key from the raw value instead of rewriting the shared issue model
+- parent issues should remain ineligible while any `sub_issues` entry is in a non-terminal state, even if blocker relations are otherwise clear
 
 Eligibility reminders:
 
@@ -233,13 +239,16 @@ struct Issue {
     priority: Option<u8>,
     state: String,
     labels: Vec<String>,
+    parent_id: Option<String>,
     blocked_by: Vec<IssueBlocker>,
+    sub_issues: Vec<IssueRef>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
 ```
 
 `IssueBlocker` should include enough information to decide whether the blocker is terminal.
+`IssueRef` should include enough information to decide whether a child issue is terminal from the poll snapshot alone.
 
 ## 9. Error categories
 

--- a/docs/tasks/osym-305-hierarchy-aware-task-selection.md
+++ b/docs/tasks/osym-305-hierarchy-aware-task-selection.md
@@ -21,7 +21,7 @@ repo_paths:
   - crates/opensymphony-orchestrator/
 definition_of_ready:
   - OSYM-302 and OSYM-304 are merged
-  - Linear GraphQL schema for sub-issues is documented
+  - Linear GraphQL `children` schema for issue hierarchy is documented
   - Decision made on parent vs sub-issue dispatch ordering
 ---
 
@@ -44,7 +44,7 @@ The current orchestrator (OSYM-304) treats all issues as independent tasks. Howe
 ### In Scope
 
 - Add `sub_issues` field to the normalized issue model
-- Extend Linear GraphQL queries to fetch `subIssues` relationship
+- Extend Linear GraphQL queries to fetch the `children` relationship
 - Add hierarchy check to candidate filtering logic
 - Update `should_dispatch_issue?` to skip parents with incomplete sub-issues
 - Add topological sorting: prefer leaves over parents when both are ready
@@ -64,7 +64,7 @@ The current orchestrator (OSYM-304) treats all issues as independent tasks. Howe
    - Define `IssueRef` type with `id`, `identifier`, `state`
 
 2. **Linear adapter updates** (`opensymphony-linear`):
-   - Extend GraphQL query to fetch `subIssues` with their states
+   - Extend GraphQL query to fetch `children` with their states
    - Extend `normalize_issue` to extract sub-issue references
    - Add test fixtures for hierarchical issue structures
 
@@ -114,7 +114,7 @@ The current orchestrator (OSYM-304) treats all issues as independent tasks. Howe
 Add to the existing issue query:
 
 ```graphql
-subIssues(first: 50) {
+children(first: 50) {
   nodes {
     id
     identifier
@@ -161,6 +161,6 @@ Update `sort_issues_for_dispatch` to include hierarchy depth:
 
 ## References
 
-- Linear GraphQL API: `subIssues` field on Issue type
+- Linear GraphQL API: `children` field on Issue type
 - Symphony spec: "The orchestrator is the source of truth for scheduling state"
 - AGENTS.md: "Parent issues and sub-issues represent hierarchical decomposition"

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -75,7 +75,8 @@ Suggested gates:
 Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
-- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test -p opensymphony-orchestrator` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, and dynamic child-addition reblocking against normalized tracker issues
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`
@@ -177,6 +178,7 @@ Current implementation:
 ## 3.4 Orchestrator
 
 - poll candidate sorting
+- blocker-aware and hierarchy-aware dispatch eligibility
 - claim and release transitions
 - max concurrency
 - failure retry backoff
@@ -198,6 +200,7 @@ Current implementation:
 Current implemented checks:
 
 - snapshot serialization in `opensymphony-domain`
+- parent/sub-issue tracker normalization and issue-ref terminal matching in `opensymphony-domain`
 - forward-compatible snapshot decoding for unknown additive recent event kinds in `opensymphony-domain`
 - forward-compatible snapshot decoding for unknown additive `daemon.state`, `runtime_state`, and `last_outcome` values in `opensymphony-control`
 - control-plane HTTP plus SSE round-trip coverage in `opensymphony-control/tests/control_plane.rs`


### PR DESCRIPTION
## Summary

Implement hierarchy-aware task selection primitives across the shared issue model, Linear read adapter, and orchestrator helper surface.

## Changes

- add `parent_id` and `sub_issues` support to the shared tracker and normalized issue models
- extend the Linear `IssuesByState` query and normalization path to read `parent` and `children` hierarchy metadata
- add reusable orchestrator dispatch helpers for blocker-aware and hierarchy-aware filtering plus leaf-before-parent ordering
- add hierarchy fixtures/tests, including fake Linear integration coverage, and update architecture/testing/reference docs to match the live Linear `children` schema

## Evidence

### Test output

```text
$ cargo test -p opensymphony-domain -p opensymphony-linear -p opensymphony-orchestrator -p opensymphony-openhands
...
opensymphony-domain: 26 unit tests passed, snapshot serialization passed
opensymphony-linear: 8 unit tests passed, 17 integration tests passed
opensymphony-openhands: 63 tests passed across unit/integration/live-gated suites
opensymphony-orchestrator: 8 unit tests passed and 2 fake-Linear integration tests passed

$ cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) successfully with no warnings
```

### Verification

Verified that parent issues stay blocked while any child issue is non-terminal, that ready leaf issues sort ahead of ready parents, that parent issues become dispatchable after child completion, that dynamic child addition re-blocks a parent on the next snapshot, and that the Linear adapter now normalizes `parent` plus `children` data from fixture-backed GraphQL responses.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

- COE-277

## Additional notes

The live Linear schema exposes issue hierarchy through `children`, not `subIssues`, so the repository's hierarchy reference notes were updated to match the actual contract used by the implementation.
