### PR TITLE
Implement orchestrator scheduler retries and reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,8 +1473,11 @@ dependencies = [
  "chrono",
  "opensymphony-domain",
  "opensymphony-linear",
+ "opensymphony-workflow",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -178,6 +178,18 @@ impl IssueExecution {
         &self.issue
     }
 
+    pub fn refresh_issue(&mut self, issue: NormalizedIssue) -> Result<(), StateTransitionError> {
+        if issue.id != self.issue.id {
+            return Err(StateTransitionError::IssueMismatch {
+                expected: self.issue.id.clone(),
+                actual: issue.id,
+            });
+        }
+
+        self.issue = issue;
+        Ok(())
+    }
+
     pub fn workspace(&self) -> Option<&WorkspaceRecord> {
         self.workspace.as_ref()
     }

--- a/crates/opensymphony-orchestrator/Cargo.toml
+++ b/crates/opensymphony-orchestrator/Cargo.toml
@@ -9,7 +9,12 @@ repository.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+chrono = { workspace = true }
 opensymphony-domain = { path = "../opensymphony-domain" }
+opensymphony-workflow = { path = "../opensymphony-workflow" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 axum = { workspace = true }

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -1,3 +1,4 @@
+mod scheduler;
 mod selection;
 
 pub const CRATE_NAME: &str = "opensymphony-orchestrator";
@@ -12,6 +13,10 @@ pub use opensymphony_domain::{
     TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind, TrackerIssueStateSnapshot,
     TrackerStateId, TransitionAction, WorkerAttemptSnapshot, WorkerId, WorkerOutcomeKind,
     WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
+};
+pub use scheduler::{
+    RecoveryRecord, Scheduler, SchedulerConfig, SchedulerError, TrackerBackend, WorkerAbortReason,
+    WorkerBackend, WorkerLaunch, WorkerStartRequest, WorkerUpdate, WorkspaceBackend,
 };
 pub use selection::{
     filter_issues_for_dispatch, issue_blocked_by_non_terminal_blockers,

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -1,0 +1,1046 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    future::Future,
+};
+
+use chrono::{DateTime, Utc};
+use opensymphony_domain::{
+    ComponentHealthSnapshot, ConversationMetadata, DaemonSnapshot, DurationMs, HealthStatus,
+    IdentifierError, IssueExecution, IssueId, IssueIdentifier, IssueRef, IssueSnapshot, IssueState,
+    IssueStateCategory, NormalizedIssue, OrchestratorSnapshot, ReleaseReason,
+    RetryCalculationError, RetryEntry, RetryPolicy, RetryReason, RunAttempt, SchedulerStatus,
+    StateTransitionError, TimestampMs, TrackerIssue, TrackerIssueStateSnapshot, TrackerStateId,
+    WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceRecord,
+};
+use opensymphony_workflow::ResolvedWorkflow;
+use thiserror::Error;
+use tokio::{
+    select,
+    time::{MissedTickBehavior, interval},
+};
+use tracing::{debug, warn};
+
+use crate::{filter_issues_for_dispatch, sort_issues_for_dispatch};
+
+const DISABLED_STALL_TIMEOUT_MS: u64 = u64::MAX / 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchedulerConfig {
+    pub poll_interval_ms: u64,
+    pub max_concurrent_agents: u32,
+    pub max_turns: u32,
+    pub max_concurrent_agents_by_state: BTreeMap<String, u32>,
+    pub retry_policy: RetryPolicy,
+    pub stall_timeout_ms: Option<u64>,
+    pub active_states: Vec<String>,
+    pub terminal_states: Vec<String>,
+}
+
+impl SchedulerConfig {
+    pub fn from_workflow(workflow: &ResolvedWorkflow) -> Result<Self, SchedulerError> {
+        Ok(Self {
+            poll_interval_ms: workflow.config.polling.interval_ms,
+            max_concurrent_agents: u32::try_from(workflow.config.agent.max_concurrent_agents)
+                .map_err(|_| SchedulerError::InvalidConfiguration {
+                    detail: format!(
+                        "workflow max_concurrent_agents {} exceeds u32::MAX ({})",
+                        workflow.config.agent.max_concurrent_agents,
+                        u32::MAX
+                    ),
+                })?,
+            max_turns: u32::try_from(workflow.config.agent.max_turns).map_err(|_| {
+                SchedulerError::InvalidConfiguration {
+                    detail: format!(
+                        "workflow max_turns {} exceeds u32::MAX ({})",
+                        workflow.config.agent.max_turns,
+                        u32::MAX
+                    ),
+                }
+            })?,
+            max_concurrent_agents_by_state: workflow
+                .config
+                .agent
+                .max_concurrent_agents_by_state
+                .iter()
+                .map(|(state, limit)| {
+                    u32::try_from(*limit)
+                        .map(|limit| (state.clone(), limit))
+                        .map_err(|_| SchedulerError::InvalidConfiguration {
+                            detail: format!(
+                                "workflow max_concurrent_agents_by_state[{state}] {limit} exceeds u32::MAX ({})",
+                                u32::MAX
+                            ),
+                        })
+                })
+                .collect::<Result<_, _>>()?,
+            retry_policy: RetryPolicy {
+                max_backoff_ms: DurationMs::new(workflow.config.agent.max_retry_backoff_ms),
+                ..RetryPolicy::default()
+            },
+            stall_timeout_ms: workflow.config.agent.stall_timeout_ms,
+            active_states: workflow.config.tracker.active_states.clone(),
+            terminal_states: workflow.config.tracker.terminal_states.clone(),
+        })
+    }
+
+    fn terminal_state_set(&self) -> HashSet<String> {
+        normalized_state_set(&self.terminal_states)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryRecord {
+    pub issue: NormalizedIssue,
+    pub workspace: WorkspaceRecord,
+    pub had_in_flight_run: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerStartRequest {
+    pub issue: NormalizedIssue,
+    pub workspace: WorkspaceRecord,
+    pub run: RunAttempt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerLaunch {
+    pub conversation: ConversationMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkerUpdate {
+    RuntimeEvent {
+        worker_id: WorkerId,
+        observed_at: TimestampMs,
+        event_id: Option<String>,
+        event_kind: Option<String>,
+        summary: Option<String>,
+    },
+    Finished {
+        worker_id: WorkerId,
+        outcome: WorkerOutcomeRecord,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerAbortReason {
+    TrackerInactive,
+    TrackerTerminal,
+    Stalled,
+}
+
+#[allow(async_fn_in_trait)]
+pub trait TrackerBackend {
+    type Error: std::fmt::Display + Send + Sync + 'static;
+
+    async fn candidate_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error>;
+    async fn terminal_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error>;
+    async fn issue_states_by_ids(
+        &mut self,
+        issue_ids: &[String],
+    ) -> Result<Vec<TrackerIssueStateSnapshot>, Self::Error>;
+}
+
+#[allow(async_fn_in_trait)]
+pub trait WorkspaceBackend {
+    type Error: std::fmt::Display + Send + Sync + 'static;
+
+    async fn ensure_workspace(
+        &mut self,
+        issue: &NormalizedIssue,
+        observed_at: TimestampMs,
+    ) -> Result<WorkspaceRecord, Self::Error>;
+
+    async fn recover_workspaces(&mut self) -> Result<Vec<RecoveryRecord>, Self::Error>;
+
+    async fn cleanup_workspace(
+        &mut self,
+        workspace: &WorkspaceRecord,
+        terminal: bool,
+    ) -> Result<(), Self::Error>;
+}
+
+#[allow(async_fn_in_trait)]
+pub trait WorkerBackend {
+    type Error: std::fmt::Display + Send + Sync + 'static;
+
+    async fn start_worker(
+        &mut self,
+        request: WorkerStartRequest,
+    ) -> Result<WorkerLaunch, Self::Error>;
+
+    async fn poll_updates(&mut self) -> Result<Vec<WorkerUpdate>, Self::Error>;
+
+    async fn abort_worker(
+        &mut self,
+        worker_id: &WorkerId,
+        reason: WorkerAbortReason,
+    ) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Error)]
+pub enum SchedulerError {
+    #[error("invalid scheduler configuration: {detail}")]
+    InvalidConfiguration { detail: String },
+    #[error("tracker backend failed: {detail}")]
+    Tracker { detail: String },
+    #[error("workspace backend failed: {detail}")]
+    Workspace { detail: String },
+    #[error("worker backend failed: {detail}")]
+    Worker { detail: String },
+    #[error(transparent)]
+    StateTransition(#[from] StateTransitionError),
+    #[error(transparent)]
+    RetryCalculation(#[from] RetryCalculationError),
+    #[error(transparent)]
+    Identifier(#[from] IdentifierError),
+}
+
+pub struct Scheduler<T, W, M> {
+    tracker: T,
+    workspace: W,
+    worker: M,
+    config: SchedulerConfig,
+    executions: BTreeMap<IssueId, IssueExecution>,
+    worker_index: HashMap<WorkerId, IssueId>,
+    pending_recovery: Option<Vec<RecoveryRecord>>,
+    recovered: bool,
+    next_worker_ordinal: u64,
+    last_poll_at: Option<TimestampMs>,
+    health: HealthStatus,
+}
+
+impl<T, W, M> Scheduler<T, W, M>
+where
+    T: TrackerBackend,
+    W: WorkspaceBackend,
+    M: WorkerBackend,
+{
+    pub fn new(tracker: T, workspace: W, worker: M, config: SchedulerConfig) -> Self {
+        Self {
+            tracker,
+            workspace,
+            worker,
+            config,
+            executions: BTreeMap::new(),
+            worker_index: HashMap::new(),
+            pending_recovery: None,
+            recovered: false,
+            next_worker_ordinal: 0,
+            last_poll_at: None,
+            health: HealthStatus::Starting,
+        }
+    }
+
+    pub fn config(&self) -> &SchedulerConfig {
+        &self.config
+    }
+
+    pub fn tracker(&self) -> &T {
+        &self.tracker
+    }
+
+    pub fn tracker_mut(&mut self) -> &mut T {
+        &mut self.tracker
+    }
+
+    pub fn workspace(&self) -> &W {
+        &self.workspace
+    }
+
+    pub fn workspace_mut(&mut self) -> &mut W {
+        &mut self.workspace
+    }
+
+    pub fn worker(&self) -> &M {
+        &self.worker
+    }
+
+    pub fn worker_mut(&mut self) -> &mut M {
+        &mut self.worker
+    }
+
+    pub fn executions(&self) -> &BTreeMap<IssueId, IssueExecution> {
+        &self.executions
+    }
+
+    pub fn execution(&self, issue_id: &IssueId) -> Option<&IssueExecution> {
+        self.executions.get(issue_id)
+    }
+
+    pub fn snapshot(&self, generated_at: TimestampMs) -> OrchestratorSnapshot {
+        let daemon = DaemonSnapshot::new(
+            self.health,
+            self.config.poll_interval_ms,
+            self.config.max_concurrent_agents,
+            self.last_poll_at,
+            ComponentHealthSnapshot::default(),
+            Default::default(),
+        );
+        let mut issues = self
+            .executions
+            .values()
+            .map(IssueSnapshot::from)
+            .collect::<Vec<_>>();
+        issues.sort_by(|left, right| left.issue.identifier.cmp(&right.issue.identifier));
+        OrchestratorSnapshot::new(generated_at, daemon, issues)
+    }
+
+    pub async fn tick(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<OrchestratorSnapshot, SchedulerError> {
+        if self.pending_recovery.is_none() {
+            self.pending_recovery =
+                Some(self.workspace.recover_workspaces().await.map_err(|error| {
+                    SchedulerError::Workspace {
+                        detail: error.to_string(),
+                    }
+                })?);
+        }
+
+        let updates = self
+            .worker
+            .poll_updates()
+            .await
+            .map_err(|error| SchedulerError::Worker {
+                detail: error.to_string(),
+            })?;
+        self.apply_worker_updates(updates).await?;
+
+        let tracker_snapshot = self.load_tracker_snapshot().await?;
+        self.bootstrap_recovery(&tracker_snapshot, observed_at)
+            .await?;
+        self.reconcile_tracker_state(&tracker_snapshot, observed_at)
+            .await?;
+        self.handle_stalls(observed_at).await?;
+        self.dispatch_ready_issues(&tracker_snapshot.active, observed_at)
+            .await?;
+
+        self.last_poll_at = Some(observed_at);
+        self.health = HealthStatus::Healthy;
+        Ok(self.snapshot(observed_at))
+    }
+
+    pub async fn run_until_shutdown<F>(&mut self, shutdown: F) -> Result<(), SchedulerError>
+    where
+        F: Future<Output = ()>,
+    {
+        let mut shutdown = std::pin::pin!(shutdown);
+        let mut ticker = interval(std::time::Duration::from_millis(
+            self.config.poll_interval_ms,
+        ));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            select! {
+                _ = shutdown.as_mut() => break,
+                _ = ticker.tick() => {
+                    let now = TimestampMs::new(current_epoch_millis());
+                    if let Err(error) = self.tick(now).await {
+                        self.health = HealthStatus::Degraded;
+                        warn!(%error, "scheduler tick failed");
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn load_tracker_snapshot(&mut self) -> Result<TrackerSnapshot, SchedulerError> {
+        let active =
+            self.tracker
+                .candidate_issues()
+                .await
+                .map_err(|error| SchedulerError::Tracker {
+                    detail: error.to_string(),
+                })?;
+        let terminal =
+            self.tracker
+                .terminal_issues()
+                .await
+                .map_err(|error| SchedulerError::Tracker {
+                    detail: error.to_string(),
+                })?;
+
+        let active_ids = active
+            .iter()
+            .map(|issue| issue.id.clone())
+            .collect::<HashSet<_>>();
+        let terminal_ids = terminal
+            .iter()
+            .map(|issue| issue.id.clone())
+            .collect::<HashSet<_>>();
+
+        let mut lookup_ids = self
+            .executions
+            .keys()
+            .map(|id| id.as_str().to_string())
+            .collect::<BTreeSet<_>>();
+        if let Some(records) = &self.pending_recovery {
+            lookup_ids.extend(
+                records
+                    .iter()
+                    .map(|record| record.issue.id.as_str().to_string()),
+            );
+        }
+        lookup_ids.retain(|id| !active_ids.contains(id) && !terminal_ids.contains(id));
+
+        let state_by_id = if lookup_ids.is_empty() {
+            HashMap::new()
+        } else {
+            self.tracker
+                .issue_states_by_ids(&lookup_ids.into_iter().collect::<Vec<_>>())
+                .await
+                .map_err(|error| SchedulerError::Tracker {
+                    detail: error.to_string(),
+                })?
+                .into_iter()
+                .map(|snapshot| (snapshot.id.clone(), snapshot))
+                .collect()
+        };
+
+        Ok(TrackerSnapshot {
+            active_by_id: active
+                .iter()
+                .cloned()
+                .map(|issue| (issue.id.clone(), issue))
+                .collect(),
+            terminal_by_id: terminal
+                .iter()
+                .cloned()
+                .map(|issue| (issue.id.clone(), issue))
+                .collect(),
+            state_by_id,
+            active,
+        })
+    }
+
+    async fn bootstrap_recovery(
+        &mut self,
+        tracker_snapshot: &TrackerSnapshot,
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        if self.recovered {
+            return Ok(());
+        }
+
+        let Some(records) = self.pending_recovery.take() else {
+            self.recovered = true;
+            return Ok(());
+        };
+
+        for record in records {
+            let issue_id = record.issue.id.clone();
+            if let Some(active_issue) = tracker_snapshot.active_by_id.get(issue_id.as_str()) {
+                let normalized = normalize_tracker_issue(active_issue, &self.config)?;
+                self.upsert_active_execution(normalized, observed_at, Some(record.workspace))?;
+                continue;
+            }
+
+            if tracker_snapshot
+                .terminal_by_id
+                .contains_key(issue_id.as_str())
+            {
+                self.workspace
+                    .cleanup_workspace(&record.workspace, true)
+                    .await
+                    .map_err(|error| SchedulerError::Workspace {
+                        detail: error.to_string(),
+                    })?;
+                continue;
+            }
+
+            let mut issue = record.issue.clone();
+            if let Some(snapshot) = tracker_snapshot.state_by_id.get(issue_id.as_str()) {
+                issue.state = issue_state_from_name(&snapshot.state.name, &self.config);
+            }
+
+            let mut execution = IssueExecution::new(issue.clone(), observed_at);
+            execution.attach_workspace(record.workspace)?;
+            let execution = execution.release(observed_at, ReleaseReason::TrackerInactive, None)?;
+            self.executions.entry(issue.id.clone()).or_insert(execution);
+        }
+
+        self.recovered = true;
+        Ok(())
+    }
+
+    async fn reconcile_tracker_state(
+        &mut self,
+        tracker_snapshot: &TrackerSnapshot,
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        for tracker_issue in tracker_snapshot.active_by_id.values() {
+            let normalized = normalize_tracker_issue(tracker_issue, &self.config)?;
+            self.upsert_active_execution(normalized, observed_at, None)?;
+        }
+
+        let existing_ids = self.executions.keys().cloned().collect::<Vec<_>>();
+        for issue_id in existing_ids {
+            if tracker_snapshot
+                .active_by_id
+                .contains_key(issue_id.as_str())
+            {
+                continue;
+            }
+
+            if let Some(tracker_issue) = tracker_snapshot.terminal_by_id.get(issue_id.as_str()) {
+                let normalized = normalize_tracker_issue(tracker_issue, &self.config)?;
+                self.release_issue(
+                    issue_id.clone(),
+                    normalized,
+                    observed_at,
+                    ReleaseReason::TrackerTerminal,
+                    true,
+                    Some(WorkerAbortReason::TrackerTerminal),
+                )
+                .await?;
+                continue;
+            }
+
+            if let Some(snapshot) = tracker_snapshot.state_by_id.get(issue_id.as_str()) {
+                let category = state_category_from_name(&snapshot.state.name, &self.config);
+                if category == IssueStateCategory::Active {
+                    continue;
+                }
+
+                let normalized = if let Some(existing) = self.executions.get(&issue_id) {
+                    let mut issue = existing.issue().clone();
+                    issue.state = issue_state_from_name(&snapshot.state.name, &self.config);
+                    issue
+                } else {
+                    minimal_issue_from_state_snapshot(snapshot, &self.config)?
+                };
+
+                let (reason, cleanup, abort_reason) = match category {
+                    IssueStateCategory::Terminal => (
+                        ReleaseReason::TrackerTerminal,
+                        true,
+                        Some(WorkerAbortReason::TrackerTerminal),
+                    ),
+                    IssueStateCategory::NonActive => (
+                        ReleaseReason::TrackerInactive,
+                        false,
+                        Some(WorkerAbortReason::TrackerInactive),
+                    ),
+                    IssueStateCategory::Active => continue,
+                };
+                self.release_issue(
+                    issue_id.clone(),
+                    normalized,
+                    observed_at,
+                    reason,
+                    cleanup,
+                    abort_reason,
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn dispatch_ready_issues(
+        &mut self,
+        active_issues: &[TrackerIssue],
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        let mut ready =
+            filter_issues_for_dispatch(active_issues.to_vec(), &self.config.terminal_state_set());
+        sort_issues_for_dispatch(&mut ready);
+
+        for tracker_issue in ready {
+            if self.worker_index.len()
+                >= usize::try_from(self.config.max_concurrent_agents).unwrap_or(usize::MAX)
+            {
+                break;
+            }
+
+            let normalized = normalize_tracker_issue(&tracker_issue, &self.config)?;
+            let issue_id = normalized.id.clone();
+            let should_dispatch = match self.executions.get(&issue_id) {
+                Some(execution) => match execution.status() {
+                    SchedulerStatus::Unclaimed => true,
+                    SchedulerStatus::RetryQueued => execution
+                        .retry()
+                        .is_some_and(|retry| retry.due_at <= observed_at),
+                    SchedulerStatus::Released => false,
+                    SchedulerStatus::Claimed | SchedulerStatus::Running => false,
+                },
+                None => true,
+            };
+            if !should_dispatch {
+                continue;
+            }
+
+            if let Some(limit) = state_limit_for(
+                &self.config.max_concurrent_agents_by_state,
+                &normalized.state.name,
+            ) {
+                let running_in_state = self
+                    .executions
+                    .values()
+                    .filter(|execution| {
+                        execution.status() == SchedulerStatus::Running
+                            && execution
+                                .issue()
+                                .state
+                                .name
+                                .eq_ignore_ascii_case(&normalized.state.name)
+                    })
+                    .count();
+                if running_in_state >= usize::try_from(limit).unwrap_or(usize::MAX) {
+                    continue;
+                }
+            }
+
+            let workspace = self
+                .workspace
+                .ensure_workspace(&normalized, observed_at)
+                .await
+                .map_err(|error| SchedulerError::Workspace {
+                    detail: error.to_string(),
+                })?;
+
+            let issue_id = normalized.id.clone();
+            let worker_id = self.next_worker_id()?;
+            let previous_retry = self
+                .executions
+                .get(&issue_id)
+                .and_then(IssueExecution::retry)
+                .map(|retry| retry.attempt);
+            let run = RunAttempt::new(
+                worker_id.clone(),
+                normalized.id.clone(),
+                normalized.identifier.clone(),
+                workspace.path.clone(),
+                observed_at,
+                previous_retry,
+                self.config.max_turns,
+            );
+
+            let mut execution = self
+                .executions
+                .remove(&issue_id)
+                .unwrap_or_else(|| IssueExecution::new(normalized.clone(), observed_at));
+            execution.refresh_issue(normalized.clone())?;
+            execution.attach_workspace(workspace.clone())?;
+            execution = execution.claim(run.clone())?;
+            let claimed_run = execution
+                .current_run()
+                .cloned()
+                .expect("claimed execution must expose the claimed run");
+
+            let start_request = WorkerStartRequest {
+                issue: normalized.clone(),
+                workspace,
+                run: claimed_run.clone(),
+            };
+            match self.worker.start_worker(start_request).await {
+                Ok(launch) => {
+                    execution = execution.start_running(
+                        observed_at,
+                        effective_stall_timeout(self.config.stall_timeout_ms),
+                        Some(launch.conversation),
+                    )?;
+                    execution.record_turn_started(observed_at)?;
+                    self.worker_index.insert(worker_id, issue_id.clone());
+                    debug!(issue_id = %issue_id, "dispatched scheduler worker");
+                }
+                Err(error) => {
+                    let detail = error.to_string();
+                    let outcome = WorkerOutcomeRecord::from_run(
+                        &claimed_run,
+                        WorkerOutcomeKind::Failed,
+                        observed_at,
+                        Some("failed to start worker".to_string()),
+                        Some(detail),
+                    );
+                    execution = self.resolve_finished_execution(execution, outcome, observed_at)?;
+                }
+            }
+
+            self.executions.insert(issue_id, execution);
+        }
+
+        Ok(())
+    }
+
+    async fn apply_worker_updates(
+        &mut self,
+        updates: Vec<WorkerUpdate>,
+    ) -> Result<(), SchedulerError> {
+        for update in updates {
+            match update {
+                WorkerUpdate::RuntimeEvent {
+                    worker_id,
+                    observed_at,
+                    event_id,
+                    event_kind,
+                    summary,
+                } => {
+                    let Some(issue_id) = self.worker_index.get(&worker_id).cloned() else {
+                        continue;
+                    };
+                    if let Some(execution) = self.executions.get_mut(&issue_id) {
+                        execution.observe_runtime_event(
+                            observed_at,
+                            event_id,
+                            event_kind,
+                            summary,
+                        )?;
+                    }
+                }
+                WorkerUpdate::Finished { worker_id, outcome } => {
+                    let Some(issue_id) = self.worker_index.remove(&worker_id) else {
+                        continue;
+                    };
+                    let Some(execution) = self.executions.remove(&issue_id) else {
+                        continue;
+                    };
+                    let finished_at = outcome.finished_at;
+                    let execution =
+                        self.resolve_finished_execution(execution, outcome, finished_at)?;
+                    self.executions.insert(issue_id, execution);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_stalls(&mut self, observed_at: TimestampMs) -> Result<(), SchedulerError> {
+        if self.config.stall_timeout_ms.is_none() {
+            return Ok(());
+        }
+
+        let stalled = self
+            .executions
+            .iter()
+            .filter_map(|(issue_id, execution)| match execution.state() {
+                opensymphony_domain::SchedulerState::Running { stall, .. }
+                    if stall.stalled_at <= observed_at =>
+                {
+                    Some(issue_id.clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        for issue_id in stalled {
+            let Some(mut execution) = self.executions.remove(&issue_id) else {
+                continue;
+            };
+            let Some(run) = execution.current_run().cloned() else {
+                self.executions.insert(issue_id, execution);
+                continue;
+            };
+
+            self.abort_worker(&run.worker_id, WorkerAbortReason::Stalled)
+                .await?;
+            let outcome = WorkerOutcomeRecord::from_run(
+                &run,
+                WorkerOutcomeKind::Stalled,
+                observed_at,
+                Some("worker exceeded the configured stall timeout".to_string()),
+                Some("scheduler stall timeout reached".to_string()),
+            );
+            execution = self.resolve_finished_execution(execution, outcome, observed_at)?;
+            self.executions.insert(issue_id, execution);
+        }
+
+        Ok(())
+    }
+
+    fn upsert_active_execution(
+        &mut self,
+        issue: NormalizedIssue,
+        observed_at: TimestampMs,
+        recovered_workspace: Option<WorkspaceRecord>,
+    ) -> Result<(), SchedulerError> {
+        let issue_id = issue.id.clone();
+        let mut execution = match self.executions.remove(&issue_id) {
+            Some(existing) => existing,
+            None => IssueExecution::new(issue.clone(), observed_at),
+        };
+        if execution.status() == SchedulerStatus::Released {
+            execution = execution.reopen(observed_at)?;
+        }
+        execution.refresh_issue(issue.clone())?;
+        if let Some(workspace) = recovered_workspace {
+            execution.attach_workspace(workspace)?;
+        }
+        self.executions.insert(issue_id, execution);
+        Ok(())
+    }
+
+    async fn release_issue(
+        &mut self,
+        issue_id: IssueId,
+        issue: NormalizedIssue,
+        observed_at: TimestampMs,
+        reason: ReleaseReason,
+        cleanup_terminal: bool,
+        abort_reason: Option<WorkerAbortReason>,
+    ) -> Result<(), SchedulerError> {
+        let Some(mut execution) = self.executions.remove(&issue_id) else {
+            return Ok(());
+        };
+
+        execution.refresh_issue(issue)?;
+        if let Some(run) = execution.current_run().cloned()
+            && let Some(abort_reason) = abort_reason
+        {
+            self.abort_worker(&run.worker_id, abort_reason).await?;
+        }
+        if execution.status() != SchedulerStatus::Released {
+            execution = execution.release(observed_at, reason, None)?;
+        }
+        if cleanup_terminal && let Some(workspace) = execution.workspace().cloned() {
+            self.workspace
+                .cleanup_workspace(&workspace, true)
+                .await
+                .map_err(|error| SchedulerError::Workspace {
+                    detail: error.to_string(),
+                })?;
+        }
+        self.executions.insert(issue_id, execution);
+        Ok(())
+    }
+
+    async fn abort_worker(
+        &mut self,
+        worker_id: &WorkerId,
+        reason: WorkerAbortReason,
+    ) -> Result<(), SchedulerError> {
+        self.worker_index.remove(worker_id);
+        self.worker
+            .abort_worker(worker_id, reason)
+            .await
+            .map_err(|error| SchedulerError::Worker {
+                detail: error.to_string(),
+            })
+    }
+
+    fn resolve_finished_execution(
+        &self,
+        execution: IssueExecution,
+        outcome: WorkerOutcomeRecord,
+        observed_at: TimestampMs,
+    ) -> Result<IssueExecution, SchedulerError> {
+        let active = execution.issue().state.category == IssueStateCategory::Active;
+        if !active {
+            let reason = match execution.issue().state.category {
+                IssueStateCategory::Terminal => ReleaseReason::TrackerTerminal,
+                IssueStateCategory::NonActive => ReleaseReason::TrackerInactive,
+                IssueStateCategory::Active => ReleaseReason::Completed,
+            };
+            return Ok(execution.release(observed_at, reason, Some(outcome))?);
+        }
+
+        match outcome.outcome {
+            WorkerOutcomeKind::Succeeded => {
+                let run = execution
+                    .current_run()
+                    .expect("running execution must have a run");
+                let retry = RetryEntry::continuation(
+                    execution.issue(),
+                    run.attempt,
+                    run.normal_retry_count,
+                    observed_at,
+                    self.config.retry_policy,
+                )?;
+                Ok(execution.queue_retry(retry, outcome)?)
+            }
+            WorkerOutcomeKind::Failed | WorkerOutcomeKind::TimedOut => {
+                let run = execution
+                    .current_run()
+                    .expect("running execution must have a run");
+                let retry = RetryEntry::failure(
+                    execution.issue(),
+                    run.attempt,
+                    run.normal_retry_count,
+                    observed_at,
+                    RetryReason::Failure,
+                    outcome.error.clone().or(outcome.summary.clone()),
+                    self.config.retry_policy,
+                )?;
+                Ok(execution.queue_retry(retry, outcome)?)
+            }
+            WorkerOutcomeKind::Stalled => {
+                let run = execution
+                    .current_run()
+                    .expect("running execution must have a run");
+                let retry = RetryEntry::failure(
+                    execution.issue(),
+                    run.attempt,
+                    run.normal_retry_count,
+                    observed_at,
+                    RetryReason::Stalled,
+                    outcome.error.clone().or(outcome.summary.clone()),
+                    self.config.retry_policy,
+                )?;
+                Ok(execution.queue_retry(retry, outcome)?)
+            }
+            WorkerOutcomeKind::Cancelled => {
+                let run = execution
+                    .current_run()
+                    .expect("running execution must have a run");
+                let retry = RetryEntry::failure(
+                    execution.issue(),
+                    run.attempt,
+                    run.normal_retry_count,
+                    observed_at,
+                    RetryReason::Cancelled,
+                    outcome.error.clone().or(outcome.summary.clone()),
+                    self.config.retry_policy,
+                )?;
+                Ok(execution.queue_retry(retry, outcome)?)
+            }
+        }
+    }
+
+    fn next_worker_id(&mut self) -> Result<WorkerId, SchedulerError> {
+        self.next_worker_ordinal = self.next_worker_ordinal.saturating_add(1);
+        WorkerId::new(format!("scheduler-worker-{}", self.next_worker_ordinal))
+            .map_err(SchedulerError::Identifier)
+    }
+}
+
+struct TrackerSnapshot {
+    active: Vec<TrackerIssue>,
+    active_by_id: HashMap<String, TrackerIssue>,
+    terminal_by_id: HashMap<String, TrackerIssue>,
+    state_by_id: HashMap<String, TrackerIssueStateSnapshot>,
+}
+
+fn normalize_tracker_issue(
+    issue: &TrackerIssue,
+    config: &SchedulerConfig,
+) -> Result<NormalizedIssue, SchedulerError> {
+    Ok(NormalizedIssue {
+        id: IssueId::new(issue.id.clone())?,
+        identifier: IssueIdentifier::new(issue.identifier.clone())?,
+        title: issue.title.clone(),
+        description: issue.description.clone(),
+        priority: issue.priority,
+        state: issue_state_from_name(&issue.state, config),
+        branch_name: None,
+        url: Some(issue.url.clone()),
+        labels: issue.labels.clone(),
+        parent_id: match &issue.parent_id {
+            Some(parent_id) => Some(IssueId::new(parent_id.clone())?),
+            None => None,
+        },
+        blocked_by: issue
+            .blocked_by
+            .iter()
+            .map(|blocker| {
+                Ok(opensymphony_domain::BlockerRef {
+                    id: Some(IssueId::new(blocker.id.clone())?),
+                    identifier: Some(IssueIdentifier::new(blocker.identifier.clone())?),
+                    state: Some(blocker.state.name.clone()),
+                    created_at: None,
+                    updated_at: None,
+                })
+            })
+            .collect::<Result<Vec<_>, SchedulerError>>()?,
+        sub_issues: issue
+            .sub_issues
+            .iter()
+            .map(|child| {
+                Ok(IssueRef {
+                    id: IssueId::new(child.id.clone())?,
+                    identifier: IssueIdentifier::new(child.identifier.clone())?,
+                    state: child.state.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, SchedulerError>>()?,
+        created_at: Some(datetime_to_timestamp(issue.created_at)),
+        updated_at: Some(datetime_to_timestamp(issue.updated_at)),
+    })
+}
+
+fn minimal_issue_from_state_snapshot(
+    snapshot: &TrackerIssueStateSnapshot,
+    config: &SchedulerConfig,
+) -> Result<NormalizedIssue, SchedulerError> {
+    Ok(NormalizedIssue {
+        id: IssueId::new(snapshot.id.clone())?,
+        identifier: IssueIdentifier::new(snapshot.identifier.clone())?,
+        title: snapshot.identifier.clone(),
+        description: None,
+        priority: None,
+        state: issue_state_from_name(&snapshot.state.name, config),
+        branch_name: None,
+        url: None,
+        labels: Vec::new(),
+        parent_id: None,
+        blocked_by: Vec::new(),
+        sub_issues: Vec::new(),
+        created_at: None,
+        updated_at: Some(datetime_to_timestamp(snapshot.updated_at)),
+    })
+}
+
+fn issue_state_from_name(name: &str, config: &SchedulerConfig) -> IssueState {
+    IssueState {
+        id: TrackerStateId::new(name.to_ascii_lowercase().replace(' ', "-")).ok(),
+        name: name.to_string(),
+        category: state_category_from_name(name, config),
+    }
+}
+
+fn state_category_from_name(name: &str, config: &SchedulerConfig) -> IssueStateCategory {
+    if matches_state_name(name, &config.terminal_states) {
+        IssueStateCategory::Terminal
+    } else if matches_state_name(name, &config.active_states) {
+        IssueStateCategory::Active
+    } else {
+        IssueStateCategory::NonActive
+    }
+}
+
+fn state_limit_for(limits: &BTreeMap<String, u32>, state_name: &str) -> Option<u32> {
+    limits
+        .iter()
+        .find_map(|(state, limit)| state.eq_ignore_ascii_case(state_name).then_some(*limit))
+}
+
+fn normalized_state_set(states: &[String]) -> HashSet<String> {
+    states
+        .iter()
+        .map(|state| state.trim().to_ascii_lowercase())
+        .collect()
+}
+
+fn matches_state_name(name: &str, states: &[String]) -> bool {
+    let name = name.trim().to_ascii_lowercase();
+    states
+        .iter()
+        .any(|state| state.trim().eq_ignore_ascii_case(&name))
+}
+
+fn effective_stall_timeout(stall_timeout_ms: Option<u64>) -> DurationMs {
+    DurationMs::new(stall_timeout_ms.unwrap_or(DISABLED_STALL_TIMEOUT_MS))
+}
+
+fn datetime_to_timestamp(datetime: DateTime<Utc>) -> TimestampMs {
+    let millis = datetime.timestamp_millis();
+    if millis <= 0 {
+        TimestampMs::new(0)
+    } else {
+        TimestampMs::new(millis as u64)
+    }
+}
+
+fn current_epoch_millis() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -20,7 +20,7 @@ use tokio::{
 };
 use tracing::{debug, warn};
 
-use crate::{filter_issues_for_dispatch, sort_issues_for_dispatch};
+use crate::filter_issues_for_dispatch;
 
 const DISABLED_STALL_TIMEOUT_MS: u64 = u64::MAX / 4;
 
@@ -366,11 +366,11 @@ where
 
         let active_ids = active
             .iter()
-            .map(|issue| issue.id.clone())
+            .map(|issue| issue.id.as_str())
             .collect::<HashSet<_>>();
         let terminal_ids = terminal
             .iter()
-            .map(|issue| issue.id.clone())
+            .map(|issue| issue.id.as_str())
             .collect::<HashSet<_>>();
 
         let mut lookup_ids = self
@@ -385,7 +385,18 @@ where
                     .map(|record| record.issue.id.as_str().to_string()),
             );
         }
-        lookup_ids.retain(|id| !active_ids.contains(id) && !terminal_ids.contains(id));
+        lookup_ids
+            .retain(|id| !active_ids.contains(id.as_str()) && !terminal_ids.contains(id.as_str()));
+
+        let active_index = active
+            .iter()
+            .enumerate()
+            .map(|(index, issue)| (issue.id.clone(), index))
+            .collect();
+        let terminal_state_by_id = terminal
+            .into_iter()
+            .map(|issue| (issue.id, issue.state))
+            .collect();
 
         let state_by_id = if lookup_ids.is_empty() {
             HashMap::new()
@@ -402,16 +413,8 @@ where
         };
 
         Ok(TrackerSnapshot {
-            active_by_id: active
-                .iter()
-                .cloned()
-                .map(|issue| (issue.id.clone(), issue))
-                .collect(),
-            terminal_by_id: terminal
-                .iter()
-                .cloned()
-                .map(|issue| (issue.id.clone(), issue))
-                .collect(),
+            active_index,
+            terminal_state_by_id,
             state_by_id,
             active,
         })
@@ -433,16 +436,13 @@ where
 
         for record in records {
             let issue_id = record.issue.id.clone();
-            if let Some(active_issue) = tracker_snapshot.active_by_id.get(issue_id.as_str()) {
+            if let Some(active_issue) = tracker_snapshot.active_issue(&issue_id) {
                 let normalized = normalize_tracker_issue(active_issue, &self.config)?;
                 self.upsert_active_execution(normalized, observed_at, Some(record.workspace))?;
                 continue;
             }
 
-            if tracker_snapshot
-                .terminal_by_id
-                .contains_key(issue_id.as_str())
-            {
+            if tracker_snapshot.contains_terminal(issue_id.as_str()) {
                 self.workspace
                     .cleanup_workspace(&record.workspace, true)
                     .await
@@ -472,22 +472,25 @@ where
         tracker_snapshot: &TrackerSnapshot,
         observed_at: TimestampMs,
     ) -> Result<(), SchedulerError> {
-        for tracker_issue in tracker_snapshot.active_by_id.values() {
+        for tracker_issue in &tracker_snapshot.active {
             let normalized = normalize_tracker_issue(tracker_issue, &self.config)?;
             self.upsert_active_execution(normalized, observed_at, None)?;
         }
 
         let existing_ids = self.executions.keys().cloned().collect::<Vec<_>>();
         for issue_id in existing_ids {
-            if tracker_snapshot
-                .active_by_id
-                .contains_key(issue_id.as_str())
-            {
+            if tracker_snapshot.contains_active(issue_id.as_str()) {
                 continue;
             }
 
-            if let Some(tracker_issue) = tracker_snapshot.terminal_by_id.get(issue_id.as_str()) {
-                let normalized = normalize_tracker_issue(tracker_issue, &self.config)?;
+            if let Some(terminal_state_name) =
+                tracker_snapshot.terminal_state_name(issue_id.as_str())
+            {
+                let Some(existing) = self.executions.get(&issue_id) else {
+                    continue;
+                };
+                let mut normalized = existing.issue().clone();
+                normalized.state = issue_state_from_name(terminal_state_name, &self.config);
                 self.release_issue(
                     issue_id.clone(),
                     normalized,
@@ -547,9 +550,8 @@ where
         active_issues: &[TrackerIssue],
         observed_at: TimestampMs,
     ) -> Result<(), SchedulerError> {
-        let mut ready =
+        let ready =
             filter_issues_for_dispatch(active_issues.to_vec(), &self.config.terminal_state_set());
-        sort_issues_for_dispatch(&mut ready);
 
         for tracker_issue in ready {
             if self.worker_index.len()
@@ -830,76 +832,41 @@ where
         outcome: WorkerOutcomeRecord,
         observed_at: TimestampMs,
     ) -> Result<IssueExecution, SchedulerError> {
-        let active = execution.issue().state.category == IssueStateCategory::Active;
-        if !active {
-            let reason = match execution.issue().state.category {
-                IssueStateCategory::Terminal => ReleaseReason::TrackerTerminal,
-                IssueStateCategory::NonActive => ReleaseReason::TrackerInactive,
-                IssueStateCategory::Active => ReleaseReason::Completed,
-            };
+        if let Some(reason) = non_active_release_reason(execution.issue().state.category.clone()) {
             return Ok(execution.release(observed_at, reason, Some(outcome))?);
         }
 
-        match outcome.outcome {
-            WorkerOutcomeKind::Succeeded => {
-                let run = execution
-                    .current_run()
-                    .expect("running execution must have a run");
-                let retry = RetryEntry::continuation(
-                    execution.issue(),
-                    run.attempt,
-                    run.normal_retry_count,
-                    observed_at,
-                    self.config.retry_policy,
-                )?;
-                Ok(execution.queue_retry(retry, outcome)?)
-            }
-            WorkerOutcomeKind::Failed | WorkerOutcomeKind::TimedOut => {
-                let run = execution
-                    .current_run()
-                    .expect("running execution must have a run");
-                let retry = RetryEntry::failure(
-                    execution.issue(),
-                    run.attempt,
-                    run.normal_retry_count,
-                    observed_at,
-                    RetryReason::Failure,
-                    outcome.error.clone().or(outcome.summary.clone()),
-                    self.config.retry_policy,
-                )?;
-                Ok(execution.queue_retry(retry, outcome)?)
-            }
-            WorkerOutcomeKind::Stalled => {
-                let run = execution
-                    .current_run()
-                    .expect("running execution must have a run");
-                let retry = RetryEntry::failure(
-                    execution.issue(),
-                    run.attempt,
-                    run.normal_retry_count,
-                    observed_at,
-                    RetryReason::Stalled,
-                    outcome.error.clone().or(outcome.summary.clone()),
-                    self.config.retry_policy,
-                )?;
-                Ok(execution.queue_retry(retry, outcome)?)
-            }
-            WorkerOutcomeKind::Cancelled => {
-                let run = execution
-                    .current_run()
-                    .expect("running execution must have a run");
-                let retry = RetryEntry::failure(
-                    execution.issue(),
-                    run.attempt,
-                    run.normal_retry_count,
-                    observed_at,
-                    RetryReason::Cancelled,
-                    outcome.error.clone().or(outcome.summary.clone()),
-                    self.config.retry_policy,
-                )?;
-                Ok(execution.queue_retry(retry, outcome)?)
-            }
-        }
+        self.queue_retry_for_outcome(execution, outcome, observed_at)
+    }
+
+    fn queue_retry_for_outcome(
+        &self,
+        execution: IssueExecution,
+        outcome: WorkerOutcomeRecord,
+        observed_at: TimestampMs,
+    ) -> Result<IssueExecution, SchedulerError> {
+        let run = execution
+            .current_run()
+            .expect("running execution must have a run");
+        let retry = match retry_reason_for_outcome(outcome.outcome) {
+            None => RetryEntry::continuation(
+                execution.issue(),
+                run.attempt,
+                run.normal_retry_count,
+                observed_at,
+                self.config.retry_policy,
+            )?,
+            Some(reason) => RetryEntry::failure(
+                execution.issue(),
+                run.attempt,
+                run.normal_retry_count,
+                observed_at,
+                reason,
+                outcome.error.clone().or(outcome.summary.clone()),
+                self.config.retry_policy,
+            )?,
+        };
+        Ok(execution.queue_retry(retry, outcome)?)
     }
 
     fn next_worker_id(&mut self) -> Result<WorkerId, SchedulerError> {
@@ -911,9 +878,29 @@ where
 
 struct TrackerSnapshot {
     active: Vec<TrackerIssue>,
-    active_by_id: HashMap<String, TrackerIssue>,
-    terminal_by_id: HashMap<String, TrackerIssue>,
+    active_index: HashMap<String, usize>,
+    terminal_state_by_id: HashMap<String, String>,
     state_by_id: HashMap<String, TrackerIssueStateSnapshot>,
+}
+
+impl TrackerSnapshot {
+    fn active_issue(&self, issue_id: &IssueId) -> Option<&TrackerIssue> {
+        self.active_index
+            .get(issue_id.as_str())
+            .and_then(|index| self.active.get(*index))
+    }
+
+    fn contains_active(&self, issue_id: &str) -> bool {
+        self.active_index.contains_key(issue_id)
+    }
+
+    fn contains_terminal(&self, issue_id: &str) -> bool {
+        self.terminal_state_by_id.contains_key(issue_id)
+    }
+
+    fn terminal_state_name(&self, issue_id: &str) -> Option<&str> {
+        self.terminal_state_by_id.get(issue_id).map(String::as_str)
+    }
 }
 
 fn normalize_tracker_issue(
@@ -1007,6 +994,23 @@ fn state_limit_for(limits: &BTreeMap<String, u32>, state_name: &str) -> Option<u
     limits
         .iter()
         .find_map(|(state, limit)| state.eq_ignore_ascii_case(state_name).then_some(*limit))
+}
+
+fn non_active_release_reason(category: IssueStateCategory) -> Option<ReleaseReason> {
+    match category {
+        IssueStateCategory::Terminal => Some(ReleaseReason::TrackerTerminal),
+        IssueStateCategory::NonActive => Some(ReleaseReason::TrackerInactive),
+        IssueStateCategory::Active => None,
+    }
+}
+
+fn retry_reason_for_outcome(outcome: WorkerOutcomeKind) -> Option<RetryReason> {
+    match outcome {
+        WorkerOutcomeKind::Succeeded => None,
+        WorkerOutcomeKind::Failed | WorkerOutcomeKind::TimedOut => Some(RetryReason::Failure),
+        WorkerOutcomeKind::Stalled => Some(RetryReason::Stalled),
+        WorkerOutcomeKind::Cancelled => Some(RetryReason::Cancelled),
+    }
 }
 
 fn normalized_state_set(states: &[String]) -> HashSet<String> {

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -1,0 +1,589 @@
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    path::PathBuf,
+};
+
+use chrono::{TimeZone, Utc};
+use opensymphony_orchestrator::{
+    ConversationId, ConversationMetadata, IssueId, IssueIdentifier, IssueRef, IssueState,
+    IssueStateCategory, NormalizedIssue, RecoveryRecord, ReleaseReason, RetryReason,
+    RuntimeStreamState, Scheduler, SchedulerConfig, SchedulerStatus, TimestampMs, TrackerBackend,
+    TrackerIssue, TrackerIssueStateSnapshot, WorkerAbortReason, WorkerBackend, WorkerId,
+    WorkerLaunch, WorkerOutcomeKind, WorkerOutcomeRecord, WorkerStartRequest, WorkerUpdate,
+    WorkspaceBackend, WorkspaceKey, WorkspaceRecord,
+};
+
+fn ts(value: u64) -> TimestampMs {
+    TimestampMs::new(value)
+}
+
+fn dt(value: u64) -> chrono::DateTime<Utc> {
+    Utc.timestamp_millis_opt(value as i64)
+        .single()
+        .expect("timestamp should be valid")
+}
+
+fn scheduler_config() -> SchedulerConfig {
+    SchedulerConfig {
+        poll_interval_ms: 1_000,
+        max_concurrent_agents: 2,
+        max_turns: 4,
+        max_concurrent_agents_by_state: BTreeMap::new(),
+        retry_policy: Default::default(),
+        stall_timeout_ms: Some(100),
+        active_states: vec!["In Progress".to_string()],
+        terminal_states: vec!["Done".to_string(), "Canceled".to_string()],
+    }
+}
+
+fn tracker_issue(id: &str, identifier: &str, state: &str, created_at: u64) -> TrackerIssue {
+    TrackerIssue {
+        id: id.to_string(),
+        identifier: identifier.to_string(),
+        url: format!("https://linear.app/example/{identifier}"),
+        title: format!("Issue {identifier}"),
+        description: Some("scheduler test fixture".to_string()),
+        priority: Some(1),
+        state: state.to_string(),
+        labels: Vec::new(),
+        parent_id: None,
+        blocked_by: Vec::new(),
+        sub_issues: Vec::new(),
+        created_at: dt(created_at),
+        updated_at: dt(created_at),
+    }
+}
+
+fn normalized_issue(id: &str, identifier: &str, state: &str) -> NormalizedIssue {
+    NormalizedIssue {
+        id: IssueId::new(id).expect("issue id should be valid"),
+        identifier: IssueIdentifier::new(identifier).expect("issue identifier should be valid"),
+        title: format!("Issue {identifier}"),
+        description: None,
+        priority: Some(1),
+        state: IssueState {
+            id: None,
+            name: state.to_string(),
+            category: if state == "In Progress" {
+                IssueStateCategory::Active
+            } else if matches!(state, "Done" | "Canceled") {
+                IssueStateCategory::Terminal
+            } else {
+                IssueStateCategory::NonActive
+            },
+        },
+        branch_name: None,
+        url: Some(format!("https://linear.app/example/{identifier}")),
+        labels: Vec::new(),
+        parent_id: None,
+        blocked_by: Vec::new(),
+        sub_issues: vec![IssueRef {
+            id: IssueId::new(format!("{id}-child")).expect("child id should be valid"),
+            identifier: IssueIdentifier::new(format!("{identifier}-child"))
+                .expect("child identifier should be valid"),
+            state: "Done".to_string(),
+        }],
+        created_at: Some(ts(0)),
+        updated_at: Some(ts(0)),
+    }
+}
+
+fn workspace_record(identifier: &str, path: &str) -> WorkspaceRecord {
+    WorkspaceRecord {
+        path: PathBuf::from(path),
+        workspace_key: WorkspaceKey::new(identifier).expect("workspace key should be valid"),
+        created_now: false,
+        created_at: Some(ts(0)),
+        updated_at: Some(ts(0)),
+        last_seen_tracker_refresh_at: Some(ts(0)),
+    }
+}
+
+fn conversation(worker_id: &WorkerId) -> ConversationMetadata {
+    ConversationMetadata {
+        conversation_id: ConversationId::new(format!("conv-{}", worker_id.as_str()))
+            .expect("conversation id should be valid"),
+        server_base_url: Some("http://127.0.0.1:8000".to_string()),
+        transport_target: Some("loopback".to_string()),
+        http_auth_mode: Some("none".to_string()),
+        websocket_auth_mode: Some("none".to_string()),
+        websocket_query_param_name: None,
+        fresh_conversation: true,
+        runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_string()),
+        stream_state: RuntimeStreamState::Ready,
+        last_event_id: None,
+        last_event_kind: None,
+        last_event_at: None,
+        last_event_summary: None,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FakeError(String);
+
+impl std::fmt::Display for FakeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for FakeError {}
+
+#[derive(Default)]
+struct FakeTracker {
+    active: Vec<TrackerIssue>,
+    terminal: Vec<TrackerIssue>,
+    states: HashMap<String, TrackerIssueStateSnapshot>,
+    state_requests: Vec<Vec<String>>,
+}
+
+impl TrackerBackend for FakeTracker {
+    type Error = FakeError;
+
+    async fn candidate_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error> {
+        Ok(self.active.clone())
+    }
+
+    async fn terminal_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error> {
+        Ok(self.terminal.clone())
+    }
+
+    async fn issue_states_by_ids(
+        &mut self,
+        issue_ids: &[String],
+    ) -> Result<Vec<TrackerIssueStateSnapshot>, Self::Error> {
+        self.state_requests.push(issue_ids.to_vec());
+        Ok(issue_ids
+            .iter()
+            .filter_map(|id| self.states.get(id).cloned())
+            .collect())
+    }
+}
+
+#[derive(Default)]
+struct FakeWorkspace {
+    recoveries: Vec<RecoveryRecord>,
+    ensured: Vec<String>,
+    cleaned: Vec<(String, bool)>,
+    records: HashMap<String, WorkspaceRecord>,
+}
+
+impl WorkspaceBackend for FakeWorkspace {
+    type Error = FakeError;
+
+    async fn ensure_workspace(
+        &mut self,
+        issue: &NormalizedIssue,
+        _observed_at: TimestampMs,
+    ) -> Result<WorkspaceRecord, Self::Error> {
+        self.ensured.push(issue.identifier.to_string());
+        let record = self
+            .records
+            .entry(issue.id.to_string())
+            .or_insert_with(|| {
+                workspace_record(
+                    issue.identifier.as_str(),
+                    &format!("/tmp/workspaces/{}", issue.identifier),
+                )
+            })
+            .clone();
+        Ok(record)
+    }
+
+    async fn recover_workspaces(&mut self) -> Result<Vec<RecoveryRecord>, Self::Error> {
+        Ok(self.recoveries.clone())
+    }
+
+    async fn cleanup_workspace(
+        &mut self,
+        workspace: &WorkspaceRecord,
+        terminal: bool,
+    ) -> Result<(), Self::Error> {
+        self.cleaned
+            .push((workspace.workspace_key.to_string(), terminal));
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct FakeWorker {
+    launches: Vec<WorkerStartRequest>,
+    updates: VecDeque<WorkerUpdate>,
+    aborted: Vec<(String, WorkerAbortReason)>,
+    launch_results: VecDeque<Result<WorkerLaunch, FakeError>>,
+}
+
+impl WorkerBackend for FakeWorker {
+    type Error = FakeError;
+
+    async fn start_worker(
+        &mut self,
+        request: WorkerStartRequest,
+    ) -> Result<WorkerLaunch, Self::Error> {
+        self.launches.push(request.clone());
+        match self.launch_results.pop_front() {
+            Some(result) => result,
+            None => Ok(WorkerLaunch {
+                conversation: conversation(&request.run.worker_id),
+            }),
+        }
+    }
+
+    async fn poll_updates(&mut self) -> Result<Vec<WorkerUpdate>, Self::Error> {
+        Ok(self.updates.drain(..).collect())
+    }
+
+    async fn abort_worker(
+        &mut self,
+        worker_id: &WorkerId,
+        reason: WorkerAbortReason,
+    ) -> Result<(), Self::Error> {
+        self.aborted.push((worker_id.to_string(), reason));
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn successful_worker_exit_queues_continuation_retry_for_active_issue() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-268", "COE-268", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("first tick should succeed");
+
+    let issue_id = IssueId::new("lin-268").expect("issue id should be valid");
+    assert_eq!(
+        scheduler
+            .execution(&issue_id)
+            .expect("execution should exist")
+            .status(),
+        SchedulerStatus::Running
+    );
+    assert_eq!(scheduler.worker().launches.len(), 1);
+
+    let first_run = scheduler.worker().launches[0].run.clone();
+    scheduler
+        .worker_mut()
+        .updates
+        .push_back(WorkerUpdate::Finished {
+            worker_id: first_run.worker_id.clone(),
+            outcome: WorkerOutcomeRecord::from_run(
+                &first_run,
+                WorkerOutcomeKind::Succeeded,
+                ts(200),
+                Some("worker exited cleanly".to_string()),
+                None,
+            ),
+        });
+
+    scheduler
+        .tick(ts(200))
+        .await
+        .expect("second tick should succeed");
+
+    let execution = scheduler
+        .execution(&issue_id)
+        .expect("execution should still exist");
+    assert_eq!(execution.status(), SchedulerStatus::RetryQueued);
+    let retry = execution.retry().expect("retry metadata should exist");
+    assert_eq!(retry.reason, RetryReason::Continuation);
+    assert_eq!(retry.due_at, ts(1_200));
+
+    scheduler
+        .tick(ts(1_300))
+        .await
+        .expect("third tick should redispatch the issue");
+
+    let execution = scheduler
+        .execution(&issue_id)
+        .expect("execution should still exist");
+    assert_eq!(execution.status(), SchedulerStatus::Running);
+    assert_eq!(scheduler.worker().launches.len(), 2);
+    let second_run = &scheduler.worker().launches[1].run;
+    assert_eq!(
+        second_run
+            .attempt
+            .expect("retry run should carry a retry attempt")
+            .get(),
+        1
+    );
+    assert_eq!(second_run.normal_retry_count, 1);
+}
+
+#[tokio::test]
+async fn failures_schedule_exponential_backoff() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-269", "COE-269", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("first tick should succeed");
+
+    let issue_id = IssueId::new("lin-269").expect("issue id should be valid");
+    let first_run = scheduler.worker().launches[0].run.clone();
+    scheduler
+        .worker_mut()
+        .updates
+        .push_back(WorkerUpdate::Finished {
+            worker_id: first_run.worker_id.clone(),
+            outcome: WorkerOutcomeRecord::from_run(
+                &first_run,
+                WorkerOutcomeKind::Failed,
+                ts(200),
+                Some("worker failed".to_string()),
+                Some("boom".to_string()),
+            ),
+        });
+
+    scheduler
+        .tick(ts(200))
+        .await
+        .expect("failure tick should succeed");
+
+    let retry = scheduler
+        .execution(&issue_id)
+        .expect("execution should exist")
+        .retry()
+        .expect("retry should exist")
+        .clone();
+    assert_eq!(retry.reason, RetryReason::Failure);
+    assert_eq!(retry.due_at, ts(10_200));
+
+    scheduler
+        .tick(ts(10_200))
+        .await
+        .expect("first retry dispatch should succeed");
+
+    let second_run = scheduler.worker().launches[1].run.clone();
+    scheduler
+        .worker_mut()
+        .updates
+        .push_back(WorkerUpdate::Finished {
+            worker_id: second_run.worker_id.clone(),
+            outcome: WorkerOutcomeRecord::from_run(
+                &second_run,
+                WorkerOutcomeKind::Failed,
+                ts(10_400),
+                Some("worker failed again".to_string()),
+                Some("still broken".to_string()),
+            ),
+        });
+
+    scheduler
+        .tick(ts(10_400))
+        .await
+        .expect("second failure tick should succeed");
+
+    let retry = scheduler
+        .execution(&issue_id)
+        .expect("execution should exist")
+        .retry()
+        .expect("retry should exist")
+        .clone();
+    assert_eq!(
+        retry.attempt.get(),
+        2,
+        "second retry should increment the retry attempt"
+    );
+    assert_eq!(retry.due_at, ts(30_400));
+}
+
+#[tokio::test]
+async fn terminal_reconciliation_aborts_running_worker_and_cleans_up_workspace() {
+    let issue = tracker_issue("lin-270", "COE-270", "In Progress", 0);
+    let tracker = FakeTracker {
+        active: vec![issue.clone()],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("first tick should succeed");
+
+    scheduler.tracker_mut().active.clear();
+    scheduler.tracker_mut().terminal = vec![tracker_issue("lin-270", "COE-270", "Done", 0)];
+
+    scheduler
+        .tick(ts(200))
+        .await
+        .expect("terminal reconciliation should succeed");
+
+    let issue_id = IssueId::new("lin-270").expect("issue id should be valid");
+    let execution = scheduler
+        .execution(&issue_id)
+        .expect("released execution should still exist");
+    assert_eq!(execution.status(), SchedulerStatus::Released);
+    match execution.state() {
+        opensymphony_orchestrator::SchedulerState::Released { reason, .. } => {
+            assert_eq!(*reason, ReleaseReason::TrackerTerminal);
+        }
+        other => panic!("expected released state, got {other:?}"),
+    }
+    assert_eq!(scheduler.worker().aborted.len(), 1);
+    assert_eq!(
+        scheduler.worker().aborted[0].1,
+        WorkerAbortReason::TrackerTerminal
+    );
+    assert_eq!(
+        scheduler.workspace().cleaned,
+        vec![("COE-270".to_string(), true)]
+    );
+}
+
+#[tokio::test]
+async fn runtime_events_extend_stall_deadlines_before_retrying_a_stalled_worker() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-271", "COE-271", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+
+    scheduler
+        .tick(ts(0))
+        .await
+        .expect("first tick should succeed");
+
+    let running = scheduler.worker().launches[0].run.clone();
+    scheduler
+        .worker_mut()
+        .updates
+        .push_back(WorkerUpdate::RuntimeEvent {
+            worker_id: running.worker_id.clone(),
+            observed_at: ts(50),
+            event_id: Some("evt-1".to_string()),
+            event_kind: Some("conversation_state_update".to_string()),
+            summary: Some("agent still making progress".to_string()),
+        });
+
+    scheduler
+        .tick(ts(50))
+        .await
+        .expect("runtime event tick should succeed");
+    let snapshot = scheduler.snapshot(ts(50));
+    assert_eq!(snapshot.issues[0].runtime.stalled_at, Some(ts(150)));
+
+    scheduler
+        .tick(ts(120))
+        .await
+        .expect("pre-stall tick should succeed");
+    assert_eq!(
+        scheduler
+            .execution(&IssueId::new("lin-271").expect("issue id should be valid"))
+            .expect("execution should exist")
+            .status(),
+        SchedulerStatus::Running
+    );
+
+    scheduler
+        .tick(ts(160))
+        .await
+        .expect("stall tick should succeed");
+
+    let execution = scheduler
+        .execution(&IssueId::new("lin-271").expect("issue id should be valid"))
+        .expect("execution should still exist");
+    assert_eq!(execution.status(), SchedulerStatus::RetryQueued);
+    assert_eq!(scheduler.worker().aborted.len(), 1);
+    assert_eq!(scheduler.worker().aborted[0].1, WorkerAbortReason::Stalled);
+    assert_eq!(
+        execution.retry().expect("retry should exist").reason,
+        RetryReason::Stalled
+    );
+}
+
+#[tokio::test]
+async fn recovery_reuses_manifest_workspace_for_active_issue_dispatch() {
+    let recovered_workspace = workspace_record("COE-272", "/tmp/recovered/COE-272");
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-272", "COE-272", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace {
+        recoveries: vec![RecoveryRecord {
+            issue: normalized_issue("lin-272", "COE-272", "In Progress"),
+            workspace: recovered_workspace.clone(),
+            had_in_flight_run: true,
+        }],
+        records: HashMap::from([("lin-272".to_string(), recovered_workspace.clone())]),
+        ..Default::default()
+    };
+    let worker = FakeWorker::default();
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("recovery tick should succeed");
+
+    let issue_id = IssueId::new("lin-272").expect("issue id should be valid");
+    let execution = scheduler
+        .execution(&issue_id)
+        .expect("execution should exist after recovery");
+    assert_eq!(execution.status(), SchedulerStatus::Running);
+    assert_eq!(
+        execution
+            .workspace()
+            .expect("workspace should be attached")
+            .path,
+        recovered_workspace.path
+    );
+    assert_eq!(scheduler.worker().launches.len(), 1);
+    assert_eq!(
+        scheduler.worker().launches[0].workspace.path,
+        recovered_workspace.path
+    );
+    assert!(scheduler.workspace().cleaned.is_empty());
+}
+
+#[tokio::test]
+async fn per_state_capacity_limits_dispatches_even_when_multiple_issues_are_ready() {
+    let tracker = FakeTracker {
+        active: vec![
+            tracker_issue("lin-273", "COE-273", "In Progress", 0),
+            tracker_issue("lin-274", "COE-274", "In Progress", 1),
+        ],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler.tick(ts(100)).await.expect("tick should succeed");
+
+    assert_eq!(scheduler.worker().launches.len(), 1);
+    let running = scheduler
+        .executions()
+        .values()
+        .filter(|execution| execution.status() == SchedulerStatus::Running)
+        .count();
+    let unclaimed = scheduler
+        .executions()
+        .values()
+        .filter(|execution| execution.status() == SchedulerStatus::Unclaimed)
+        .count();
+    assert_eq!(running, 1);
+    assert_eq!(unclaimed, 1);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,11 +162,11 @@ Current crate boundaries:
   - event cache
   - issue session runner
 - `opensymphony-orchestrator`
-  - poll tick
-  - scheduler actor and policy decisions over the shared state machine
-  - worker supervision
-  - retry timers
-  - reconciliation
+  - poll tick and long-running scheduler loop
+  - generic `Scheduler<TTracker, TWorkspace, TWorker>` core over tracker, workspace, and worker backends
+  - worker registry plus worker-report ingestion
+  - retry timers, stall handling, and state reconciliation
+  - manifest-backed restart recovery for workspace reuse
 - `opensymphony-control`
   - snapshot store
   - local HTTP and WebSocket control-plane API
@@ -201,9 +201,9 @@ The repository now exposes three stable foundation contracts that later mileston
 - `opensymphony-orchestrator`
   - deterministic candidate sorting with leaf-before-parent ordering
   - blocker-aware and hierarchy-aware dispatch eligibility helpers
-  - claim logic and claimed-to-running enforcement
-  - explicit `Claimed` / `Running` / `RetryQueued` / `Released` transitions
-  - fixed continuation retry, exponential failure backoff, stall detection, retry-start validation for `due_at`, `attempt`, latest dispatch eligibility, and bounded global/per-state capacity using the reservation's current state, reconciliation of running, retry-queued, and claimed-only issues including a claim-to-start grace window that remains independent from disabled stall detection before stale claimed-only release, freshest global rate-limit retention, and restart recovery
+  - generic scheduler configuration sourced from workflow polling, concurrency, retry, and stall settings
+  - explicit `Claimed` / `Running` / `RetryQueued` / `Released` transitions driven only by orchestrator-owned commands and worker reports
+  - fixed continuation retry, exponential failure backoff, bounded global/per-state capacity, running-worker reconciliation, terminal cleanup, and manifest-backed restart recovery for workspace reuse
 
 The other crates are already present at their final ownership boundaries, but for M1 they intentionally expose only thin re-exports or placeholders rather than premature transport logic.
 
@@ -367,9 +367,9 @@ This slice deliberately keeps the UI on a stable read-only contract while the or
 9. OpenHands runtime attaches WebSocket stream and reconciles event history.
 10. Prompt is chosen and sent as a user event.
 11. OpenHands run is triggered.
-12. Runtime events stream back over WebSocket and are mirrored into state and logs.
+12. Runtime events stream back over WebSocket and are mirrored into state, logs, and scheduler worker reports.
 13. Worker decides whether to do another in-process turn.
-14. Worker exits and reports success, failure, timeout, stall, or cancellation.
+14. Worker backend reports runtime progress and the terminal worker outcome to the scheduler.
 15. Orchestrator schedules a continuation retry, failure retry, release, or cleanup.
 
 ## 7.2 ASCII sequence
@@ -415,10 +415,16 @@ On startup:
 - initialize control-plane state
 - clean up terminal-state workspaces if configured
 - load known issue metadata from workspace manifests if present
-- rebuild retry queue from persisted retry metadata if implemented
+- reuse recovered workspace attachments for still-active issues on the next scheduler poll
+- rebuild retry queue from persisted retry metadata if implemented in a later milestone
 - treat OpenHands conversations as attachable resources, not as scheduler truth
 
 If a conversation exists but its issue is no longer active, the orchestrator does not resume it.
+
+Current repository implementation:
+
+- `opensymphony-orchestrator::Scheduler` recovers workspace ownership from manifest-derived `RecoveryRecord` entries and uses tracker state to decide whether recovered work should be redispatched, retained as inactive, or cleaned up as terminal
+- retry scheduling itself is still derived in memory from live worker outcomes rather than a separately persisted retry journal
 
 ## 8.2 WebSocket disconnect
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -17,7 +17,7 @@ This document is the planning index for OpenSymphony. It is designed to be direc
 |---|---|---|
 | M1 Foundation and contracts | repo bootstrap, workflow/config, domain model | stable repo skeleton and core invariants |
 | M2 OpenHands runtime adapter | local supervisor, REST client, WebSocket runtime, session runner | working agent runtime path |
-| M3 Symphony orchestration core | workspace lifecycle, Linear adapter, scheduler, MCP writes | issue-driven autonomous execution |
+| M3 Symphony orchestration core | workspace lifecycle, Linear adapter, scheduler, MCP writes | issue-driven autonomous execution with a generic scheduler core over tracker, workspace, and worker backends |
 | M4 Operator UX and repo harness | control plane, FrankenTUI, generated context artifacts | usable local operator experience |
 | M5 Validation and local packaging | fake server, live tests, doctor, packaging | reliable local MVP |
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -14,6 +14,11 @@ OpenSymphony follows that boundary strictly:
 
 The Rust Linear adapter must implement the minimum read surface Symphony requires.
 
+Current repository implementation:
+
+- `opensymphony-orchestrator::Scheduler` now drives every tick from three Linear read paths: active candidates, terminal issues, and by-ID state refresh for anything already tracked locally
+- candidate reads decide new dispatches, by-ID refresh releases work that falls out of the configured active states, and terminal reads drive startup cleanup plus terminal reconciliation
+
 ## 2.1 Candidate issue fetch
 
 Fetch issues that:

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -255,6 +255,22 @@ Current implementation detail:
 - if a reused conversation is already active, the runner waits for that turn to finish before sending the next prompt, and it retries `POST /run` after a `409 Conflict` on the same attached stream
 - each fresh create also snapshots `create-conversation-request.json`, `last-conversation-state.json`, and `generated/session-context.json` inside the issue workspace for recovery and observability
 
+## 6.4 Scheduler handoff contract
+
+The orchestrator does not consume raw OpenHands protocol frames directly.
+
+The scheduler-facing worker boundary should provide:
+
+- a launch acknowledgment that includes `ConversationMetadata` so the issue can move into `Running`
+- incremental runtime-event reports used to refresh last-event timestamps and stall deadlines
+- one terminal worker outcome report used to schedule continuation retry, failure backoff, or release
+
+Current repository implementation:
+
+- `opensymphony-openhands::IssueSessionRunner` still owns the concrete attach/create/send/run/await flow
+- `opensymphony-orchestrator::Scheduler` is now implemented as a generic core over a worker backend that emits the launch plus runtime/outcome reports above
+- fake-backend scheduler tests currently lock down the orchestration semantics while a thin production adapter from `IssueSessionRunner` into that worker contract remains follow-on wiring
+
 ## 7. REST endpoints used by OpenSymphony
 
 Use the smallest necessary subset of the agent-server API.

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -76,7 +76,7 @@ Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
 - `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, non-archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
-- `cargo test -p opensymphony-orchestrator` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, and dynamic child-addition reblocking against normalized tracker issues
+- `cargo test -p opensymphony-orchestrator` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, and manifest-backed workspace recovery against fake tracker/workspace/worker backends
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`
@@ -187,6 +187,10 @@ Current implementation:
 - active-state refresh
 - terminal cleanup
 - restart recovery from manifests
+
+Current repository implementation:
+
+- `crates/opensymphony-orchestrator/tests/scheduler.rs` covers continuation retry, failure backoff, per-state dispatch limits, runtime-event-fed stall detection, terminal reconciliation with cleanup, and manifest-backed workspace recovery using fake backends
 
 ## 3.5 Control plane and TUI
 

--- a/docs/websocket-runtime.md
+++ b/docs/websocket-runtime.md
@@ -231,6 +231,18 @@ Current repository implementation:
 - `RuntimeEventStream` reapplies the non-replayable readiness snapshot after attach/reconnect and after later cache-driven mirror rebuilds only when reconcile and REST refresh do not already carry an equal or newer decodable state update, still derives a minimal mirror patch from forward-compatible `state_delta` payloads even when typed state decoding would otherwise fall back, and lets an active `queued` or `running` ready barrier clear stale terminal REST fallback for restarted reused conversations
 - `ConversationStateMirror::terminal_status` provides the current finished/error/stuck classification used by the probe and future workers
 
+## 6.5 Scheduler-facing event handoff
+
+The orchestrator does not need the full OpenHands wire contract at its boundary.
+
+The worker backend that bridges `RuntimeEventStream` into the scheduler should surface:
+
+- launch-time `ConversationMetadata`
+- ordered runtime-event updates carrying `event_id`, `event_kind`, `summary`, and `observed_at`
+- a terminal worker outcome once the stream resolves to `finished`, `error`, `stuck`, or another final condition
+
+This keeps WebSocket protocol churn isolated inside `opensymphony-openhands` while still giving the orchestrator enough information for stall detection, reconciliation, and snapshot derivation.
+
 ## 7. Run lifecycle over REST plus WebSocket
 
 ## 7.1 Sending a turn

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -197,6 +197,11 @@ Use cases:
 - workspace introspection
 - authoritative ownership check for non-injective sanitized workspace keys
 
+Current repository implementation:
+
+- the scheduler recovery path consumes manifest-derived records that include the normalized issue identity plus the attached workspace record
+- recovered active issues reuse that workspace attachment on the next scheduler poll instead of recreating the workspace path
+
 ## 7.1 Run metadata manifest
 
 Persist the latest worker-lifetime manifest under `.opensymphony/run.json`.
@@ -220,6 +225,10 @@ Use cases:
 - capture `before_run` and `after_run` hook outcomes with stdout/stderr for diagnostics
 - explain the latest worker-lifetime state during restart recovery
 - make cleanup and retry decisions inspectable without daemon memory
+
+Current repository note:
+
+- the run manifest is currently explanatory recovery evidence for operators and future adapters; the generic scheduler core already reuses workspace ownership from recovery records, while persisted retry-queue reconstruction remains a later follow-on
 
 ## 8. Conversation metadata manifest
 


### PR DESCRIPTION
## Summary

Implement the orchestrator scheduler core for COE-268 with bounded dispatch, retry/release handling, runtime-event-fed stall detection, and manifest-backed recovery.

## Changes

- add a generic `opensymphony-orchestrator::Scheduler<TTracker, TWorkspace, TWorker>` engine with workflow-derived config, running worker registry, retry queue, reconciliation, and long-running tick-loop support
- add fake-backend orchestrator integration tests covering continuation retry, exponential backoff, per-state capacity limits, terminal cleanup/release, stall detection, and recovery from persisted workspace state
- extend `IssueExecution` with explicit tracker-state refresh support and update orchestration/runtime/workspace/Linear/testing docs to describe the shipped scheduler contract

## Evidence

### Test output

```text
cargo fmt --check
cargo test -p opensymphony-orchestrator
cargo clippy --workspace --all-targets --all-features
cargo test --workspace
```

### Verification

- Verified successful worker completion transitions an active issue into `RetryQueued` with the fixed continuation delay and then redispatches with the expected retry attempt metadata.
- Verified failed and stalled workers schedule exponential backoff retries, and runtime events extend stall deadlines before the scheduler aborts and retries the worker.
- Verified terminal reconciliation aborts the running worker, releases the issue, and requests terminal workspace cleanup, while recovery reuses manifest-backed workspaces for active issues on restart.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- COE-268

## Additional notes

- The scheduler core is intentionally generic over tracker, workspace, and worker backends so orchestration policy is testable in isolation; the thin production adapter from `IssueSessionRunner` into that worker-report contract remains follow-on daemon wiring.