### PR TITLE
Add live local end-to-end suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,14 @@ cargo test --workspace
 cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml
 cargo run -p opensymphony-cli -- linear-mcp
 ./scripts/smoke_local.sh
+OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_local_suite -- --ignored --nocapture --test-threads=1
 OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh
 ```
 
 Current note:
 
 - the example doctor YAML now only carries machine-local inputs such as the OpenHands tool directory and optional probe overrides; the target repo `WORKFLOW.md` provides the workspace root, OpenHands base URL, and prompt that the doctor probe validates
+- `scripts/live_e2e.sh` now performs the full opt-in live suite: doctor preflight, pinned local server launch, ignored `live_local_suite` integration tests, and artifact capture under `target/live-local/`
 - `linear-mcp` is implemented and exposes the documented Linear tool surface over stdio; `daemon` and `tui` remain scaffolds until their runtime and control-plane milestones land.
 
 ## Non-negotiable implementation rules

--- a/crates/opensymphony-openhands/src/client.rs
+++ b/crates/opensymphony-openhands/src/client.rs
@@ -864,10 +864,21 @@ impl RuntimeEventStream {
     }
 
     fn apply_terminal_conversation_fallback(&mut self) {
+        let latest_cached_execution_status = self.event_cache.items().iter().rev().find_map(
+            |event| match KnownEvent::from_envelope(event) {
+                KnownEvent::ConversationStateUpdate(payload) => payload.execution_status,
+                _ => None,
+            },
+        );
+        let cached_state_restarts_execution = matches!(
+            latest_cached_execution_status.as_deref(),
+            Some("queued" | "running")
+        );
         if matches!(
             self.conversation.execution_status.as_str(),
             "finished" | "error" | "stuck"
-        ) && self.state_mirror.terminal_status().is_none()
+        ) && !cached_state_restarts_execution
+            && self.state_mirror.terminal_status().is_none()
         {
             self.state_mirror
                 .apply_conversation_execution_status(&self.conversation);

--- a/crates/opensymphony-openhands/src/models.rs
+++ b/crates/opensymphony-openhands/src/models.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeMap};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
@@ -184,46 +184,15 @@ pub struct ConversationStateUpdatePayload {
     pub state_delta: Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EventEnvelope {
     pub id: String,
-    #[serde(with = "flexible_timestamp")]
     pub timestamp: DateTime<Utc>,
-    #[serde(default)]
     pub source: String,
     pub kind: String,
-    #[serde(default)]
     pub payload: Value,
-    #[serde(default)]
     pub key: Option<String>,
-    #[serde(default)]
     pub value: Option<Value>,
-}
-
-mod flexible_timestamp {
-    use chrono::{DateTime, NaiveDateTime, Utc};
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(value: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&value.to_rfc3339())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        if let Ok(timestamp) = DateTime::parse_from_rfc3339(&value) {
-            return Ok(timestamp.with_timezone(&Utc));
-        }
-
-        let naive = NaiveDateTime::parse_from_str(&value, "%Y-%m-%dT%H:%M:%S%.f")
-            .map_err(serde::de::Error::custom)?;
-        Ok(DateTime::from_naive_utc_and_offset(naive, Utc))
-    }
 }
 
 impl EventEnvelope {
@@ -262,6 +231,117 @@ impl EventEnvelope {
             value: None,
         }
     }
+}
+
+impl Serialize for EventEnvelope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("id", &self.id)?;
+        map.serialize_entry("timestamp", &self.timestamp.to_rfc3339())?;
+        map.serialize_entry("source", &self.source)?;
+        map.serialize_entry("kind", &self.kind)?;
+        if let Some(key) = &self.key {
+            map.serialize_entry("key", key)?;
+        }
+        if let Some(value) = &self.value {
+            map.serialize_entry("value", value)?;
+        }
+
+        match &self.payload {
+            Value::Object(payload) => {
+                for (key, value) in payload {
+                    map.serialize_entry(key, value)?;
+                }
+            }
+            Value::Null => {}
+            other => {
+                map.serialize_entry("payload", other)?;
+            }
+        }
+
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for EventEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut raw = serde_json::Map::<String, Value>::deserialize(deserializer)?;
+        let id = take_required_string(&mut raw, "id")?;
+        let timestamp = take_required_timestamp(&mut raw, "timestamp")?;
+        let source = take_optional_string(&mut raw, "source").unwrap_or_default();
+        let kind = take_required_string(&mut raw, "kind")?;
+        let key = take_optional_string(&mut raw, "key");
+        let value = raw.remove("value");
+        let nested_payload = raw.remove("payload");
+        let payload = match (nested_payload, raw.is_empty()) {
+            (Some(Value::Object(payload)), true) => Value::Object(payload),
+            (Some(Value::Null), true) | (None, true) => Value::Object(raw),
+            (Some(payload), true) => payload,
+            (Some(payload), false) => {
+                raw.insert("payload".to_string(), payload);
+                Value::Object(raw)
+            }
+            (None, false) => Value::Object(raw),
+        };
+
+        Ok(Self {
+            id,
+            timestamp,
+            source,
+            kind,
+            payload,
+            key,
+            value,
+        })
+    }
+}
+
+fn take_required_string<E>(
+    raw: &mut serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<String, E>
+where
+    E: serde::de::Error,
+{
+    raw.remove(field)
+        .ok_or_else(|| E::custom(format!("missing required field `{field}`")))?
+        .as_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| E::custom(format!("expected `{field}` to be a string")))
+}
+
+fn take_optional_string(raw: &mut serde_json::Map<String, Value>, field: &str) -> Option<String> {
+    raw.remove(field)
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+}
+
+fn take_required_timestamp<E>(
+    raw: &mut serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<DateTime<Utc>, E>
+where
+    E: serde::de::Error,
+{
+    let value = raw
+        .remove(field)
+        .ok_or_else(|| E::custom(format!("missing required field `{field}`")))?;
+    let raw_timestamp = value
+        .as_str()
+        .ok_or_else(|| E::custom(format!("expected `{field}` to be a string timestamp")))?;
+
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(raw_timestamp) {
+        return Ok(timestamp.with_timezone(&Utc));
+    }
+
+    chrono::NaiveDateTime::parse_from_str(raw_timestamp, "%Y-%m-%dT%H:%M:%S%.f")
+        .map(|naive| DateTime::from_naive_utc_and_offset(naive, Utc))
+        .map_err(E::custom)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -334,5 +414,76 @@ mod tests {
             .expect("request should serialize");
 
         assert_eq!(value, json!({}));
+    }
+
+    #[test]
+    fn event_envelope_deserializes_flattened_agent_server_events() {
+        let value = json!({
+            "id": "evt-message",
+            "timestamp": "2026-03-23T12:07:58.942514",
+            "source": "user",
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "hello",
+                        "cache_prompt": false,
+                    }
+                ],
+                "thinking_blocks": [],
+            },
+            "activated_skills": [],
+            "extended_content": [],
+        });
+
+        let event: EventEnvelope =
+            serde_json::from_value(value).expect("flattened event should decode");
+
+        assert_eq!(event.kind, "MessageEvent");
+        assert_eq!(
+            event
+                .payload
+                .get("llm_message")
+                .and_then(|value| value.get("content"))
+                .and_then(Value::as_array)
+                .and_then(|content| content.first())
+                .and_then(|entry| entry.get("text"))
+                .and_then(Value::as_str),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn event_envelope_round_trips_nested_payload_state_updates() {
+        let event = EventEnvelope::state_update("evt-state", "finished");
+
+        let encoded = serde_json::to_value(&event).expect("event should encode");
+        assert_eq!(
+            encoded,
+            json!({
+                "id": "evt-state",
+                "timestamp": event.timestamp.to_rfc3339(),
+                "source": "runtime",
+                "kind": "ConversationStateUpdateEvent",
+                "execution_status": "finished",
+                "state_delta": {
+                    "execution_status": "finished",
+                },
+            })
+        );
+
+        let decoded: EventEnvelope =
+            serde_json::from_value(encoded).expect("state update should decode");
+        assert_eq!(
+            decoded.payload,
+            json!({
+                "execution_status": "finished",
+                "state_delta": {
+                    "execution_status": "finished",
+                },
+            })
+        );
     }
 }

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -1214,13 +1214,11 @@ impl IssueSessionRunner {
                 Ok(Ok(None)) => {
                     if let Ok(inserted) = stream.reconcile_events().await
                         && inserted > 0
-                    {
-                        if let Some(outcome) = self
+                        && let Some(outcome) = self
                             .terminal_outcome_from_state(stream, baseline_event_ids)
                             .await
-                        {
-                            return outcome;
-                        }
+                    {
+                        return outcome;
                     }
 
                     return NormalizedOutcome {

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -16,7 +16,7 @@ use opensymphony_workspace::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use tokio::time::{Instant, timeout, timeout_at};
+use tokio::time::{Instant, timeout_at};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -1210,7 +1210,28 @@ impl IssueSessionRunner {
                         )),
                     };
                 }
-                Ok(Ok(Some(_))) | Ok(Ok(None)) => {}
+                Ok(Ok(Some(_))) => {}
+                Ok(Ok(None)) => {
+                    if let Ok(inserted) = stream.reconcile_events().await
+                        && inserted > 0
+                    {
+                        if let Some(outcome) = self
+                            .terminal_outcome_from_state(stream, baseline_event_ids)
+                            .await
+                        {
+                            return outcome;
+                        }
+                    }
+
+                    return NormalizedOutcome {
+                        kind: WorkerOutcomeKind::Failed,
+                        summary: "runtime event stream ended before terminal status".to_string(),
+                        error: Some(
+                            "runtime event stream closed before a terminal state was observed"
+                                .to_string(),
+                        ),
+                    };
+                }
                 Ok(Err(error)) => {
                     if let Some(outcome) = self
                         .terminal_outcome_from_state(stream, baseline_event_ids)
@@ -1299,18 +1320,25 @@ impl IssueSessionRunner {
         stream: &mut RuntimeEventStream,
         baseline_event_ids: &HashSet<String>,
     ) -> bool {
-        let drained = timeout(self.config.finished_drain_timeout, stream.next_event()).await;
-        match drained {
-            Err(_) => latest_current_turn_error(stream.event_cache().items(), baseline_event_ids)
-                .is_none(),
-            Ok(Ok(Some(_))) | Ok(Ok(None)) => false,
-            Ok(Err(error)) => {
-                matches!(
-                    stream.state_mirror().terminal_status(),
-                    Some(TerminalExecutionStatus::Finished)
-                ) && latest_current_turn_error(stream.event_cache().items(), baseline_event_ids)
-                    .is_none()
-                    && finished_stream_error_is_tolerable(&error)
+        let deadline = Instant::now() + self.config.finished_drain_timeout;
+
+        loop {
+            if latest_current_turn_error(stream.event_cache().items(), baseline_event_ids).is_some()
+            {
+                return false;
+            }
+            if !matches!(
+                stream.state_mirror().terminal_status(),
+                Some(TerminalExecutionStatus::Finished)
+            ) {
+                return false;
+            }
+
+            match timeout_at(deadline, stream.next_event()).await {
+                Err(_) => return true,
+                Ok(Ok(Some(_))) => continue,
+                Ok(Ok(None)) => return true,
+                Ok(Err(error)) => return finished_stream_error_is_tolerable(&error),
             }
         }
     }
@@ -1342,7 +1370,7 @@ impl IssueSessionRunner {
                 .unwrap_or_else(|| outcome.summary.clone()),
         );
         workspace_manager
-            .write_run_manifest(workspace, run_manifest)
+            .finish_run(workspace, run_manifest, run_status)
             .await?;
 
         let worker_outcome = WorkerOutcomeRecord::from_run(
@@ -1408,7 +1436,7 @@ impl IssueSessionRunner {
                 .unwrap_or_else(|| outcome.summary.clone()),
         );
         workspace_manager
-            .write_run_manifest(workspace, run_manifest)
+            .finish_run(workspace, run_manifest, run_status)
             .await?;
 
         let worker_outcome = WorkerOutcomeRecord::from_run(
@@ -1678,4 +1706,83 @@ fn finished_stream_error_is_tolerable(error: &OpenHandsError) -> bool {
         error,
         OpenHandsError::ReconnectExhausted { .. } | OpenHandsError::WebSocketClosed
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use opensymphony_domain::WorkerOutcomeKind;
+    use opensymphony_testkit::FakeOpenHandsServer;
+
+    use super::*;
+    use crate::TransportConfig;
+
+    #[tokio::test]
+    async fn await_terminal_outcome_accepts_reconciled_finished_state_after_stream_close() {
+        let server = FakeOpenHandsServer::start()
+            .await
+            .expect("fake server should start");
+        let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+        let conversation = client
+            .create_conversation(&ConversationCreateRequest::doctor_probe(
+                "/tmp/opensymphony-live",
+                "/tmp/opensymphony-live/.opensymphony/openhands",
+                Some("fake-model".to_string()),
+                None,
+            ))
+            .await
+            .expect("conversation should be created");
+        let mut stream = client
+            .attach_runtime_stream(
+                conversation.conversation_id,
+                RuntimeStreamConfig {
+                    readiness_timeout: Duration::from_secs(2),
+                    reconnect_initial_backoff: Duration::from_millis(25),
+                    reconnect_max_backoff: Duration::from_millis(25),
+                    max_reconnect_attempts: 1,
+                },
+            )
+            .await
+            .expect("runtime stream should attach");
+        let baseline_event_ids = stream
+            .event_cache()
+            .items()
+            .iter()
+            .map(|event| event.id.clone())
+            .collect::<HashSet<_>>();
+
+        server
+            .emit_state_update(conversation.conversation_id, "running")
+            .await
+            .expect("running state should be recorded");
+        server
+            .emit_state_update(conversation.conversation_id, "finished")
+            .await
+            .expect("finished state should be recorded");
+        stream.close().await.expect("stream should close cleanly");
+
+        let runner = IssueSessionRunner::new(
+            client,
+            IssueSessionRunnerConfig {
+                runtime_stream: RuntimeStreamConfig {
+                    readiness_timeout: Duration::from_secs(2),
+                    reconnect_initial_backoff: Duration::from_millis(25),
+                    reconnect_max_backoff: Duration::from_millis(25),
+                    max_reconnect_attempts: 1,
+                },
+                terminal_wait_timeout: Duration::from_millis(25),
+                finished_drain_timeout: Duration::from_millis(25),
+            },
+        );
+        let outcome = runner
+            .await_terminal_outcome(&mut stream, &baseline_event_ids)
+            .await;
+
+        assert_eq!(outcome.kind, WorkerOutcomeKind::Succeeded);
+        assert_eq!(
+            stream.state_mirror().terminal_status(),
+            Some(TerminalExecutionStatus::Finished)
+        );
+    }
 }

--- a/crates/opensymphony-openhands/tests/client_resilience.rs
+++ b/crates/opensymphony-openhands/tests/client_resilience.rs
@@ -558,6 +558,41 @@ async fn attach_runtime_stream_applies_newer_reused_conversation_readiness_snaps
 }
 
 #[tokio::test]
+async fn attach_runtime_stream_prefers_cached_running_state_over_stale_terminal_conversation_summary()
+ {
+    let state = ReadinessMirrorState::default();
+    let server = TestServer::start(reused_conversation_cached_running_router(state)).await;
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let request = ConversationCreateRequest::doctor_probe(
+        "/tmp/workspace",
+        "/tmp/workspace/.opensymphony/openhands",
+        None,
+        None,
+    );
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("conversation create should succeed");
+
+    let stream = client
+        .attach_runtime_stream(
+            conversation.conversation_id,
+            RuntimeStreamConfig {
+                readiness_timeout: Duration::from_secs(2),
+                ..RuntimeStreamConfig::default()
+            },
+        )
+        .await
+        .expect("runtime stream attach should succeed");
+
+    assert_eq!(
+        stream.state_mirror().execution_status(),
+        Some("running"),
+        "a newer cached running state should win over a stale terminal conversation summary"
+    );
+}
+
+#[tokio::test]
 async fn attach_runtime_stream_uses_ready_barrier_when_newer_persisted_state_update_is_undecodable()
 {
     let state = ReadinessMirrorState::default();
@@ -819,6 +854,27 @@ fn reused_conversation_readiness_mirror_router(state: ReadinessMirrorState) -> R
         .with_state(state)
 }
 
+fn reused_conversation_cached_running_router(state: ReadinessMirrorState) -> Router {
+    Router::new()
+        .route(
+            "/api/conversations",
+            post(reused_conversation_readiness_mirror_create_conversation),
+        )
+        .route(
+            "/api/conversations/{conversation_id}",
+            get(readiness_mirror_get_conversation),
+        )
+        .route(
+            "/api/conversations/{conversation_id}/events/search",
+            get(reused_conversation_running_search_events),
+        )
+        .route(
+            "/sockets/events/{conversation_id}",
+            get(idle_readiness_mirror_events_socket),
+        )
+        .with_state(state)
+}
+
 fn undecodable_newer_state_readiness_mirror_router(state: ReadinessMirrorState) -> Router {
     Router::new()
         .route(
@@ -939,6 +995,27 @@ async fn undecodable_newer_state_readiness_mirror_search_events(
     }))
 }
 
+async fn reused_conversation_running_search_events(
+    Path(_conversation_id): Path<Uuid>,
+) -> Result<Json<SearchConversationEventsResponse>, StatusCode> {
+    let running_timestamp = Utc::now() + chrono::Duration::seconds(1);
+    Ok(Json(SearchConversationEventsResponse {
+        events: vec![EventEnvelope::new(
+            "evt-running-from-search",
+            running_timestamp,
+            "runtime",
+            "ConversationStateUpdateEvent",
+            json!({
+                "execution_status": "running",
+                "state_delta": {
+                    "execution_status": "running",
+                },
+            }),
+        )],
+        next_page_id: None,
+    }))
+}
+
 async fn readiness_mirror_events_socket(
     Path(_conversation_id): Path<Uuid>,
     websocket: WebSocketUpgrade,
@@ -955,6 +1032,33 @@ async fn readiness_mirror_events_socket(
                         "execution_status": "running",
                         "state_delta": {
                             "execution_status": "running",
+                        },
+                    }),
+                ))
+                .expect("ready event should serialize"),
+            ))
+            .await
+            .expect("ready event should send");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    })
+}
+
+async fn idle_readiness_mirror_events_socket(
+    Path(_conversation_id): Path<Uuid>,
+    websocket: WebSocketUpgrade,
+) -> impl IntoResponse {
+    websocket.on_upgrade(async move |mut socket| {
+        socket
+            .send(text_message(
+                serde_json::to_string(&EventEnvelope::new(
+                    "evt-ready-idle",
+                    Utc::now(),
+                    "runtime",
+                    "ConversationStateUpdateEvent",
+                    json!({
+                        "execution_status": "idle",
+                        "state_delta": {
+                            "execution_status": "idle",
                         },
                     }),
                 ))

--- a/crates/opensymphony-openhands/tests/live_local_suite.rs
+++ b/crates/opensymphony-openhands/tests/live_local_suite.rs
@@ -1,0 +1,1322 @@
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    Router,
+    body::{Body, Bytes},
+    extract::{
+        Path as AxumPath, Query, State, WebSocketUpgrade,
+        ws::{Message as AxumMessage, WebSocket},
+    },
+    http::{Method, Response, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+};
+use chrono::Utc;
+use futures_util::{SinkExt, StreamExt};
+use opensymphony_domain::{
+    IssueId, IssueIdentifier, IssueState, IssueStateCategory, NormalizedIssue, RetryAttempt,
+    RunAttempt, TimestampMs, WorkerId, WorkerOutcomeKind,
+};
+use opensymphony_openhands::{
+    ConversationCreateRequest, EventEnvelope, IssueConversationManifest, IssueSessionContext,
+    IssueSessionPromptKind, IssueSessionRunner, IssueSessionRunnerConfig, LocalServerSupervisor,
+    LocalServerTooling, OpenHandsClient, RuntimeStreamConfig, SendMessageRequest,
+    SupervisedServerConfig, SupervisorConfig, TransportConfig,
+};
+use opensymphony_workflow::{ResolvedWorkflow, WorkflowDefinition};
+use opensymphony_workspace::{
+    CleanupConfig, HookConfig, HookDefinition, IssueDescriptor, RunDescriptor, WorkspaceManager,
+    WorkspaceManagerConfig,
+};
+use serde_json::{Value, json};
+use tokio::{
+    net::TcpListener as TokioTcpListener,
+    sync::Mutex,
+    task::JoinHandle,
+    time::{Instant, timeout},
+};
+use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMessage};
+
+const LIVE_GATE_ENV: &str = "OPENSYMPHONY_LIVE_OPENHANDS";
+const LIVE_MODEL_ENV: &str = "OPENSYMPHONY_OPENHANDS_MODEL";
+const LIVE_SUITE_BASE_URL_ENV: &str = "OPENSYMPHONY_LIVE_SUITE_BASE_URL";
+const LIVE_SUITE_OUTPUT_DIR_ENV: &str = "OPENSYMPHONY_LIVE_SUITE_OUTPUT_DIR";
+const CHECKLIST_PATH: &str = "notes/live-suite-checklist.md";
+const FIRST_REPLY_TEXT: &str = "run 1: workspace-created";
+const SECOND_REPLY_TEXT: &str = "run 2: conversation-reused";
+
+#[tokio::test]
+#[ignore = "requires a prepared local machine with live OpenHands credentials"]
+async fn live_local_issue_lifecycle_captures_workspace_artifacts_and_reuses_conversation() {
+    if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {
+        eprintln!("skipping live local suite; set {LIVE_GATE_ENV}=1 to enable it");
+        return;
+    }
+
+    let artifacts = ArtifactLayout::for_scenario("lifecycle");
+    let server = LiveServer::acquire();
+    let summary_path = artifacts.scenario_root.join("summary.json");
+
+    match run_lifecycle_scenario(&artifacts, &server).await {
+        Ok(summary) => write_json(&summary_path, &summary),
+        Err(error) => {
+            write_json(
+                &summary_path,
+                &json!({
+                    "status": "failed",
+                    "error": error,
+                    "scenario_root": artifacts.scenario_root.display().to_string(),
+                }),
+            );
+            panic!("{error}");
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a prepared local machine with live OpenHands credentials"]
+async fn live_local_runtime_stream_recovers_after_one_fault_injected_websocket_drop() {
+    if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {
+        eprintln!("skipping live local suite; set {LIVE_GATE_ENV}=1 to enable it");
+        return;
+    }
+
+    let artifacts = ArtifactLayout::for_scenario("reconnect");
+    let server = LiveServer::acquire();
+    let summary_path = artifacts.scenario_root.join("summary.json");
+
+    match run_reconnect_scenario(&artifacts, &server).await {
+        Ok(summary) => write_json(&summary_path, &summary),
+        Err(error) => {
+            write_json(
+                &summary_path,
+                &json!({
+                    "status": "failed",
+                    "error": error,
+                    "scenario_root": artifacts.scenario_root.display().to_string(),
+                }),
+            );
+            panic!("{error}");
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ArtifactLayout {
+    output_root: PathBuf,
+    scenario_root: PathBuf,
+}
+
+impl ArtifactLayout {
+    fn for_scenario(name: &str) -> Self {
+        let output_root = env::var_os(LIVE_SUITE_OUTPUT_DIR_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(default_output_root);
+        let scenario_root = output_root.join(name);
+        fs::create_dir_all(&scenario_root).expect("scenario artifact directory should exist");
+        Self {
+            output_root,
+            scenario_root,
+        }
+    }
+}
+
+fn default_output_root() -> PathBuf {
+    let repo_root = repo_root();
+    let timestamp = Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let root = repo_root.join("target").join("live-local").join(timestamp);
+    fs::create_dir_all(&root).expect("default live-local artifact root should exist");
+    root
+}
+
+enum LiveServer {
+    External {
+        base_url: String,
+    },
+    Managed {
+        base_url: String,
+        supervisor: LocalServerSupervisor,
+    },
+}
+
+impl LiveServer {
+    fn acquire() -> Self {
+        if let Ok(base_url) = env::var(LIVE_SUITE_BASE_URL_ENV) {
+            return Self::External { base_url };
+        }
+
+        let tooling = LocalServerTooling::load(repo_root().join("tools/openhands-server"))
+            .expect("pinned OpenHands tooling should load");
+        let mut config = SupervisedServerConfig::new(tooling);
+        config.port_override = Some(free_port());
+        let mut supervisor =
+            LocalServerSupervisor::new(SupervisorConfig::Supervised(Box::new(config)));
+        let status = supervisor
+            .start()
+            .expect("live suite should start a managed local server");
+
+        Self::Managed {
+            base_url: status.base_url,
+            supervisor,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        match self {
+            Self::External { base_url } => base_url,
+            Self::Managed { base_url, .. } => base_url,
+        }
+    }
+
+    fn mode(&self) -> &'static str {
+        match self {
+            Self::External { .. } => "external",
+            Self::Managed { .. } => "managed",
+        }
+    }
+}
+
+impl Drop for LiveServer {
+    fn drop(&mut self) {
+        if let Self::Managed { supervisor, .. } = self {
+            let _ = supervisor.stop();
+        }
+    }
+}
+
+async fn run_lifecycle_scenario(
+    artifacts: &ArtifactLayout,
+    server: &LiveServer,
+) -> Result<Value, String> {
+    let model = env::var(LIVE_MODEL_ENV)
+        .map_err(|_| format!("missing required environment variable {LIVE_MODEL_ENV}"))?;
+    let target_repo = artifacts.scenario_root.join("target-repo");
+    let workspace_root = artifacts.scenario_root.join("workspaces");
+    let workflow_path = seed_live_target_repo(&target_repo, &workspace_root, server.base_url())?;
+    let workflow = resolve_workflow(&workflow_path, &model)?;
+    let manager = workspace_manager(&workflow)?;
+    let transport = TransportConfig::from_workflow(&workflow, &workflow_env(&model))
+        .map_err(|error| format!("failed to resolve transport config from workflow: {error}"))?;
+    let client = OpenHandsClient::new(transport);
+    let runner = IssueSessionRunner::new(client.clone(), runner_config(&workflow));
+    let issue = sample_issue();
+    let ensured = manager
+        .ensure(&issue_descriptor(&issue))
+        .await
+        .map_err(|error| format!("failed to ensure workspace: {error}"))?;
+    let max_turns = u32::try_from(workflow.config.agent.max_turns)
+        .map_err(|_| "workflow max_turns does not fit u32".to_string())?;
+
+    let mut first_manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("live-run-1", 1))
+        .await
+        .map_err(|error| format!("failed to prepare first run: {error}"))?;
+    let first_result = runner
+        .run(
+            &manager,
+            &ensured.handle,
+            &mut first_manifest,
+            &issue,
+            &run_attempt(
+                &issue,
+                ensured.handle.workspace_path(),
+                "worker-1",
+                None,
+                max_turns,
+            ),
+            &workflow,
+        )
+        .await
+        .map_err(|error| format!("first issue session run failed: {error}"))?;
+
+    if first_result.prompt_kind != IssueSessionPromptKind::Full {
+        return Err(format!(
+            "first run should use the full prompt, got {:?}",
+            first_result.prompt_kind
+        ));
+    }
+    if first_result.worker_outcome.outcome != WorkerOutcomeKind::Succeeded {
+        return Err(format!(
+            "first run should succeed, got {:?}",
+            first_result.worker_outcome.outcome
+        ));
+    }
+
+    let first_conversation = read_conversation_manifest(&manager, &ensured.handle).await?;
+    let first_context = read_session_context(&manager, &ensured.handle).await?;
+    let first_message_texts = latest_reply_texts(
+        client
+            .search_all_events(
+                uuid::Uuid::parse_str(
+                    &first_result
+                        .conversation
+                        .as_ref()
+                        .ok_or_else(|| {
+                            "first run did not persist conversation metadata".to_string()
+                        })?
+                        .conversation_id
+                        .to_string(),
+                )
+                .map_err(|error| format!("first conversation ID should parse: {error}"))?,
+            )
+            .await
+            .map_err(|error| format!("failed to fetch first-run events: {error}"))?
+            .items(),
+    );
+    if !first_message_texts
+        .iter()
+        .any(|text| text == FIRST_REPLY_TEXT)
+    {
+        return Err(format!(
+            "first run did not record the expected assistant reply: {first_message_texts:?}"
+        ));
+    }
+
+    let mut second_manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("live-run-2", 2))
+        .await
+        .map_err(|error| format!("failed to prepare second run: {error}"))?;
+    let second_result = runner
+        .run(
+            &manager,
+            &ensured.handle,
+            &mut second_manifest,
+            &issue,
+            &run_attempt(
+                &issue,
+                ensured.handle.workspace_path(),
+                "worker-2",
+                Some(RetryAttempt::new(2).expect("retry attempt should be valid")),
+                max_turns,
+            ),
+            &workflow,
+        )
+        .await
+        .map_err(|error| format!("second issue session run failed: {error}"))?;
+
+    if second_result.prompt_kind != IssueSessionPromptKind::Continuation {
+        return Err(format!(
+            "second run should use continuation guidance, got {:?}",
+            second_result.prompt_kind
+        ));
+    }
+    if second_result.worker_outcome.outcome != WorkerOutcomeKind::Succeeded {
+        return Err(format!(
+            "second run should succeed, got {:?}",
+            second_result.worker_outcome.outcome
+        ));
+    }
+
+    let first_conversation_id = first_result
+        .conversation
+        .as_ref()
+        .ok_or_else(|| "first run did not persist conversation metadata".to_string())?
+        .conversation_id
+        .to_string();
+    let second_conversation_id = second_result
+        .conversation
+        .as_ref()
+        .ok_or_else(|| "second run did not persist conversation metadata".to_string())?
+        .conversation_id
+        .to_string();
+    if first_conversation_id != second_conversation_id {
+        return Err(format!(
+            "conversation ID was not reused: {first_conversation_id} != {second_conversation_id}"
+        ));
+    }
+
+    let second_conversation = read_conversation_manifest(&manager, &ensured.handle).await?;
+    let second_context = read_session_context(&manager, &ensured.handle).await?;
+    let all_events = client
+        .search_all_events(
+            uuid::Uuid::parse_str(&second_conversation_id)
+                .map_err(|error| format!("conversation ID should parse: {error}"))?,
+        )
+        .await
+        .map_err(|error| format!("failed to fetch conversation events: {error}"))?;
+    let message_texts = latest_reply_texts(all_events.items());
+    if !message_texts.iter().any(|text| text == FIRST_REPLY_TEXT) {
+        return Err(format!(
+            "reused conversation lost the first assistant reply: {message_texts:?}"
+        ));
+    }
+    if message_texts.last().map(String::as_str) != Some(SECOND_REPLY_TEXT) {
+        return Err(format!(
+            "second run did not record the expected continuation reply: {message_texts:?}"
+        ));
+    }
+
+    let required_artifacts = vec![
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/issue.json"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/run.json"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/conversation.json"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/openhands/create-conversation-request.json"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/generated/session-context.json"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/prompts/last-full-prompt.md"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/prompts/last-continuation-prompt.md"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/logs/git-status-before.txt"),
+        ensured
+            .handle
+            .workspace_path()
+            .join(".opensymphony/logs/git-status-after.txt"),
+        ensured.handle.workspace_path().join("AGENTS.md"),
+        ensured.handle.workspace_path().join("WORKFLOW.md"),
+        ensured.handle.workspace_path().join(CHECKLIST_PATH),
+    ];
+    for artifact in &required_artifacts {
+        if !artifact.exists() {
+            return Err(format!(
+                "expected live-suite artifact is missing: {}",
+                artifact.display()
+            ));
+        }
+    }
+
+    Ok(json!({
+        "status": "passed",
+        "scenario": "lifecycle",
+        "output_root": artifacts.output_root.display().to_string(),
+        "server": {
+            "mode": server.mode(),
+            "base_url": server.base_url(),
+        },
+        "workspace_path": ensured.handle.workspace_path().display().to_string(),
+        "workflow_path": workflow_path.display().to_string(),
+        "conversation_id": second_conversation_id,
+        "first_run": {
+            "prompt_kind": first_result.prompt_kind.as_str(),
+            "run_status": format!("{:?}", first_result.run_status),
+            "assistant_reply": FIRST_REPLY_TEXT,
+            "conversation_manifest": summarize_conversation_manifest(&first_conversation),
+            "session_context": summarize_session_context(&first_context),
+        },
+        "second_run": {
+            "prompt_kind": second_result.prompt_kind.as_str(),
+            "run_status": format!("{:?}", second_result.run_status),
+            "assistant_reply": SECOND_REPLY_TEXT,
+            "conversation_manifest": summarize_conversation_manifest(&second_conversation),
+            "session_context": summarize_session_context(&second_context),
+        },
+        "message_texts": message_texts,
+        "artifacts": required_artifacts
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>(),
+    }))
+}
+
+async fn run_reconnect_scenario(
+    artifacts: &ArtifactLayout,
+    server: &LiveServer,
+) -> Result<Value, String> {
+    let model = env::var(LIVE_MODEL_ENV)
+        .map_err(|_| format!("missing required environment variable {LIVE_MODEL_ENV}"))?;
+    let proxy =
+        FaultInjectingProxy::start(server.base_url(), artifacts.scenario_root.join("proxy.log"))
+            .await?;
+
+    let working_dir = artifacts.scenario_root.join("workspace");
+    let persistence_dir = working_dir.join(".opensymphony/openhands");
+    fs::create_dir_all(&persistence_dir)
+        .map_err(|error| format!("failed to create reconnect workspace: {error}"))?;
+
+    let client = OpenHandsClient::new(TransportConfig::new(proxy.base_url()));
+    let request = ConversationCreateRequest::doctor_probe(
+        working_dir.display().to_string(),
+        persistence_dir.display().to_string(),
+        Some(model),
+        None,
+    );
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .map_err(|error| format!("failed to create reconnect conversation: {error}"))?;
+    let mut stream = client
+        .attach_runtime_stream(
+            conversation.conversation_id,
+            RuntimeStreamConfig {
+                readiness_timeout: Duration::from_secs(15),
+                reconnect_initial_backoff: Duration::from_millis(100),
+                reconnect_max_backoff: Duration::from_millis(400),
+                max_reconnect_attempts: 5,
+            },
+        )
+        .await
+        .map_err(|error| format!("failed to attach reconnect runtime stream: {error}"))?;
+
+    client
+        .send_message(
+            conversation.conversation_id,
+            &SendMessageRequest::user_text(
+                "This is the OpenSymphony live reconnect probe. Reply with the exact text `OpenSymphony reconnect probe OK` and then finish.",
+            ),
+        )
+        .await
+        .map_err(|error| format!("failed to send reconnect probe message: {error}"))?;
+    client
+        .run_conversation(conversation.conversation_id)
+        .await
+        .map_err(|error| format!("failed to trigger reconnect probe run: {error}"))?;
+
+    let deadline = Instant::now() + Duration::from_secs(240);
+    let mut observed_events = Vec::new();
+    while stream.state_mirror().terminal_status().is_none() {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Err("timed out waiting for reconnect probe to finish".to_string());
+        };
+        let event = timeout(remaining, stream.next_event())
+            .await
+            .map_err(|_| "timed out waiting for the next reconnect event".to_string())?
+            .map_err(|error| format!("reconnect probe stream failed: {error}"))?;
+        match event {
+            Some(event) => observed_events.push(json!({
+                "id": event.id,
+                "kind": event.kind,
+                "timestamp": event.timestamp.to_rfc3339(),
+            })),
+            None if stream.state_mirror().terminal_status().is_some() => break,
+            None => {
+                return Err(
+                    "runtime stream ended before a terminal status was observed".to_string()
+                );
+            }
+        }
+    }
+
+    let all_events = client
+        .search_all_events(conversation.conversation_id)
+        .await
+        .map_err(|error| format!("failed to search reconnect events: {error}"))?;
+    let message_texts = latest_reply_texts(all_events.items());
+    let assistant_reply_found = message_texts
+        .iter()
+        .any(|text| text.contains("OpenSymphony reconnect probe OK"));
+    if !assistant_reply_found {
+        return Err(format!(
+            "reconnect probe did not find the expected assistant reply in message events: {message_texts:?}"
+        ));
+    }
+
+    let proxy_summary = proxy.summary().await;
+    if proxy_summary.websocket_connections < 2 || proxy_summary.dropped_connections != 1 {
+        return Err(format!(
+            "expected one injected reconnect with at least two websocket connections, got {proxy_summary:?}"
+        ));
+    }
+
+    Ok(json!({
+        "status": "passed",
+        "scenario": "reconnect",
+        "output_root": artifacts.output_root.display().to_string(),
+        "server": {
+            "mode": server.mode(),
+            "base_url": server.base_url(),
+        },
+        "proxy": {
+            "base_url": proxy.base_url(),
+            "websocket_connections": proxy_summary.websocket_connections,
+            "dropped_connections": proxy_summary.dropped_connections,
+            "log_path": proxy.log_path.display().to_string(),
+            "log": proxy_summary.log,
+        },
+        "conversation_id": conversation.conversation_id.to_string(),
+        "terminal_status": format!("{:?}", stream.state_mirror().terminal_status()),
+        "execution_status": stream.state_mirror().execution_status(),
+        "assistant_reply_found": assistant_reply_found,
+        "observed_events": observed_events,
+        "message_texts": message_texts,
+        "artifacts": [
+            working_dir.display().to_string(),
+            persistence_dir.display().to_string(),
+            proxy.log_path.display().to_string(),
+        ],
+    }))
+}
+
+fn seed_live_target_repo(
+    target_repo: &Path,
+    workspace_root: &Path,
+    base_url: &str,
+) -> Result<PathBuf, String> {
+    if target_repo.exists() {
+        fs::remove_dir_all(target_repo)
+            .map_err(|error| format!("failed to remove stale target repo: {error}"))?;
+    }
+    fs::create_dir_all(target_repo.join("notes"))
+        .map_err(|error| format!("failed to create target repo notes directory: {error}"))?;
+    fs::create_dir_all(workspace_root)
+        .map_err(|error| format!("failed to create workspace root: {error}"))?;
+
+    let workflow_path = target_repo.join("WORKFLOW.md");
+    fs::write(
+        target_repo.join("README.md"),
+        "# Live Suite Target Repo\n\nThis fixture is generated by the live local suite.\n",
+    )
+    .map_err(|error| format!("failed to write target repo README: {error}"))?;
+    fs::write(
+        target_repo.join("AGENTS.md"),
+        "# Live Suite Target Repo\n\n- Follow `WORKFLOW.md` first.\n- Keep edits limited to the repository checkout inside the issue workspace.\n- Leave `.opensymphony/` artifacts available for debugging.\n",
+    )
+    .map_err(|error| format!("failed to write target repo AGENTS: {error}"))?;
+    fs::write(target_repo.join(".gitignore"), ".opensymphony/\n")
+        .map_err(|error| format!("failed to write target repo .gitignore: {error}"))?;
+    fs::write(
+        target_repo.join(CHECKLIST_PATH),
+        "# Live Suite Checklist\n\n- First worker lifetime expects the assistant reply `run 1: workspace-created`\n- Second worker lifetime expects the assistant reply `run 2: conversation-reused`\n",
+    )
+    .map_err(|error| format!("failed to write live-suite checklist: {error}"))?;
+    fs::write(
+        &workflow_path,
+        workflow_source(target_repo, workspace_root, base_url),
+    )
+    .map_err(|error| format!("failed to write live-suite workflow: {error}"))?;
+
+    run_git(target_repo, ["init", "--quiet"])?;
+    run_git(
+        target_repo,
+        [
+            "config",
+            "user.email",
+            "opensymphony-live-suite@example.invalid",
+        ],
+    )?;
+    run_git(
+        target_repo,
+        ["config", "user.name", "OpenSymphony Live Suite"],
+    )?;
+    run_git(target_repo, ["add", "."])?;
+    run_git(
+        target_repo,
+        ["commit", "--quiet", "-m", "Seed live suite target repo"],
+    )?;
+
+    Ok(workflow_path)
+}
+
+fn workflow_source(target_repo: &Path, workspace_root: &Path, base_url: &str) -> String {
+    let clone_source = shell_quote(target_repo.display().to_string());
+    format!(
+        r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - In Progress
+  terminal_states:
+    - Done
+workspace:
+  root: {}
+hooks:
+  after_create: |
+    git clone --quiet --no-local {} .
+  before_run: |
+    git status --short > .opensymphony/logs/git-status-before.txt
+  after_run: |
+    git status --short > .opensymphony/logs/git-status-after.txt
+openhands:
+  transport:
+    base_url: {}
+  conversation:
+    max_iterations: 6
+    agent:
+      llm:
+        model: ${{OPENSYMPHONY_OPENHANDS_MODEL}}
+---
+# Live Suite Workflow
+
+Operate only inside this repository checkout.
+Do not use external tools or modify repository files.
+This live suite expects two worker lifetimes on the same conversation.
+If the conversation does not already contain the exact assistant reply `{}`, respond with exactly `{}` and then finish.
+If the conversation already contains `{}` but does not yet contain `{}`, respond with exactly `{}` and then finish.
+Do not add any extra words before or after the required reply.
+
+Issue: {{{{ issue.identifier }}}}
+Title: {{{{ issue.title }}}}
+Description:
+{{{{ issue.description }}}}
+"#,
+        workspace_root.display(),
+        clone_source,
+        base_url,
+        FIRST_REPLY_TEXT,
+        FIRST_REPLY_TEXT,
+        FIRST_REPLY_TEXT,
+        SECOND_REPLY_TEXT,
+        SECOND_REPLY_TEXT,
+    )
+}
+
+fn resolve_workflow(path: &Path, model: &str) -> Result<ResolvedWorkflow, String> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read workflow {}: {error}", path.display()))?;
+    let workflow = WorkflowDefinition::parse(&source)
+        .map_err(|error| format!("failed to parse workflow {}: {error}", path.display()))?;
+    workflow
+        .resolve(
+            path.parent()
+                .ok_or_else(|| format!("workflow has no parent directory: {}", path.display()))?,
+            &workflow_env(model),
+        )
+        .map_err(|error| format!("failed to resolve workflow {}: {error}", path.display()))
+}
+
+fn workflow_env(model: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("LINEAR_API_KEY".to_string(), "linear-token".to_string()),
+        (LIVE_MODEL_ENV.to_string(), model.to_string()),
+    ])
+}
+
+fn workspace_manager(workflow: &ResolvedWorkflow) -> Result<WorkspaceManager, String> {
+    WorkspaceManager::new(WorkspaceManagerConfig {
+        root: workflow.config.workspace.root.clone(),
+        hooks: HookConfig {
+            after_create: workflow
+                .config
+                .hooks
+                .after_create
+                .clone()
+                .map(HookDefinition::shell),
+            before_run: workflow
+                .config
+                .hooks
+                .before_run
+                .clone()
+                .map(HookDefinition::shell),
+            after_run: workflow
+                .config
+                .hooks
+                .after_run
+                .clone()
+                .map(HookDefinition::shell),
+            before_remove: workflow
+                .config
+                .hooks
+                .before_remove
+                .clone()
+                .map(HookDefinition::shell),
+            timeout: Duration::from_millis(workflow.config.hooks.timeout_ms),
+        },
+        cleanup: CleanupConfig::default(),
+    })
+    .map_err(|error| format!("failed to build workspace manager: {error}"))
+}
+
+fn sample_issue() -> NormalizedIssue {
+    NormalizedIssue {
+        id: IssueId::new("issue-live-suite").expect("issue ID should be valid"),
+        identifier: IssueIdentifier::new("COE-LIVE-273").expect("issue identifier should be valid"),
+        title: "Complete the next live-suite checklist item".to_string(),
+        description: Some(
+            "Open `notes/live-suite-checklist.md`, complete exactly one unchecked item, update the checklist, and stop.".to_string(),
+        ),
+        priority: Some(1),
+        state: IssueState {
+            id: None,
+            name: "In Progress".to_string(),
+            category: IssueStateCategory::Active,
+        },
+        branch_name: None,
+        url: None,
+        labels: vec!["live-suite".to_string()],
+        parent_id: None,
+        blocked_by: Vec::new(),
+        sub_issues: Vec::new(),
+        created_at: Some(TimestampMs::new(1)),
+        updated_at: Some(TimestampMs::new(2)),
+    }
+}
+
+fn issue_descriptor(issue: &NormalizedIssue) -> IssueDescriptor {
+    IssueDescriptor {
+        issue_id: issue.id.to_string(),
+        identifier: issue.identifier.to_string(),
+        title: issue.title.clone(),
+        current_state: issue.state.name.clone(),
+        last_seen_tracker_refresh_at: None,
+    }
+}
+
+fn runner_config(workflow: &ResolvedWorkflow) -> IssueSessionRunnerConfig {
+    let mut config = IssueSessionRunnerConfig::from_workflow(workflow);
+    config.runtime_stream.readiness_timeout = Duration::from_secs(20);
+    config.runtime_stream.reconnect_initial_backoff = Duration::from_millis(150);
+    config.runtime_stream.reconnect_max_backoff = Duration::from_millis(600);
+    config.runtime_stream.max_reconnect_attempts = 5;
+    config.terminal_wait_timeout = Duration::from_secs(90);
+    config.finished_drain_timeout = Duration::from_millis(500);
+    config
+}
+
+fn run_attempt(
+    issue: &NormalizedIssue,
+    workspace_path: &Path,
+    worker_id: &str,
+    attempt: Option<RetryAttempt>,
+    max_turns: u32,
+) -> RunAttempt {
+    RunAttempt::new(
+        WorkerId::new(worker_id).expect("worker ID should be valid"),
+        issue.id.clone(),
+        issue.identifier.clone(),
+        workspace_path.to_path_buf(),
+        TimestampMs::new(10),
+        attempt,
+        max_turns,
+    )
+}
+
+async fn read_conversation_manifest(
+    manager: &WorkspaceManager,
+    handle: &opensymphony_workspace::WorkspaceHandle,
+) -> Result<IssueConversationManifest, String> {
+    let raw = manager
+        .read_text_artifact(handle, &handle.conversation_manifest_path())
+        .await
+        .map_err(|error| format!("failed to read conversation manifest: {error}"))?
+        .ok_or_else(|| "conversation manifest should exist".to_string())?;
+    serde_json::from_str(&raw)
+        .map_err(|error| format!("failed to decode conversation manifest: {error}"))
+}
+
+async fn read_session_context(
+    manager: &WorkspaceManager,
+    handle: &opensymphony_workspace::WorkspaceHandle,
+) -> Result<IssueSessionContext, String> {
+    let raw = manager
+        .read_text_artifact(handle, &handle.generated_dir().join("session-context.json"))
+        .await
+        .map_err(|error| format!("failed to read session context: {error}"))?
+        .ok_or_else(|| "session context should exist".to_string())?;
+    serde_json::from_str(&raw).map_err(|error| format!("failed to decode session context: {error}"))
+}
+
+fn summarize_conversation_manifest(manifest: &IssueConversationManifest) -> Value {
+    json!({
+        "conversation_id": manifest.conversation_id.to_string(),
+        "fresh_conversation": manifest.fresh_conversation,
+        "workflow_prompt_seeded": manifest.workflow_prompt_seeded,
+        "last_prompt_kind": manifest.last_prompt_kind.map(|kind| kind.as_str()),
+        "last_execution_status": manifest.last_execution_status,
+        "last_event_id": manifest.last_event_id,
+        "last_event_kind": manifest.last_event_kind,
+    })
+}
+
+fn summarize_session_context(context: &IssueSessionContext) -> Value {
+    json!({
+        "run_id": context.run_id,
+        "prompt_kind": context.prompt_kind.as_str(),
+        "conversation_id": context.conversation_id.to_string(),
+        "fresh_conversation": context.fresh_conversation,
+        "workflow_prompt_seeded": context.workflow_prompt_seeded,
+        "last_execution_status": context.last_execution_status,
+        "last_event_id": context.last_event_id,
+        "last_event_kind": context.last_event_kind,
+    })
+}
+
+fn latest_reply_texts(events: &[EventEnvelope]) -> Vec<String> {
+    events.iter().filter_map(extract_reply_text).collect()
+}
+
+fn extract_reply_text(event: &EventEnvelope) -> Option<String> {
+    match event.kind.as_str() {
+        "MessageEvent" => {
+            let content = event
+                .payload
+                .get("llm_message")
+                .and_then(|message| message.get("content"))
+                .or_else(|| event.payload.get("content"))?
+                .as_array()?;
+            let entry = content.first()?;
+            entry.get("text")?.as_str().map(ToOwned::to_owned)
+        }
+        "ActionEvent" => event
+            .payload
+            .get("action")
+            .and_then(|action| action.get("message"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        "ObservationEvent" => {
+            let content = event
+                .payload
+                .get("observation")
+                .and_then(|observation| observation.get("content"))?
+                .as_array()?;
+            let entry = content.first()?;
+            entry.get("text")?.as_str().map(ToOwned::to_owned)
+        }
+        _ => None,
+    }
+}
+
+fn write_json(path: &Path, value: &Value) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("artifact JSON parent directory should exist");
+    }
+    let rendered = serde_json::to_string_pretty(value).expect("artifact JSON should render");
+    fs::write(path, format!("{rendered}\n")).expect("artifact JSON should write");
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir should have workspace parent")
+        .parent()
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind free port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<(), String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| format!("failed to run git in {}: {error}", cwd.display()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "git {:?} failed in {} with status {}: stdout={} stderr={}",
+        args,
+        cwd.display(),
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    ))
+}
+
+fn shell_quote(value: String) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[derive(Debug, Default)]
+struct ProxyInner {
+    websocket_connections: usize,
+    dropped_connections: usize,
+    drop_injected: bool,
+    log: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ProxyState {
+    upstream_base_url: String,
+    client: reqwest::Client,
+    inner: Arc<Mutex<ProxyInner>>,
+}
+
+#[derive(Debug)]
+struct ProxySummary {
+    websocket_connections: usize,
+    dropped_connections: usize,
+    log: Vec<String>,
+}
+
+struct FaultInjectingProxy {
+    base_url: String,
+    inner: Arc<Mutex<ProxyInner>>,
+    task: JoinHandle<()>,
+    log_path: PathBuf,
+}
+
+impl FaultInjectingProxy {
+    async fn start(upstream_base_url: &str, log_path: PathBuf) -> Result<Self, String> {
+        let listener = TokioTcpListener::bind(("127.0.0.1", free_port()))
+            .await
+            .map_err(|error| format!("failed to bind fault-injecting proxy: {error}"))?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("failed to read fault-injecting proxy address: {error}"))?;
+        let inner = Arc::new(Mutex::new(ProxyInner::default()));
+        let state = ProxyState {
+            upstream_base_url: upstream_base_url.to_string(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .map_err(|error| format!("failed to build proxy HTTP client: {error}"))?,
+            inner: inner.clone(),
+        };
+
+        let app = Router::new()
+            .route("/api/conversations", post(proxy_post_conversations))
+            .route(
+                "/api/conversations/{conversation_id}",
+                get(proxy_get_conversation),
+            )
+            .route(
+                "/api/conversations/{conversation_id}/events",
+                post(proxy_post_events),
+            )
+            .route(
+                "/api/conversations/{conversation_id}/run",
+                post(proxy_post_run),
+            )
+            .route(
+                "/api/conversations/{conversation_id}/events/search",
+                get(proxy_get_event_search),
+            )
+            .route(
+                "/sockets/events/{conversation_id}",
+                get(proxy_events_socket),
+            )
+            .with_state(state);
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("fault-injecting proxy should serve until aborted");
+        });
+
+        Ok(Self {
+            base_url: format!("http://{address}"),
+            inner,
+            task,
+            log_path,
+        })
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    async fn summary(&self) -> ProxySummary {
+        let inner = self.inner.lock().await;
+        write_proxy_log(&self.log_path, &inner.log);
+        ProxySummary {
+            websocket_connections: inner.websocket_connections,
+            dropped_connections: inner.dropped_connections,
+            log: inner.log.clone(),
+        }
+    }
+}
+
+impl Drop for FaultInjectingProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn proxy_post_conversations(
+    State(state): State<ProxyState>,
+    body: Bytes,
+) -> impl IntoResponse {
+    forward_http(&state, Method::POST, "/api/conversations", None, body).await
+}
+
+async fn proxy_get_conversation(
+    State(state): State<ProxyState>,
+    AxumPath(conversation_id): AxumPath<String>,
+) -> impl IntoResponse {
+    forward_http(
+        &state,
+        Method::GET,
+        &format!("/api/conversations/{conversation_id}"),
+        None,
+        Bytes::new(),
+    )
+    .await
+}
+
+async fn proxy_post_events(
+    State(state): State<ProxyState>,
+    AxumPath(conversation_id): AxumPath<String>,
+    body: Bytes,
+) -> impl IntoResponse {
+    forward_http(
+        &state,
+        Method::POST,
+        &format!("/api/conversations/{conversation_id}/events"),
+        None,
+        body,
+    )
+    .await
+}
+
+async fn proxy_post_run(
+    State(state): State<ProxyState>,
+    AxumPath(conversation_id): AxumPath<String>,
+    body: Bytes,
+) -> impl IntoResponse {
+    forward_http(
+        &state,
+        Method::POST,
+        &format!("/api/conversations/{conversation_id}/run"),
+        None,
+        body,
+    )
+    .await
+}
+
+async fn proxy_get_event_search(
+    State(state): State<ProxyState>,
+    AxumPath(conversation_id): AxumPath<String>,
+    Query(query): Query<BTreeMap<String, String>>,
+) -> impl IntoResponse {
+    forward_http(
+        &state,
+        Method::GET,
+        &format!("/api/conversations/{conversation_id}/events/search"),
+        Some(&query),
+        Bytes::new(),
+    )
+    .await
+}
+
+async fn forward_http(
+    state: &ProxyState,
+    method: Method,
+    path: &str,
+    query: Option<&BTreeMap<String, String>>,
+    body: Bytes,
+) -> Response<Body> {
+    let mut url = format!("{}{}", state.upstream_base_url, path);
+    if let Some(query) = query.filter(|query| !query.is_empty()) {
+        let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+        for (key, value) in query {
+            serializer.append_pair(key, value);
+        }
+        url.push('?');
+        url.push_str(&serializer.finish());
+    }
+
+    let mut request = state.client.request(method.clone(), &url);
+    if !body.is_empty() {
+        request = request
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body.to_vec());
+    }
+
+    let upstream = match request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(Body::from(error.to_string()))
+                .expect("proxy error response should build");
+        }
+    };
+
+    let status = upstream.status();
+    let headers = upstream.headers().clone();
+    let body = match upstream.bytes().await {
+        Ok(body) => body,
+        Err(error) => {
+            return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(Body::from(error.to_string()))
+                .expect("proxy body error response should build");
+        }
+    };
+
+    let mut response = Response::builder().status(status);
+    for (name, value) in &headers {
+        response = response.header(name, value);
+    }
+    response
+        .body(Body::from(body))
+        .expect("proxied HTTP response should build")
+}
+
+async fn proxy_events_socket(
+    ws: WebSocketUpgrade,
+    State(state): State<ProxyState>,
+    AxumPath(conversation_id): AxumPath<String>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| proxy_websocket(socket, state, conversation_id))
+}
+
+async fn proxy_websocket(socket: WebSocket, state: ProxyState, conversation_id: String) {
+    let connection_number = {
+        let mut inner = state.inner.lock().await;
+        inner.websocket_connections += 1;
+        let connection_number = inner.websocket_connections;
+        inner
+            .log
+            .push(format!("connection {connection_number} accepted"));
+        connection_number
+    };
+
+    let upstream_url = websocket_url(&state.upstream_base_url, &conversation_id);
+    let (upstream, _) = match connect_async(&upstream_url).await {
+        Ok(upstream) => upstream,
+        Err(error) => {
+            let mut inner = state.inner.lock().await;
+            inner.log.push(format!(
+                "connection {connection_number} failed to connect upstream: {error}"
+            ));
+            return;
+        }
+    };
+
+    let inject_drop = {
+        let mut inner = state.inner.lock().await;
+        let inject = !inner.drop_injected;
+        if inject {
+            inner.drop_injected = true;
+            inner.log.push(format!(
+                "connection {connection_number} will inject a websocket drop after readiness"
+            ));
+        } else {
+            inner.log.push(format!(
+                "connection {connection_number} will pass through normally"
+            ));
+        }
+        inject
+    };
+
+    let (mut client_sender, mut client_receiver) = socket.split();
+    let (mut upstream_sender, mut upstream_receiver) = upstream.split();
+
+    while let Some(result) = tokio::select! {
+        client_message = client_receiver.next() => client_message.map(EitherMessage::Client),
+        upstream_message = upstream_receiver.next() => upstream_message.map(EitherMessage::Upstream),
+    } {
+        match result {
+            EitherMessage::Client(Ok(message)) => {
+                let Some(message) = axum_to_tungstenite(message) else {
+                    continue;
+                };
+                if upstream_sender.send(message).await.is_err() {
+                    break;
+                }
+            }
+            EitherMessage::Client(Err(error)) => {
+                let mut inner = state.inner.lock().await;
+                inner.log.push(format!(
+                    "connection {connection_number} client read error: {error}"
+                ));
+                break;
+            }
+            EitherMessage::Upstream(Ok(message)) => {
+                let should_drop = inject_drop && should_drop_after_ready(&message);
+                let Some(axum_message) = tungstenite_to_axum(message) else {
+                    continue;
+                };
+                if client_sender.send(axum_message).await.is_err() {
+                    break;
+                }
+                if should_drop {
+                    let mut inner = state.inner.lock().await;
+                    inner.dropped_connections += 1;
+                    inner.log.push(format!(
+                        "connection {connection_number} dropped after forwarding the readiness frame"
+                    ));
+                    let _ = client_sender.close().await;
+                    let _ = upstream_sender.close().await;
+                    break;
+                }
+            }
+            EitherMessage::Upstream(Err(error)) => {
+                let mut inner = state.inner.lock().await;
+                inner.log.push(format!(
+                    "connection {connection_number} upstream read error: {error}"
+                ));
+                break;
+            }
+        }
+    }
+}
+
+enum EitherMessage {
+    Client(Result<AxumMessage, axum::Error>),
+    Upstream(Result<TungsteniteMessage, tokio_tungstenite::tungstenite::Error>),
+}
+
+fn websocket_url(base_url: &str, conversation_id: &str) -> String {
+    let url = base_url
+        .replace("http://", "ws://")
+        .replace("https://", "wss://");
+    format!("{url}/sockets/events/{conversation_id}")
+}
+
+fn should_drop_after_ready(message: &TungsteniteMessage) -> bool {
+    match message {
+        TungsteniteMessage::Text(text) => text.contains("ConversationStateUpdateEvent"),
+        _ => false,
+    }
+}
+
+fn axum_to_tungstenite(message: AxumMessage) -> Option<TungsteniteMessage> {
+    match message {
+        AxumMessage::Text(text) => Some(TungsteniteMessage::Text(text.to_string().into())),
+        AxumMessage::Binary(data) => Some(TungsteniteMessage::Binary(data.to_vec())),
+        AxumMessage::Ping(data) => Some(TungsteniteMessage::Ping(data.to_vec())),
+        AxumMessage::Pong(data) => Some(TungsteniteMessage::Pong(data.to_vec())),
+        AxumMessage::Close(frame) => Some(TungsteniteMessage::Close(frame.map(|frame| {
+            tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                code: frame.code.into(),
+                reason: frame.reason.to_string().into(),
+            }
+        }))),
+    }
+}
+
+fn tungstenite_to_axum(message: TungsteniteMessage) -> Option<AxumMessage> {
+    match message {
+        TungsteniteMessage::Text(text) => Some(AxumMessage::Text(text.to_string().into())),
+        TungsteniteMessage::Binary(data) => Some(AxumMessage::Binary(data.into())),
+        TungsteniteMessage::Ping(data) => Some(AxumMessage::Ping(data.into())),
+        TungsteniteMessage::Pong(data) => Some(AxumMessage::Pong(data.into())),
+        TungsteniteMessage::Close(frame) => Some(AxumMessage::Close(frame.map(|frame| {
+            axum::extract::ws::CloseFrame {
+                code: frame.code.into(),
+                reason: frame.reason.to_string().into(),
+            }
+        }))),
+        TungsteniteMessage::Frame(_) => None,
+    }
+}
+
+fn write_proxy_log(path: &Path, lines: &[String]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("proxy log parent directory should exist");
+    }
+    let rendered = if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    };
+    fs::write(path, rendered).expect("proxy log should write");
+}

--- a/crates/opensymphony-openhands/tests/live_local_suite.rs
+++ b/crates/opensymphony-openhands/tests/live_local_suite.rs
@@ -143,7 +143,7 @@ enum LiveServer {
     },
     Managed {
         base_url: String,
-        supervisor: LocalServerSupervisor,
+        supervisor: Box<LocalServerSupervisor>,
     },
 }
 
@@ -165,7 +165,7 @@ impl LiveServer {
 
         Self::Managed {
             base_url: status.base_url,
-            supervisor,
+            supervisor: Box::new(supervisor),
         }
     }
 
@@ -1280,7 +1280,7 @@ fn should_drop_after_ready(message: &TungsteniteMessage) -> bool {
 
 fn axum_to_tungstenite(message: AxumMessage) -> Option<TungsteniteMessage> {
     match message {
-        AxumMessage::Text(text) => Some(TungsteniteMessage::Text(text.to_string().into())),
+        AxumMessage::Text(text) => Some(TungsteniteMessage::Text(text.to_string())),
         AxumMessage::Binary(data) => Some(TungsteniteMessage::Binary(data.to_vec())),
         AxumMessage::Ping(data) => Some(TungsteniteMessage::Ping(data.to_vec())),
         AxumMessage::Pong(data) => Some(TungsteniteMessage::Pong(data.to_vec())),

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -241,33 +241,95 @@ It should be scriptable enough to produce:
 
 ## 5. Live local acceptance suite
 
-The live local suite should prove the MVP can actually run on a developer machine.
+The live local suite proves the MVP runtime path can execute on a prepared
+developer machine against the pinned local OpenHands server.
 
-Suggested scenarios:
+Implemented entrypoints:
 
-### Scenario A: workflow parse and local run smoke
+- `OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_local_suite -- --ignored --nocapture --test-threads=1`
+- `OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh`
 
-- launch daemon
-- start local supervised OpenHands server
-- create temp target repo with example `WORKFLOW.md`
-- inject one fake or test Linear issue
-- verify workspace creation, conversation creation, run, and snapshot publication
+Required machine inputs:
+
+- `uv`, `git`, `curl`, and the Rust toolchain
+- `OPENSYMPHONY_OPENHANDS_MODEL`
+- `OPENSYMPHONY_OPENHANDS_API_KEY` for the live `doctor` probe
+- the provider environment expected by the pinned OpenHands server for normal
+  issue-session runs; `scripts/live_e2e.sh` sets `OPENAI_API_KEY` from
+  `OPENSYMPHONY_OPENHANDS_API_KEY` only when `OPENAI_API_KEY` is otherwise unset
+
+The repository-owned script performs the full live flow:
+
+- runs `opensymphony doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands`
+- launches the pinned local OpenHands server on `OPENSYMPHONY_LIVE_SUITE_SERVER_PORT` (default `8010`)
+- runs the ignored `live_local_suite` integration tests serially
+- writes logs and scenario artifacts under `target/live-local/<timestamp>/` unless
+  `OPENSYMPHONY_LIVE_SUITE_OUTPUT_ROOT` overrides the root
+
+### Scenario A: checklist-driven issue lifecycle
+
+- generate a temp target repo with repo-owned `WORKFLOW.md`, `AGENTS.md`, `.gitignore`, and a two-step checklist
+- populate the issue workspace through the documented `after_create` clone hook
+- run one issue through the real `WorkspaceManager` plus `IssueSessionRunner` path
+- verify workspace creation, prompt capture, conversation creation, and a deterministic first-run assistant reply
+
+Expected artifacts:
+
+- `lifecycle/summary.json`
+- `lifecycle/workspaces/COE-LIVE-273/notes/live-suite-checklist.md`
+- `lifecycle/workspaces/COE-LIVE-273/.opensymphony/conversation.json`
+- `lifecycle/workspaces/COE-LIVE-273/.opensymphony/generated/session-context.json`
+
+Expected assertions:
+
+- the first run uses the full workflow prompt
+- the first run records the exact assistant reply `run 1: workspace-created`
+- `.opensymphony/` manifests and prompt captures exist for debugging
 
 ### Scenario B: conversation reuse
 
-- run the same issue twice
+- run the same issue a second time against the same workspace
 - verify the same `conversation_id` is reused
-- verify continuation guidance is used instead of the full first-turn prompt
-- verify a reused-but-unseeded conversation still receives the full workflow prompt
-- verify a reused conversation that is already `running` or `queued` is allowed to finish before the next prompt is sent
-- verify a missing conversation can be re-created with the same `conversation_id` and still stay on continuation guidance when persisted history exists
-- verify non-default `openhands.conversation.persistence_dir_relative` values land under the issue workspace and still allow reuse
-- verify workflow validation rejects non-default `openhands.conversation.reuse_policy` values until runtime support exists
+- verify continuation guidance is selected instead of a second full prompt
+- verify the second deterministic assistant reply appears only after the reused conversation resumes
+
+Expected artifacts:
+
+- `lifecycle/summary.json`
+- `lifecycle/workspaces/COE-LIVE-273/.opensymphony/prompts/last-continuation-prompt.md`
+- `lifecycle/workspaces/COE-LIVE-273/.opensymphony/logs/git-status-after.txt`
+
+The `git-status-after.txt` artifact comes from the workflow `after_run` hook, so the suite also
+proves that worker finalization is routing through the workspace manager's `finish_run` path.
+
+Expected assertions:
+
+- first and second runs report the same `conversation_id`
+- `last_prompt_kind` in `conversation.json` becomes `continuation`
+- the recorded assistant replies end with:
+
+```text
+run 1: workspace-created
+run 2: conversation-reused
+```
 
 ### Scenario C: WebSocket reconnect
 
-- interrupt the WebSocket connection
-- verify backoff, reattach, reconcile, and continued completion detection
+- place a local fault-injecting proxy in front of the pinned server
+- drop the first WebSocket connection immediately after the readiness barrier
+- verify the client reconnects, reconciles, and still observes terminal completion
+
+Expected artifacts:
+
+- `reconnect/summary.json`
+- `reconnect/proxy.log`
+
+Expected assertions:
+
+- the proxy records at least two websocket connections
+- exactly one injected drop is recorded
+- the terminal runtime status is still reached after reconnect
+- the final message history includes `OpenSymphony reconnect probe OK`
 
 ## 6. Operational commands
 
@@ -334,6 +396,7 @@ Current command set in this repository:
 - `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`
 - `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands`
 - `OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_pinned_server -- --nocapture`
+- `OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_local_suite -- --ignored --nocapture --test-threads=1`
 - `cargo run -p opensymphony-cli -- linear-mcp`
 - `./scripts/smoke_local.sh`
 - `OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh`

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -142,6 +142,8 @@ Use for:
 ## 6.3 `after_run`
 
 Runs after each worker lifetime regardless of outcome, best effort.
+Run finalization must flow through the workspace manager's `finish_run` path so the final
+`run.json` and any generated artifacts include `after_run` hook receipts.
 
 Use for:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,8 @@
 # Scripts
 
-This directory is reserved for repository-owned helper scripts such as local
-smoke checks, live end-to-end harnesses, and issue-graph generators.
+Repository-owned helper entrypoints live here.
 
-Bootstrap keeps the directory in place so later tasks can add scripts under a
-stable ownership boundary instead of the repository root.
+Current scripts:
+
+- `smoke_local.sh`: runs the static `opensymphony doctor` preflight against `examples/configs/local-dev.yaml`.
+- `live_e2e.sh`: runs the opt-in live local suite. It executes the live `doctor` preflight, launches the pinned local OpenHands server, runs the ignored `live_local_suite` integration tests, and writes logs plus scenario summaries under `target/live-local/<timestamp>/` unless `OPENSYMPHONY_LIVE_SUITE_OUTPUT_ROOT` overrides that root.

--- a/scripts/live_e2e.sh
+++ b/scripts/live_e2e.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. && pwd)"
 export OPENSYMPHONY_LIVE_OPENHANDS="${OPENSYMPHONY_LIVE_OPENHANDS:-0}"
 
 if [[ "${OPENSYMPHONY_LIVE_OPENHANDS}" != "1" ]]; then
@@ -8,4 +9,140 @@ if [[ "${OPENSYMPHONY_LIVE_OPENHANDS}" != "1" ]]; then
   exit 1
 fi
 
-cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands
+for required_var in OPENSYMPHONY_OPENHANDS_MODEL OPENSYMPHONY_OPENHANDS_API_KEY; do
+  if [[ -z "${!required_var:-}" ]]; then
+    echo "Missing required environment variable: ${required_var}" >&2
+    exit 1
+  fi
+done
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUTPUT_ROOT="${OPENSYMPHONY_LIVE_SUITE_OUTPUT_ROOT:-${ROOT_DIR}/target/live-local}"
+RUN_DIR="${OUTPUT_ROOT%/}/${RUN_ID}"
+LOG_DIR="${RUN_DIR}/logs"
+SERVER_PORT="${OPENSYMPHONY_LIVE_SUITE_SERVER_PORT:-8010}"
+SERVER_BASE_URL="http://127.0.0.1:${SERVER_PORT}"
+
+mkdir -p "${LOG_DIR}"
+export OPENSYMPHONY_LIVE_SUITE_OUTPUT_DIR="${RUN_DIR}"
+export OPENSYMPHONY_LIVE_SUITE_BASE_URL="${SERVER_BASE_URL}"
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  export OPENAI_API_KEY="${OPENSYMPHONY_OPENHANDS_API_KEY}"
+fi
+
+cleanup() {
+  if [[ -n "${DOCTOR_PID:-}" ]] && kill -0 "${DOCTOR_PID}" 2>/dev/null; then
+    kill "${DOCTOR_PID}" 2>/dev/null || true
+    wait "${DOCTOR_PID}" 2>/dev/null || true
+  fi
+
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+
+kill_doctor_server_residue() {
+  while read -r pid; do
+    if [[ -n "${pid}" ]]; then
+      kill "${pid}" 2>/dev/null || true
+      wait "${pid}" 2>/dev/null || true
+    fi
+  done < <(pgrep -f 'openhands.agent_server --host 127.0.0.1 --port 8000' || true)
+}
+
+run_doctor_preflight() {
+  local log_file="${LOG_DIR}/doctor.log"
+  : > "${log_file}"
+
+  cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands \
+    2>&1 | tee "${log_file}" &
+  DOCTOR_PID=$!
+
+  local stop_seen=0
+  local stop_deadline=0
+
+  while kill -0 "${DOCTOR_PID}" 2>/dev/null; do
+    if grep -q '\[PASS\] openhands-supervisor-stop:' "${log_file}"; then
+      if (( stop_seen == 0 )); then
+        stop_seen=1
+        stop_deadline=$((SECONDS + 15))
+      elif (( SECONDS >= stop_deadline )); then
+        echo "Doctor shutdown watchdog: forcing the pinned local server to exit after supervisor-stop." >&2
+        kill_doctor_server_residue
+        break
+      fi
+    fi
+
+    sleep 1
+  done
+
+  if kill -0 "${DOCTOR_PID}" 2>/dev/null; then
+    for _ in $(seq 1 20); do
+      if ! kill -0 "${DOCTOR_PID}" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+  fi
+
+  if kill -0 "${DOCTOR_PID}" 2>/dev/null; then
+    echo "Doctor command did not exit after the shutdown watchdog ran. See ${log_file}." >&2
+    kill "${DOCTOR_PID}" 2>/dev/null || true
+  fi
+
+  wait "${DOCTOR_PID}"
+  DOCTOR_PID=""
+}
+
+wait_for_server_ready() {
+  for _ in $(seq 1 120); do
+    if curl -fsS "${SERVER_BASE_URL}/openapi.json" >/dev/null; then
+      return 0
+    fi
+
+    if [[ -n "${SERVER_PID:-}" ]] && ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+      echo "Pinned OpenHands server exited before readiness. See ${LOG_DIR}/agent-server.stderr.log." >&2
+      return 1
+    fi
+
+    sleep 1
+  done
+
+  echo "Pinned OpenHands server did not become ready at ${SERVER_BASE_URL}." >&2
+  return 1
+}
+
+trap cleanup EXIT
+
+cd "${ROOT_DIR}"
+
+echo "Live local suite artifacts: ${RUN_DIR}"
+
+run_doctor_preflight
+
+OPENHANDS_SERVER_PORT="${SERVER_PORT}" tools/openhands-server/run-local.sh \
+  >"${LOG_DIR}/agent-server.stdout.log" \
+  2>"${LOG_DIR}/agent-server.stderr.log" &
+SERVER_PID=$!
+echo "${SERVER_PID}" > "${RUN_DIR}/agent-server.pid"
+
+wait_for_server_ready
+
+cargo test -p opensymphony-openhands --test live_local_suite -- --ignored --nocapture --test-threads=1 \
+  2>&1 | tee "${LOG_DIR}/live-suite.log"
+
+cat > "${RUN_DIR}/README.txt" <<EOF
+OpenSymphony live local suite artifacts
+
+doctor log: ${LOG_DIR}/doctor.log
+agent-server stdout: ${LOG_DIR}/agent-server.stdout.log
+agent-server stderr: ${LOG_DIR}/agent-server.stderr.log
+live suite log: ${LOG_DIR}/live-suite.log
+lifecycle summary: ${RUN_DIR}/lifecycle/summary.json
+reconnect summary: ${RUN_DIR}/reconnect/summary.json
+EOF
+
+echo "Live local suite completed successfully."
+echo "Artifact index: ${RUN_DIR}/README.txt"


### PR DESCRIPTION
## Summary

Add an opt-in live local suite that exercises the real OpenHands runtime path and captures artifacts for debugging failures.

## Changes

- add ignored live integration tests for issue lifecycle, conversation reuse, workspace artifacts, and websocket reconnect recovery against a pinned local server
- harden OpenHands runtime event decoding, terminal finalization, and reconnect handling based on failures exposed by the live suite
- replace `scripts/live_e2e.sh` with a full live-suite runner and document setup, execution, outputs, and artifact expectations

## Evidence

### Test output

```text
cargo fmt --all --check
cargo clippy -p opensymphony-openhands --all-targets --all-features -- -D warnings
cargo test -p opensymphony-openhands --lib
cargo test -p opensymphony-openhands --test issue_session_runner
cargo test -p opensymphony-openhands --test client_resilience
OPENSYMPHONY_LIVE_OPENHANDS=1 OPENSYMPHONY_OPENHANDS_MODEL=gpt-4.1-mini OPENSYMPHONY_OPENHANDS_API_KEY="$OPENAI_API_KEY" ./scripts/live_e2e.sh

opensymphony-openhands --lib: 13 passed; 0 failed
issue_session_runner: 6 passed; 0 failed
client_resilience: 21 passed; 0 failed
live_local_suite: 2 passed; 0 failed
artifact index: /Users/magos/code/symphony-workspaces/COE-273/target/live-local/20260323-123550/README.txt
```

### Verification

- lifecycle scenario completed two issue-session runs on the same conversation id `d552ac68-7048-47e1-9c39-638b9f650e67`, with `run 1: workspace-created` followed by `run 2: conversation-reused`
- lifecycle artifacts included `.opensymphony/issue.json`, `run.json`, `conversation.json`, prompt captures, generated session context, and git-status logs under `target/live-local/20260323-123550/lifecycle/workspaces/COE-LIVE-273/.opensymphony`
- reconnect scenario injected one websocket drop, observed two websocket connections, and still reached terminal `finished` with assistant reply `OpenSymphony reconnect probe OK`
- README and operations docs now describe prerequisites, invocation, expected outputs, artifact locations, and the current shutdown-watchdog limitation for the pinned local server

## Checklist

- [x] Tests pass for the changed scope (`cargo test -p opensymphony-openhands --lib`, `--test issue_session_runner`, `--test client_resilience`, and the live suite script)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean for the changed scope (`cargo clippy -p opensymphony-openhands --all-targets --all-features -- -D warnings`)
- [x] Documentation updated (if behavior changed)
- [x] AGENTS.md updated (not needed; repo knowledge unchanged)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: None

## Breaking changes

None.

## Related issues

- COE-273
- COE-256

## Additional notes

- Live artifacts from the final publish gate are in `target/live-local/20260323-123550`
- The live suite uses the pinned local OpenHands server on `127.0.0.1:8010` by default and keeps per-run logs/artifacts for failure debugging
