### PR TITLE
Package CLI doctor preflight and local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ Available today:
   - reconnects to the SSE stream after disconnect
   - renders focused issue/workspace detail plus recent event or metrics panes in inline mode
   - shows the active focus pane in the status line and pane headers for keyboard-driven navigation
-- a small `opensymphony-cli` demo path so the control plane and UI can be validated without coupling the TUI to orchestrator internals
+- a packaged `opensymphony` CLI so the control plane, preflight checks, and Linear MCP surface can be validated without coupling the TUI to orchestrator internals
 
 Local commands:
 
 - `cargo run -p opensymphony-cli -- daemon --bind 127.0.0.1:3000`
 - `cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:3000/`
+- `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`
+- `cargo run -p opensymphony-cli -- linear-mcp`
 
 ## Core design decisions
 
@@ -185,6 +187,8 @@ This repository now includes the local validation scaffolding for M5:
 Useful commands:
 
 ```bash
+./tools/openhands-server/install.sh
+cargo run -p opensymphony-cli -- --help
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
@@ -197,9 +201,25 @@ OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh
 
 Current note:
 
+- `./tools/openhands-server/install.sh` runs the pinned `uv sync --locked --extra agent-server` flow for the trusted-machine OpenHands toolchain
 - the example doctor YAML now only carries machine-local inputs such as the OpenHands tool directory and optional probe overrides; the target repo `WORKFLOW.md` provides the workspace root, OpenHands base URL, and prompt that the doctor probe validates
+- `opensymphony doctor` now checks for `cargo`, `curl`, `git`, and `uv` on `PATH`, validates the pinned tool directory packaging, prints the trusted-machine safety warning on every run, and warns when a local deployment points at a non-loopback OpenHands target
 - `scripts/live_e2e.sh` now performs the full opt-in live suite: doctor preflight, pinned local server launch, ignored `live_local_suite` integration tests, and artifact capture under `target/live-local/`
-- `linear-mcp` is implemented and exposes the documented Linear tool surface over stdio; `daemon` and `tui` remain scaffolds until their runtime and control-plane milestones land.
+- `linear-mcp` exposes the documented Linear tool surface over stdio, `daemon` serves the current control-plane demo stream for smoke coverage, and `tui` attaches to any compatible local control-plane URL
+
+## Local trusted-machine quick start
+
+1. Install the machine prerequisites: Rust stable, `uv`, `git`, and `curl`.
+2. Provision the pinned OpenHands environment with `./tools/openhands-server/install.sh`.
+3. Review the command surface with `cargo run -p opensymphony-cli -- --help`.
+4. Run the static preflight with `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`.
+5. Use `tools/openhands-server/run-local.sh` only after the static doctor run is green.
+
+Safety note:
+
+- the local MVP runs agent activity on the host with process-level isolation only
+- it is not a sandbox
+- `opensymphony doctor` repeats that warning in its output so the local posture stays explicit during setup
 
 ## Non-negotiable implementation rules
 

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -33,7 +33,10 @@ use url::Url;
 
 #[derive(Debug, Parser)]
 #[command(name = "opensymphony")]
-#[command(about = "OpenSymphony local MVP CLI")]
+#[command(about = "Operate the OpenSymphony local MVP on a trusted machine")]
+#[command(
+    long_about = "Operate the OpenSymphony local MVP on a trusted machine.\n\nUse this CLI to run local control-plane demos, preflight checks, and the Linear MCP bridge.\n\nSafety: local OpenSymphony runs agent activity on the host with process-level isolation only. It is not sandboxed."
+)]
 pub struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -41,32 +44,42 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    #[command(about = "Serve the local control-plane demo stream")]
     Daemon(DaemonArgs),
+    #[command(about = "Attach the FrankenTUI operator client to a control plane")]
     Tui(TuiArgs),
+    #[command(about = "Start the stdio Linear MCP server for agent-side writes")]
     LinearMcp(LinearMcpArgs),
+    #[command(about = "Run local preflight checks for trusted-machine deployment")]
     Doctor(DoctorArgs),
 }
 
 #[derive(Debug, Args)]
 struct DaemonArgs {
+    #[arg(help = "Socket address for the local control-plane HTTP and SSE server")]
     #[arg(long, default_value = "127.0.0.1:3000")]
     bind: SocketAddr,
+    #[arg(help = "Milliseconds between sample snapshot updates")]
     #[arg(long, default_value = "1200")]
     sample_interval_ms: NonZeroU64,
 }
 
 #[derive(Debug, Args)]
 struct TuiArgs {
+    #[arg(help = "Control-plane base URL")]
     #[arg(long, default_value = "http://127.0.0.1:3000/")]
     url: Url,
+    #[arg(help = "Exit after the specified number of milliseconds; useful for smoke tests")]
     #[arg(long)]
     exit_after_ms: Option<u64>,
 }
 
 #[derive(Debug, Args)]
 pub struct DoctorArgs {
+    #[arg(help = "Doctor config YAML path")]
     #[arg(long, default_value = "examples/configs/local-dev.yaml")]
     config: PathBuf,
+    #[arg(help = "Run the live OpenHands probe instead of static preflight only")]
     #[arg(long)]
     live_openhands: bool,
 }
@@ -366,6 +379,8 @@ pub async fn run_doctor_command(config_path: PathBuf, live_openhands: bool) -> E
 
             checks.push(check_workspace_root(&runtime.workflow.config.workspace.root).await);
             checks.push(check_tool_dir(&runtime.tool_dir).await);
+            checks.extend(check_required_commands());
+            checks.push(check_local_safety());
             checks.push(check_openhands_transport(&runtime.workflow));
             checks.push(check_linear(&config.linear, &runtime.workflow));
             (runtime, rendered_probe_prompt)
@@ -539,7 +554,15 @@ fn find_cargo_workspace_root(path: &Path) -> Option<PathBuf> {
     start
         .ancestors()
         .find(|candidate| candidate.join("Cargo.toml").is_file())
-        .map(|candidate| candidate.to_path_buf())
+        .map(normalize_workspace_root)
+}
+
+fn normalize_workspace_root(path: &Path) -> PathBuf {
+    if path.as_os_str().is_empty() {
+        env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
 }
 
 fn effective_openhands_probe_base_url(
@@ -708,24 +731,104 @@ async fn check_workspace_root(workspace_root: &Path) -> CheckResult {
 async fn check_tool_dir(tool_dir: &Path) -> CheckResult {
     let version = tool_dir.join("version.txt");
     let pyproject = tool_dir.join("pyproject.toml");
+    let installer = tool_dir.join("install.sh");
     let runner = tool_dir.join("run-local.sh");
 
-    if version.exists() && pyproject.exists() && runner.exists() {
+    if version.exists() && pyproject.exists() && installer.exists() && runner.exists() {
         CheckResult::pass(
             "openhands-tooling",
-            format!("pin files found in {}", tool_dir.display()),
+            format!(
+                "pin files and helper scripts found in {}",
+                tool_dir.display()
+            ),
         )
     } else {
         CheckResult::fail(
             "openhands-tooling",
             format!(
-                "expected {}, {}, and {}",
+                "expected {}, {}, {}, and {}",
                 version.display(),
                 pyproject.display(),
+                installer.display(),
                 runner.display()
             ),
         )
     }
+}
+
+fn check_required_commands() -> Vec<CheckResult> {
+    [
+        (
+            "cargo",
+            "Rust workspace builds, tests, and CLI smoke checks",
+        ),
+        ("curl", "local control-plane and agent-server smoke probes"),
+        ("git", "workspace hooks and local repository operations"),
+        (
+            "uv",
+            "the pinned OpenHands environment under tools/openhands-server",
+        ),
+    ]
+    .into_iter()
+    .map(|(name, purpose)| match find_executable(name) {
+        Some(path) => CheckResult::pass(
+            command_check_name(name),
+            format!("found {} at {} ({purpose})", name, path.display()),
+        ),
+        None => CheckResult::fail(
+            command_check_name(name),
+            format!("{} is not on PATH ({purpose})", name),
+        ),
+    })
+    .collect()
+}
+
+fn command_check_name(name: &'static str) -> &'static str {
+    match name {
+        "cargo" => "prereq-cargo",
+        "curl" => "prereq-curl",
+        "git" => "prereq-git",
+        "uv" => "prereq-uv",
+        _ => "prereq",
+    }
+}
+
+fn find_executable(name: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    let suffixes = executable_suffixes();
+
+    for directory in env::split_paths(&path) {
+        for suffix in &suffixes {
+            let candidate = directory.join(format!("{name}{suffix}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+fn executable_suffixes() -> Vec<String> {
+    if cfg!(windows) {
+        env::var_os("PATHEXT")
+            .map(|value| {
+                env::split_paths(&value)
+                    .map(|entry| entry.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|suffixes| !suffixes.is_empty())
+            .unwrap_or_else(|| vec![".EXE".to_string(), ".BAT".to_string(), ".CMD".to_string()])
+    } else {
+        vec![String::new()]
+    }
+}
+
+fn check_local_safety() -> CheckResult {
+    CheckResult::warn(
+        "local-safety",
+        "trusted-machine mode only; agent runs with host filesystem and host process access, with process-level isolation but no sandbox boundary",
+    )
 }
 
 fn inspect_local_tooling(tool_dir: &Path) -> ToolingInspection {
@@ -789,10 +892,10 @@ fn check_openhands_transport(workflow: &ResolvedWorkflow) -> CheckResult {
                 .unwrap_or_else(|| "no session API key env".to_string());
             let remote_target = !matches!(host, "127.0.0.1" | "localhost");
             if remote_target {
-                CheckResult::pass(
+                CheckResult::warn(
                     "bind-scope",
                     format!(
-                        "OpenHands remote target {base_url} ({path}, websocket auth {}, {auth_detail})",
+                        "OpenHands target {base_url} is not loopback; local trusted-machine mode treats it as an external trusted server ({path}, websocket auth {}, {auth_detail})",
                         workflow.extensions.openhands.websocket.auth_mode
                     ),
                 )
@@ -1321,8 +1424,9 @@ mod tests {
 
     use super::{
         Cli, Command, DoctorRuntimeConfig, SnapshotStore, build_doctor_probe_request,
-        discover_checkout_root, effective_openhands_probe_base_url, find_cargo_workspace_root,
-        resolve_doctor_workflow, sample_snapshot, spawn_demo_updates,
+        command_check_name, discover_checkout_root, effective_openhands_probe_base_url,
+        executable_suffixes, find_cargo_workspace_root, resolve_doctor_workflow, sample_snapshot,
+        spawn_demo_updates,
     };
 
     #[test]
@@ -1434,12 +1538,17 @@ mod tests {
             .expect("Cargo.toml should exist");
 
         let config_path = config_root.join("local-dev.yaml");
+        let canonical_repo_root =
+            fs::canonicalize(&repo_root).expect("repo root should canonicalize");
 
         assert_eq!(
             find_cargo_workspace_root(&config_path),
-            Some(repo_root.clone())
+            Some(canonical_repo_root.clone())
         );
-        assert_eq!(find_cargo_workspace_root(&tool_dir), Some(repo_root));
+        assert_eq!(
+            find_cargo_workspace_root(&tool_dir),
+            Some(canonical_repo_root)
+        );
     }
 
     #[test]
@@ -1454,11 +1563,13 @@ mod tests {
         fs::create_dir_all(&target_repo).expect("target repo should exist");
         fs::write(repo_root.join("Cargo.toml"), "[workspace]\nmembers = []\n")
             .expect("Cargo.toml should exist");
+        let canonical_repo_root =
+            fs::canonicalize(&repo_root).expect("repo root should canonicalize");
 
         let discovered = discover_checkout_root(&config_root, Some(&target_repo), &tool_dir)
             .expect("repo root should be discovered");
 
-        assert_eq!(discovered, repo_root);
+        assert_eq!(discovered, canonical_repo_root);
     }
 
     #[test]
@@ -1473,6 +1584,22 @@ mod tests {
         assert_eq!(
             effective_openhands_probe_base_url("http://localhost:8000/opensymphony", None),
             "http://localhost:8000/opensymphony"
+        );
+    }
+
+    #[test]
+    fn command_check_names_are_stable() {
+        assert_eq!(command_check_name("cargo"), "prereq-cargo");
+        assert_eq!(command_check_name("curl"), "prereq-curl");
+        assert_eq!(command_check_name("git"), "prereq-git");
+        assert_eq!(command_check_name("uv"), "prereq-uv");
+    }
+
+    #[test]
+    fn executable_suffixes_are_non_empty() {
+        assert!(
+            !executable_suffixes().is_empty(),
+            "executable lookup should always have at least one suffix"
         );
     }
 

--- a/crates/opensymphony-cli/tests/doctor.rs
+++ b/crates/opensymphony-cli/tests/doctor.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     path::PathBuf,
     process::{Command, ExitCode},
 };
@@ -276,6 +277,99 @@ fn doctor_ignores_unset_optional_live_placeholders_without_live_openhands() {
 }
 
 #[test]
+fn doctor_reports_local_safety_warning_and_repo_root_path() {
+    let repo_root = repo_root();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("doctor")
+        .arg("--config")
+        .arg("examples/configs/local-dev.yaml")
+        .current_dir(&repo_root)
+        .output()
+        .expect("doctor command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "doctor should succeed in the repo fixture environment: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("[WARN] local-safety: trusted-machine mode only"),
+        "doctor output should state the trusted-machine limitation: stdout={stdout}",
+    );
+    assert!(
+        stdout.contains(&format!(
+            "[PASS] repo: found Cargo workspace at {}",
+            repo_root.display()
+        )),
+        "doctor should print the resolved repo root path instead of an empty detail: stdout={stdout}",
+    );
+}
+
+#[test]
+fn doctor_fails_when_required_prerequisite_is_missing() {
+    let repo_root = repo_root();
+    let fake_bin_dir = TempDir::new().expect("fake bin dir should be created");
+
+    for command in ["cargo", "curl", "git"] {
+        write_fake_executable(fake_bin_dir.path().join(command));
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("doctor")
+        .arg("--config")
+        .arg("examples/configs/local-dev.yaml")
+        .current_dir(&repo_root)
+        .env("PATH", path_only(fake_bin_dir.path()))
+        .output()
+        .expect("doctor command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "doctor should fail when a required prerequisite is missing: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("[FAIL] prereq-uv: uv is not on PATH"),
+        "doctor should name the missing prerequisite explicitly: stdout={stdout}",
+    );
+}
+
+#[test]
+fn doctor_accepts_present_prerequisites_from_path() {
+    let repo_root = repo_root();
+    let fake_bin_dir = TempDir::new().expect("fake bin dir should be created");
+
+    for command in ["cargo", "curl", "git", "uv"] {
+        write_fake_executable(fake_bin_dir.path().join(command));
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("doctor")
+        .arg("--config")
+        .arg("examples/configs/local-dev.yaml")
+        .current_dir(&repo_root)
+        .env("PATH", path_only(fake_bin_dir.path()))
+        .output()
+        .expect("doctor command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "doctor should succeed when required prerequisites are present: stdout={stdout}, stderr={stderr}",
+    );
+    for check in ["prereq-cargo", "prereq-curl", "prereq-git", "prereq-uv"] {
+        assert!(
+            stdout.contains(&format!("[PASS] {check}:")),
+            "doctor should report a passing prerequisite check for {check}: stdout={stdout}",
+        );
+    }
+}
+
+#[test]
 fn run_local_launcher_enforces_pinned_supervised_contract() {
     let repo_root = repo_root();
     let tool_dir = repo_root.join("tools/openhands-server");
@@ -393,6 +487,22 @@ fn repo_root() -> PathBuf {
         .parent()
         .expect("workspace root should exist")
         .to_path_buf()
+}
+
+fn path_only(path: &std::path::Path) -> OsString {
+    std::env::join_paths([path]).expect("path should join")
+}
+
+fn write_fake_executable(path: PathBuf) {
+    std::fs::write(&path, "#!/bin/sh\nexit 0\n").expect("fake executable should be written");
+    #[cfg(unix)]
+    {
+        let mut perms = std::fs::metadata(&path)
+            .expect("fake executable metadata should exist")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("fake executable should be executable");
+    }
 }
 
 fn doctor_workflow_source(workspace_root: &std::path::Path, base_url: &str) -> String {

--- a/crates/opensymphony-cli/tests/doctor.rs
+++ b/crates/opensymphony-cli/tests/doctor.rs
@@ -1,13 +1,8 @@
-use std::{
-    ffi::OsString,
-    path::PathBuf,
-    process::{Command, ExitCode},
-};
+use std::{ffi::OsString, path::PathBuf, process::Command};
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-use opensymphony_cli::run_doctor_command;
 use opensymphony_testkit::FakeOpenHandsServer;
 use serde_yaml::Value;
 use tempfile::TempDir;
@@ -73,9 +68,28 @@ async fn doctor_live_probe_succeeds_against_fake_server() {
     ))
     .expect("config should serialize");
     std::fs::write(&config_path, config).expect("config should be written");
+    let fake_uv = fake_command_on_path("uv");
 
-    let status = run_doctor_command(config_path, true).await;
-    assert_eq!(status, ExitCode::SUCCESS);
+    let path = fake_uv.path.clone();
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+            .arg("doctor")
+            .arg("--config")
+            .arg(&config_path)
+            .arg("--live-openhands")
+            .env("PATH", path)
+            .output()
+    })
+    .await
+    .expect("doctor child task should join")
+    .expect("doctor command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "doctor live probe should succeed against the fake server: stdout={stdout}, stderr={stderr}",
+    );
 }
 
 #[test]
@@ -85,6 +99,7 @@ fn doctor_defaults_target_repo_from_checkout_root_even_outside_the_repo_cwd() {
         tempfile::tempdir_in(repo_root.join("examples/configs")).expect("config dir should exist");
     let config_path = config_dir.path().join("doctor-default-target.yaml");
     let outside_repo = TempDir::new().expect("outside repo dir should be created");
+    let fake_uv = fake_command_on_path("uv");
     let config = serde_yaml::to_string(&Value::Mapping(
         [
             (
@@ -127,6 +142,7 @@ fn doctor_defaults_target_repo_from_checkout_root_even_outside_the_repo_cwd() {
         .arg("--config")
         .arg(&config_path)
         .current_dir(outside_repo.path())
+        .env("PATH", fake_uv.path)
         .output()
         .expect("doctor command should run");
 
@@ -211,6 +227,7 @@ fn doctor_ignores_unset_optional_live_placeholders_without_live_openhands() {
         .path()
         .join("doctor-optional-live-placeholder.yaml");
     let missing_var = "OSYM_TEST_MISSING_PROBE_MODEL";
+    let fake_uv = fake_command_on_path("uv");
     let config = serde_yaml::to_string(&Value::Mapping(
         [
             (
@@ -260,6 +277,7 @@ fn doctor_ignores_unset_optional_live_placeholders_without_live_openhands() {
         .arg("--config")
         .arg(&config_path)
         .current_dir(&repo_root)
+        .env("PATH", fake_uv.path)
         .env_remove(missing_var)
         .output()
         .expect("doctor command should run");
@@ -279,12 +297,14 @@ fn doctor_ignores_unset_optional_live_placeholders_without_live_openhands() {
 #[test]
 fn doctor_reports_local_safety_warning_and_repo_root_path() {
     let repo_root = repo_root();
+    let fake_uv = fake_command_on_path("uv");
 
     let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
         .arg("doctor")
         .arg("--config")
         .arg("examples/configs/local-dev.yaml")
         .current_dir(&repo_root)
+        .env("PATH", fake_uv.path)
         .output()
         .expect("doctor command should run");
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -491,6 +511,25 @@ fn repo_root() -> PathBuf {
 
 fn path_only(path: &std::path::Path) -> OsString {
     std::env::join_paths([path]).expect("path should join")
+}
+
+struct FakeCommandPath {
+    _dir: TempDir,
+    path: OsString,
+}
+
+fn fake_command_on_path(command: &str) -> FakeCommandPath {
+    let dir = TempDir::new().expect("fake bin dir should be created");
+    write_fake_executable(dir.path().join(command));
+
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.path().to_path_buf()];
+    paths.extend(std::env::split_paths(&inherited));
+
+    FakeCommandPath {
+        path: std::env::join_paths(paths).expect("path should join"),
+        _dir: dir,
+    }
 }
 
 fn write_fake_executable(path: PathBuf) {

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -1,0 +1,54 @@
+use std::process::Command;
+
+#[test]
+fn top_level_help_describes_commands_and_safety_posture() {
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("--help")
+        .output()
+        .expect("help command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "top-level help should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    for snippet in [
+        "Operate the OpenSymphony local MVP on a trusted machine",
+        "process-level isolation only",
+        "Serve the local control-plane demo stream",
+        "Attach the FrankenTUI operator client to a control plane",
+        "Run local preflight checks for trusted-machine deployment",
+        "Start the stdio Linear MCP server for agent-side writes",
+    ] {
+        assert!(
+            stdout.contains(snippet),
+            "top-level help should include `{snippet}`: stdout={stdout}",
+        );
+    }
+}
+
+#[test]
+fn doctor_help_explains_config_and_live_probe_options() {
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["doctor", "--help"])
+        .output()
+        .expect("doctor help should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "doctor help should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    for snippet in [
+        "Run local preflight checks for trusted-machine deployment",
+        "Doctor config YAML path",
+        "Run the live OpenHands probe instead of static preflight only",
+    ] {
+        assert!(
+            stdout.contains(snippet),
+            "doctor help should include `{snippet}`: stdout={stdout}",
+        );
+    }
+}

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -56,6 +56,8 @@ developer machine
 ### Security posture
 
 This is a trusted-machine mode. Treat it as process-level isolation, not sandbox isolation.
+`opensymphony doctor` repeats that warning during setup and warns when a local
+deployment points at a non-loopback OpenHands target.
 
 ## 3. Mode B: external local server mode
 

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -58,7 +58,7 @@ Key properties:
 - the local supervised launch path forces OpenHands process-sandbox mode via
   `RUNTIME=process`
 - the current implementation resolves supervised-mode metadata from
-  `tools/openhands-server/{pyproject.toml,version.txt,uv.lock,run-local.sh}`
+  `tools/openhands-server/{pyproject.toml,version.txt,uv.lock,install.sh,run-local.sh}`
   with a repo-owned package and lockfile pin
 - the repo-local quick-run wrapper rejects user-supplied agent-server CLI flags
   so smoke runs cannot diverge from the daemon-managed single-server topology
@@ -100,10 +100,11 @@ Local MVP work starts with supervised mode, but the trait boundary must support 
 
 Current repository implementation:
 
-- `tools/openhands-server/pyproject.toml` pins the local server environment and `tools/openhands-server/run-local.sh` starts it via `uv`
+- `tools/openhands-server/pyproject.toml` pins the local server environment, `tools/openhands-server/install.sh` performs the locked `uv sync --extra agent-server` bootstrap, and `tools/openhands-server/run-local.sh` starts it via `uv`
 - `opensymphony-openhands` currently implements the typed conversation create, get, send-message, run, paginated event search, readiness probe, and `RuntimeEventStream` attach/reconcile/reconnect surface used by validation and doctor flows
 - `opensymphony-testkit` emulates the same endpoint subset for deterministic CI coverage and now supports scripted `/events/search` responses plus per-connection WebSocket frame sequences so attach/reconcile race windows, buffered live events, and reconnect drops can be reproduced without bespoke inline servers
 - `opensymphony doctor` now resolves the target repo `WORKFLOW.md` before probing OpenHands, so the live probe uses workflow-derived workspace, transport, conversation, and prompt inputs instead of only static CLI YAML fields
+- `opensymphony doctor` now checks for `cargo`, `curl`, `git`, and `uv` on `PATH`, prints the trusted-machine local-safety warning on every run, and warns when a local deployment points at a non-loopback OpenHands target
 - `tools/openhands-server/run-local.sh` resolves its own directory before invoking `uv`, enforces `uv run --directory <tool-dir> --locked --extra agent-server --module openhands.agent_server`, and rejects extra agent-server CLI flags so the pinned project works the same way from the repo root, CI, and the local supervisor
 - when `openhands.local_server.command` is omitted, workflow resolution leaves the field unset and the runtime-owned local tooling layer resolves the pinned `tools/openhands-server/run-local.sh` launcher from the OpenSymphony checkout before the supervisor switches `cwd` to the issue workspace, even when the workflow itself lives in a separate target repo
 - explicit `openhands.local_server.command` overrides are currently rejected during workflow resolution until the runtime supervisor can honor workflow-owned launcher commands instead of always starting the pinned repo-local launcher

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -340,6 +340,12 @@ Recommended CLI commands for the repo:
 - `opensymphony doctor`
 - `opensymphony linear-mcp`
 
+Recommended first-run sequence:
+
+- `./tools/openhands-server/install.sh`
+- `cargo run -p opensymphony-cli -- --help`
+- `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`
+
 Current workspace commands:
 
 - `cargo run -p opensymphony-cli -- daemon --bind 127.0.0.1:3000`
@@ -389,6 +395,7 @@ for the UI. For scripted smoke coverage, also confirm that an unreachable
 control plane causes `opensymphony tui --exit-after-ms ...` to exit non-zero.
 Current command set in this repository:
 
+- `./tools/openhands-server/install.sh`
 - `cargo run -p opensymphony-cli -- daemon --bind 127.0.0.1:4010 --sample-interval-ms 250`
 - `curl http://127.0.0.1:4010/healthz`
 - `curl http://127.0.0.1:4010/api/v1/snapshot`
@@ -456,13 +463,14 @@ Required checks:
 ### Repository and config
 
 - config file exists and parses
+- required local commands (`cargo`, `curl`, `git`, and `uv`) are present on `PATH`
 - required env-backed config placeholders resolve instead of silently collapsing to empty strings
 - target repo exists
 - target repo contains `WORKFLOW.md`
 - target repo `WORKFLOW.md` resolves against the current environment
 - target repo prompt template renders against the current issue/attempt input shape
 - workspace root exists or can be created
-- OpenHands version pin files exist in `tools/openhands-server/`
+- OpenHands version pin files and helper scripts exist in `tools/openhands-server/`
 
 ### Local runtime
 
@@ -488,8 +496,10 @@ Required checks:
 Current implementation notes:
 
 - the static doctor path checks config parsing, target-repo presence, workflow load/resolve/render, workspace-root creation from the workflow, loopback bind scope from the workflow OpenHands transport, pinned-tooling files, launcher metadata, and pin consistency across `version.txt`, `pyproject.toml`, and `uv.lock`
+- the static doctor path also checks that `cargo`, `curl`, `git`, and `uv` are present on `PATH`, so local operations docs and machine readiness stay aligned
 - checkout-relative doctor defaults are derived from the config and tooling paths rather than the caller `cwd`, so running `opensymphony doctor` outside the repo root still validates the intended checkout and bundled `examples/target-repo`
 - the live doctor and supervised local-server paths normalize the configured `openhands.tool_dir` to an absolute path before launch, so checked-in configs such as `examples/configs/local-dev.with-live-openhands.yaml` can keep repo-relative tooling paths without depending on the caller `cwd`
+- doctor prints an explicit trusted-machine warning on every run and warns when the configured OpenHands target is not loopback, so local safety posture remains visible during setup and troubleshooting
 - the live doctor path additionally probes `GET /openapi.json`, creates a temp conversation using workflow-derived OpenHands conversation settings, attaches `RuntimeEventStream`, waits through non-readiness WebSocket traffic until the readiness barrier is observed, sends a doctor message that includes the rendered workflow prompt, triggers `/run`, and waits for a healthy terminal `execution_status` of `finished` after post-ready reconcile and reconnect-aware streaming, including terminal REST refresh fallback when a post-completion WebSocket reattach exhausts and one final scheduler-turn buffered drain before success is accepted
 - once that live doctor path has already observed terminal success on the attached stream, it reuses the last successful stream-backed conversation snapshot instead of requiring a final `GET /api/conversations/{id}` that can flap during agent-server shutdown
 - when the configured workflow loopback base URL is down but the repo-owned tooling pin is ready, the live doctor path temporarily starts the local supervised server only for unauthenticated loopback root-path targets, switches follow-up probes to the launched supervisor base URL, uses it for the probe, then stops it again
@@ -585,6 +595,9 @@ host-process mode.
 The current implementation follows that fail-closed rule: doctor and the local
 supervisor validate the repo-owned pin files before launch and refuse to start
 if the version file, direct dependency pin, and resolved lockfile drift apart.
+The packaged tool directory now also carries `install.sh`, which runs the
+locked `uv sync --extra agent-server` flow that the README and doctor-guided
+setup path expect.
 The launcher itself now enforces `uv run --locked --extra agent-server`,
 exports `RUNTIME=process`, only accepts `OPENHANDS_SERVER_PORT` as a runtime
 override, and rejects extra agent-server CLI flags before `uv` is invoked.
@@ -635,5 +648,6 @@ The MVP local mode runs agent activity on the host with process-level isolation.
 
 The current `tools/openhands-server/run-local.sh` script binds OpenHands to
 loopback by default, enforces the pinned `uv.lock` in host-process mode, and
-the doctor command warns when the configured base URL is not loopback in local
-mode.
+the doctor command now always prints an explicit trusted-machine warning before
+reporting readiness. It also warns when the configured base URL is not loopback
+in local mode.

--- a/tools/openhands-server/README.md
+++ b/tools/openhands-server/README.md
@@ -16,13 +16,24 @@ Current pin:
 Requirements:
 
 - `uv`
+- `git`
+- `curl`
+- Rust stable toolchain
 - Python `3.12.x`
 
-## Provision with `uv`
+## Install the pinned environment
+
+Recommended first-run command:
+
+```bash
+./tools/openhands-server/install.sh
+```
+
+Equivalent raw `uv` command:
 
 ```bash
 cd tools/openhands-server
-uv sync --extra agent-server
+uv sync --locked --extra agent-server
 ```
 
 ## Run locally
@@ -30,6 +41,9 @@ uv sync --extra agent-server
 ```bash
 ./tools/openhands-server/run-local.sh
 ```
+
+The helper `install.sh` keeps the provisioning path aligned with the same
+tool directory that `opensymphony doctor` and the local supervisor validate.
 
 The launcher binds to loopback-only at `127.0.0.1:8000` by default and only accepts `OPENHANDS_SERVER_PORT` as a runtime override. It intentionally rejects extra agent-server CLI flags so smoke runs stay aligned with the daemon-managed supervised topology.
 It also fails fast if `uv` is missing, if `OPENHANDS_SERVER_PORT` is invalid, or if the pinned `uv.lock` cannot be honored through `uv run --locked`.

--- a/tools/openhands-server/install.sh
+++ b/tools/openhands-server/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required to install the pinned OpenHands agent-server environment" >&2
+  exit 1
+fi
+
+if (( $# > 0 )); then
+  echo "install.sh does not accept extra arguments." >&2
+  echo "It always runs: uv sync --directory <tool-dir> --locked --extra agent-server" >&2
+  exit 1
+fi
+
+exec uv sync \
+  --directory "${SCRIPT_DIR}" \
+  --locked \
+  --extra agent-server


### PR DESCRIPTION
## Summary

Package the local CLI doctor and trusted-machine setup flow so a new developer can install the pinned OpenHands tooling, run coherent command help, and get to a passing preflight from repo docs.

## Changes

- add descriptive help text for `opensymphony`, `daemon`, `tui`, `doctor`, and `linear-mcp`
- extend `opensymphony doctor` with prerequisite checks for `cargo`, `curl`, `git`, and `uv`, plus an explicit trusted-machine warning and non-loopback local transport warning
- fix doctor repo-root reporting so checkout detection prints the resolved workspace path instead of an empty detail
- add `tools/openhands-server/install.sh` for the locked pinned-tooling bootstrap path
- refresh README and operations/runtime docs to match the packaged CLI and local safety posture
- add CLI integration coverage for help text, doctor prerequisite failures, and the trusted-machine warning

## Evidence

### Test output

```text
cargo fmt --all
cargo test -p opensymphony-cli
cargo test -p opensymphony-cli doctor
cargo clippy -p opensymphony-cli --all-targets -- -D warnings
./tools/openhands-server/install.sh
cargo run -p opensymphony-cli -- --help
cargo run -p opensymphony-cli -- doctor --help
cargo run -p opensymphony-cli -- daemon --help
cargo run -p opensymphony-cli -- tui --help
cargo run -p opensymphony-cli -- linear-mcp --help
cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml
```

### Verification

Verified the clean-machine-style first-run path by running `./tools/openhands-server/install.sh` followed by the static doctor command from the updated docs. The resulting doctor output now reports the resolved repo root, passes the required local prerequisite checks, and prints the trusted-machine safety warning.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: 

## Breaking changes

None.

## Related issues

- https://linear.app/trilogy-ai-coe/issue/COE-274/cli-packaging-doctor-and-local-operations-docs

## Additional notes

The `daemon` and `tui` help text now describe their current demo/control-plane role precisely instead of implying a fully landed orchestrator surface.
