### PR TITLE
Add installable opensymphony run command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,12 @@ Do not silently invent behavior when the upstream spec or chosen integration con
 - The UI consumes the control-plane snapshot and event stream only.
 - UI code must not reach into orchestrator internals directly.
 
+### CLI surface
+
+- `opensymphony run` is the real local orchestrator entrypoint.
+- `opensymphony daemon` is demo-only and exists for smoke tests or UI-focused development.
+- When documenting, validating, or operating the system, prefer `opensymphony run` unless the task is specifically about the demo control-plane publisher.
+
 ## Design rules
 
 ### Keep boundaries explicit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opensymphony"
+version = "0.1.0"
+dependencies = [
+ "opensymphony-cli",
+ "tokio",
+]
+
+[[package]]
 name = "opensymphony-cli"
 version = "0.1.0"
 dependencies = [
@@ -1366,11 +1374,15 @@ dependencies = [
  "clap",
  "opensymphony-control",
  "opensymphony-domain",
+ "opensymphony-linear",
  "opensymphony-linear-mcp",
  "opensymphony-openhands",
+ "opensymphony-orchestrator",
  "opensymphony-testkit",
  "opensymphony-tui",
  "opensymphony-workflow",
+ "opensymphony-workspace",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
+[package]
+name = "opensymphony"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
 [workspace]
 members = [
     "crates/opensymphony-domain",
@@ -13,6 +21,13 @@ members = [
     "crates/opensymphony-testkit",
 ]
 resolver = "2"
+
+[lints]
+workspace = true
+
+[dependencies]
+opensymphony-cli = { path = "crates/opensymphony-cli" }
+tokio.workspace = true
 
 [workspace.package]
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ OpenSymphony automates software development workflows by:
 git clone https://github.com/kumanday/OpenSymphony.git
 cd OpenSymphony
 
-# Build the project
-cargo build --release
+# Install the CLI as `opensymphony`
+cargo install --path .
 
-# Run preflight checks
-cargo run -p opensymphony-cli -- doctor
+# Inspect the command surface
+opensymphony --help
 ```
 
 ### Configuration
@@ -84,18 +84,38 @@ openhands:
         model: ${LLM_MODEL}
 ```
 
-### Running the Daemon
+Add a `config.yaml` file next to your target repository `WORKFLOW.md`. A minimal local-supervised config looks like this:
+
+```yaml
+control_plane:
+  bind: 127.0.0.1:3000
+
+openhands:
+  tool_dir: /absolute/path/to/OpenSymphony/tools/openhands-server
+```
+
+When your workflow points at an external OpenHands agent-server with `openhands.transport.session_api_key_env`, `config.yaml` can omit `openhands.tool_dir`.
+
+See [`examples/target-repo/config.yaml`](examples/target-repo/config.yaml) for a checked-in example.
+
+### Running the Orchestrator
 
 ```bash
-# Start the OpenHands server (in one terminal)
-./tools/openhands-server/run-local.sh
+# Run preflight checks from the OpenSymphony checkout
+opensymphony doctor --config examples/configs/local-dev.yaml
 
-# Start OpenSymphony (in another terminal)
-cargo run -p opensymphony-cli -- daemon --config /path/to/config.yaml
+# Start the orchestrator from the target repository
+cd /path/to/target-repo
+opensymphony run
+
+# Or point at an explicit runtime config file
+opensymphony run --config ./config.yaml
 
 # Optional: Start the TUI for monitoring
-cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:3000/
+opensymphony tui --url http://127.0.0.1:3000/
 ```
+
+The legacy `opensymphony daemon` command is still available as a demo control-plane publisher for smoke tests, but it is not the real orchestrator entrypoint.
 
 ## Architecture
 
@@ -142,7 +162,7 @@ cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:3000/
 | `opensymphony-workspace` | Workspace lifecycle, hooks, containment |
 | `opensymphony-control` | Control plane API and snapshot derivation |
 | `opensymphony-tui` | FrankenTUI operator client |
-| `opensymphony-cli` | CLI entrypoints: daemon, tui, doctor, linear-mcp |
+| `opensymphony-cli` | CLI entrypoints: run, daemon (demo), tui, doctor, linear-mcp |
 
 ## Deployment Modes
 

--- a/crates/opensymphony-cli/Cargo.toml
+++ b/crates/opensymphony-cli/Cargo.toml
@@ -18,12 +18,15 @@ workspace = true
 [dependencies]
 chrono.workspace = true
 clap.workspace = true
+opensymphony-linear = { path = "../opensymphony-linear" }
 opensymphony-linear-mcp = { path = "../opensymphony-linear-mcp" }
 opensymphony-control = { path = "../opensymphony-control" }
 opensymphony-domain = { path = "../opensymphony-domain" }
 opensymphony-openhands = { path = "../opensymphony-openhands" }
+opensymphony-orchestrator = { path = "../opensymphony-orchestrator" }
 opensymphony-workflow = { path = "../opensymphony-workflow" }
 opensymphony-tui = { path = "../opensymphony-tui" }
+opensymphony-workspace = { path = "../opensymphony-workspace" }
 serde.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
@@ -36,5 +39,6 @@ url.workspace = true
 [dev-dependencies]
 axum.workspace = true
 opensymphony-testkit = { path = "../opensymphony-testkit" }
+reqwest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1,3 +1,5 @@
+mod orchestrator_run;
+
 use std::{
     collections::BTreeSet,
     env,
@@ -35,7 +37,7 @@ use url::Url;
 #[command(name = "opensymphony")]
 #[command(about = "Operate the OpenSymphony local MVP on a trusted machine")]
 #[command(
-    long_about = "Operate the OpenSymphony local MVP on a trusted machine.\n\nUse this CLI to run local control-plane demos, preflight checks, and the Linear MCP bridge.\n\nSafety: local OpenSymphony runs agent activity on the host with process-level isolation only. It is not sandboxed."
+    long_about = "Operate the OpenSymphony local MVP on a trusted machine.\n\nUse this CLI to run the orchestrator, local control-plane demos, preflight checks, and the Linear MCP bridge.\n\nSafety: local OpenSymphony runs agent activity on the host with process-level isolation only. It is not sandboxed."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -44,6 +46,8 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    #[command(about = "Run the real orchestrator against the current project workflow")]
+    Run(orchestrator_run::RunArgs),
     #[command(about = "Serve the local control-plane demo stream")]
     Daemon(DaemonArgs),
     #[command(about = "Attach the FrankenTUI operator client to a control plane")]
@@ -222,6 +226,7 @@ pub async fn run() -> ExitCode {
     init_tracing();
     let cli = Cli::parse();
     match cli.command {
+        Command::Run(args) => orchestrator_run::run_command(args).await,
         Command::Doctor(args) => run_doctor(args).await,
         Command::Daemon(args) => run_daemon(args).await,
         Command::Tui(args) => run_tui(args).await,
@@ -1475,7 +1480,7 @@ mod tests {
 
         match cli.command {
             Command::Daemon(args) => assert_eq!(args.sample_interval_ms.get(), 250),
-            Command::Tui(_) | Command::LinearMcp(_) | Command::Doctor(_) => {
+            Command::Run(_) | Command::Tui(_) | Command::LinearMcp(_) | Command::Doctor(_) => {
                 panic!("expected daemon command")
             }
         }

--- a/crates/opensymphony-cli/src/orchestrator_run.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run.rs
@@ -1242,7 +1242,7 @@ mod tests {
 
     fn sample_workflow(base_dir: &Path, workspace_root: &Path) -> ResolvedWorkflow {
         let source = format!(
-            "---\ntracker:\n  kind: linear\n  endpoint: http://127.0.0.1:3001/graphql\n  project_slug: sample-project\n  active_states:\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: {}\nopenhands:\n  transport:\n    base_url: http://127.0.0.1:1\n    session_api_key_env: OPENHANDS_API_KEY\n---\n\n# Test Workflow\n\nRun the scheduler.\n",
+            "---\ntracker:\n  kind: linear\n  endpoint: http://127.0.0.1:3001/graphql\n  api_key: test-linear-key\n  project_slug: sample-project\n  active_states:\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: {}\nopenhands:\n  transport:\n    base_url: http://127.0.0.1:1\n    session_api_key_env: OPENHANDS_API_KEY\n---\n\n# Test Workflow\n\nRun the scheduler.\n",
             workspace_root.display()
         );
         WorkflowDefinition::parse(&source)

--- a/crates/opensymphony-cli/src/orchestrator_run.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run.rs
@@ -1,0 +1,1099 @@
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    env,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    process::ExitCode,
+    sync::Arc,
+    time::Duration,
+};
+
+use chrono::{DateTime, Utc};
+use clap::Args;
+use opensymphony_control::{
+    AgentServerStatus, ControlPlaneServer, DaemonSnapshot, DaemonState, DaemonStatus,
+    IssueRuntimeState, IssueSnapshot, MetricsSnapshot, RecentEvent, RecentEventKind, SnapshotStore,
+    WorkerOutcome,
+};
+use opensymphony_domain::{
+    ConversationMetadata, HealthStatus, IssueIdentifier, NormalizedIssue, OrchestratorSnapshot,
+    SchedulerStatus, TimestampMs, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey,
+    WorkspaceRecord,
+};
+use opensymphony_linear::{LinearClient, LinearConfig, LinearError};
+use opensymphony_openhands::{
+    IssueSessionObserver, IssueSessionRunner, IssueSessionRunnerConfig, LocalServerSupervisor,
+    LocalServerTooling, OpenHandsClient, OpenHandsError, SupervisedServerConfig, SupervisorConfig,
+    TransportConfig,
+};
+use opensymphony_orchestrator::{
+    RecoveryRecord, Scheduler, SchedulerConfig, SchedulerError, TrackerBackend, WorkerAbortReason,
+    WorkerBackend, WorkerLaunch, WorkerStartRequest, WorkerUpdate, WorkspaceBackend,
+};
+use opensymphony_workflow::{ProcessEnvironment, ResolvedWorkflow, WorkflowDefinition};
+use opensymphony_workspace::{
+    CleanupConfig, HookConfig, HookDefinition, IssueDescriptor, RunDescriptor, WorkspaceError,
+    WorkspaceManager, WorkspaceManagerConfig,
+};
+use serde::Deserialize;
+use thiserror::Error;
+use tokio::{
+    fs,
+    net::TcpListener,
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+    time::{MissedTickBehavior, interval, timeout},
+};
+use tracing::{info, warn};
+use url::Url;
+
+const DEFAULT_CONFIG_FILE: &str = "config.yaml";
+const DEFAULT_CONTROL_PLANE_BIND: &str = "127.0.0.1:3000";
+const RECENT_EVENT_LIMIT: usize = 24;
+const DEFAULT_WORKER_LAUNCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Args, Clone)]
+pub struct RunArgs {
+    #[arg(help = "Runtime config YAML path; defaults to ./config.yaml when present")]
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RunConfigFile {
+    #[serde(default)]
+    target_repo: Option<String>,
+    #[serde(default)]
+    control_plane: ControlPlaneConfigFile,
+    #[serde(default)]
+    openhands: RunOpenHandsConfigFile,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ControlPlaneConfigFile {
+    #[serde(default)]
+    bind: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RunOpenHandsConfigFile {
+    #[serde(default)]
+    tool_dir: Option<String>,
+}
+
+struct RunRuntimeConfig {
+    config_path: Option<PathBuf>,
+    target_repo: PathBuf,
+    workflow_path: PathBuf,
+    workflow: ResolvedWorkflow,
+    bind: SocketAddr,
+    tool_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Error)]
+enum RunCommandError {
+    #[error("failed to determine the current working directory: {0}")]
+    CurrentDir(#[source] std::io::Error),
+    #[error("failed to read {path}: {source}")]
+    ReadConfig {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse {path}: {source}")]
+    ParseConfig {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("failed to expand {path}: {detail}")]
+    ResolveConfig { path: PathBuf, detail: String },
+    #[error("invalid control-plane bind address `{value}`: {source}")]
+    InvalidBind {
+        value: String,
+        #[source]
+        source: std::net::AddrParseError,
+    },
+    #[error("failed to load workflow {path}: {source}")]
+    LoadWorkflow {
+        path: PathBuf,
+        #[source]
+        source: opensymphony_workflow::WorkflowLoadError,
+    },
+    #[error("failed to resolve workflow {path}: {source}")]
+    ResolveWorkflow {
+        path: PathBuf,
+        #[source]
+        source: opensymphony_workflow::WorkflowConfigError,
+    },
+    #[error("failed to build tracker client: {0}")]
+    Tracker(#[from] LinearError),
+    #[error("failed to create workspace manager: {0}")]
+    WorkspaceManager(#[from] WorkspaceError),
+    #[error("failed to prepare OpenHands transport: {0}")]
+    Transport(#[from] OpenHandsError),
+    #[error("failed to load local OpenHands tooling: {0}")]
+    Tooling(#[from] opensymphony_openhands::LocalToolingError),
+    #[error("failed to start local OpenHands supervisor: {0}")]
+    Supervisor(#[from] opensymphony_openhands::SupervisorError),
+    #[error("failed to build scheduler configuration: {0}")]
+    SchedulerConfig(#[from] SchedulerError),
+    #[error("failed to bind control-plane listener: {0}")]
+    BindListener(#[source] std::io::Error),
+    #[error("control-plane server exited unexpectedly: {0}")]
+    Serve(#[source] std::io::Error),
+    #[error(
+        "workflow config requires a local OpenHands server, but no `openhands.tool_dir` was provided via config"
+    )]
+    MissingToolDir,
+}
+
+#[derive(Debug, Error)]
+enum CliWorkspaceError {
+    #[error(transparent)]
+    Workspace(#[from] WorkspaceError),
+    #[error(transparent)]
+    Identifier(#[from] opensymphony_domain::IdentifierError),
+    #[error("failed to remove workspace {path}: {source}")]
+    RemoveWorkspace {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Error)]
+enum CliWorkerError {
+    #[error(transparent)]
+    Workspace(#[from] WorkspaceError),
+    #[error("worker launch timed out after {0:?}")]
+    LaunchTimeout(Duration),
+    #[error("worker exited before reporting a conversation launch")]
+    LaunchChannelClosed,
+    #[error("worker task failed: {0}")]
+    Join(#[from] tokio::task::JoinError),
+}
+
+struct RuntimeTrackerBackend {
+    client: LinearClient,
+}
+
+struct RuntimeWorkspaceBackend {
+    manager: Arc<WorkspaceManager>,
+}
+
+struct RuntimeWorkerBackend {
+    client: OpenHandsClient,
+    workflow: Arc<ResolvedWorkflow>,
+    workspace_manager: Arc<WorkspaceManager>,
+    runner_config: IssueSessionRunnerConfig,
+    launch_timeout: Duration,
+    updates_tx: mpsc::UnboundedSender<WorkerUpdate>,
+    updates_rx: mpsc::UnboundedReceiver<WorkerUpdate>,
+    tasks: HashMap<String, ActiveWorkerTask>,
+}
+
+struct ActiveWorkerTask {
+    handle: JoinHandle<()>,
+    run: opensymphony_domain::RunAttempt,
+}
+
+struct SchedulerObserver {
+    worker_id: String,
+    launch_tx: Option<oneshot::Sender<ConversationMetadata>>,
+    updates_tx: mpsc::UnboundedSender<WorkerUpdate>,
+}
+
+impl SchedulerObserver {
+    fn mark_launched(&mut self) -> bool {
+        self.launch_tx.is_none()
+    }
+}
+
+impl IssueSessionObserver for SchedulerObserver {
+    fn on_launch(&mut self, conversation: &ConversationMetadata) {
+        if let Some(sender) = self.launch_tx.take() {
+            let _ = sender.send(conversation.clone());
+        }
+    }
+
+    fn on_runtime_event(
+        &mut self,
+        observed_at: TimestampMs,
+        event_id: Option<String>,
+        event_kind: Option<String>,
+        summary: Option<String>,
+    ) {
+        let worker_id = self.worker_id.clone();
+        let _ = self.updates_tx.send(WorkerUpdate::RuntimeEvent {
+            worker_id: opensymphony_domain::WorkerId::new(worker_id)
+                .expect("worker id should remain valid"),
+            observed_at,
+            event_id,
+            event_kind,
+            summary,
+        });
+    }
+}
+
+pub async fn run_command(args: RunArgs) -> ExitCode {
+    match run_orchestrator(args).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
+    let runtime = resolve_runtime_config(&args).await?;
+    info!(
+        config = runtime
+            .config_path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<none>".to_string()),
+        target_repo = %runtime.target_repo.display(),
+        workflow = %runtime.workflow_path.display(),
+        bind = %runtime.bind,
+        "starting OpenSymphony orchestrator"
+    );
+
+    let tracker = build_tracker_backend(&runtime.workflow)?;
+    let workspace_manager = Arc::new(WorkspaceManager::new(build_workspace_manager_config(
+        &runtime.workflow,
+    ))?);
+    let workspace = RuntimeWorkspaceBackend {
+        manager: workspace_manager.clone(),
+    };
+
+    let (transport, mut supervisor) = build_runtime_transport(&runtime).await?;
+    let client = OpenHandsClient::new(transport);
+    client.openapi_probe().await?;
+
+    let worker = RuntimeWorkerBackend::new(
+        client.clone(),
+        Arc::new(runtime.workflow.clone()),
+        workspace_manager,
+    );
+    let mut scheduler = Scheduler::new(
+        tracker,
+        workspace,
+        worker,
+        SchedulerConfig::from_workflow(&runtime.workflow)?,
+    );
+
+    let mut recent_events = VecDeque::new();
+    push_recent_event(
+        &mut recent_events,
+        RecentEventKind::SnapshotPublished,
+        None,
+        format!("loaded {}", runtime.workflow_path.display()),
+        Utc::now(),
+    );
+
+    let initial_snapshot = map_snapshot(
+        &scheduler.snapshot(now_timestamp()),
+        runtime.workflow.config.workspace.root.as_path(),
+        &terminal_state_set(&runtime.workflow),
+        current_agent_server_status(&mut supervisor, client.base_url()),
+        &recent_events,
+    );
+
+    let store = SnapshotStore::new(initial_snapshot);
+    let listener = TcpListener::bind(runtime.bind)
+        .await
+        .map_err(RunCommandError::BindListener)?;
+    let server = ControlPlaneServer::new(store.clone());
+    let mut server_task = tokio::spawn(async move { server.serve(listener).await });
+
+    let poll_interval = Duration::from_millis(runtime.workflow.config.polling.interval_ms);
+    let mut ticker = interval(poll_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("received shutdown signal");
+                break;
+            }
+            result = &mut server_task => {
+                match result {
+                    Ok(Ok(())) => break,
+                    Ok(Err(error)) => return Err(RunCommandError::Serve(error)),
+                    Err(error) => return Err(RunCommandError::Serve(std::io::Error::other(error.to_string()))),
+                }
+            }
+            _ = ticker.tick() => {
+                let observed_at = now_timestamp();
+                match scheduler.tick(observed_at).await {
+                    Ok(snapshot) => {
+                        push_recent_event(
+                            &mut recent_events,
+                            RecentEventKind::SnapshotPublished,
+                            None,
+                            format!(
+                                "polled tracker; running={}, retry_queue={}",
+                                snapshot.daemon.running_issue_count,
+                                snapshot.daemon.retry_queue_count
+                            ),
+                            Utc::now(),
+                        );
+                        store.publish(map_snapshot(
+                            &snapshot,
+                            runtime.workflow.config.workspace.root.as_path(),
+                            &terminal_state_set(&runtime.workflow),
+                            current_agent_server_status(&mut supervisor, client.base_url()),
+                            &recent_events,
+                        )).await;
+                    }
+                    Err(error) => {
+                        warn!(%error, "scheduler tick failed");
+                        push_recent_event(
+                            &mut recent_events,
+                            RecentEventKind::Warning,
+                            None,
+                            format!("scheduler tick failed: {error}"),
+                            Utc::now(),
+                        );
+                        let snapshot = scheduler.snapshot(observed_at);
+                        store.publish(map_snapshot(
+                            &snapshot,
+                            runtime.workflow.config.workspace.root.as_path(),
+                            &terminal_state_set(&runtime.workflow),
+                            current_agent_server_status(&mut supervisor, client.base_url()),
+                            &recent_events,
+                        )).await;
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(mut supervisor) = supervisor {
+        let _ = supervisor.stop();
+    }
+
+    Ok(())
+}
+
+async fn resolve_runtime_config(args: &RunArgs) -> Result<RunRuntimeConfig, RunCommandError> {
+    let cwd = env::current_dir().map_err(RunCommandError::CurrentDir)?;
+    let config_path = match &args.config {
+        Some(path) => Some(resolve_relative_to(&cwd, path)),
+        None => {
+            let candidate = cwd.join(DEFAULT_CONFIG_FILE);
+            candidate.exists().then_some(candidate)
+        }
+    };
+
+    let config = match &config_path {
+        Some(path) => load_run_config(path).await?,
+        None => RunConfigFile::default(),
+    };
+    let config_root = config_path
+        .as_deref()
+        .and_then(Path::parent)
+        .unwrap_or(cwd.as_path());
+    let target_repo = config
+        .target_repo
+        .as_deref()
+        .map(|path| super::resolve_path(config_root, path))
+        .unwrap_or_else(|| cwd.clone());
+    let workflow_path = target_repo.join("WORKFLOW.md");
+    let workflow = WorkflowDefinition::load_from_path(&workflow_path).map_err(|source| {
+        RunCommandError::LoadWorkflow {
+            path: workflow_path.clone(),
+            source,
+        }
+    })?;
+    let workflow = workflow
+        .resolve_with_process_env(&target_repo)
+        .map_err(|source| RunCommandError::ResolveWorkflow {
+            path: workflow_path.clone(),
+            source,
+        })?;
+    let bind_value = config
+        .control_plane
+        .bind
+        .as_deref()
+        .unwrap_or(DEFAULT_CONTROL_PLANE_BIND);
+    let bind = bind_value
+        .parse()
+        .map_err(|source| RunCommandError::InvalidBind {
+            value: bind_value.to_string(),
+            source,
+        })?;
+    let tool_dir = config
+        .openhands
+        .tool_dir
+        .as_deref()
+        .map(|path| super::resolve_path(config_root, path));
+
+    Ok(RunRuntimeConfig {
+        config_path,
+        target_repo,
+        workflow_path,
+        workflow,
+        bind,
+        tool_dir,
+    })
+}
+
+async fn load_run_config(path: &Path) -> Result<RunConfigFile, RunCommandError> {
+    let raw = fs::read_to_string(path)
+        .await
+        .map_err(|source| RunCommandError::ReadConfig {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let config = serde_yaml::from_str::<RunConfigFile>(&raw).map_err(|source| {
+        RunCommandError::ParseConfig {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+    resolve_run_config(path, config)
+}
+
+fn resolve_run_config(
+    path: &Path,
+    mut config: RunConfigFile,
+) -> Result<RunConfigFile, RunCommandError> {
+    config.target_repo = config
+        .target_repo
+        .take()
+        .map(|value| expand_run_value(path, value))
+        .transpose()?;
+    config.control_plane.bind = config
+        .control_plane
+        .bind
+        .take()
+        .map(|value| expand_run_value(path, value))
+        .transpose()?;
+    config.openhands.tool_dir = config
+        .openhands
+        .tool_dir
+        .take()
+        .map(|value| expand_run_value(path, value))
+        .transpose()?;
+    Ok(config)
+}
+
+fn expand_run_value(path: &Path, value: String) -> Result<String, RunCommandError> {
+    super::expand_env_tokens(&value).map_err(|error| RunCommandError::ResolveConfig {
+        path: path.to_path_buf(),
+        detail: error.to_string(),
+    })
+}
+
+fn resolve_relative_to(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn build_tracker_backend(
+    workflow: &ResolvedWorkflow,
+) -> Result<RuntimeTrackerBackend, LinearError> {
+    let tracker = &workflow.config.tracker;
+    let mut config = LinearConfig::new(tracker.api_key.clone(), tracker.project_slug.clone());
+    config.base_url = tracker.endpoint.clone();
+    config.active_states = tracker.active_states.clone();
+    config.terminal_states = tracker.terminal_states.clone();
+    Ok(RuntimeTrackerBackend {
+        client: LinearClient::new(config)?,
+    })
+}
+
+fn build_workspace_manager_config(workflow: &ResolvedWorkflow) -> WorkspaceManagerConfig {
+    let hooks = &workflow.config.hooks;
+    WorkspaceManagerConfig {
+        root: workflow.config.workspace.root.clone(),
+        hooks: HookConfig {
+            after_create: hooks.after_create.clone().map(HookDefinition::shell),
+            before_run: hooks.before_run.clone().map(HookDefinition::shell),
+            after_run: hooks.after_run.clone().map(HookDefinition::shell),
+            before_remove: hooks.before_remove.clone().map(HookDefinition::shell),
+            timeout: Duration::from_millis(hooks.timeout_ms),
+        },
+        cleanup: CleanupConfig {
+            remove_terminal_workspaces: false,
+        },
+    }
+}
+
+async fn build_runtime_transport(
+    runtime: &RunRuntimeConfig,
+) -> Result<(TransportConfig, Option<LocalServerSupervisor>), RunCommandError> {
+    let transport = TransportConfig::from_workflow(&runtime.workflow, &ProcessEnvironment)?;
+    if !requires_supervisor(&runtime.workflow) {
+        return Ok((transport, None));
+    }
+
+    let tool_dir = runtime
+        .tool_dir
+        .clone()
+        .ok_or(RunCommandError::MissingToolDir)?;
+    let tooling = LocalServerTooling::load(tool_dir)?;
+    let base_url = &runtime.workflow.extensions.openhands.transport.base_url;
+    let url = Url::parse(base_url).expect("validated transport base URL should parse");
+    let mut config = SupervisedServerConfig::new(tooling);
+    config.extra_env = runtime
+        .workflow
+        .extensions
+        .openhands
+        .local_server
+        .env
+        .clone();
+    config.startup_timeout = Duration::from_millis(
+        runtime
+            .workflow
+            .extensions
+            .openhands
+            .local_server
+            .startup_timeout_ms,
+    );
+    config.probe.path = runtime
+        .workflow
+        .extensions
+        .openhands
+        .local_server
+        .readiness_probe_path
+        .clone();
+    config.port_override = Some(
+        url.port_or_known_default()
+            .ok_or(RunCommandError::MissingToolDir)?,
+    );
+
+    let mut supervisor = LocalServerSupervisor::new(SupervisorConfig::Supervised(Box::new(config)));
+    let status = supervisor.start()?;
+    let transport = TransportConfig::new(status.base_url).with_auth(transport.auth().clone());
+    Ok((transport, Some(supervisor)))
+}
+
+fn requires_supervisor(workflow: &ResolvedWorkflow) -> bool {
+    let transport = &workflow.extensions.openhands.transport;
+    if transport.session_api_key_env.is_some()
+        || !workflow.extensions.openhands.local_server.enabled
+    {
+        return false;
+    }
+
+    let Ok(url) = Url::parse(&transport.base_url) else {
+        return false;
+    };
+    url.scheme() == "http"
+        && url.path().trim_matches('/').is_empty()
+        && matches!(url.host_str(), Some("127.0.0.1") | Some("localhost"))
+}
+
+impl TrackerBackend for RuntimeTrackerBackend {
+    type Error = LinearError;
+
+    async fn candidate_issues(
+        &mut self,
+    ) -> Result<Vec<opensymphony_domain::TrackerIssue>, Self::Error> {
+        self.client.candidate_issues().await
+    }
+
+    async fn terminal_issues(
+        &mut self,
+    ) -> Result<Vec<opensymphony_domain::TrackerIssue>, Self::Error> {
+        self.client.terminal_issues().await
+    }
+
+    async fn issue_states_by_ids(
+        &mut self,
+        issue_ids: &[String],
+    ) -> Result<Vec<opensymphony_domain::TrackerIssueStateSnapshot>, Self::Error> {
+        self.client.issue_states_by_ids(issue_ids).await
+    }
+}
+
+impl WorkspaceBackend for RuntimeWorkspaceBackend {
+    type Error = CliWorkspaceError;
+
+    async fn ensure_workspace(
+        &mut self,
+        issue: &NormalizedIssue,
+        _observed_at: TimestampMs,
+    ) -> Result<WorkspaceRecord, Self::Error> {
+        let ensured = self.manager.ensure(&issue_descriptor(issue)).await?;
+        Ok(WorkspaceRecord {
+            path: ensured.handle.workspace_path().to_path_buf(),
+            workspace_key: WorkspaceKey::new(ensured.handle.workspace_key().to_string())?,
+            created_now: ensured.created,
+            created_at: Some(datetime_to_timestamp_ms(ensured.issue_manifest.created_at)),
+            updated_at: Some(datetime_to_timestamp_ms(ensured.issue_manifest.updated_at)),
+            last_seen_tracker_refresh_at: ensured
+                .issue_manifest
+                .last_seen_tracker_refresh_at
+                .map(datetime_to_timestamp_ms),
+        })
+    }
+
+    async fn recover_workspaces(&mut self) -> Result<Vec<RecoveryRecord>, Self::Error> {
+        Ok(Vec::new())
+    }
+
+    async fn cleanup_workspace(
+        &mut self,
+        workspace: &WorkspaceRecord,
+        terminal: bool,
+    ) -> Result<(), Self::Error> {
+        if terminal {
+            match fs::remove_dir_all(&workspace.path).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(CliWorkspaceError::RemoveWorkspace {
+                        path: workspace.path.clone(),
+                        source,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl RuntimeWorkerBackend {
+    fn new(
+        client: OpenHandsClient,
+        workflow: Arc<ResolvedWorkflow>,
+        workspace_manager: Arc<WorkspaceManager>,
+    ) -> Self {
+        let (updates_tx, updates_rx) = mpsc::unbounded_channel();
+        Self {
+            client,
+            workflow: workflow.clone(),
+            workspace_manager,
+            runner_config: IssueSessionRunnerConfig::from_workflow(&workflow),
+            launch_timeout: DEFAULT_WORKER_LAUNCH_TIMEOUT,
+            updates_tx,
+            updates_rx,
+            tasks: HashMap::new(),
+        }
+    }
+}
+
+impl WorkerBackend for RuntimeWorkerBackend {
+    type Error = CliWorkerError;
+
+    async fn start_worker(
+        &mut self,
+        request: WorkerStartRequest,
+    ) -> Result<WorkerLaunch, Self::Error> {
+        let runner = IssueSessionRunner::new(self.client.clone(), self.runner_config.clone());
+        let workspace_manager = self.workspace_manager.clone();
+        let workflow = self.workflow.clone();
+        let updates_tx = self.updates_tx.clone();
+        let worker_id = request.run.worker_id.clone();
+        let observer_worker_id = worker_id.clone();
+        let finished_worker_id = worker_id.clone();
+        let (launch_tx, launch_rx) = oneshot::channel();
+        let run = request.run.clone();
+        let issue = request.issue.clone();
+        let launch_worker_id = worker_id.clone();
+        let handle = tokio::spawn(async move {
+            let ensured = match workspace_manager.ensure(&issue_descriptor(&issue)).await {
+                Ok(ensured) => ensured,
+                Err(_) => return,
+            };
+            let attempt = run.attempt.map(|attempt| attempt.get()).unwrap_or(1);
+            let run_descriptor = RunDescriptor::new(format!("run-{launch_worker_id}"), attempt);
+            let mut run_manifest = match workspace_manager
+                .start_run(&ensured.handle, &run_descriptor)
+                .await
+            {
+                Ok(run_manifest) => run_manifest,
+                Err(_) => return,
+            };
+
+            let mut observer = SchedulerObserver {
+                worker_id: observer_worker_id.to_string(),
+                launch_tx: Some(launch_tx),
+                updates_tx: updates_tx.clone(),
+            };
+            let result = runner
+                .run_with_observer(
+                    &workspace_manager,
+                    &ensured.handle,
+                    &mut run_manifest,
+                    &issue,
+                    &run,
+                    &workflow,
+                    &mut observer,
+                )
+                .await;
+
+            if !observer.mark_launched() {
+                return;
+            }
+
+            let outcome = match result {
+                Ok(result) => result.worker_outcome,
+                Err(error) => WorkerOutcomeRecord::from_run(
+                    &run,
+                    WorkerOutcomeKind::Failed,
+                    now_timestamp(),
+                    Some("worker task failed before completing".to_string()),
+                    Some(error.to_string()),
+                ),
+            };
+            let _ = updates_tx.send(WorkerUpdate::Finished {
+                worker_id: finished_worker_id.clone(),
+                outcome,
+            });
+        });
+
+        self.tasks.insert(
+            worker_id.to_string(),
+            ActiveWorkerTask {
+                handle,
+                run: request.run.clone(),
+            },
+        );
+
+        match timeout(self.launch_timeout, launch_rx).await {
+            Ok(Ok(conversation)) => Ok(WorkerLaunch { conversation }),
+            Ok(Err(_)) => {
+                if let Some(task) = self.tasks.remove(worker_id.as_str()) {
+                    task.handle.await?;
+                }
+                Err(CliWorkerError::LaunchChannelClosed)
+            }
+            Err(_) => {
+                if let Some(task) = self.tasks.remove(worker_id.as_str()) {
+                    task.handle.abort();
+                }
+                Err(CliWorkerError::LaunchTimeout(self.launch_timeout))
+            }
+        }
+    }
+
+    async fn poll_updates(&mut self) -> Result<Vec<WorkerUpdate>, Self::Error> {
+        let mut updates = Vec::new();
+        while let Ok(update) = self.updates_rx.try_recv() {
+            if let WorkerUpdate::Finished { worker_id, .. } = &update
+                && let Some(task) = self.tasks.remove(worker_id.as_str())
+            {
+                let _ = task.handle.await;
+            }
+            updates.push(update);
+        }
+
+        let finished = self
+            .tasks
+            .iter()
+            .filter_map(|(worker_id, task)| task.handle.is_finished().then_some(worker_id.clone()))
+            .collect::<Vec<_>>();
+        for worker_id in finished {
+            let Some(task) = self.tasks.remove(worker_id.as_str()) else {
+                continue;
+            };
+            if let Err(error) = task.handle.await {
+                updates.push(WorkerUpdate::Finished {
+                    worker_id: opensymphony_domain::WorkerId::new(worker_id)
+                        .expect("worker id should remain valid"),
+                    outcome: WorkerOutcomeRecord::from_run(
+                        &task.run,
+                        WorkerOutcomeKind::Failed,
+                        now_timestamp(),
+                        Some("worker task terminated unexpectedly".to_string()),
+                        Some(error.to_string()),
+                    ),
+                });
+            }
+        }
+
+        Ok(updates)
+    }
+
+    async fn abort_worker(
+        &mut self,
+        worker_id: &opensymphony_domain::WorkerId,
+        _reason: WorkerAbortReason,
+    ) -> Result<(), Self::Error> {
+        if let Some(task) = self.tasks.remove(worker_id.as_str()) {
+            task.handle.abort();
+        }
+        Ok(())
+    }
+}
+
+fn map_snapshot(
+    snapshot: &OrchestratorSnapshot,
+    workspace_root: &Path,
+    terminal_states: &HashSet<String>,
+    agent_server: AgentServerStatus,
+    recent_events: &VecDeque<RecentEvent>,
+) -> DaemonSnapshot {
+    let generated_at = timestamp_to_datetime(snapshot.generated_at);
+    let last_poll_at = snapshot
+        .daemon
+        .last_poll_at
+        .map(timestamp_to_datetime)
+        .unwrap_or(generated_at);
+    DaemonSnapshot {
+        generated_at,
+        daemon: DaemonStatus {
+            state: map_daemon_state(snapshot.daemon.health),
+            last_poll_at,
+            workspace_root: workspace_root.display().to_string(),
+            status_line: format!(
+                "poll={}ms, running={}, retry_queue={}",
+                snapshot.daemon.poll_interval_ms,
+                snapshot.daemon.running_issue_count,
+                snapshot.daemon.retry_queue_count
+            ),
+        },
+        agent_server,
+        metrics: MetricsSnapshot {
+            running_issues: snapshot.daemon.running_issue_count as u32,
+            retry_queue_depth: snapshot.daemon.retry_queue_count as u32,
+            total_tokens: snapshot.daemon.usage.total_tokens,
+            total_cost_micros: snapshot.daemon.usage.estimated_cost_usd_micros.unwrap_or(0),
+        },
+        issues: snapshot
+            .issues
+            .iter()
+            .map(|issue| map_issue(issue, terminal_states, generated_at))
+            .collect(),
+        recent_events: recent_events.iter().cloned().collect(),
+    }
+}
+
+fn map_issue(
+    issue: &opensymphony_domain::IssueSnapshot,
+    terminal_states: &HashSet<String>,
+    generated_at: DateTime<Utc>,
+) -> IssueSnapshot {
+    let runtime_state = match issue.runtime.state {
+        SchedulerStatus::Running | SchedulerStatus::Claimed => IssueRuntimeState::Running,
+        SchedulerStatus::RetryQueued => IssueRuntimeState::RetryQueued,
+        SchedulerStatus::Released => match issue
+            .last_worker_outcome
+            .as_ref()
+            .map(|outcome| outcome.outcome)
+        {
+            Some(
+                WorkerOutcomeKind::Failed
+                | WorkerOutcomeKind::TimedOut
+                | WorkerOutcomeKind::Stalled,
+            ) => IssueRuntimeState::Failed,
+            _ => IssueRuntimeState::Completed,
+        },
+        SchedulerStatus::Unclaimed => IssueRuntimeState::Idle,
+    };
+    let last_outcome = map_worker_outcome(issue, runtime_state);
+    let last_event_at = issue
+        .conversation
+        .as_ref()
+        .and_then(|conversation| conversation.last_event_at)
+        .map(timestamp_to_datetime)
+        .or_else(|| {
+            issue
+                .last_worker_outcome
+                .as_ref()
+                .map(|outcome| timestamp_to_datetime(outcome.finished_at))
+        })
+        .unwrap_or(generated_at);
+
+    IssueSnapshot {
+        identifier: issue.issue.identifier.to_string(),
+        title: issue.issue.title.clone(),
+        tracker_state: issue.issue.state.name.clone(),
+        runtime_state,
+        last_outcome,
+        last_event_at,
+        conversation_id_suffix: issue
+            .conversation
+            .as_ref()
+            .map(|conversation| suffix(conversation.conversation_id.as_str()))
+            .unwrap_or_else(|| "-".to_string()),
+        workspace_path_suffix: issue
+            .workspace
+            .as_ref()
+            .map(|workspace| suffix_path(&workspace.path))
+            .unwrap_or_else(|| "-".to_string()),
+        retry_count: issue
+            .retry
+            .as_ref()
+            .map(|retry| retry.normal_retry_count)
+            .unwrap_or(0),
+        blocked: issue.issue.blocked_by.iter().any(|blocker| {
+            blocker
+                .state
+                .as_deref()
+                .is_none_or(|state| !is_terminal_state(terminal_states, state))
+        }) || (!issue.issue.sub_issues.is_empty()
+            && issue
+                .issue
+                .sub_issues
+                .iter()
+                .any(|sub_issue| !is_terminal_state(terminal_states, &sub_issue.state))),
+        server_base_url: issue
+            .conversation
+            .as_ref()
+            .and_then(|conversation| conversation.server_base_url.clone()),
+        transport_target: issue
+            .conversation
+            .as_ref()
+            .and_then(|conversation| conversation.transport_target.clone()),
+        http_auth_mode: issue
+            .conversation
+            .as_ref()
+            .and_then(|conversation| conversation.http_auth_mode.clone()),
+        websocket_auth_mode: issue
+            .conversation
+            .as_ref()
+            .and_then(|conversation| conversation.websocket_auth_mode.clone()),
+        websocket_query_param_name: issue
+            .conversation
+            .as_ref()
+            .and_then(|conversation| conversation.websocket_query_param_name.clone()),
+    }
+}
+
+fn map_worker_outcome(
+    issue: &opensymphony_domain::IssueSnapshot,
+    runtime_state: IssueRuntimeState,
+) -> WorkerOutcome {
+    match runtime_state {
+        IssueRuntimeState::Running => WorkerOutcome::Running,
+        IssueRuntimeState::RetryQueued => match issue
+            .last_worker_outcome
+            .as_ref()
+            .map(|outcome| outcome.outcome)
+        {
+            Some(WorkerOutcomeKind::Succeeded) => WorkerOutcome::Continued,
+            Some(WorkerOutcomeKind::Cancelled) => WorkerOutcome::Canceled,
+            Some(
+                WorkerOutcomeKind::Failed
+                | WorkerOutcomeKind::TimedOut
+                | WorkerOutcomeKind::Stalled,
+            ) => WorkerOutcome::Failed,
+            None => WorkerOutcome::Continued,
+        },
+        IssueRuntimeState::Completed => match issue
+            .last_worker_outcome
+            .as_ref()
+            .map(|outcome| outcome.outcome)
+        {
+            Some(WorkerOutcomeKind::Cancelled) => WorkerOutcome::Canceled,
+            Some(
+                WorkerOutcomeKind::Failed
+                | WorkerOutcomeKind::TimedOut
+                | WorkerOutcomeKind::Stalled,
+            ) => WorkerOutcome::Failed,
+            _ => WorkerOutcome::Completed,
+        },
+        IssueRuntimeState::Failed => WorkerOutcome::Failed,
+        IssueRuntimeState::Idle => WorkerOutcome::Unknown,
+        IssueRuntimeState::Releasing => WorkerOutcome::Unknown,
+    }
+}
+
+fn current_agent_server_status(
+    supervisor: &mut Option<LocalServerSupervisor>,
+    base_url: &str,
+) -> AgentServerStatus {
+    if let Some(supervisor) = supervisor.as_mut()
+        && let Ok(status) = supervisor.status()
+    {
+        return AgentServerStatus {
+            reachable: matches!(status.state, opensymphony_openhands::ServerState::Ready),
+            base_url: status.base_url,
+            conversation_count: 0,
+            status_line: format!("{:?}", status.state).to_ascii_lowercase(),
+        };
+    }
+
+    AgentServerStatus {
+        reachable: true,
+        base_url: base_url.to_string(),
+        conversation_count: 0,
+        status_line: "reachable".to_string(),
+    }
+}
+
+fn push_recent_event(
+    recent_events: &mut VecDeque<RecentEvent>,
+    kind: RecentEventKind,
+    issue_identifier: Option<IssueIdentifier>,
+    summary: String,
+    happened_at: DateTime<Utc>,
+) {
+    recent_events.push_front(RecentEvent {
+        happened_at,
+        issue_identifier: issue_identifier.map(|identifier| identifier.to_string()),
+        kind,
+        summary,
+    });
+    while recent_events.len() > RECENT_EVENT_LIMIT {
+        let _ = recent_events.pop_back();
+    }
+}
+
+fn terminal_state_set(workflow: &ResolvedWorkflow) -> HashSet<String> {
+    workflow
+        .config
+        .tracker
+        .terminal_states
+        .iter()
+        .map(|state| state.trim().to_ascii_lowercase())
+        .collect()
+}
+
+fn is_terminal_state(terminal_states: &HashSet<String>, state: &str) -> bool {
+    terminal_states.contains(&state.trim().to_ascii_lowercase())
+}
+
+fn issue_descriptor(issue: &NormalizedIssue) -> IssueDescriptor {
+    IssueDescriptor {
+        issue_id: issue.id.to_string(),
+        identifier: issue.identifier.to_string(),
+        title: issue.title.clone(),
+        current_state: issue.state.name.clone(),
+        last_seen_tracker_refresh_at: issue.updated_at.map(timestamp_to_datetime),
+    }
+}
+
+fn map_daemon_state(health: HealthStatus) -> DaemonState {
+    match health {
+        HealthStatus::Unknown | HealthStatus::Starting => DaemonState::Starting,
+        HealthStatus::Healthy => DaemonState::Ready,
+        HealthStatus::Degraded | HealthStatus::Failed => DaemonState::Degraded,
+    }
+}
+
+fn suffix(value: &str) -> String {
+    if value.len() <= 8 {
+        value.to_string()
+    } else {
+        value[value.len() - 8..].to_string()
+    }
+}
+
+fn suffix_path(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn timestamp_to_datetime(value: TimestampMs) -> DateTime<Utc> {
+    DateTime::from_timestamp_millis(value.as_u64() as i64).unwrap_or_else(Utc::now)
+}
+
+fn datetime_to_timestamp_ms(value: DateTime<Utc>) -> TimestampMs {
+    TimestampMs::new(value.timestamp_millis().max(0) as u64)
+}
+
+fn now_timestamp() -> TimestampMs {
+    TimestampMs::new(Utc::now().timestamp_millis().max(0) as u64)
+}

--- a/crates/opensymphony-cli/src/orchestrator_run.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run.rs
@@ -22,9 +22,9 @@ use opensymphony_domain::{
 };
 use opensymphony_linear::{LinearClient, LinearConfig, LinearError};
 use opensymphony_openhands::{
-    IssueSessionObserver, IssueSessionRunner, IssueSessionRunnerConfig, LocalServerSupervisor,
-    LocalServerTooling, OpenHandsClient, OpenHandsError, SupervisedServerConfig, SupervisorConfig,
-    TransportConfig,
+    IssueSessionError, IssueSessionObserver, IssueSessionResult, IssueSessionRunner,
+    IssueSessionRunnerConfig, LocalServerSupervisor, LocalServerTooling, OpenHandsClient,
+    OpenHandsError, SupervisedServerConfig, SupervisorConfig, TransportConfig,
 };
 use opensymphony_orchestrator::{
     RecoveryRecord, Scheduler, SchedulerConfig, SchedulerError, TrackerBackend, WorkerAbortReason,
@@ -146,6 +146,10 @@ enum RunCommandError {
         "workflow config requires a local OpenHands server, but no `openhands.tool_dir` was provided via config"
     )]
     MissingToolDir,
+    #[error(
+        "OpenHands transport URL `{value}` does not include an explicit port and has no default port"
+    )]
+    MissingTransportPort { value: String },
 }
 
 #[derive(Debug, Error)]
@@ -168,10 +172,18 @@ enum CliWorkerError {
     Workspace(#[from] WorkspaceError),
     #[error("worker launch timed out after {0:?}")]
     LaunchTimeout(Duration),
+    #[error("worker failed before reporting a conversation launch: {0}")]
+    LaunchFailed(String),
     #[error("worker exited before reporting a conversation launch")]
     LaunchChannelClosed,
     #[error("worker task failed: {0}")]
     Join(#[from] tokio::task::JoinError),
+}
+
+#[derive(Debug)]
+enum LaunchReport {
+    Conversation(Box<ConversationMetadata>),
+    Failed(String),
 }
 
 struct RuntimeTrackerBackend {
@@ -200,20 +212,14 @@ struct ActiveWorkerTask {
 
 struct SchedulerObserver {
     worker_id: String,
-    launch_tx: Option<oneshot::Sender<ConversationMetadata>>,
+    launch_tx: Option<oneshot::Sender<LaunchReport>>,
     updates_tx: mpsc::UnboundedSender<WorkerUpdate>,
-}
-
-impl SchedulerObserver {
-    fn mark_launched(&mut self) -> bool {
-        self.launch_tx.is_none()
-    }
 }
 
 impl IssueSessionObserver for SchedulerObserver {
     fn on_launch(&mut self, conversation: &ConversationMetadata) {
         if let Some(sender) = self.launch_tx.take() {
-            let _ = sender.send(conversation.clone());
+            let _ = sender.send(LaunchReport::Conversation(Box::new(conversation.clone())));
         }
     }
 
@@ -564,10 +570,7 @@ async fn build_runtime_transport(
         .local_server
         .readiness_probe_path
         .clone();
-    config.port_override = Some(
-        url.port_or_known_default()
-            .ok_or(RunCommandError::MissingToolDir)?,
-    );
+    config.port_override = Some(transport_port_override(&url)?);
 
     let mut supervisor = LocalServerSupervisor::new(SupervisorConfig::Supervised(Box::new(config)));
     let status = supervisor.start()?;
@@ -681,6 +684,39 @@ impl RuntimeWorkerBackend {
     }
 }
 
+fn transport_port_override(url: &Url) -> Result<u16, RunCommandError> {
+    url.port_or_known_default()
+        .ok_or_else(|| RunCommandError::MissingTransportPort {
+            value: url.as_str().to_string(),
+        })
+}
+
+fn report_launch_failure(
+    launch_tx: &mut Option<oneshot::Sender<LaunchReport>>,
+    detail: impl Into<String>,
+) {
+    if let Some(sender) = launch_tx.take() {
+        let _ = sender.send(LaunchReport::Failed(detail.into()));
+    }
+}
+
+fn pending_launch_failure_detail(result: &Result<IssueSessionResult, IssueSessionError>) -> String {
+    match result {
+        Ok(result) => {
+            let detail = result
+                .worker_outcome
+                .error
+                .clone()
+                .or_else(|| result.worker_outcome.summary.clone())
+                .unwrap_or_else(|| {
+                    "worker finished before reporting a conversation launch".to_string()
+                });
+            format!("worker finished before reporting a conversation launch: {detail}")
+        }
+        Err(error) => format!("worker failed before reporting a conversation launch: {error}"),
+    }
+}
+
 impl WorkerBackend for RuntimeWorkerBackend {
     type Error = CliWorkerError;
 
@@ -700,9 +736,16 @@ impl WorkerBackend for RuntimeWorkerBackend {
         let issue = request.issue.clone();
         let launch_worker_id = worker_id.clone();
         let handle = tokio::spawn(async move {
+            let mut launch_tx = Some(launch_tx);
             let ensured = match workspace_manager.ensure(&issue_descriptor(&issue)).await {
                 Ok(ensured) => ensured,
-                Err(_) => return,
+                Err(error) => {
+                    report_launch_failure(
+                        &mut launch_tx,
+                        format!("failed to ensure workspace: {error}"),
+                    );
+                    return;
+                }
             };
             let attempt = run.attempt.map(|attempt| attempt.get()).unwrap_or(1);
             let run_descriptor = RunDescriptor::new(format!("run-{launch_worker_id}"), attempt);
@@ -711,12 +754,18 @@ impl WorkerBackend for RuntimeWorkerBackend {
                 .await
             {
                 Ok(run_manifest) => run_manifest,
-                Err(_) => return,
+                Err(error) => {
+                    report_launch_failure(
+                        &mut launch_tx,
+                        format!("failed to prepare workspace run: {error}"),
+                    );
+                    return;
+                }
             };
 
             let mut observer = SchedulerObserver {
                 worker_id: observer_worker_id.to_string(),
-                launch_tx: Some(launch_tx),
+                launch_tx,
                 updates_tx: updates_tx.clone(),
             };
             let result = runner
@@ -731,7 +780,11 @@ impl WorkerBackend for RuntimeWorkerBackend {
                 )
                 .await;
 
-            if !observer.mark_launched() {
+            if observer.launch_tx.is_some() {
+                report_launch_failure(
+                    &mut observer.launch_tx,
+                    pending_launch_failure_detail(&result),
+                );
                 return;
             }
 
@@ -760,7 +813,15 @@ impl WorkerBackend for RuntimeWorkerBackend {
         );
 
         match timeout(self.launch_timeout, launch_rx).await {
-            Ok(Ok(conversation)) => Ok(WorkerLaunch { conversation }),
+            Ok(Ok(LaunchReport::Conversation(conversation))) => Ok(WorkerLaunch {
+                conversation: *conversation,
+            }),
+            Ok(Ok(LaunchReport::Failed(detail))) => {
+                if let Some(task) = self.tasks.remove(worker_id.as_str()) {
+                    task.handle.await?;
+                }
+                Err(CliWorkerError::LaunchFailed(detail))
+            }
             Ok(Err(_)) => {
                 if let Some(task) = self.tasks.remove(worker_id.as_str()) {
                     task.handle.await?;
@@ -1096,4 +1157,131 @@ fn datetime_to_timestamp_ms(value: DateTime<Utc>) -> TimestampMs {
 
 fn now_timestamp() -> TimestampMs {
     TimestampMs::new(Utc::now().timestamp_millis().max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use opensymphony_domain::{
+        IssueId, IssueState, IssueStateCategory, RunAttempt, WorkerId, WorkspaceKey,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn transport_port_override_reports_missing_port_separately() {
+        let url = Url::parse("custom-scheme://openhands.local").expect("URL should parse");
+
+        let error = transport_port_override(&url).expect_err("custom scheme should need a port");
+
+        assert!(matches!(
+            error,
+            RunCommandError::MissingTransportPort { value }
+                if value == "custom-scheme://openhands.local"
+        ));
+    }
+
+    #[tokio::test]
+    async fn start_worker_reports_workspace_setup_failures_before_launch() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let blocked_root = tempdir.path().join("workspace-root");
+        fs::write(&blocked_root, "not a directory").expect("blocking file should be created");
+
+        let workflow = Arc::new(sample_workflow(tempdir.path(), &blocked_root));
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let mut backend = RuntimeWorkerBackend::new(
+            OpenHandsClient::new(TransportConfig::new("http://127.0.0.1:1")),
+            workflow,
+            workspace_manager,
+        );
+
+        let issue = sample_issue();
+        let workspace = sample_workspace(&blocked_root);
+        let run = RunAttempt::new(
+            WorkerId::new("worker-1").expect("worker id should be valid"),
+            issue.id.clone(),
+            issue.identifier.clone(),
+            workspace.path.clone(),
+            TimestampMs::new(1),
+            None,
+            8,
+        );
+
+        let error = backend
+            .start_worker(WorkerStartRequest {
+                issue,
+                workspace,
+                run,
+            })
+            .await
+            .expect_err("workspace setup failure should fail the launch immediately");
+
+        assert!(matches!(
+            error,
+            CliWorkerError::LaunchFailed(detail)
+                if detail.contains("failed to ensure workspace")
+        ));
+        assert!(
+            backend.tasks.is_empty(),
+            "failed launches should not leave worker tasks behind"
+        );
+        assert!(
+            backend
+                .poll_updates()
+                .await
+                .expect("poll_updates should succeed")
+                .is_empty(),
+            "launch failures should be surfaced through start_worker, not queued as runtime updates",
+        );
+    }
+
+    fn sample_workflow(base_dir: &Path, workspace_root: &Path) -> ResolvedWorkflow {
+        let source = format!(
+            "---\ntracker:\n  kind: linear\n  endpoint: http://127.0.0.1:3001/graphql\n  project_slug: sample-project\n  active_states:\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: {}\nopenhands:\n  transport:\n    base_url: http://127.0.0.1:1\n    session_api_key_env: OPENHANDS_API_KEY\n---\n\n# Test Workflow\n\nRun the scheduler.\n",
+            workspace_root.display()
+        );
+        WorkflowDefinition::parse(&source)
+            .expect("workflow should parse")
+            .resolve_with_process_env(base_dir)
+            .expect("workflow should resolve")
+    }
+
+    fn sample_issue() -> NormalizedIssue {
+        NormalizedIssue {
+            id: IssueId::new("issue-1").expect("issue id should be valid"),
+            identifier: IssueIdentifier::new("COE-284").expect("issue identifier should be valid"),
+            title: "Test issue".to_string(),
+            description: None,
+            priority: None,
+            state: IssueState {
+                id: None,
+                name: "In Progress".to_string(),
+                category: IssueStateCategory::Active,
+            },
+            branch_name: None,
+            url: None,
+            labels: Vec::new(),
+            parent_id: None,
+            blocked_by: Vec::new(),
+            sub_issues: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn sample_workspace(workspace_root: &Path) -> WorkspaceRecord {
+        WorkspaceRecord {
+            path: workspace_root.join("COE-284"),
+            workspace_key: WorkspaceKey::new("COE-284").expect("workspace key should be valid"),
+            created_now: false,
+            created_at: None,
+            updated_at: None,
+            last_seen_tracker_refresh_at: None,
+        }
+    }
 }

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -16,6 +16,7 @@ fn top_level_help_describes_commands_and_safety_posture() {
     for snippet in [
         "Operate the OpenSymphony local MVP on a trusted machine",
         "process-level isolation only",
+        "Run the real orchestrator against the current project workflow",
         "Serve the local control-plane demo stream",
         "Attach the FrankenTUI operator client to a control plane",
         "Run local preflight checks for trusted-machine deployment",
@@ -49,6 +50,30 @@ fn doctor_help_explains_config_and_live_probe_options() {
         assert!(
             stdout.contains(snippet),
             "doctor help should include `{snippet}`: stdout={stdout}",
+        );
+    }
+}
+
+#[test]
+fn run_help_explains_config_autodetection() {
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["run", "--help"])
+        .output()
+        .expect("run help should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "run help should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    for snippet in [
+        "Run the real orchestrator against the current project workflow",
+        "Runtime config YAML path; defaults to ./config.yaml when present",
+    ] {
+        assert!(
+            stdout.contains(snippet),
+            "run help should include `{snippet}`: stdout={stdout}",
         );
     }
 }

--- a/crates/opensymphony-cli/tests/run.rs
+++ b/crates/opensymphony-cli/tests/run.rs
@@ -1,0 +1,214 @@
+use std::{process::Stdio, time::Duration};
+
+use axum::{Json, Router, routing::post};
+use opensymphony_testkit::FakeOpenHandsServer;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::{
+    net::TcpListener,
+    process::{Child, Command},
+    task::JoinHandle,
+    time::{Instant, sleep},
+};
+
+#[tokio::test]
+async fn run_auto_detects_config_and_workflow_from_project_directory() {
+    let openhands = FakeOpenHandsServer::start()
+        .await
+        .expect("fake OpenHands server should start");
+    let linear = MockLinearGraphqlServer::start().await;
+    let project = TempDir::new().expect("temp project should exist");
+    let bind_addr = reserve_socket_addr();
+
+    write_project_files(
+        project.path(),
+        linear.base_url(),
+        openhands.base_url(),
+        format!("control_plane:\n  bind: {bind_addr}\n"),
+    );
+
+    let mut child = spawn_run_child(project.path(), &[]);
+
+    wait_for_health(&format!("http://{bind_addr}/healthz"))
+        .await
+        .expect("run command should become healthy from the project directory");
+
+    terminate_child(&mut child).await;
+}
+
+#[tokio::test]
+async fn run_config_flag_overrides_auto_detected_config_file() {
+    let openhands = FakeOpenHandsServer::start()
+        .await
+        .expect("fake OpenHands server should start");
+    let linear = MockLinearGraphqlServer::start().await;
+    let project = TempDir::new().expect("temp project should exist");
+    let default_bind = reserve_socket_addr();
+    let override_bind = reserve_socket_addr();
+
+    write_project_files(
+        project.path(),
+        linear.base_url(),
+        openhands.base_url(),
+        format!("control_plane:\n  bind: {default_bind}\n"),
+    );
+    std::fs::write(
+        project.path().join("override.yaml"),
+        format!("control_plane:\n  bind: {override_bind}\n"),
+    )
+    .expect("override config should be written");
+
+    let mut child = spawn_run_child(project.path(), &["--config", "override.yaml"]);
+
+    wait_for_health(&format!("http://{override_bind}/healthz"))
+        .await
+        .expect("explicit --config should control the bind address");
+    assert!(
+        !health_endpoint_ready(&format!("http://{default_bind}/healthz")).await,
+        "default auto-detected config should not be used when --config is passed",
+    );
+
+    terminate_child(&mut child).await;
+}
+
+#[tokio::test]
+async fn run_accepts_existing_repo_config_shape_with_extra_doctor_fields() {
+    let openhands = FakeOpenHandsServer::start()
+        .await
+        .expect("fake OpenHands server should start");
+    let linear = MockLinearGraphqlServer::start().await;
+    let project = TempDir::new().expect("temp project should exist");
+    let bind_addr = reserve_socket_addr();
+
+    write_project_files(
+        project.path(),
+        linear.base_url(),
+        openhands.base_url(),
+        format!(
+            "target_repo: .\ncontrol_plane:\n  bind: {bind_addr}\nopenhands:\n  probe_model: fake-model\n  probe_api_key_env: FAKE_API_KEY\nlinear:\n  enabled: false\n"
+        ),
+    );
+
+    let mut child = spawn_run_child(project.path(), &[]);
+
+    wait_for_health(&format!("http://{bind_addr}/healthz"))
+        .await
+        .expect("run command should ignore doctor-only config fields");
+
+    terminate_child(&mut child).await;
+}
+
+fn spawn_run_child(project_root: &std::path::Path, extra_args: &[&str]) -> Child {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_opensymphony"));
+    command
+        .arg("run")
+        .args(extra_args)
+        .current_dir(project_root)
+        .env("LINEAR_API_KEY", "test-linear-key")
+        .env("OPENHANDS_API_KEY", "test-openhands-key")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command.spawn().expect("run command should spawn")
+}
+
+fn write_project_files(
+    project_root: &std::path::Path,
+    linear_base_url: &str,
+    openhands_base_url: &str,
+    config_contents: String,
+) {
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        format!(
+            "---\ntracker:\n  kind: linear\n  endpoint: {linear_base_url}\n  project_slug: test-project\n  active_states:\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: ./var/workspaces\nopenhands:\n  transport:\n    base_url: {openhands_base_url}\n    session_api_key_env: OPENHANDS_API_KEY\n---\n\n# Test Workflow\n\nRun the scheduler.\n"
+        ),
+    )
+    .expect("workflow should be written");
+    std::fs::write(project_root.join("config.yaml"), config_contents)
+        .expect("config should be written");
+}
+
+fn reserve_socket_addr() -> std::net::SocketAddr {
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("temporary listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("temporary listener should expose its address");
+    drop(listener);
+    address
+}
+
+async fn wait_for_health(url: &str) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if health_endpoint_ready(url).await {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    Err(format!("timed out waiting for {url}"))
+}
+
+async fn health_endpoint_ready(url: &str) -> bool {
+    match reqwest::Client::new().get(url).send().await {
+        Ok(response) => response.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+async fn terminate_child(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+struct MockLinearGraphqlServer {
+    base_url: String,
+    task: JoinHandle<()>,
+}
+
+impl MockLinearGraphqlServer {
+    async fn start() -> Self {
+        let app = Router::new().route("/graphql", post(handle_graphql));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock Linear listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock Linear listener should expose an address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("mock Linear server should run");
+        });
+
+        Self {
+            base_url: format!("http://{address}/graphql"),
+            task,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for MockLinearGraphqlServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn handle_graphql() -> Json<serde_json::Value> {
+    Json(json!({
+        "data": {
+            "issues": {
+                "nodes": [],
+                "pageInfo": {
+                    "hasNextPage": false,
+                    "endCursor": null
+                }
+            }
+        }
+    }))
+}

--- a/crates/opensymphony-openhands/src/lib.rs
+++ b/crates/opensymphony-openhands/src/lib.rs
@@ -20,8 +20,9 @@ pub use models::{
     LlmConfig, SearchConversationEventsResponse, SendMessageRequest, TextContent, WorkspaceConfig,
 };
 pub use session::{
-    IssueConversationManifest, IssueSessionContext, IssueSessionError, IssueSessionPromptKind,
-    IssueSessionResult, IssueSessionRunner, IssueSessionRunnerConfig, RUNTIME_CONTRACT_VERSION,
+    IssueConversationManifest, IssueSessionContext, IssueSessionError, IssueSessionObserver,
+    IssueSessionPromptKind, IssueSessionResult, IssueSessionRunner, IssueSessionRunnerConfig,
+    RUNTIME_CONTRACT_VERSION,
 };
 pub use supervisor::{
     ExternalServerConfig, LaunchOwnership, LocalServerSupervisor, ProbeConfig, ServerMode,

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -35,6 +35,21 @@ pub struct IssueSessionRunnerConfig {
     pub finished_drain_timeout: Duration,
 }
 
+pub trait IssueSessionObserver {
+    fn on_launch(&mut self, _conversation: &ConversationMetadata) {}
+
+    fn on_runtime_event(
+        &mut self,
+        _observed_at: TimestampMs,
+        _event_id: Option<String>,
+        _event_kind: Option<String>,
+        _summary: Option<String>,
+    ) {
+    }
+}
+
+impl IssueSessionObserver for () {}
+
 impl Default for IssueSessionRunnerConfig {
     fn default() -> Self {
         Self {
@@ -367,6 +382,32 @@ impl IssueSessionRunner {
         run: &RunAttempt,
         workflow: &ResolvedWorkflow,
     ) -> Result<IssueSessionResult, IssueSessionError> {
+        self.run_with_observer(
+            workspace_manager,
+            workspace,
+            run_manifest,
+            issue,
+            run,
+            workflow,
+            &mut (),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_with_observer<O>(
+        &self,
+        workspace_manager: &WorkspaceManager,
+        workspace: &WorkspaceHandle,
+        run_manifest: &mut RunManifest,
+        issue: &NormalizedIssue,
+        run: &RunAttempt,
+        workflow: &ResolvedWorkflow,
+        observer: &mut O,
+    ) -> Result<IssueSessionResult, IssueSessionError>
+    where
+        O: IssueSessionObserver,
+    {
         let observed_run = observed_run_for_turn(run);
         let active_session = match self
             .initialize_session(
@@ -393,6 +434,7 @@ impl IssueSessionRunner {
                 issue,
                 run,
                 active_session,
+                observer,
             )
             .await?
         {
@@ -408,6 +450,7 @@ impl IssueSessionRunner {
                 &observed_run,
                 active_session,
                 &mut prepared_turn,
+                observer,
             )
             .await?
         {
@@ -419,6 +462,7 @@ impl IssueSessionRunner {
             .await_terminal_outcome(
                 &mut active_session.stream,
                 &prepared_turn.baseline_event_ids,
+                observer,
             )
             .await;
         self.finalize_active_session(
@@ -480,7 +524,7 @@ impl IssueSessionRunner {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn prepare_turn(
+    async fn prepare_turn<O>(
         &self,
         workspace_manager: &WorkspaceManager,
         workspace: &WorkspaceHandle,
@@ -490,13 +534,17 @@ impl IssueSessionRunner {
         issue: &NormalizedIssue,
         run: &RunAttempt,
         mut active_session: ActiveSession,
-    ) -> Result<Step<(ActiveSession, PreparedTurn)>, IssueSessionError> {
+        observer: &mut O,
+    ) -> Result<Step<(ActiveSession, PreparedTurn)>, IssueSessionError>
+    where
+        O: IssueSessionObserver,
+    {
         let mut waited_for_prior_turn = false;
         if let Some(status) = active_session.stream.state_mirror().execution_status()
             && turn_is_in_progress(status)
         {
             if let Err(error) = self
-                .wait_for_active_turn_to_finish(&mut active_session.stream)
+                .wait_for_active_turn_to_finish(&mut active_session.stream, observer)
                 .await
             {
                 return self
@@ -602,7 +650,8 @@ impl IssueSessionRunner {
         )))
     }
 
-    async fn start_turn(
+    #[allow(clippy::too_many_arguments)]
+    async fn start_turn<O>(
         &self,
         workspace_manager: &WorkspaceManager,
         workspace: &WorkspaceHandle,
@@ -610,7 +659,11 @@ impl IssueSessionRunner {
         observed_run: &RunAttempt,
         mut active_session: ActiveSession,
         prepared_turn: &mut PreparedTurn,
-    ) -> Result<Step<ActiveSession>, IssueSessionError> {
+        observer: &mut O,
+    ) -> Result<Step<ActiveSession>, IssueSessionError>
+    where
+        O: IssueSessionObserver,
+    {
         if let Err(error) = self
             .client
             .send_message(
@@ -661,7 +714,7 @@ impl IssueSessionRunner {
                 }) => {
                     had_run_conflict = true;
                     if let Err(error) = self
-                        .wait_for_active_turn_to_finish(&mut active_session.stream)
+                        .wait_for_active_turn_to_finish(&mut active_session.stream, observer)
                         .await
                     {
                         return self
@@ -741,6 +794,12 @@ impl IssueSessionRunner {
                 ),
             )
             .await?;
+
+        observer.on_launch(
+            &active_session
+                .manifest
+                .to_domain_metadata(RuntimeStreamState::Ready),
+        );
 
         Ok(Step::Continue(active_session))
     }
@@ -1119,10 +1178,14 @@ impl IssueSessionRunner {
         }
     }
 
-    async fn wait_for_active_turn_to_finish(
+    async fn wait_for_active_turn_to_finish<O>(
         &self,
         stream: &mut RuntimeEventStream,
-    ) -> Result<(), OpenHandsError> {
+        observer: &mut O,
+    ) -> Result<(), OpenHandsError>
+    where
+        O: IssueSessionObserver,
+    {
         if stream
             .state_mirror()
             .execution_status()
@@ -1155,7 +1218,8 @@ impl IssueSessionRunner {
                         ),
                     });
                 }
-                Ok(Ok(Some(_))) | Ok(Ok(None)) => {}
+                Ok(Ok(Some(event))) => observe_event(observer, &event),
+                Ok(Ok(None)) => {}
                 Ok(Err(error)) => {
                     if stream
                         .state_mirror()
@@ -1171,16 +1235,20 @@ impl IssueSessionRunner {
         }
     }
 
-    async fn await_terminal_outcome(
+    async fn await_terminal_outcome<O>(
         &self,
         stream: &mut RuntimeEventStream,
         baseline_event_ids: &HashSet<String>,
-    ) -> NormalizedOutcome {
+        observer: &mut O,
+    ) -> NormalizedOutcome
+    where
+        O: IssueSessionObserver,
+    {
         let deadline = Instant::now() + self.config.terminal_wait_timeout;
 
         loop {
             if let Some(outcome) = self
-                .terminal_outcome_from_state(stream, baseline_event_ids)
+                .terminal_outcome_from_state(stream, baseline_event_ids, observer)
                 .await
             {
                 return outcome;
@@ -1192,8 +1260,9 @@ impl IssueSessionRunner {
                     if let Ok(inserted) = stream.reconcile_events().await
                         && inserted > 0
                     {
+                        observe_latest_event(observer, stream);
                         if let Some(outcome) = self
-                            .terminal_outcome_from_state(stream, baseline_event_ids)
+                            .terminal_outcome_from_state(stream, baseline_event_ids, observer)
                             .await
                         {
                             return outcome;
@@ -1210,15 +1279,18 @@ impl IssueSessionRunner {
                         )),
                     };
                 }
-                Ok(Ok(Some(_))) => {}
+                Ok(Ok(Some(event))) => observe_event(observer, &event),
                 Ok(Ok(None)) => {
                     if let Ok(inserted) = stream.reconcile_events().await
                         && inserted > 0
-                        && let Some(outcome) = self
-                            .terminal_outcome_from_state(stream, baseline_event_ids)
-                            .await
                     {
-                        return outcome;
+                        observe_latest_event(observer, stream);
+                        if let Some(outcome) = self
+                            .terminal_outcome_from_state(stream, baseline_event_ids, observer)
+                            .await
+                        {
+                            return outcome;
+                        }
                     }
 
                     return NormalizedOutcome {
@@ -1232,7 +1304,7 @@ impl IssueSessionRunner {
                 }
                 Ok(Err(error)) => {
                     if let Some(outcome) = self
-                        .terminal_outcome_from_state(stream, baseline_event_ids)
+                        .terminal_outcome_from_state(stream, baseline_event_ids, observer)
                         .await
                     {
                         return outcome;
@@ -1248,11 +1320,15 @@ impl IssueSessionRunner {
         }
     }
 
-    async fn terminal_outcome_from_state(
+    async fn terminal_outcome_from_state<O>(
         &self,
         stream: &mut RuntimeEventStream,
         baseline_event_ids: &HashSet<String>,
-    ) -> Option<NormalizedOutcome> {
+        observer: &mut O,
+    ) -> Option<NormalizedOutcome>
+    where
+        O: IssueSessionObserver,
+    {
         let has_current_turn_activity = stream
             .event_cache()
             .items()
@@ -1275,7 +1351,7 @@ impl IssueSessionRunner {
         match stream.state_mirror().terminal_status() {
             Some(TerminalExecutionStatus::Finished) => {
                 if self
-                    .confirm_finished_terminal_state(stream, baseline_event_ids)
+                    .confirm_finished_terminal_state(stream, baseline_event_ids, observer)
                     .await
                 {
                     Some(NormalizedOutcome {
@@ -1313,11 +1389,15 @@ impl IssueSessionRunner {
         }
     }
 
-    async fn confirm_finished_terminal_state(
+    async fn confirm_finished_terminal_state<O>(
         &self,
         stream: &mut RuntimeEventStream,
         baseline_event_ids: &HashSet<String>,
-    ) -> bool {
+        observer: &mut O,
+    ) -> bool
+    where
+        O: IssueSessionObserver,
+    {
         let deadline = Instant::now() + self.config.finished_drain_timeout;
 
         loop {
@@ -1334,7 +1414,10 @@ impl IssueSessionRunner {
 
             match timeout_at(deadline, stream.next_event()).await {
                 Err(_) => return true,
-                Ok(Ok(Some(_))) => continue,
+                Ok(Ok(Some(event))) => {
+                    observe_event(observer, &event);
+                    continue;
+                }
                 Ok(Ok(None)) => return true,
                 Ok(Err(error)) => return finished_stream_error_is_tolerable(&error),
             }
@@ -1612,6 +1695,27 @@ fn build_summary_metadata(
     }
 }
 
+fn observe_event<O>(observer: &mut O, event: &EventEnvelope)
+where
+    O: IssueSessionObserver,
+{
+    observer.on_runtime_event(
+        timestamp_ms_from_datetime(event.timestamp),
+        Some(event.id.clone()),
+        Some(event.kind.clone()),
+        Some(summarize_event(event)),
+    );
+}
+
+fn observe_latest_event<O>(observer: &mut O, stream: &RuntimeEventStream)
+where
+    O: IssueSessionObserver,
+{
+    if let Some(event) = stream.event_cache().items().last() {
+        observe_event(observer, event);
+    }
+}
+
 fn failed_outcome(summary: impl Into<String>, error: impl Into<String>) -> NormalizedOutcome {
     NormalizedOutcome {
         kind: WorkerOutcomeKind::Failed,
@@ -1781,7 +1885,7 @@ mod tests {
             },
         );
         let outcome = runner
-            .await_terminal_outcome(&mut stream, &baseline_event_ids)
+            .await_terminal_outcome(&mut stream, &baseline_event_ids, &mut ())
             .await;
 
         assert_eq!(outcome.kind, WorkerOutcomeKind::Succeeded);

--- a/crates/opensymphony-openhands/src/tooling.rs
+++ b/crates/opensymphony-openhands/src/tooling.rs
@@ -227,10 +227,10 @@ impl LocalServerTooling {
             "LLM_API_KEY",
             "FIREWORKS_API_KEY",
         ] {
-            if let Ok(value) = std::env::var(key) {
-                if !value.is_empty() {
-                    env.insert(key.to_string(), value);
-                }
+            if let Ok(value) = std::env::var(key)
+                && !value.is_empty()
+            {
+                env.insert(key.to_string(), value);
             }
         }
         env.extend(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,7 +171,8 @@ Current crate boundaries:
   - snapshot store
   - local HTTP and WebSocket control-plane API
 - `opensymphony-cli`
-  - daemon startup
+  - `run` orchestrator startup
+  - `daemon` demo control-plane startup
   - doctor command
   - target-repo `WORKFLOW.md` resolution and prompt preflight for doctor
   - repo-root OpenHands preflight checks
@@ -211,7 +212,7 @@ The other crates are already present at their final ownership boundaries, but fo
 
 Local MVP process graph:
 
-- `opensymphony daemon`
+- `opensymphony run`
   - owns orchestrator and control plane
   - may spawn:
     - `bash tools/openhands-server/run-local.sh`
@@ -395,15 +396,17 @@ PollTick
 
 ## 7.3 Current local attach path
 
-The implemented local observability flow is narrower than the full future daemon path, but it already preserves the same boundary:
+The implemented local attach path now uses the real orchestrator entrypoint while preserving the same boundary:
 
-1. `opensymphony-cli daemon` starts a local control-plane server.
+1. `opensymphony-cli run` starts the orchestrator and local control-plane server.
 2. A snapshot store publishes immutable `SnapshotEnvelope` values.
 3. `opensymphony-cli tui` fetches `/api/v1/snapshot` and renders it as bootstrap state.
 4. The TUI gives that snapshot fetch a bounded timeout, then opens `/api/v1/events` behind a separate bounded stream-attach watchdog that stays armed until the first snapshot arrives. That deadline is measured across the whole pre-snapshot phase rather than restarting on keepalive comments or other non-snapshot SSE frames, keeps `conn=connecting` until the stream delivers that first snapshot, and publishes the first streamed snapshot plus the live attachment signal atomically before listening for ongoing SSE updates.
 5. If an SSE client lags, the control plane immediately fast-forwards it to `store.current()` instead of waiting for the retained broadcast backlog to drain, and suppresses any older retained sequences so reducers never regress.
 6. On snapshot or stream failure, the TUI keeps rendering the last good snapshot, marks the connection as reconnecting, then retries the current snapshot fetch before resubscribing.
 7. Detaching the UI leaves the daemon process and snapshot publication unaffected.
+
+The separate `opensymphony-cli daemon` command remains available only as a demo snapshot publisher for smoke tests and UI-focused development.
 
 ## 8. Recovery model
 

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -26,7 +26,7 @@ This is the MVP target.
 
 ```text
 developer machine
-  ├─ opensymphony daemon
+  ├─ opensymphony run
   │   ├─ orchestrator
   │   ├─ workspace manager
   │   ├─ linear adapter
@@ -67,7 +67,7 @@ This mode uses the same Rust runtime adapter but skips local subprocess supervis
 
 ```text
 developer machine
-  ├─ opensymphony daemon
+  ├─ opensymphony run
   └─ external OpenHands agent-server
 ```
 
@@ -101,11 +101,11 @@ This is the primary follow-on after the local MVP.
 
 ```text
 developer laptop
-  ├─ opensymphony daemon or thin client
+  ├─ opensymphony run or thin client
   └─ remote OpenSymphony control plane
 
 server side
-  ├─ opensymphony daemon
+  ├─ opensymphony run
   ├─ remote OpenHands agent-server fleet
   ├─ remote workspace isolation layer
   └─ shared observability and auth

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -38,7 +38,7 @@ OpenSymphony keeps all Symphony-specific scheduling rules in Rust and uses OpenH
 ## 3. Local MVP topology
 
 ```text
-opensymphony daemon
+opensymphony run
   ├─ orchestrator
   ├─ workspace manager
   ├─ linear adapter

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -335,21 +335,23 @@ Expected assertions:
 
 Recommended CLI commands for the repo:
 
-- `opensymphony daemon`
+- `opensymphony run`
 - `opensymphony tui`
 - `opensymphony doctor`
 - `opensymphony linear-mcp`
 
 Recommended first-run sequence:
 
+- `cargo install --path .`
 - `./tools/openhands-server/install.sh`
-- `cargo run -p opensymphony-cli -- --help`
-- `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`
+- `opensymphony --help`
+- `opensymphony doctor --config examples/configs/local-dev.yaml`
 
 Current workspace commands:
 
-- `cargo run -p opensymphony-cli -- daemon --bind 127.0.0.1:3000`
-- `cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:3000/`
+- `cd /path/to/target-repo && opensymphony run`
+- `cd /path/to/target-repo && opensymphony run --config ./config.yaml`
+- `opensymphony tui --url http://127.0.0.1:3000/`
 
 Possible helper commands later:
 
@@ -357,14 +359,15 @@ Possible helper commands later:
 - `opensymphony inspect workspace <issue-id>`
 - `opensymphony inspect conversation <issue-id>`
 
-Current validation commands for the implemented observability slice:
+Current validation commands for the implemented orchestrator and observability slice:
 
 - `cargo test`
 - `cargo clippy --workspace --all-targets -- -D warnings`
-- `cargo run -p opensymphony-cli -- daemon --bind 127.0.0.1:4010 --sample-interval-ms 250`
-- `curl http://127.0.0.1:4010/api/v1/snapshot`
-- `cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:4010/ --exit-after-ms 1200`
-- `curl http://127.0.0.1:4010/healthz`
+- `cargo install --path . --locked --root /tmp/opensymphony-install-check`
+- `cd /path/to/target-repo && /tmp/opensymphony-install-check/bin/opensymphony run`
+- `curl http://127.0.0.1:3000/api/v1/snapshot`
+- `opensymphony tui --url http://127.0.0.1:3000/ --exit-after-ms 1200`
+- `curl http://127.0.0.1:3000/healthz`
 
 The scripted `tui --exit-after-ms` smoke path now exits `0` only when the
 final reduced control-plane state is still a real streamed
@@ -396,15 +399,16 @@ control plane causes `opensymphony tui --exit-after-ms ...` to exit non-zero.
 Current command set in this repository:
 
 - `./tools/openhands-server/install.sh`
-- `cargo run -p opensymphony-cli -- daemon --bind 127.0.0.1:4010 --sample-interval-ms 250`
-- `curl http://127.0.0.1:4010/healthz`
-- `curl http://127.0.0.1:4010/api/v1/snapshot`
-- `cargo run -p opensymphony-cli -- tui --url http://127.0.0.1:4010/ --exit-after-ms 1200`
-- `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.yaml`
-- `cargo run -p opensymphony-cli -- doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands`
+- `cargo install --path .`
+- `cd /path/to/target-repo && opensymphony run --config ./config.yaml`
+- `curl http://127.0.0.1:3000/healthz`
+- `curl http://127.0.0.1:3000/api/v1/snapshot`
+- `opensymphony tui --url http://127.0.0.1:3000/ --exit-after-ms 1200`
+- `opensymphony doctor --config examples/configs/local-dev.yaml`
+- `opensymphony doctor --config examples/configs/local-dev.with-live-openhands.yaml --live-openhands`
 - `OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_pinned_server -- --nocapture`
 - `OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test -p opensymphony-openhands --test live_local_suite -- --ignored --nocapture --test-threads=1`
-- `cargo run -p opensymphony-cli -- linear-mcp`
+- `opensymphony linear-mcp`
 - `./scripts/smoke_local.sh`
 - `OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh`
 
@@ -437,8 +441,8 @@ When validating the local control-plane and TUI slice, also confirm that:
 - lagged SSE consumers immediately fast-forward to the newest published snapshot instead of waiting for the retained broadcast backlog to go empty, and they only advance to newer snapshot sequences
 - newline-bearing, control-character-bearing, or full-width tracker and event text stays within
   the pane row and column budget
-- `opensymphony daemon --sample-interval-ms ...` keeps the initial `Starting` snapshot in place
-  until the configured interval elapses
+- the demo-only `opensymphony daemon --sample-interval-ms ...` command keeps the initial
+  `Starting` snapshot in place until the configured interval elapses
 
 ## 7. Doctor checks
 

--- a/examples/target-repo/config.yaml
+++ b/examples/target-repo/config.yaml
@@ -1,0 +1,5 @@
+control_plane:
+  bind: 127.0.0.1:3000
+
+openhands:
+  tool_dir: ../../tools/openhands-server

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,4 @@
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    opensymphony_cli::run().await
+}


### PR DESCRIPTION
## Summary

Add a real `opensymphony run` entrypoint for the orchestrator, make the repo
root installable as `opensymphony`, and update the docs to match the shipped
CLI surface.

## Changes

- add `opensymphony run` with `--config`, `config.yaml` auto-detection, and
  current-directory `WORKFLOW.md` loading
- wire the CLI into the existing scheduler, workspace, Linear, OpenHands, and
  control-plane crates and stream runtime events through the session runner
- add a root package plus binary wrapper so `cargo install --path .` installs
  `opensymphony`
- add regression coverage for project-directory startup, explicit config
  override, and compatibility with the repo's existing config YAML shape
- replace incorrect `daemon --config` docs with `opensymphony run` guidance in
  the README and affected architecture/operations docs

## Evidence

### Test output

```text
$ cargo test -p opensymphony-cli
passed: 10 unit tests, 9 doctor tests, 3 help tests, 1 linear_mcp test,
2 tui tests, and 3 run-command integration tests.

$ cargo test -p opensymphony-openhands issue_session_runner -- --nocapture
passed: 6 issue_session_runner tests.

$ cargo clippy -p opensymphony-cli -p opensymphony-openhands --all-targets -- -D warnings
passed.

$ cargo install --path . --locked --root /tmp/opensymphony-install-check.m0QSzp
Installed package `opensymphony v0.1.0` (executable `opensymphony`)

$ /tmp/opensymphony-install-check.m0QSzp/bin/opensymphony run --help
Run the real orchestrator against the current project workflow
Usage: opensymphony run [OPTIONS]
```

### Verification

Validated the ticket test plan in three ways:
1. `cargo install --path .` now succeeds from the repo root and installs an
   `opensymphony` binary.
2. New CLI integration tests start `opensymphony run` inside a temp project
   containing `WORKFLOW.md` plus `config.yaml`, then verify the control-plane
   health endpoint becomes reachable.
3. A second integration test verifies `--config override.yaml` wins over an
   auto-detected `config.yaml` in the same project directory.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: 

## Breaking changes

None.

## Related issues

- COE-284

## Additional notes

`opensymphony daemon` remains available as the demo-only control-plane stream
used by existing smoke/UI flows, but the README and operational docs now point
at `opensymphony run` as the real orchestrator entrypoint.

