### PR TITLE
Add opensymphony debug command for issue conversations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ opensymphony run
 # Or point at an explicit runtime config file
 opensymphony run --config ./config.yaml
 
+# Resume the persisted OpenHands conversation for one issue
+opensymphony debug COE-284
+
 # Optional: Start the TUI for monitoring
 opensymphony tui --url http://127.0.0.1:3000/
 ```
@@ -215,13 +218,36 @@ Each issue gets a deterministic workspace:
 <workspace_root>/<issue_identifier>/
 ├── .opensymphony/
 │   ├── issue.json              # Issue metadata
-│   ├── conversation.json       # OpenHands conversation ID
+│   ├── conversation.json       # Conversation registry and launch profile
 │   └── openhands/
 │       └── create-conversation-request.json
 ├── .opensymphony.after_create.json  # Hook receipt
 ├── <repo_files>                # Cloned repository
 └── logs/                       # Execution logs
 ```
+
+## Debugging Sessions
+
+Use `opensymphony debug <issue-id>` to reopen the OpenHands conversation that OpenSymphony used for that issue:
+
+```bash
+cd /path/to/target-repo
+opensymphony debug COE-284
+```
+
+The command resolves the issue reference to its managed workspace, reads
+`.opensymphony/conversation.json`, and resumes the same `conversation_id` from the
+original working directory. The conversation registry persists the issue reference,
+stable OpenHands conversation ID, timestamps, transport details, and the launch
+profile that created the session so a missing-but-recoverable thread can be
+rehydrated without losing continuity.
+
+When the workflow uses the local supervised OpenHands server, `opensymphony debug`
+targets the same configured base URL as the orchestrator. If a ready server is
+already listening there, the debug command reuses it; otherwise it starts a local
+server for the session. For the most predictable behavior, prefer the
+orchestrator-managed server and avoid leaving unrelated standalone `openhands`
+CLI sessions bound to the same port.
 
 ### Lifecycle Hooks
 

--- a/crates/opensymphony-cli/Cargo.toml
+++ b/crates/opensymphony-cli/Cargo.toml
@@ -28,6 +28,7 @@ opensymphony-workflow = { path = "../opensymphony-workflow" }
 opensymphony-tui = { path = "../opensymphony-tui" }
 opensymphony-workspace = { path = "../opensymphony-workspace" }
 serde.workspace = true
+serde_json.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
@@ -35,6 +36,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -490,7 +490,7 @@ async fn attach_or_rehydrate_stream(
         .await
     {
         Ok(stream) => Ok(stream),
-        Err(_) => {
+        Err(error) if should_rehydrate_after_attach_failure(&error) => {
             let launch_profile = resolve_launch_profile(manifest, workflow)
                 .map_err(|detail| DebugCommandError::LaunchProfile { detail })?;
             let request = launch_profile.to_create_request(
@@ -515,7 +515,18 @@ async fn attach_or_rehydrate_stream(
 
             Ok(stream)
         }
+        Err(error) => Err(error.into()),
     }
+}
+
+fn should_rehydrate_after_attach_failure(error: &OpenHandsError) -> bool {
+    matches!(
+        error,
+        OpenHandsError::HttpStatus {
+            status_code: 404,
+            ..
+        }
+    )
 }
 
 fn resolve_launch_profile(
@@ -874,4 +885,34 @@ fn turn_is_in_progress(status: &str) -> bool {
 
 fn turn_has_stopped(status: &str) -> bool {
     !turn_is_in_progress(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_rehydrate_after_attach_failure;
+    use opensymphony_openhands::OpenHandsError;
+
+    #[test]
+    fn rehydrate_only_when_conversation_is_missing() {
+        assert!(should_rehydrate_after_attach_failure(
+            &OpenHandsError::HttpStatus {
+                operation: "fetch conversation",
+                status_code: 404,
+                body: "missing".to_string(),
+            }
+        ));
+        assert!(!should_rehydrate_after_attach_failure(
+            &OpenHandsError::HttpStatus {
+                operation: "fetch conversation",
+                status_code: 401,
+                body: "unauthorized".to_string(),
+            }
+        ));
+        assert!(!should_rehydrate_after_attach_failure(
+            &OpenHandsError::Transport {
+                operation: "fetch conversation",
+                detail: "connection refused".to_string(),
+            }
+        ));
+    }
 }

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -1,0 +1,877 @@
+use std::{
+    collections::HashSet,
+    env, io,
+    io::Write,
+    path::{Path, PathBuf},
+    process::ExitCode,
+    time::Duration,
+};
+
+use clap::Args;
+use opensymphony_openhands::{
+    ConversationLaunchProfile, EventEnvelope, IssueConversationManifest, IssueSessionRunnerConfig,
+    KnownEvent, LocalServerSupervisor, LocalServerTooling, OpenHandsClient, OpenHandsError,
+    RuntimeEventStream, SendMessageRequest, SupervisedServerConfig, SupervisorConfig,
+    SupervisorError, TerminalExecutionStatus, TransportConfig,
+};
+use opensymphony_workflow::{ProcessEnvironment, ResolvedWorkflow, WorkflowDefinition};
+use opensymphony_workspace::{
+    CleanupConfig, HookConfig, HookDefinition, WorkspaceError, WorkspaceHandle, WorkspaceManager,
+    WorkspaceManagerConfig,
+};
+use serde::Deserialize;
+use thiserror::Error;
+use tokio::{fs, time::timeout_at};
+use url::Url;
+use uuid::Uuid;
+
+const DEFAULT_CONFIG_FILE: &str = "config.yaml";
+const RECENT_HISTORY_LIMIT: usize = 8;
+
+#[derive(Debug, Args, Clone)]
+pub struct DebugArgs {
+    #[arg(help = "Linear issue identifier or persisted issue ID to resume")]
+    pub issue_id: String,
+    #[arg(help = "Runtime config YAML path; defaults to ./config.yaml when present")]
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DebugConfigFile {
+    #[serde(default)]
+    target_repo: Option<String>,
+    #[serde(default)]
+    openhands: DebugOpenHandsConfigFile,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DebugOpenHandsConfigFile {
+    #[serde(default)]
+    tool_dir: Option<String>,
+}
+
+struct DebugRuntimeConfig {
+    repo_root: PathBuf,
+    workflow: ResolvedWorkflow,
+    tool_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Error)]
+enum DebugCommandError {
+    #[error("failed to determine the current working directory: {0}")]
+    CurrentDir(#[source] io::Error),
+    #[error("failed to read {path}: {source}")]
+    ReadConfig {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to parse {path}: {source}")]
+    ParseConfig {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("failed to expand {path}: {detail}")]
+    ResolveConfig { path: PathBuf, detail: String },
+    #[error("failed to load workflow {path}: {source}")]
+    LoadWorkflow {
+        path: PathBuf,
+        #[source]
+        source: opensymphony_workflow::WorkflowLoadError,
+    },
+    #[error("failed to resolve workflow {path}: {source}")]
+    ResolveWorkflow {
+        path: PathBuf,
+        #[source]
+        source: opensymphony_workflow::WorkflowConfigError,
+    },
+    #[error("failed to create workspace manager: {0}")]
+    WorkspaceManager(#[from] WorkspaceError),
+    #[error(
+        "no managed workspace for issue reference `{issue_reference}` exists under {workspace_root}"
+    )]
+    WorkspaceNotFound {
+        issue_reference: String,
+        workspace_root: PathBuf,
+    },
+    #[error("conversation manifest is missing: {path}")]
+    ConversationManifestMissing { path: PathBuf },
+    #[error("failed to decode conversation manifest {path}: {source}")]
+    DecodeConversationManifest {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("conversation manifest contains invalid conversation id `{value}`: {source}")]
+    InvalidConversationId {
+        value: String,
+        #[source]
+        source: uuid::Error,
+    },
+    #[error("failed to build conversation launch profile: {detail}")]
+    LaunchProfile { detail: String },
+    #[error(transparent)]
+    Transport(#[from] OpenHandsError),
+    #[error(transparent)]
+    Tooling(#[from] opensymphony_openhands::LocalToolingError),
+    #[error(transparent)]
+    Supervisor(#[from] SupervisorError),
+    #[error(
+        "workflow config requires a local OpenHands server, but no tooling directory was configured and {repo_root}/tools/openhands-server was not found"
+    )]
+    MissingToolDir { repo_root: PathBuf },
+    #[error(
+        "OpenHands transport URL `{value}` does not include an explicit port and has no default port"
+    )]
+    MissingTransportPort { value: String },
+    #[error("runtime rehydration returned conversation {actual}, expected {expected}")]
+    RehydratedConversationMismatch { expected: Uuid, actual: Uuid },
+    #[error("rehydrated conversation {conversation_id} did not expose persisted history")]
+    PersistedHistoryMissing { conversation_id: Uuid },
+    #[error(
+        "conversation {conversation_id} remained active past the wait timeout ({timeout_ms} ms)"
+    )]
+    ActiveTurnTimeout {
+        conversation_id: Uuid,
+        timeout_ms: u128,
+    },
+    #[error("conversation {conversation_id} ended before the debug turn reached a terminal status")]
+    StreamEnded { conversation_id: Uuid },
+    #[error("conversation {conversation_id} emitted ConversationErrorEvent {event_id}")]
+    ConversationError {
+        conversation_id: Uuid,
+        event_id: String,
+    },
+    #[error("conversation {conversation_id} reported terminal execution_status `{status}`")]
+    TerminalStatus {
+        conversation_id: Uuid,
+        status: String,
+    },
+    #[error(
+        "debug interaction timed out waiting for new runtime activity on conversation {conversation_id}"
+    )]
+    DebugTurnTimeout { conversation_id: Uuid },
+    #[error("terminal I/O failed: {0}")]
+    TerminalIo(#[source] io::Error),
+}
+
+#[derive(Clone, Copy)]
+enum TranscriptRole {
+    User,
+    Assistant,
+    Action,
+    Observation,
+}
+
+impl TranscriptRole {
+    fn label(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::Action => "action",
+            Self::Observation => "observation",
+        }
+    }
+}
+
+struct TranscriptEntry {
+    event_id: String,
+    role: TranscriptRole,
+    text: String,
+}
+
+pub async fn run_command(args: DebugArgs) -> ExitCode {
+    match run_debug_session(args).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run_debug_session(args: DebugArgs) -> Result<(), DebugCommandError> {
+    let runtime = resolve_runtime_config(&args).await?;
+    let manager = WorkspaceManager::new(build_workspace_manager_config(&runtime.workflow))?;
+    let workspace = manager
+        .find_workspace_by_issue_reference(&args.issue_id)
+        .await?
+        .ok_or_else(|| DebugCommandError::WorkspaceNotFound {
+            issue_reference: args.issue_id.clone(),
+            workspace_root: runtime.workflow.config.workspace.root.clone(),
+        })?;
+    let manifest = load_conversation_manifest(&manager, &workspace).await?;
+    let (client, mut supervisor, server_message) = build_debug_client(&runtime)?;
+    let config = IssueSessionRunnerConfig::from_workflow(&runtime.workflow);
+    let conversation_id = parse_conversation_id(&manifest)?;
+    let mut stream =
+        attach_or_rehydrate_stream(&client, &runtime.workflow, &workspace, &manifest, &config)
+            .await?;
+
+    println!(
+        "Resumed conversation {} for issue {} in {}",
+        manifest.conversation_id,
+        workspace.identifier(),
+        workspace.workspace_path().display()
+    );
+    println!("{server_message}");
+
+    if turn_is_in_progress(stream.state_mirror().execution_status().unwrap_or("idle")) {
+        println!("Waiting for the current OpenHands turn to finish before accepting input...");
+        wait_for_turn_to_stop(&mut stream, conversation_id, config.terminal_wait_timeout).await?;
+    }
+
+    print_recent_history(stream.event_cache().items());
+    println!(
+        "Type a prompt to continue the conversation. Use /history to reprint recent context and /exit to quit."
+    );
+
+    let result = interactive_debug_loop(
+        &client,
+        &mut stream,
+        conversation_id,
+        config.terminal_wait_timeout,
+    )
+    .await;
+
+    let close_result = stream.close().await;
+    drop(supervisor.take());
+    result?;
+    close_result?;
+    Ok(())
+}
+
+async fn resolve_runtime_config(args: &DebugArgs) -> Result<DebugRuntimeConfig, DebugCommandError> {
+    let current_dir = env::current_dir().map_err(DebugCommandError::CurrentDir)?;
+    let config_path = match &args.config {
+        Some(path) => Some(resolve_cli_path(&current_dir, path)),
+        None => {
+            let default = current_dir.join(DEFAULT_CONFIG_FILE);
+            default.is_file().then_some(default)
+        }
+    };
+
+    let repo_root_hint = super::find_cargo_workspace_root(&current_dir);
+    let default_target_repo = if current_dir.join("WORKFLOW.md").is_file() {
+        current_dir.clone()
+    } else if let Some(repo_root) = repo_root_hint
+        .as_ref()
+        .filter(|repo_root| repo_root.join("WORKFLOW.md").is_file())
+    {
+        repo_root.clone()
+    } else {
+        current_dir.clone()
+    };
+
+    let (target_repo, configured_tool_dir) = if let Some(path) = config_path.as_ref() {
+        let config = load_config(path).await?;
+        let config_root = path.parent().unwrap_or(&current_dir);
+        let target_repo = config
+            .target_repo
+            .as_deref()
+            .map(|value| resolve_config_path(path, config_root, value))
+            .transpose()?
+            .unwrap_or_else(|| default_target_repo.clone());
+        let tool_dir = config
+            .openhands
+            .tool_dir
+            .as_deref()
+            .map(|value| resolve_config_path(path, config_root, value))
+            .transpose()?;
+        (target_repo, tool_dir)
+    } else {
+        (default_target_repo, None)
+    };
+
+    let repo_root = super::find_cargo_workspace_root(&target_repo)
+        .unwrap_or_else(|| super::normalize_workspace_root(&target_repo));
+    let inferred_tool_dir = repo_root.join("tools").join("openhands-server");
+    let tool_dir =
+        configured_tool_dir.or_else(|| inferred_tool_dir.is_dir().then_some(inferred_tool_dir));
+    let workflow_path = target_repo.join("WORKFLOW.md");
+    let workflow = WorkflowDefinition::load_from_path(&workflow_path).map_err(|source| {
+        DebugCommandError::LoadWorkflow {
+            path: workflow_path.clone(),
+            source,
+        }
+    })?;
+    let workflow = workflow
+        .resolve_with_process_env(&target_repo)
+        .map_err(|source| DebugCommandError::ResolveWorkflow {
+            path: workflow_path.clone(),
+            source,
+        })?;
+
+    Ok(DebugRuntimeConfig {
+        repo_root,
+        workflow,
+        tool_dir,
+    })
+}
+
+async fn load_config(path: &Path) -> Result<DebugConfigFile, DebugCommandError> {
+    let raw = fs::read_to_string(path)
+        .await
+        .map_err(|source| DebugCommandError::ReadConfig {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    serde_yaml::from_str(&raw).map_err(|source| DebugCommandError::ParseConfig {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn resolve_config_path(
+    config_path: &Path,
+    config_root: &Path,
+    raw: &str,
+) -> Result<PathBuf, DebugCommandError> {
+    let expanded =
+        super::expand_env_tokens(raw).map_err(|error| DebugCommandError::ResolveConfig {
+            path: config_path.to_path_buf(),
+            detail: error.to_string(),
+        })?;
+    Ok(super::resolve_path(config_root, &expanded))
+}
+
+fn resolve_cli_path(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn build_workspace_manager_config(workflow: &ResolvedWorkflow) -> WorkspaceManagerConfig {
+    let hooks = &workflow.config.hooks;
+    WorkspaceManagerConfig {
+        root: workflow.config.workspace.root.clone(),
+        hooks: HookConfig {
+            after_create: hooks.after_create.clone().map(HookDefinition::shell),
+            before_run: hooks.before_run.clone().map(HookDefinition::shell),
+            after_run: hooks.after_run.clone().map(HookDefinition::shell),
+            before_remove: hooks.before_remove.clone().map(HookDefinition::shell),
+            timeout: Duration::from_millis(hooks.timeout_ms),
+        },
+        cleanup: CleanupConfig {
+            remove_terminal_workspaces: false,
+        },
+    }
+}
+
+fn build_debug_client(
+    runtime: &DebugRuntimeConfig,
+) -> Result<(OpenHandsClient, Option<LocalServerSupervisor>, String), DebugCommandError> {
+    let transport = TransportConfig::from_workflow(&runtime.workflow, &ProcessEnvironment)?;
+    if !requires_supervisor(&runtime.workflow) {
+        let message = format!(
+            "Using configured OpenHands server at {}.",
+            transport.base_url()
+        );
+        return Ok((OpenHandsClient::new(transport), None, message));
+    }
+
+    let tool_dir = runtime
+        .tool_dir
+        .clone()
+        .ok_or_else(|| DebugCommandError::MissingToolDir {
+            repo_root: runtime.repo_root.clone(),
+        })?;
+    let tooling = LocalServerTooling::load(tool_dir)?;
+    let url = Url::parse(&runtime.workflow.extensions.openhands.transport.base_url)
+        .expect("validated transport URL should parse");
+    let mut config = SupervisedServerConfig::new(tooling);
+    config.extra_env = runtime
+        .workflow
+        .extensions
+        .openhands
+        .local_server
+        .env
+        .clone();
+    config.startup_timeout = Duration::from_millis(
+        runtime
+            .workflow
+            .extensions
+            .openhands
+            .local_server
+            .startup_timeout_ms,
+    );
+    config.probe.path = runtime
+        .workflow
+        .extensions
+        .openhands
+        .local_server
+        .readiness_probe_path
+        .clone();
+    config.port_override = Some(transport_port_override(&url)?);
+
+    let mut supervisor = LocalServerSupervisor::new(SupervisorConfig::Supervised(Box::new(config)));
+    match supervisor.start() {
+        Ok(status) => {
+            let base_url = status.base_url.clone();
+            let transport = TransportConfig::new(&base_url).with_auth(transport.auth().clone());
+            Ok((
+                OpenHandsClient::new(transport),
+                Some(supervisor),
+                format!("Started local OpenHands server at {base_url} for the debug session."),
+            ))
+        }
+        Err(SupervisorError::ExistingReadyServer { base_url, .. }) => {
+            let transport = TransportConfig::new(&base_url).with_auth(transport.auth().clone());
+            Ok((
+                OpenHandsClient::new(transport),
+                None,
+                format!("Using existing OpenHands server at {base_url}."),
+            ))
+        }
+        Err(error) => Err(DebugCommandError::Supervisor(error)),
+    }
+}
+
+fn requires_supervisor(workflow: &ResolvedWorkflow) -> bool {
+    let transport = &workflow.extensions.openhands.transport;
+    if transport.session_api_key_env.is_some()
+        || !workflow.extensions.openhands.local_server.enabled
+    {
+        return false;
+    }
+
+    let Ok(url) = Url::parse(&transport.base_url) else {
+        return false;
+    };
+    url.scheme() == "http"
+        && url.path().trim_matches('/').is_empty()
+        && matches!(url.host_str(), Some("127.0.0.1") | Some("localhost"))
+}
+
+fn transport_port_override(url: &Url) -> Result<u16, DebugCommandError> {
+    url.port_or_known_default()
+        .ok_or_else(|| DebugCommandError::MissingTransportPort {
+            value: url.as_str().to_string(),
+        })
+}
+
+async fn load_conversation_manifest(
+    manager: &WorkspaceManager,
+    workspace: &WorkspaceHandle,
+) -> Result<IssueConversationManifest, DebugCommandError> {
+    let path = workspace.conversation_manifest_path();
+    let raw = manager
+        .read_text_artifact(workspace, &path)
+        .await?
+        .ok_or_else(|| DebugCommandError::ConversationManifestMissing { path: path.clone() })?;
+    serde_json::from_str(&raw)
+        .map_err(|source| DebugCommandError::DecodeConversationManifest { path, source })
+}
+
+fn parse_conversation_id(manifest: &IssueConversationManifest) -> Result<Uuid, DebugCommandError> {
+    Uuid::parse_str(manifest.conversation_id.as_str()).map_err(|source| {
+        DebugCommandError::InvalidConversationId {
+            value: manifest.conversation_id.to_string(),
+            source,
+        }
+    })
+}
+
+async fn attach_or_rehydrate_stream(
+    client: &OpenHandsClient,
+    workflow: &ResolvedWorkflow,
+    workspace: &WorkspaceHandle,
+    manifest: &IssueConversationManifest,
+    config: &IssueSessionRunnerConfig,
+) -> Result<RuntimeEventStream, DebugCommandError> {
+    let conversation_id = parse_conversation_id(manifest)?;
+    let stream_config = config.runtime_stream.clone();
+    match client
+        .attach_runtime_stream(conversation_id, stream_config.clone())
+        .await
+    {
+        Ok(stream) => Ok(stream),
+        Err(_) => {
+            let launch_profile = resolve_launch_profile(manifest, workflow)
+                .map_err(|detail| DebugCommandError::LaunchProfile { detail })?;
+            let request = launch_profile.to_create_request(
+                workspace.workspace_path(),
+                &manifest.persistence_dir,
+                Some(conversation_id),
+            );
+            let conversation = client.create_conversation(&request).await?;
+            if conversation.conversation_id != conversation_id {
+                return Err(DebugCommandError::RehydratedConversationMismatch {
+                    expected: conversation_id,
+                    actual: conversation.conversation_id,
+                });
+            }
+
+            let stream = client
+                .attach_runtime_stream(conversation_id, stream_config)
+                .await?;
+            if stream.event_cache().items().len() <= 1 {
+                return Err(DebugCommandError::PersistedHistoryMissing { conversation_id });
+            }
+
+            Ok(stream)
+        }
+    }
+}
+
+fn resolve_launch_profile(
+    manifest: &IssueConversationManifest,
+    workflow: &ResolvedWorkflow,
+) -> Result<ConversationLaunchProfile, String> {
+    manifest
+        .launch_profile
+        .clone()
+        .map(Ok)
+        .unwrap_or_else(|| ConversationLaunchProfile::from_workflow(workflow))
+}
+
+async fn interactive_debug_loop(
+    client: &OpenHandsClient,
+    stream: &mut RuntimeEventStream,
+    conversation_id: Uuid,
+    wait_timeout: Duration,
+) -> Result<(), DebugCommandError> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut line = String::new();
+
+    loop {
+        print!("debug> ");
+        stdout.flush().map_err(DebugCommandError::TerminalIo)?;
+        line.clear();
+        let read = stdin
+            .read_line(&mut line)
+            .map_err(DebugCommandError::TerminalIo)?;
+        if read == 0 {
+            return Ok(());
+        }
+
+        let input = line.trim();
+        if input.is_empty() {
+            continue;
+        }
+        if matches!(input, "/exit" | "exit" | "quit") {
+            return Ok(());
+        }
+        if input == "/history" {
+            print_recent_history(stream.event_cache().items());
+            continue;
+        }
+
+        run_debug_turn(client, stream, conversation_id, input, wait_timeout).await?;
+    }
+}
+
+async fn run_debug_turn(
+    client: &OpenHandsClient,
+    stream: &mut RuntimeEventStream,
+    conversation_id: Uuid,
+    prompt: &str,
+    wait_timeout: Duration,
+) -> Result<(), DebugCommandError> {
+    if turn_is_in_progress(stream.state_mirror().execution_status().unwrap_or("idle")) {
+        wait_for_turn_to_stop(stream, conversation_id, wait_timeout).await?;
+    }
+
+    let baseline_event_ids = stream
+        .event_cache()
+        .items()
+        .iter()
+        .map(|event| event.id.clone())
+        .collect::<HashSet<_>>();
+
+    client
+        .send_message(conversation_id, &SendMessageRequest::user_text(prompt))
+        .await?;
+    loop {
+        match client.run_conversation(conversation_id).await {
+            Ok(_) => break,
+            Err(OpenHandsError::HttpStatus {
+                status_code: 409, ..
+            }) => {
+                wait_for_turn_to_stop(stream, conversation_id, wait_timeout).await?;
+                let _ = stream.reconcile_events().await;
+            }
+            Err(error) => return Err(DebugCommandError::Transport(error)),
+        }
+    }
+
+    wait_for_turn_terminal(stream, &baseline_event_ids, conversation_id, wait_timeout).await?;
+    let new_entries = transcript_entries(stream.event_cache().items())
+        .into_iter()
+        .filter(|entry| !baseline_event_ids.contains(&entry.event_id))
+        .filter(|entry| !matches!(entry.role, TranscriptRole::User))
+        .collect::<Vec<_>>();
+
+    if new_entries.is_empty() {
+        println!("assistant> (no printable assistant text was emitted for this turn)");
+    } else {
+        for entry in new_entries {
+            println!("{}> {}", entry.role.label(), entry.text);
+        }
+    }
+
+    Ok(())
+}
+
+async fn wait_for_turn_to_stop(
+    stream: &mut RuntimeEventStream,
+    conversation_id: Uuid,
+    wait_timeout: Duration,
+) -> Result<(), DebugCommandError> {
+    if stream
+        .state_mirror()
+        .execution_status()
+        .is_none_or(turn_has_stopped)
+    {
+        return Ok(());
+    }
+
+    let deadline = tokio::time::Instant::now() + wait_timeout;
+    loop {
+        if stream
+            .state_mirror()
+            .execution_status()
+            .is_some_and(turn_has_stopped)
+        {
+            return Ok(());
+        }
+
+        match timeout_at(deadline, stream.next_event()).await {
+            Err(_) => {
+                return Err(DebugCommandError::ActiveTurnTimeout {
+                    conversation_id,
+                    timeout_ms: wait_timeout.as_millis(),
+                });
+            }
+            Ok(Ok(Some(_))) => {}
+            Ok(Ok(None)) => {
+                if let Ok(inserted) = stream.reconcile_events().await
+                    && inserted > 0
+                {
+                    continue;
+                }
+            }
+            Ok(Err(error)) => {
+                if stream
+                    .state_mirror()
+                    .execution_status()
+                    .is_some_and(turn_has_stopped)
+                {
+                    return Ok(());
+                }
+                return Err(DebugCommandError::Transport(error));
+            }
+        }
+    }
+}
+
+async fn wait_for_turn_terminal(
+    stream: &mut RuntimeEventStream,
+    baseline_event_ids: &HashSet<String>,
+    conversation_id: Uuid,
+    wait_timeout: Duration,
+) -> Result<(), DebugCommandError> {
+    let deadline = tokio::time::Instant::now() + wait_timeout;
+    loop {
+        if let Some(result) = current_turn_outcome(stream, baseline_event_ids, conversation_id) {
+            return result;
+        }
+
+        match timeout_at(deadline, stream.next_event()).await {
+            Err(_) => {
+                if let Ok(inserted) = stream.reconcile_events().await
+                    && inserted > 0
+                {
+                    continue;
+                }
+                return Err(DebugCommandError::DebugTurnTimeout { conversation_id });
+            }
+            Ok(Ok(Some(_))) => {}
+            Ok(Ok(None)) => {
+                if let Ok(inserted) = stream.reconcile_events().await
+                    && inserted > 0
+                {
+                    continue;
+                }
+                if let Some(result) =
+                    current_turn_outcome(stream, baseline_event_ids, conversation_id)
+                {
+                    return result;
+                }
+                return Err(DebugCommandError::StreamEnded { conversation_id });
+            }
+            Ok(Err(error)) => {
+                if let Some(result) =
+                    current_turn_outcome(stream, baseline_event_ids, conversation_id)
+                {
+                    return result;
+                }
+                return Err(DebugCommandError::Transport(error));
+            }
+        }
+    }
+}
+
+fn current_turn_outcome(
+    stream: &RuntimeEventStream,
+    baseline_event_ids: &HashSet<String>,
+    conversation_id: Uuid,
+) -> Option<Result<(), DebugCommandError>> {
+    let current_turn_events = stream
+        .event_cache()
+        .items()
+        .iter()
+        .filter(|event| !baseline_event_ids.contains(&event.id))
+        .collect::<Vec<_>>();
+    if current_turn_events.is_empty() {
+        return None;
+    }
+
+    if let Some(error_event) = current_turn_events.iter().find(|event| {
+        matches!(
+            KnownEvent::from_envelope(event),
+            KnownEvent::ConversationError(_)
+        )
+    }) {
+        return Some(Err(DebugCommandError::ConversationError {
+            conversation_id,
+            event_id: error_event.id.clone(),
+        }));
+    }
+
+    match stream.state_mirror().terminal_status() {
+        Some(TerminalExecutionStatus::Finished) => Some(Ok(())),
+        Some(TerminalExecutionStatus::Error) | Some(TerminalExecutionStatus::Stuck) => {
+            Some(Err(DebugCommandError::TerminalStatus {
+                conversation_id,
+                status: stream
+                    .state_mirror()
+                    .execution_status()
+                    .unwrap_or("unknown")
+                    .to_string(),
+            }))
+        }
+        None => None,
+    }
+}
+
+fn print_recent_history(events: &[EventEnvelope]) {
+    let entries = transcript_entries(events);
+    if entries.is_empty() {
+        println!("No prior printable transcript entries were found in the resumed conversation.");
+        return;
+    }
+
+    println!("Recent conversation history:");
+    let start = entries.len().saturating_sub(RECENT_HISTORY_LIMIT);
+    for entry in &entries[start..] {
+        println!(
+            "{}> {}",
+            entry.role.label(),
+            summarize_history_text(&entry.text)
+        );
+    }
+}
+
+fn transcript_entries(events: &[EventEnvelope]) -> Vec<TranscriptEntry> {
+    events.iter().filter_map(extract_transcript_entry).collect()
+}
+
+fn extract_transcript_entry(event: &EventEnvelope) -> Option<TranscriptEntry> {
+    match event.kind.as_str() {
+        "MessageEvent" => {
+            let (role, content) = if let Some(message) = event.payload.get("llm_message") {
+                (
+                    TranscriptRole::Assistant,
+                    message
+                        .get("content")?
+                        .as_array()?
+                        .first()?
+                        .get("text")?
+                        .as_str()?,
+                )
+            } else {
+                let role = match event
+                    .payload
+                    .get("role")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    Some("user") => TranscriptRole::User,
+                    _ => TranscriptRole::Assistant,
+                };
+                (
+                    role,
+                    event
+                        .payload
+                        .get("content")?
+                        .as_array()?
+                        .first()?
+                        .get("text")?
+                        .as_str()?,
+                )
+            };
+            Some(TranscriptEntry {
+                event_id: event.id.clone(),
+                role,
+                text: normalize_text(content),
+            })
+        }
+        "ActionEvent" => Some(TranscriptEntry {
+            event_id: event.id.clone(),
+            role: TranscriptRole::Action,
+            text: normalize_text(
+                event
+                    .payload
+                    .get("action")
+                    .and_then(|action| action.get("message"))?
+                    .as_str()?,
+            ),
+        }),
+        "ObservationEvent" => Some(TranscriptEntry {
+            event_id: event.id.clone(),
+            role: TranscriptRole::Observation,
+            text: normalize_text(
+                event
+                    .payload
+                    .get("observation")
+                    .and_then(|observation| observation.get("content"))?
+                    .as_array()?
+                    .first()?
+                    .get("text")?
+                    .as_str()?,
+            ),
+        }),
+        _ => None,
+    }
+}
+
+fn normalize_text(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn summarize_history_text(text: &str) -> String {
+    const LIMIT: usize = 160;
+    if text.chars().count() <= LIMIT {
+        text.to_string()
+    } else {
+        let shortened = text.chars().take(LIMIT - 3).collect::<String>();
+        format!("{shortened}...")
+    }
+}
+
+fn turn_is_in_progress(status: &str) -> bool {
+    !matches!(status, "idle" | "finished" | "error" | "stuck")
+}
+
+fn turn_has_stopped(status: &str) -> bool {
+    !turn_is_in_progress(status)
+}

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1,3 +1,4 @@
+mod debug_session;
 mod orchestrator_run;
 
 use std::{
@@ -48,6 +49,8 @@ pub struct Cli {
 enum Command {
     #[command(about = "Run the real orchestrator against the current project workflow")]
     Run(orchestrator_run::RunArgs),
+    #[command(about = "Resume an issue conversation for interactive debugging")]
+    Debug(debug_session::DebugArgs),
     #[command(about = "Serve the local control-plane demo stream")]
     Daemon(DaemonArgs),
     #[command(about = "Attach the FrankenTUI operator client to a control plane")]
@@ -227,6 +230,7 @@ pub async fn run() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
         Command::Run(args) => orchestrator_run::run_command(args).await,
+        Command::Debug(args) => debug_session::run_command(args).await,
         Command::Doctor(args) => run_doctor(args).await,
         Command::Daemon(args) => run_daemon(args).await,
         Command::Tui(args) => run_tui(args).await,
@@ -1480,7 +1484,11 @@ mod tests {
 
         match cli.command {
             Command::Daemon(args) => assert_eq!(args.sample_interval_ms.get(), 250),
-            Command::Run(_) | Command::Tui(_) | Command::LinearMcp(_) | Command::Doctor(_) => {
+            Command::Run(_)
+            | Command::Debug(_)
+            | Command::Tui(_)
+            | Command::LinearMcp(_)
+            | Command::Doctor(_) => {
                 panic!("expected daemon command")
             }
         }

--- a/crates/opensymphony-cli/tests/debug.rs
+++ b/crates/opensymphony-cli/tests/debug.rs
@@ -1,0 +1,204 @@
+use std::{process::Stdio, time::Duration};
+
+use chrono::Utc;
+use opensymphony_openhands::{
+    ConversationLaunchProfile, EventEnvelope, OpenHandsClient, RUNTIME_CONTRACT_VERSION,
+    TransportConfig,
+};
+use opensymphony_testkit::FakeOpenHandsServer;
+use opensymphony_workflow::WorkflowDefinition;
+use opensymphony_workspace::{
+    CleanupConfig, HookConfig, IssueDescriptor, WorkspaceManager, WorkspaceManagerConfig,
+};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::{io::AsyncWriteExt, process::Command};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn debug_resumes_existing_conversation_history_and_sends_follow_up_input() {
+    let openhands = FakeOpenHandsServer::start()
+        .await
+        .expect("fake OpenHands server should start");
+    let project = TempDir::new().expect("temp project should exist");
+    let workspace_root = project.path().join("var").join("workspaces");
+
+    write_project_files(project.path(), &workspace_root, openhands.base_url());
+
+    let workflow_path = project.path().join("WORKFLOW.md");
+    let workflow = WorkflowDefinition::load_from_path(&workflow_path)
+        .expect("workflow should load")
+        .resolve_with_process_env(project.path())
+        .expect("workflow should resolve");
+    let manager = WorkspaceManager::new(WorkspaceManagerConfig {
+        root: workspace_root.clone(),
+        hooks: HookConfig::default(),
+        cleanup: CleanupConfig {
+            remove_terminal_workspaces: false,
+        },
+    })
+    .expect("workspace manager should build");
+    let issue = IssueDescriptor {
+        issue_id: "issue-287".to_string(),
+        identifier: "COE-287".to_string(),
+        title: "Debuggable session".to_string(),
+        current_state: "In Progress".to_string(),
+        last_seen_tracker_refresh_at: None,
+    };
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("workspace should exist");
+
+    let transport = TransportConfig::from_workflow(
+        &workflow,
+        &std::collections::BTreeMap::from([(
+            "OPENHANDS_API_KEY".to_string(),
+            "test-openhands-key".to_string(),
+        )]),
+    )
+    .expect("transport should resolve");
+    let client = OpenHandsClient::new(transport);
+    let launch_profile =
+        ConversationLaunchProfile::from_workflow(&workflow).expect("launch profile should build");
+    let conversation_id = Uuid::new_v4();
+    let request = launch_profile.to_create_request(
+        ensured.handle.workspace_path(),
+        &ensured.handle.openhands_dir(),
+        Some(conversation_id),
+    );
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("conversation should be created");
+    assert_eq!(conversation.conversation_id, conversation_id);
+
+    openhands
+        .insert_event(
+            conversation_id,
+            EventEnvelope::new(
+                "assistant-history",
+                Utc::now(),
+                "assistant",
+                "MessageEvent",
+                json!({
+                    "role": "assistant",
+                    "content": [{ "type": "text", "text": "Earlier implementation rationale" }],
+                }),
+            ),
+        )
+        .await
+        .expect("assistant history event should insert");
+    openhands
+        .fail_next_conversation_gets(conversation_id, 1)
+        .await
+        .expect("first conversation GET should be forced to fail");
+
+    std::fs::write(
+        ensured.handle.conversation_manifest_path(),
+        serde_json::to_vec_pretty(&json!({
+            "issue_id": issue.issue_id,
+            "identifier": issue.identifier,
+            "conversation_id": conversation_id.to_string(),
+            "server_base_url": openhands.base_url(),
+            "transport_target": "loopback",
+            "http_auth_mode": "header",
+            "websocket_auth_mode": "query_param",
+            "websocket_query_param_name": "session_api_key",
+            "persistence_dir": ensured.handle.openhands_dir(),
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
+            "last_attached_at": Utc::now(),
+            "launch_profile": serde_json::to_value(&launch_profile)
+                .expect("launch profile JSON should render"),
+            "fresh_conversation": false,
+            "workflow_prompt_seeded": true,
+            "runtime_contract_version": RUNTIME_CONTRACT_VERSION,
+        }))
+        .expect("conversation manifest JSON should render"),
+    )
+    .expect("conversation manifest should write");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_opensymphony"));
+    child
+        .arg("debug")
+        .arg("COE-287")
+        .current_dir(project.path())
+        .env("OPENHANDS_API_KEY", "test-openhands-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = child.spawn().expect("debug command should spawn");
+    let mut stdin = child.stdin.take().expect("debug stdin should exist");
+    stdin
+        .write_all(b"Why did you implement it this way?\n/exit\n")
+        .await
+        .expect("debug stdin should accept scripted input");
+    drop(stdin);
+
+    let output = tokio::time::timeout(Duration::from_secs(10), child.wait_with_output())
+        .await
+        .expect("debug command should finish promptly")
+        .expect("debug command output should collect");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "debug command should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("Resumed conversation"),
+        "debug command should announce the resumed conversation: stdout={stdout}",
+    );
+    assert!(
+        stdout.contains("Earlier implementation rationale"),
+        "debug command should print recent conversation history: stdout={stdout}",
+    );
+    assert!(
+        stdout.contains("debug>"),
+        "debug command should expose the interactive prompt: stdout={stdout}",
+    );
+
+    let events = client
+        .search_all_events(conversation_id)
+        .await
+        .expect("conversation events should be searchable");
+    let user_messages = events
+        .items()
+        .iter()
+        .filter(|event| event.kind == "MessageEvent")
+        .filter_map(|event| {
+            let role = event.payload.get("role")?.as_str()?;
+            if role != "user" {
+                return None;
+            }
+            let content = event.payload.get("content")?.as_array()?;
+            let entry = content.first()?;
+            entry.get("text")?.as_str().map(ToOwned::to_owned)
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        user_messages
+            .iter()
+            .any(|message| message == "Why did you implement it this way?"),
+        "debug command should append the follow-up prompt to the resumed conversation: {user_messages:?}",
+    );
+}
+
+fn write_project_files(
+    project_root: &std::path::Path,
+    workspace_root: &std::path::Path,
+    openhands_base_url: &str,
+) {
+    std::fs::create_dir_all(workspace_root).expect("workspace root should exist");
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        format!(
+            "---\ntracker:\n  kind: linear\n  endpoint: https://api.linear.app/graphql\n  api_key: test-linear-key\n  project_slug: test-project\n  active_states:\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: {}\nopenhands:\n  transport:\n    base_url: {openhands_base_url}\n    session_api_key_env: OPENHANDS_API_KEY\n---\n\n# Test Workflow\n\nResume the stored issue conversation.\n",
+            workspace_root.display()
+        ),
+    )
+    .expect("workflow should be written");
+}

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -17,6 +17,7 @@ fn top_level_help_describes_commands_and_safety_posture() {
         "Operate the OpenSymphony local MVP on a trusted machine",
         "process-level isolation only",
         "Run the real orchestrator against the current project workflow",
+        "Resume an issue conversation for interactive debugging",
         "Serve the local control-plane demo stream",
         "Attach the FrankenTUI operator client to a control plane",
         "Run local preflight checks for trusted-machine deployment",
@@ -50,6 +51,31 @@ fn doctor_help_explains_config_and_live_probe_options() {
         assert!(
             stdout.contains(snippet),
             "doctor help should include `{snippet}`: stdout={stdout}",
+        );
+    }
+}
+
+#[test]
+fn debug_help_explains_issue_lookup_and_config() {
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["debug", "--help"])
+        .output()
+        .expect("debug help should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "debug help should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    for snippet in [
+        "Resume an issue conversation for interactive debugging",
+        "Linear issue identifier or persisted issue ID to resume",
+        "Runtime config YAML path; defaults to ./config.yaml when present",
+    ] {
+        assert!(
+            stdout.contains(snippet),
+            "debug help should include `{snippet}`: stdout={stdout}",
         );
     }
 }

--- a/crates/opensymphony-openhands/src/lib.rs
+++ b/crates/opensymphony-openhands/src/lib.rs
@@ -20,9 +20,9 @@ pub use models::{
     LlmConfig, SearchConversationEventsResponse, SendMessageRequest, TextContent, WorkspaceConfig,
 };
 pub use session::{
-    IssueConversationManifest, IssueSessionContext, IssueSessionError, IssueSessionObserver,
-    IssueSessionPromptKind, IssueSessionResult, IssueSessionRunner, IssueSessionRunnerConfig,
-    RUNTIME_CONTRACT_VERSION,
+    ConversationLaunchProfile, IssueConversationManifest, IssueSessionContext, IssueSessionError,
+    IssueSessionObserver, IssueSessionPromptKind, IssueSessionResult, IssueSessionRunner,
+    IssueSessionRunnerConfig, RUNTIME_CONTRACT_VERSION,
 };
 pub use supervisor::{
     ExternalServerConfig, LaunchOwnership, LocalServerSupervisor, ProbeConfig, ServerMode,

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -106,6 +106,76 @@ impl IssueSessionPromptKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationLaunchProfile {
+    pub workspace_kind: String,
+    pub confirmation_policy_kind: String,
+    pub agent_kind: String,
+    pub llm_model: String,
+    pub max_iterations: u32,
+    pub stuck_detection: bool,
+}
+
+impl ConversationLaunchProfile {
+    pub fn from_workflow(workflow: &ResolvedWorkflow) -> Result<Self, String> {
+        let conversation = &workflow.extensions.openhands.conversation;
+        let max_iterations = u32::try_from(conversation.max_iterations).map_err(|_| {
+            format!(
+                "workflow max_iterations {} exceeds u32::MAX ({})",
+                conversation.max_iterations,
+                u32::MAX
+            )
+        })?;
+        let llm_model = conversation
+            .agent
+            .llm
+            .as_ref()
+            .and_then(|llm| llm.model.as_ref())
+            .cloned()
+            .ok_or_else(|| {
+                "workflow openhands.conversation.agent.llm.model is required".to_string()
+            })?;
+
+        Ok(Self {
+            workspace_kind: "LocalWorkspace".to_string(),
+            confirmation_policy_kind: conversation.confirmation_policy.kind.clone(),
+            agent_kind: conversation.agent.kind.clone(),
+            llm_model,
+            max_iterations,
+            stuck_detection: conversation.stuck_detection,
+        })
+    }
+
+    pub fn to_create_request(
+        &self,
+        working_dir: &Path,
+        persistence_dir: &Path,
+        conversation_id: Option<Uuid>,
+    ) -> ConversationCreateRequest {
+        ConversationCreateRequest {
+            conversation_id: conversation_id.unwrap_or_else(Uuid::new_v4),
+            workspace: WorkspaceConfig {
+                working_dir: working_dir.display().to_string(),
+                kind: self.workspace_kind.clone(),
+            },
+            persistence_dir: persistence_dir.display().to_string(),
+            max_iterations: self.max_iterations,
+            stuck_detection: self.stuck_detection,
+            confirmation_policy: ConfirmationPolicy {
+                kind: self.confirmation_policy_kind.clone(),
+            },
+            agent: AgentConfig {
+                kind: self.agent_kind.clone(),
+                llm: LlmConfig {
+                    model: self.llm_model.clone(),
+                    api_key: None,
+                    base_url: None,
+                },
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IssueConversationManifest {
     pub issue_id: IssueId,
     pub identifier: IssueIdentifier,
@@ -123,6 +193,8 @@ pub struct IssueConversationManifest {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub last_attached_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launch_profile: Option<ConversationLaunchProfile>,
     pub fresh_conversation: bool,
     pub workflow_prompt_seeded: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -155,6 +227,7 @@ impl IssueConversationManifest {
         persistence_dir: PathBuf,
         attached_at: DateTime<Utc>,
         reset_reason: Option<String>,
+        launch_profile: ConversationLaunchProfile,
     ) -> Self {
         Self {
             issue_id,
@@ -169,6 +242,7 @@ impl IssueConversationManifest {
             created_at: attached_at,
             updated_at: attached_at,
             last_attached_at: attached_at,
+            launch_profile: Some(launch_profile),
             fresh_conversation: true,
             workflow_prompt_seeded: false,
             reset_reason,
@@ -887,6 +961,9 @@ impl IssueSessionRunner {
 
         let attached_at = Utc::now();
         manifest.fresh_conversation = false;
+        if manifest.launch_profile.is_none() {
+            manifest.launch_profile = ConversationLaunchProfile::from_workflow(workflow).ok();
+        }
         let transport_diagnostics = self.client.transport_diagnostics().ok();
         manifest
             .apply_transport_diagnostics(transport_diagnostics.as_ref(), self.client.base_url());
@@ -929,8 +1006,8 @@ impl IssueSessionRunner {
         workflow: &ResolvedWorkflow,
         reset_reason: Option<String>,
     ) -> Result<Step<ActiveSession>, IssueSessionError> {
-        let request = match build_conversation_create_request(workflow, workspace, None) {
-            Ok(request) => request,
+        let launch_profile = match ConversationLaunchProfile::from_workflow(workflow) {
+            Ok(launch_profile) => launch_profile,
             Err(detail) => {
                 return self
                     .persist_failure_without_stream(
@@ -942,7 +1019,7 @@ impl IssueSessionRunner {
                         None,
                         NormalizedOutcome {
                             kind: WorkerOutcomeKind::Failed,
-                            summary: "failed to build conversation create request".to_string(),
+                            summary: "failed to build conversation launch profile".to_string(),
                             error: Some(detail),
                         },
                     )
@@ -951,6 +1028,11 @@ impl IssueSessionRunner {
                     .map(Step::EarlyResult);
             }
         };
+        let request = launch_profile.to_create_request(
+            workspace.workspace_path(),
+            &configured_persistence_dir(workflow, workspace),
+            None,
+        );
         workspace_manager
             .write_json_artifact(
                 workspace,
@@ -1028,6 +1110,7 @@ impl IssueSessionRunner {
             configured_persistence_dir(workflow, workspace),
             attached_at,
             reset_reason,
+            launch_profile,
         );
         let transport_diagnostics = self.client.transport_diagnostics().ok();
         manifest
@@ -1065,18 +1148,22 @@ impl IssueSessionRunner {
         mut manifest: IssueConversationManifest,
         conversation_id: Uuid,
     ) -> Result<Option<ActiveSession>, IssueSessionError> {
-        let request =
-            match build_conversation_create_request(workflow, workspace, Some(conversation_id)) {
-                Ok(request) => request,
-                Err(error) => {
-                    debug!(
-                        %error,
-                        %conversation_id,
-                        "skipping session rehydrate because create request construction failed"
-                    );
-                    return Ok(None);
-                }
-            };
+        let Some(launch_profile) = manifest
+            .launch_profile
+            .clone()
+            .or_else(|| ConversationLaunchProfile::from_workflow(workflow).ok())
+        else {
+            debug!(
+                %conversation_id,
+                "skipping session rehydrate because no launch profile is available"
+            );
+            return Ok(None);
+        };
+        let request = launch_profile.to_create_request(
+            workspace.workspace_path(),
+            &configured_persistence_dir(workflow, workspace),
+            Some(conversation_id),
+        );
         workspace_manager
             .write_json_artifact(
                 workspace,
@@ -1137,6 +1224,7 @@ impl IssueSessionRunner {
         manifest.persistence_dir = configured_persistence_dir(workflow, workspace);
         manifest.last_attached_at = attached_at;
         manifest.updated_at = attached_at;
+        manifest.launch_profile.get_or_insert(launch_profile);
         manifest.reset_reason = None;
         manifest.runtime_contract_version = Some(RUNTIME_CONTRACT_VERSION.to_string());
         manifest.apply_runtime_snapshot(&stream);
@@ -1535,53 +1623,6 @@ impl IssueSessionRunner {
             run_status,
         })
     }
-}
-
-fn build_conversation_create_request(
-    workflow: &ResolvedWorkflow,
-    workspace: &WorkspaceHandle,
-    conversation_id: Option<Uuid>,
-) -> Result<ConversationCreateRequest, String> {
-    let conversation = &workflow.extensions.openhands.conversation;
-    let max_iterations = u32::try_from(conversation.max_iterations).map_err(|_| {
-        format!(
-            "workflow max_iterations {} exceeds u32::MAX ({})",
-            conversation.max_iterations,
-            u32::MAX
-        )
-    })?;
-
-    Ok(ConversationCreateRequest {
-        conversation_id: conversation_id.unwrap_or_else(Uuid::new_v4),
-        workspace: WorkspaceConfig {
-            working_dir: workspace.workspace_path().display().to_string(),
-            kind: "LocalWorkspace".to_string(),
-        },
-        persistence_dir: configured_persistence_dir(workflow, workspace)
-            .display()
-            .to_string(),
-        max_iterations,
-        stuck_detection: conversation.stuck_detection,
-        confirmation_policy: ConfirmationPolicy {
-            kind: conversation.confirmation_policy.kind.clone(),
-        },
-        agent: AgentConfig {
-            kind: conversation.agent.kind.clone(),
-            llm: conversation
-                .agent
-                .llm
-                .as_ref()
-                .and_then(|llm| llm.model.as_ref())
-                .map(|model| LlmConfig {
-                    model: model.clone(),
-                    api_key: None,
-                    base_url: None,
-                })
-                .ok_or_else(|| {
-                    "workflow openhands.conversation.agent.llm.model is required".to_string()
-                })?,
-        },
-    })
 }
 
 fn configured_persistence_dir(workflow: &ResolvedWorkflow, workspace: &WorkspaceHandle) -> PathBuf {

--- a/crates/opensymphony-openhands/tests/issue_session_runner.rs
+++ b/crates/opensymphony-openhands/tests/issue_session_runner.rs
@@ -279,6 +279,15 @@ async fn issue_session_runner_reuses_conversation_and_switches_to_continuation_p
         first_conversation.last_prompt_kind,
         Some(IssueSessionPromptKind::Full)
     );
+    let launch_profile = first_conversation
+        .launch_profile
+        .as_ref()
+        .expect("conversation manifest should persist a launch profile");
+    assert_eq!(launch_profile.workspace_kind, "LocalWorkspace");
+    assert_eq!(launch_profile.confirmation_policy_kind, "NeverConfirm");
+    assert_eq!(launch_profile.agent_kind, "Agent");
+    assert_eq!(launch_profile.llm_model, "openai/gpt-5.4");
+    assert!(launch_profile.stuck_detection);
     let first_prompt = manager
         .read_text_artifact(
             &ensured.handle,

--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -51,6 +51,8 @@ pub enum WorkspaceError {
     CreateDirectory { path: PathBuf, source: io::Error },
     #[error("failed to canonicalize {path}: {source}")]
     Canonicalize { path: PathBuf, source: io::Error },
+    #[error("failed to read directory {path}: {source}")]
+    ReadDirectory { path: PathBuf, source: io::Error },
     #[error("failed to read manifest {path}: {source}")]
     ReadManifest { path: PathBuf, source: io::Error },
     #[error("failed to read managed file {path}: {source}")]

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -254,6 +254,63 @@ impl WorkspaceManager {
             .await
     }
 
+    pub async fn find_workspace_by_issue_reference(
+        &self,
+        issue_reference: &str,
+    ) -> Result<Option<WorkspaceHandle>, WorkspaceError> {
+        self.create_directory(&self.config.root).await?;
+
+        match crate::workspace_path_for_root(&self.config.root, issue_reference) {
+            Ok(candidate) => {
+                if let Some((handle, manifest)) =
+                    self.load_workspace_from_directory(&candidate).await?
+                    && workspace_matches_issue_reference(&manifest, issue_reference)
+                {
+                    return Ok(Some(handle));
+                }
+            }
+            Err(WorkspaceError::EmptyIdentifier | WorkspaceError::InvalidWorkspaceKey { .. }) => {}
+            Err(error) => return Err(error),
+        }
+
+        let mut entries = fs::read_dir(&self.config.root).await.map_err(|source| {
+            WorkspaceError::ReadDirectory {
+                path: self.config.root.clone(),
+                source,
+            }
+        })?;
+        while let Some(entry) =
+            entries
+                .next_entry()
+                .await
+                .map_err(|source| WorkspaceError::ReadDirectory {
+                    path: self.config.root.clone(),
+                    source,
+                })?
+        {
+            let file_type =
+                entry
+                    .file_type()
+                    .await
+                    .map_err(|source| WorkspaceError::ReadDirectory {
+                        path: entry.path(),
+                        source,
+                    })?;
+            if !file_type.is_dir() {
+                continue;
+            }
+
+            if let Some((handle, manifest)) =
+                self.load_workspace_from_directory(&entry.path()).await?
+                && workspace_matches_issue_reference(&manifest, issue_reference)
+            {
+                return Ok(Some(handle));
+            }
+        }
+
+        Ok(None)
+    }
+
     pub async fn write_issue_manifest(
         &self,
         workspace: &WorkspaceHandle,
@@ -574,6 +631,48 @@ impl WorkspaceManager {
                 }
             }
         }
+    }
+
+    async fn load_workspace_from_directory(
+        &self,
+        workspace_path: &Path,
+    ) -> Result<Option<(WorkspaceHandle, IssueManifest)>, WorkspaceError> {
+        self.reject_symlinked_workspace_root(workspace_path).await?;
+        if !path_exists(workspace_path).await? {
+            return Ok(None);
+        }
+
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let canonical_workspace = self.canonicalize_path(workspace_path).await?;
+        ensure_descendant(&canonical_root, &canonical_workspace)?;
+
+        let issue_manifest_path = canonical_workspace.join(".opensymphony").join("issue.json");
+        let raw = match fs::read_to_string(&issue_manifest_path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                return Err(WorkspaceError::ReadManifest {
+                    path: issue_manifest_path,
+                    source,
+                });
+            }
+        };
+        let manifest = match serde_json::from_str::<IssueManifest>(&raw) {
+            Ok(manifest) => manifest,
+            Err(_) => return Ok(None),
+        };
+
+        let handle = WorkspaceHandle::new(
+            manifest.issue_id.clone(),
+            manifest.identifier.clone(),
+            manifest.sanitized_workspace_key.clone(),
+            canonical_workspace,
+        );
+        if !issue_manifest_claims_workspace(&handle, &manifest) {
+            return Ok(None);
+        }
+
+        Ok(Some((handle, manifest)))
     }
 
     async fn execute_hook(
@@ -1165,6 +1264,10 @@ fn ownership_claim_from_after_create_receipt(
         issue_id: receipt.issue_id,
         identifier: receipt.identifier,
     }
+}
+
+fn workspace_matches_issue_reference(manifest: &IssueManifest, issue_reference: &str) -> bool {
+    manifest.identifier == issue_reference || manifest.issue_id == issue_reference
 }
 
 fn ensure_descendant(root: &Path, candidate: &Path) -> Result<(), WorkspaceError> {

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -303,6 +303,59 @@ async fn ensure_retries_after_create_when_foreign_issue_manifest_preexists() {
 }
 
 #[tokio::test]
+async fn find_workspace_by_issue_reference_returns_identifier_match() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let ensured = manager
+        .ensure(&sample_issue("COE-287"))
+        .await
+        .expect("workspace should exist");
+
+    let found = manager
+        .find_workspace_by_issue_reference("COE-287")
+        .await
+        .expect("lookup should succeed")
+        .expect("workspace should be found");
+
+    assert_eq!(found.issue_id(), ensured.handle.issue_id());
+    assert_eq!(found.identifier(), ensured.handle.identifier());
+    assert_eq!(found.workspace_path(), ensured.handle.workspace_path());
+}
+
+#[tokio::test]
+async fn find_workspace_by_issue_reference_scans_issue_ids() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-288");
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("workspace should exist");
+
+    let found = manager
+        .find_workspace_by_issue_reference(&issue.issue_id)
+        .await
+        .expect("lookup should succeed")
+        .expect("workspace should be found");
+
+    assert_eq!(found.issue_id(), ensured.handle.issue_id());
+    assert_eq!(found.identifier(), ensured.handle.identifier());
+    assert_eq!(found.workspace_path(), ensured.handle.workspace_path());
+}
+
+#[tokio::test]
 async fn ensure_retries_after_create_when_copied_malformed_issue_manifest_preexists() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
     let workspace_root = temp_dir.path().join("workspaces");

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,7 @@ OpenSymphony creates a stable OpenHands `conversation_id` per issue and persists
 This is stricter than the minimum Symphony requirement and intentionally optimizes continuity.
 The current issue session runner also tracks whether that conversation has already been seeded with the full workflow prompt so a reused but never-started thread can still receive the original assignment on the next attempt.
 The persisted OpenHands state directory is derived from the workflow-owned `openhands.conversation.persistence_dir_relative` path inside the issue workspace, and a missing-but-recreatable conversation that still has persisted history stays on continuation guidance instead of replaying the full workflow template.
+The persisted conversation manifest also records the owning issue reference, creation and attach timestamps, and the launch profile used to create the thread so `opensymphony debug <issue-id>` can reattach to the same session or rehydrate the same `conversation_id` with matching runtime settings.
 
 ### 3.6 The UI only sees the control plane
 
@@ -216,6 +217,9 @@ Local MVP process graph:
   - owns orchestrator and control plane
   - may spawn:
     - `bash tools/openhands-server/run-local.sh`
+- `opensymphony debug <issue-id>`
+  - reuses the issue workspace and persisted conversation manifest
+  - attaches to the configured OpenHands transport directly or reuses a ready local supervised server on the same base URL
 - OpenHands MCP child processes
   - may spawn:
     - `opensymphony linear-mcp`

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -197,6 +197,7 @@ Suggested persisted fields:
 - `created_at`
 - `updated_at`
 - `last_attached_at`
+- `launch_profile`
 - `server_base_url`
 - `transport_target`
 - `http_auth_mode`
@@ -214,6 +215,15 @@ Suggested persisted fields:
 - `last_event_kind`
 - `last_event_at`
 - `last_event_summary`
+
+`launch_profile` should capture the OpenHands conversation settings that need to survive restarts and interactive debug reuse, including:
+
+- `workspace_kind`
+- `confirmation_policy_kind`
+- `agent_kind`
+- `llm_model`
+- `max_iterations`
+- `stuck_detection`
 
 Implementation note:
 
@@ -258,6 +268,21 @@ Current implementation detail:
 - the full workflow prompt is selected until a `POST /events` call accepts that first assignment message
 - once seeded, later worker lifetimes send built-in continuation guidance instead of rerendering the workflow template
 - if `GET /api/conversations/{id}` or the initial attach fails for a reused conversation, the runner retries `POST /api/conversations` with the same stable `conversation_id`; when that re-created thread still exposes persisted history, the runner keeps continuation guidance instead of downgrading to a fresh full prompt
+- the runner persists the conversation launch profile on first create and backfills older manifests on reuse so later rehydration and interactive debug sessions can recreate the same thread settings without guessing from mutable runtime state
+
+## 6.4 Interactive debug resumption
+
+`opensymphony debug <issue-id>` resolves the managed workspace for an issue, reads
+`conversation.json`, and attaches to the recorded `conversation_id` from the original
+working directory.
+
+Current implementation detail:
+
+- external configured transports are reused as-is
+- local-supervised workflows probe the configured base URL first and reuse any ready server already responding there
+- if no ready local server exists, the debug command can launch the pinned repo-local supervisor and then reattach
+- if the server no longer has the conversation but the persisted history directory still exists, the CLI recreates the same `conversation_id` using the stored `launch_profile` and then resumes the thread
+- operators should avoid unrelated standalone `openhands` CLI sessions on the same port so the orchestrator-managed transport remains the single source of truth
 - if a reused conversation is already active, the runner waits for that turn to finish before sending the next prompt, and it retries `POST /run` after a `409 Conflict` on the same attached stream
 - each fresh create also snapshots `create-conversation-request.json`, `last-conversation-state.json`, and `generated/session-context.json` inside the issue workspace for recovery and observability
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -336,6 +336,7 @@ Expected assertions:
 Recommended CLI commands for the repo:
 
 - `opensymphony run`
+- `opensymphony debug <issue-id>`
 - `opensymphony tui`
 - `opensymphony doctor`
 - `opensymphony linear-mcp`
@@ -351,11 +352,11 @@ Current workspace commands:
 
 - `cd /path/to/target-repo && opensymphony run`
 - `cd /path/to/target-repo && opensymphony run --config ./config.yaml`
+- `cd /path/to/target-repo && opensymphony debug COE-284`
 - `opensymphony tui --url http://127.0.0.1:3000/`
 
 Possible helper commands later:
 
-- `opensymphony debug openhands`
 - `opensymphony inspect workspace <issue-id>`
 - `opensymphony inspect conversation <issue-id>`
 
@@ -363,11 +364,21 @@ Current validation commands for the implemented orchestrator and observability s
 
 - `cargo test`
 - `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p opensymphony-cli --test debug`
 - `cargo install --path . --locked --root /tmp/opensymphony-install-check`
 - `cd /path/to/target-repo && /tmp/opensymphony-install-check/bin/opensymphony run`
+- `cd /path/to/target-repo && /tmp/opensymphony-install-check/bin/opensymphony debug COE-284`
 - `curl http://127.0.0.1:3000/api/v1/snapshot`
 - `opensymphony tui --url http://127.0.0.1:3000/ --exit-after-ms 1200`
 - `curl http://127.0.0.1:3000/healthz`
+
+The debug command is intentionally workspace-backed rather than tracker-backed: it
+finds the managed issue workspace, loads `.opensymphony/conversation.json`, and
+resumes the recorded OpenHands conversation from the original working directory.
+For local-supervised workflows it reuses any ready server already bound to the
+configured base URL and only launches the pinned repo-local server when nothing
+ready is already serving there. Avoid leaving unrelated standalone `openhands`
+CLI sessions on that port when validating orchestrator-managed resume behavior.
 
 The scripted `tui --exit-after-ms` smoke path now exits `0` only when the
 final reduced control-plane state is still a real streamed
@@ -569,7 +580,7 @@ Each issue workspace should expose enough local artifacts to debug recovery:
     session-context.json
 ```
 
-These files should make restart recovery explainable without scraping daemon memory. The root-scoped `after_create` receipt explains why a partially bootstrapped workspace will skip rerunning clone/worktree hooks, `run.json` retains the latest hook/status evidence for the worker lifetime, `conversation.json` records reuse plus prompt-seeding state, and the OpenHands plus generated snapshots preserve the exact create request, latest mirrored conversation state, last dispatched prompt artifacts, and latest normalized runner context without reconstructing daemon state.
+These files should make restart recovery explainable without scraping daemon memory. The root-scoped `after_create` receipt explains why a partially bootstrapped workspace will skip rerunning clone/worktree hooks, `run.json` retains the latest hook/status evidence for the worker lifetime, `conversation.json` records issue ownership, reuse state, prompt-seeding state, and the persisted launch profile used by `opensymphony debug`, and the OpenHands plus generated snapshots preserve the exact create request, latest mirrored conversation state, last dispatched prompt artifacts, and latest normalized runner context without reconstructing daemon state.
 
 ## 10. Version pinning
 

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -85,6 +85,7 @@ Notes:
 - `.opensymphony.after_create.json` is an internal OpenSymphony bootstrap receipt written at the workspace root immediately after a successful first-time `after_create` hook and before `.opensymphony/` metadata bootstrap.
 - The workspace layer bootstraps `issue.json`, `run.json`, and the supporting metadata directories after a successful first-time `after_create` hook so clone/worktree hooks still see a fresh workspace directory.
 - `conversation.json` now uses workspace-owned path and serialization helpers, but the OpenHands issue-session runner still owns when it is created, reused, or reset.
+- `conversation.json` is the issue-to-session registry: it stores the issue reference, stable `conversation_id`, timestamps, transport diagnostics, and the launch profile needed to resume or rehydrate the same OpenHands thread later through `opensymphony debug`.
 - `prompts/` holds the latest prompt of each kind plus JSON metadata that points back to the per-run archive.
 - `runs/attempt-####/` holds immutable per-run prompt captures for auditability without mutating repository-owned policy files.
 - The repository working tree remains otherwise untouched except by normal agent work.
@@ -250,6 +251,7 @@ Suggested fields:
 - `created_at`
 - `updated_at`
 - `last_attached_at`
+- `launch_profile`
 - `fresh_conversation`
 - `workflow_prompt_seeded`
 - `reset_reason`
@@ -264,6 +266,9 @@ Suggested fields:
 - `last_event_summary`
 
 This file is the bridge between Symphony issue ownership and OpenHands conversation reuse.
+It also makes conversational debugging deterministic: `opensymphony debug <issue-id>`
+uses the stored issue reference plus `launch_profile` to find the workspace, resume the
+same thread, and preserve context across orchestrator restarts or retry attempts.
 
 ## 9. Generated context artifacts
 
@@ -345,6 +350,7 @@ Default policy:
 - one conversation per issue
 - conversation persistence is stored under the issue workspace
 - reused across worker lifetimes
+- retained after worker completion so the issue remains debuggable until workspace cleanup
 - reset only on explicit error or incompatible-version policy
 
 Reset handling:


### PR DESCRIPTION
## Summary

Add `opensymphony debug <issue-id>` so operators can reopen the persisted OpenHands conversation for one managed issue and ask follow-up implementation questions in the original workspace context.

## Changes

- add the new `opensymphony debug <issue-id>` CLI flow, including workspace resolution, conversation manifest loading, attach-or-rehydrate behavior, and an interactive prompt loop
- extend `.opensymphony/conversation.json` with persisted launch-profile metadata and add workspace lookup by identifier or persisted issue ID
- cover the new behavior with CLI/workspace/OpenHands tests and document the session registry plus server-reuse guidance in the required docs

## Evidence

### Test output

```text
$ cargo test -p opensymphony-workspace --test workspace_manager -p opensymphony-openhands --test issue_session_runner -p opensymphony-cli --test help -p opensymphony-cli --test debug
Finished `test` profile [unoptimized + debuginfo] target(s) in 1.03s
running 1 test
... debug_resumes_existing_conversation_history_and_sends_follow_up_input ... ok
running 4 tests
... debug_help_explains_issue_lookup_and_config ... ok
running 6 tests
... issue_session_runner_rehydrates_a_missing_conversation_without_downgrading_to_full_prompt ... ok
running 24 tests
... find_workspace_by_issue_reference_scans_issue_ids ... ok

test result: ok. 35 passed; 0 failed

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.70s
```

### Verification

- reproduced the baseline failure with `cargo run -p opensymphony-cli -- debug COE-287`, which failed before implementation with `error: unrecognized subcommand 'debug'`
- `crates/opensymphony-cli/tests/debug.rs` provisions a managed workspace plus persisted `conversation.json`, forces the CLI down the rehydrate path, resumes prior assistant history, sends a follow-up implementation question, and verifies the same conversation receives the new user turn
- updated `README.md`, `docs/architecture.md`, `docs/openhands-agent-server.md`, `docs/workspace-and-lifecycle.md`, and `docs/testing-and-operations.md` so the new manifest contract and debug/server-management behavior are documented in the same change

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: 

## Breaking changes

None.

## Related issues

- Linear: COE-287

## Additional notes

- The debug command reuses the configured OpenHands transport. For local-supervised workflows it reuses any ready server already listening on the configured base URL and only launches the pinned repo-local supervisor when nothing ready is serving there.
- Best-practice guidance is now documented to avoid unrelated standalone `openhands` CLI sessions on the same port when relying on orchestrator-managed session state.
