### PR TITLE
Abort active CLI worker tasks on graceful shutdown

### DIFF
--- a/crates/opensymphony-cli/src/orchestrator_run.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run.rs
@@ -682,6 +682,33 @@ impl RuntimeWorkerBackend {
             tasks: HashMap::new(),
         }
     }
+
+    fn abort_tracked_task(&mut self, worker_id: &str) {
+        if let Some(task) = self.tasks.remove(worker_id) {
+            task.handle.abort();
+        }
+    }
+
+    fn abort_all_tracked_tasks(&mut self) {
+        let active_count = self.tasks.len();
+        if active_count == 0 {
+            return;
+        }
+
+        info!(
+            active_count,
+            "aborting tracked worker tasks during backend shutdown"
+        );
+        for (_, task) in self.tasks.drain() {
+            task.handle.abort();
+        }
+    }
+}
+
+impl Drop for RuntimeWorkerBackend {
+    fn drop(&mut self) {
+        self.abort_all_tracked_tasks();
+    }
 }
 
 fn transport_port_override(url: &Url) -> Result<u16, RunCommandError> {
@@ -829,9 +856,7 @@ impl WorkerBackend for RuntimeWorkerBackend {
                 Err(CliWorkerError::LaunchChannelClosed)
             }
             Err(_) => {
-                if let Some(task) = self.tasks.remove(worker_id.as_str()) {
-                    task.handle.abort();
-                }
+                self.abort_tracked_task(worker_id.as_str());
                 Err(CliWorkerError::LaunchTimeout(self.launch_timeout))
             }
         }
@@ -880,9 +905,7 @@ impl WorkerBackend for RuntimeWorkerBackend {
         worker_id: &opensymphony_domain::WorkerId,
         _reason: WorkerAbortReason,
     ) -> Result<(), Self::Error> {
-        if let Some(task) = self.tasks.remove(worker_id.as_str()) {
-            task.handle.abort();
-        }
+        self.abort_tracked_task(worker_id.as_str());
         Ok(())
     }
 }
@@ -1161,12 +1184,13 @@ fn now_timestamp() -> TimestampMs {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path};
+    use std::{fs, future::pending, path::Path};
 
     use opensymphony_domain::{
         IssueId, IssueState, IssueStateCategory, RunAttempt, WorkerId, WorkspaceKey,
     };
     use tempfile::TempDir;
+    use tokio::{sync::oneshot, time::timeout};
 
     use super::*;
 
@@ -1240,6 +1264,50 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn runtime_worker_backend_aborts_tracked_tasks_on_drop() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspace-root");
+        fs::create_dir_all(&workspace_root).expect("workspace root should be created");
+
+        let workflow = Arc::new(sample_workflow(tempdir.path(), &workspace_root));
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let mut backend = RuntimeWorkerBackend::new(
+            OpenHandsClient::new(TransportConfig::new("http://127.0.0.1:1")),
+            workflow,
+            workspace_manager,
+        );
+
+        let workspace = sample_workspace(&workspace_root);
+        let run = RunAttempt::new(
+            WorkerId::new("worker-drop").expect("worker id should be valid"),
+            IssueId::new("issue-drop").expect("issue id should be valid"),
+            IssueIdentifier::new("COE-286").expect("issue identifier should be valid"),
+            workspace.path.clone(),
+            TimestampMs::new(1),
+            None,
+            8,
+        );
+        let (aborted_tx, aborted_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _notifier = AbortNotifier(Some(aborted_tx));
+            pending::<()>().await;
+        });
+        backend
+            .tasks
+            .insert("worker-drop".to_string(), ActiveWorkerTask { handle, run });
+
+        drop(backend);
+
+        match timeout(Duration::from_millis(100), aborted_rx).await {
+            Ok(Ok(())) | Ok(Err(_)) => {}
+            Err(_) => panic!("dropping the backend should abort tracked tasks"),
+        }
+    }
+
     fn sample_workflow(base_dir: &Path, workspace_root: &Path) -> ResolvedWorkflow {
         let source = format!(
             "---\ntracker:\n  kind: linear\n  endpoint: http://127.0.0.1:3001/graphql\n  api_key: test-linear-key\n  project_slug: sample-project\n  active_states:\n    - In Progress\n  terminal_states:\n    - Done\nworkspace:\n  root: {}\nopenhands:\n  transport:\n    base_url: http://127.0.0.1:1\n    session_api_key_env: OPENHANDS_API_KEY\n---\n\n# Test Workflow\n\nRun the scheduler.\n",
@@ -1282,6 +1350,16 @@ mod tests {
             created_at: None,
             updated_at: None,
             last_seen_tracker_refresh_at: None,
+        }
+    }
+
+    struct AbortNotifier(Option<oneshot::Sender<()>>);
+
+    impl Drop for AbortNotifier {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
         }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,6 +215,7 @@ Local MVP process graph:
 
 - `opensymphony run`
   - owns orchestrator and control plane
+  - aborts any still-tracked CLI worker tasks when the runtime worker backend is dropped during graceful shutdown
   - may spawn:
     - `bash tools/openhands-server/run-local.sh`
 - `opensymphony debug <issue-id>`

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -163,6 +163,7 @@ If the daemon is using an external server, never attempt to terminate that serve
 
 Current implementation detail:
 
+- the CLI runtime worker backend aborts every still-tracked worker task from its `Drop` path, so `opensymphony run` does not rely on process teardown alone to stop in-flight issue workers
 - child ownership is tracked by the Rust supervisor instance
 - `stop()` only kills a `Child` handle created by `start()`
 - external mode may probe health, but stop remains a no-op

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -191,6 +191,7 @@ Current implementation:
 Current repository implementation:
 
 - `crates/opensymphony-orchestrator/tests/scheduler.rs` covers continuation retry, failure backoff, per-state dispatch limits, runtime-event-fed stall detection, terminal reconciliation with cleanup, and manifest-backed workspace recovery using fake backends
+- `crates/opensymphony-cli/src/orchestrator_run.rs` covers immediate launch-failure cleanup and abort-on-drop cleanup for tracked runtime worker tasks in the production CLI adapter
 
 ## 3.5 Control plane and TUI
 


### PR DESCRIPTION
## Summary

Abort tracked CLI worker tasks when `RuntimeWorkerBackend` is dropped during graceful orchestrator shutdown.

## Changes

- add backend-owned helpers to abort a single tracked worker task or drain and abort all tracked worker tasks during backend drop
- add a focused CLI unit test proving backend drop now aborts an in-flight tracked task, alongside the existing launch-failure cleanup test
- document the updated shutdown contract and the CLI adapter coverage in the architecture and operations docs
- merge `origin/main` after the PR-review workflow update so this branch reruns against the current CI configuration

## Evidence

### Test output

```text
$ cargo test -p opensymphony-cli runtime_worker_backend_aborts_tracked_tasks_on_drop -- --nocapture
test orchestrator_run::tests::runtime_worker_backend_aborts_tracked_tasks_on_drop ... ok

$ cargo fmt --all --check
(no output)

$ cargo clippy -p opensymphony-cli --lib -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo test -p opensymphony-cli
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Verification

- Captured the pre-change signal with the new drop-focused test first; it failed with a timeout because dropping `RuntimeWorkerBackend` left the tracked task alive until process teardown.
- After wiring tracked-task cleanup into `RuntimeWorkerBackend::drop`, the same test passes and the existing workspace-launch failure cleanup test still passes.
- The affected CLI crate passes `cargo fmt --all --check`, `cargo clippy -p opensymphony-cli --lib -- -D warnings`, and `cargo test -p opensymphony-cli` on the merged `origin/main` base.
- Documentation now states that `opensymphony run` aborts still-tracked CLI worker tasks during graceful shutdown instead of relying on process exit alone.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

- COE-286
- COE-289

## Additional notes

- The repo does not include the `elixir/` PR-body validation path referenced by the generic push skill, so this PR body was validated directly against `.github/pull_request_template.md`.
- The `rust` check is green on PR #49, but the advisory `ai-pr-review` workflow still fails before posting review output because the upstream OpenHands review action resolves an unsatisfiable `openhands-sdk` / `litellm` dependency set on GitHub runners.
