### PR TITLE
Cache per-state running counts in the orchestrator scheduler

### DIFF
--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -202,6 +202,7 @@ pub struct Scheduler<T, W, M> {
     worker: M,
     config: SchedulerConfig,
     executions: BTreeMap<IssueId, IssueExecution>,
+    running_counts_by_state: HashMap<String, usize>,
     worker_index: HashMap<WorkerId, IssueId>,
     pending_recovery: Option<Vec<RecoveryRecord>>,
     recovered: bool,
@@ -223,6 +224,7 @@ where
             worker,
             config,
             executions: BTreeMap::new(),
+            running_counts_by_state: HashMap::new(),
             worker_index: HashMap::new(),
             pending_recovery: None,
             recovered: false,
@@ -581,18 +583,7 @@ where
                 &self.config.max_concurrent_agents_by_state,
                 &normalized.state.name,
             ) {
-                let running_in_state = self
-                    .executions
-                    .values()
-                    .filter(|execution| {
-                        execution.status() == SchedulerStatus::Running
-                            && execution
-                                .issue()
-                                .state
-                                .name
-                                .eq_ignore_ascii_case(&normalized.state.name)
-                    })
-                    .count();
+                let running_in_state = self.running_count_for_state(&normalized.state.name);
                 if running_in_state >= usize::try_from(limit).unwrap_or(usize::MAX) {
                     continue;
                 }
@@ -624,8 +615,7 @@ where
             );
 
             let mut execution = self
-                .executions
-                .remove(&issue_id)
+                .remove_execution(&issue_id)
                 .unwrap_or_else(|| IssueExecution::new(normalized.clone(), observed_at));
             execution.refresh_issue(normalized.clone())?;
             execution.attach_workspace(workspace.clone())?;
@@ -664,7 +654,7 @@ where
                 }
             }
 
-            self.executions.insert(issue_id, execution);
+            self.insert_execution(issue_id, execution);
         }
 
         Ok(())
@@ -699,13 +689,13 @@ where
                     let Some(issue_id) = self.worker_index.remove(&worker_id) else {
                         continue;
                     };
-                    let Some(execution) = self.executions.remove(&issue_id) else {
+                    let Some(execution) = self.remove_execution(&issue_id) else {
                         continue;
                     };
                     let finished_at = outcome.finished_at;
                     let execution =
                         self.resolve_finished_execution(execution, outcome, finished_at)?;
-                    self.executions.insert(issue_id, execution);
+                    self.insert_execution(issue_id, execution);
                 }
             }
         }
@@ -732,11 +722,11 @@ where
             .collect::<Vec<_>>();
 
         for issue_id in stalled {
-            let Some(mut execution) = self.executions.remove(&issue_id) else {
+            let Some(mut execution) = self.remove_execution(&issue_id) else {
                 continue;
             };
             let Some(run) = execution.current_run().cloned() else {
-                self.executions.insert(issue_id, execution);
+                self.insert_execution(issue_id, execution);
                 continue;
             };
 
@@ -750,7 +740,7 @@ where
                 Some("scheduler stall timeout reached".to_string()),
             );
             execution = self.resolve_finished_execution(execution, outcome, observed_at)?;
-            self.executions.insert(issue_id, execution);
+            self.insert_execution(issue_id, execution);
         }
 
         Ok(())
@@ -763,7 +753,7 @@ where
         recovered_workspace: Option<WorkspaceRecord>,
     ) -> Result<(), SchedulerError> {
         let issue_id = issue.id.clone();
-        let mut execution = match self.executions.remove(&issue_id) {
+        let mut execution = match self.remove_execution(&issue_id) {
             Some(existing) => existing,
             None => IssueExecution::new(issue.clone(), observed_at),
         };
@@ -774,7 +764,7 @@ where
         if let Some(workspace) = recovered_workspace {
             execution.attach_workspace(workspace)?;
         }
-        self.executions.insert(issue_id, execution);
+        self.insert_execution(issue_id, execution);
         Ok(())
     }
 
@@ -787,7 +777,7 @@ where
         cleanup_terminal: bool,
         abort_reason: Option<WorkerAbortReason>,
     ) -> Result<(), SchedulerError> {
-        let Some(mut execution) = self.executions.remove(&issue_id) else {
+        let Some(mut execution) = self.remove_execution(&issue_id) else {
             return Ok(());
         };
 
@@ -808,7 +798,7 @@ where
                     detail: error.to_string(),
                 })?;
         }
-        self.executions.insert(issue_id, execution);
+        self.insert_execution(issue_id, execution);
         Ok(())
     }
 
@@ -873,6 +863,58 @@ where
         self.next_worker_ordinal = self.next_worker_ordinal.saturating_add(1);
         WorkerId::new(format!("scheduler-worker-{}", self.next_worker_ordinal))
             .map_err(SchedulerError::Identifier)
+    }
+
+    fn remove_execution(&mut self, issue_id: &IssueId) -> Option<IssueExecution> {
+        let execution = self.executions.remove(issue_id)?;
+        self.decrement_running_count(&execution);
+        self.debug_assert_running_counts();
+        Some(execution)
+    }
+
+    fn insert_execution(&mut self, issue_id: IssueId, execution: IssueExecution) {
+        let current_key = running_state_key_for_execution(&execution);
+        if let Some(previous) = self.executions.insert(issue_id, execution) {
+            self.decrement_running_count(&previous);
+        }
+        if let Some(state_key) = current_key {
+            *self.running_counts_by_state.entry(state_key).or_default() += 1;
+        }
+        self.debug_assert_running_counts();
+    }
+
+    fn running_count_for_state(&self, state_name: &str) -> usize {
+        self.running_counts_by_state
+            .get(&normalized_state_name(state_name))
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn decrement_running_count(&mut self, execution: &IssueExecution) {
+        let Some(state_key) = running_state_key_for_execution(execution) else {
+            return;
+        };
+        let count = self
+            .running_counts_by_state
+            .get_mut(&state_key)
+            .expect("running execution must have a cached count");
+        *count -= 1;
+        if *count == 0 {
+            self.running_counts_by_state.remove(&state_key);
+        }
+    }
+
+    fn debug_assert_running_counts(&self) {
+        #[cfg(debug_assertions)]
+        {
+            let mut expected = HashMap::new();
+            for execution in self.executions.values() {
+                if let Some(state_key) = running_state_key_for_execution(execution) {
+                    *expected.entry(state_key).or_insert(0) += 1;
+                }
+            }
+            debug_assert_eq!(self.running_counts_by_state, expected);
+        }
     }
 }
 
@@ -991,9 +1033,10 @@ fn state_category_from_name(name: &str, config: &SchedulerConfig) -> IssueStateC
 }
 
 fn state_limit_for(limits: &BTreeMap<String, u32>, state_name: &str) -> Option<u32> {
+    let normalized = normalized_state_name(state_name);
     limits
         .iter()
-        .find_map(|(state, limit)| state.eq_ignore_ascii_case(state_name).then_some(*limit))
+        .find_map(|(state, limit)| (normalized_state_name(state) == normalized).then_some(*limit))
 }
 
 fn non_active_release_reason(category: IssueStateCategory) -> Option<ReleaseReason> {
@@ -1016,15 +1059,24 @@ fn retry_reason_for_outcome(outcome: WorkerOutcomeKind) -> Option<RetryReason> {
 fn normalized_state_set(states: &[String]) -> HashSet<String> {
     states
         .iter()
-        .map(|state| state.trim().to_ascii_lowercase())
+        .map(|state| normalized_state_name(state))
         .collect()
 }
 
 fn matches_state_name(name: &str, states: &[String]) -> bool {
-    let name = name.trim().to_ascii_lowercase();
+    let normalized = normalized_state_name(name);
     states
         .iter()
-        .any(|state| state.trim().eq_ignore_ascii_case(&name))
+        .any(|state| normalized_state_name(state) == normalized)
+}
+
+fn running_state_key_for_execution(execution: &IssueExecution) -> Option<String> {
+    (execution.status() == SchedulerStatus::Running)
+        .then(|| normalized_state_name(&execution.issue().state.name))
+}
+
+fn normalized_state_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
 }
 
 fn effective_stall_timeout(stall_timeout_ms: Option<u64>) -> DurationMs {

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -8,9 +8,10 @@ use opensymphony_orchestrator::{
     ConversationId, ConversationMetadata, IssueId, IssueIdentifier, IssueRef, IssueState,
     IssueStateCategory, NormalizedIssue, RecoveryRecord, ReleaseReason, RetryReason,
     RuntimeStreamState, Scheduler, SchedulerConfig, SchedulerStatus, TimestampMs, TrackerBackend,
-    TrackerIssue, TrackerIssueStateSnapshot, WorkerAbortReason, WorkerBackend, WorkerId,
-    WorkerLaunch, WorkerOutcomeKind, WorkerOutcomeRecord, WorkerStartRequest, WorkerUpdate,
-    WorkspaceBackend, WorkspaceKey, WorkspaceRecord,
+    TrackerIssue, TrackerIssueState, TrackerIssueStateKind, TrackerIssueStateSnapshot,
+    WorkerAbortReason, WorkerBackend, WorkerId, WorkerLaunch, WorkerOutcomeKind,
+    WorkerOutcomeRecord, WorkerStartRequest, WorkerUpdate, WorkspaceBackend, WorkspaceKey,
+    WorkspaceRecord,
 };
 
 fn ts(value: u64) -> TimestampMs {
@@ -85,6 +86,26 @@ fn normalized_issue(id: &str, identifier: &str, state: &str) -> NormalizedIssue 
         }],
         created_at: Some(ts(0)),
         updated_at: Some(ts(0)),
+    }
+}
+
+fn tracker_state_snapshot(
+    id: &str,
+    identifier: &str,
+    state: &str,
+    tracker_type: &str,
+    updated_at: u64,
+) -> TrackerIssueStateSnapshot {
+    TrackerIssueStateSnapshot {
+        id: id.to_string(),
+        identifier: identifier.to_string(),
+        state: TrackerIssueState {
+            id: state.to_ascii_lowercase().replace(' ', "-"),
+            name: state.to_string(),
+            tracker_type: tracker_type.to_string(),
+            kind: TrackerIssueStateKind::from_tracker_type(tracker_type),
+        },
+        updated_at: dt(updated_at),
     }
 }
 
@@ -402,22 +423,93 @@ async fn failures_schedule_exponential_backoff() {
 }
 
 #[tokio::test]
-async fn terminal_reconciliation_aborts_running_worker_and_cleans_up_workspace() {
-    let issue = tracker_issue("lin-270", "COE-270", "In Progress", 0);
+async fn per_state_capacity_releases_slot_after_worker_finishes() {
     let tracker = FakeTracker {
-        active: vec![issue.clone()],
+        active: vec![
+            tracker_issue("lin-275", "COE-275", "In Progress", 0),
+            tracker_issue("lin-276", "COE-276", "In Progress", 1),
+        ],
         ..Default::default()
     };
     let workspace = FakeWorkspace::default();
     let worker = FakeWorker::default();
-    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+    let mut config = scheduler_config();
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("first tick should dispatch the first issue");
+
+    let first_run = scheduler.worker().launches[0].run.clone();
+    scheduler
+        .worker_mut()
+        .updates
+        .push_back(WorkerUpdate::Finished {
+            worker_id: first_run.worker_id.clone(),
+            outcome: WorkerOutcomeRecord::from_run(
+                &first_run,
+                WorkerOutcomeKind::Succeeded,
+                ts(200),
+                Some("worker exited cleanly".to_string()),
+                None,
+            ),
+        });
+
+    scheduler
+        .tick(ts(200))
+        .await
+        .expect("finish tick should free the state slot for the next issue");
+
+    assert_eq!(scheduler.worker().launches.len(), 2);
+    assert_eq!(
+        scheduler.worker().launches[1].issue.identifier.as_str(),
+        "COE-276"
+    );
+    assert_eq!(
+        scheduler
+            .execution(&IssueId::new("lin-275").expect("issue id should be valid"))
+            .expect("finished issue should still exist")
+            .status(),
+        SchedulerStatus::RetryQueued
+    );
+    assert_eq!(
+        scheduler
+            .execution(&IssueId::new("lin-276").expect("issue id should be valid"))
+            .expect("second issue should be running")
+            .status(),
+        SchedulerStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn terminal_reconciliation_aborts_running_worker_and_cleans_up_workspace() {
+    let issue = tracker_issue("lin-270", "COE-270", "In Progress", 0);
+    let tracker = FakeTracker {
+        active: vec![
+            issue.clone(),
+            tracker_issue("lin-270-b", "COE-270-B", "In Progress", 1),
+        ],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
 
     scheduler
         .tick(ts(100))
         .await
         .expect("first tick should succeed");
 
-    scheduler.tracker_mut().active.clear();
+    scheduler.tracker_mut().active =
+        vec![tracker_issue("lin-270-b", "COE-270-B", "In Progress", 1)];
     scheduler.tracker_mut().terminal = vec![tracker_issue("lin-270", "COE-270", "Done", 0)];
 
     scheduler
@@ -445,17 +537,36 @@ async fn terminal_reconciliation_aborts_running_worker_and_cleans_up_workspace()
         scheduler.workspace().cleaned,
         vec![("COE-270".to_string(), true)]
     );
+    assert_eq!(scheduler.worker().launches.len(), 2);
+    assert_eq!(
+        scheduler.worker().launches[1].issue.identifier.as_str(),
+        "COE-270-B"
+    );
+    assert_eq!(
+        scheduler
+            .execution(&IssueId::new("lin-270-b").expect("issue id should be valid"))
+            .expect("replacement issue should be running")
+            .status(),
+        SchedulerStatus::Running
+    );
 }
 
 #[tokio::test]
 async fn runtime_events_extend_stall_deadlines_before_retrying_a_stalled_worker() {
     let tracker = FakeTracker {
-        active: vec![tracker_issue("lin-271", "COE-271", "In Progress", 0)],
+        active: vec![
+            tracker_issue("lin-271", "COE-271", "In Progress", 0),
+            tracker_issue("lin-271-b", "COE-271-B", "In Progress", 1),
+        ],
         ..Default::default()
     };
     let workspace = FakeWorkspace::default();
     let worker = FakeWorker::default();
-    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+    let mut config = scheduler_config();
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
 
     scheduler
         .tick(ts(0))
@@ -508,6 +619,11 @@ async fn runtime_events_extend_stall_deadlines_before_retrying_a_stalled_worker(
         execution.retry().expect("retry should exist").reason,
         RetryReason::Stalled
     );
+    assert_eq!(scheduler.worker().launches.len(), 2);
+    assert_eq!(
+        scheduler.worker().launches[1].issue.identifier.as_str(),
+        "COE-271-B"
+    );
 }
 
 #[tokio::test]
@@ -552,6 +668,158 @@ async fn recovery_reuses_manifest_workspace_for_active_issue_dispatch() {
         recovered_workspace.path
     );
     assert!(scheduler.workspace().cleaned.is_empty());
+}
+
+#[tokio::test]
+async fn tracker_inactive_release_frees_the_per_state_slot() {
+    let tracker = FakeTracker {
+        active: vec![
+            tracker_issue("lin-277", "COE-277", "In Progress", 0),
+            tracker_issue("lin-278", "COE-278", "In Progress", 1),
+        ],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("first tick should dispatch the first issue");
+
+    scheduler.tracker_mut().active = vec![tracker_issue("lin-278", "COE-278", "In Progress", 1)];
+    scheduler.tracker_mut().states.insert(
+        "lin-277".to_string(),
+        tracker_state_snapshot("lin-277", "COE-277", "Todo", "unstarted", 200),
+    );
+
+    scheduler
+        .tick(ts(200))
+        .await
+        .expect("inactive reconciliation should release and replace the running issue");
+
+    let released = scheduler
+        .execution(&IssueId::new("lin-277").expect("issue id should be valid"))
+        .expect("released issue should still exist");
+    assert_eq!(released.status(), SchedulerStatus::Released);
+    match released.state() {
+        opensymphony_orchestrator::SchedulerState::Released { reason, .. } => {
+            assert_eq!(*reason, ReleaseReason::TrackerInactive);
+        }
+        other => panic!("expected released state, got {other:?}"),
+    }
+    assert_eq!(scheduler.worker().aborted.len(), 1);
+    assert_eq!(
+        scheduler.worker().aborted[0].1,
+        WorkerAbortReason::TrackerInactive
+    );
+    assert_eq!(scheduler.worker().launches.len(), 2);
+    assert_eq!(
+        scheduler.worker().launches[1].issue.identifier.as_str(),
+        "COE-278"
+    );
+}
+
+#[tokio::test]
+async fn running_count_follows_active_state_reconciliation() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-280", "COE-280", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.max_concurrent_agents = 3;
+    config.stall_timeout_ms = None;
+    config.active_states.push("Code Review".to_string());
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    config
+        .max_concurrent_agents_by_state
+        .insert("Code Review".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("first tick should dispatch the initial issue");
+
+    scheduler.tracker_mut().active = vec![
+        tracker_issue("lin-280", "COE-280", "Code Review", 0),
+        tracker_issue("lin-281", "COE-281", "In Progress", 1),
+        tracker_issue("lin-282", "COE-282", "Code Review", 2),
+    ];
+
+    scheduler
+        .tick(ts(200))
+        .await
+        .expect("active-state reconciliation should update running counts");
+
+    let refreshed = scheduler
+        .execution(&IssueId::new("lin-280").expect("issue id should be valid"))
+        .expect("original issue should still be running");
+    assert_eq!(refreshed.status(), SchedulerStatus::Running);
+    assert_eq!(refreshed.issue().state.name, "Code Review");
+    assert_eq!(scheduler.worker().launches.len(), 2);
+    assert_eq!(
+        scheduler.worker().launches[1].issue.identifier.as_str(),
+        "COE-281"
+    );
+    assert_eq!(
+        scheduler
+            .execution(&IssueId::new("lin-282").expect("issue id should be valid"))
+            .expect("reconciled active issue should exist")
+            .status(),
+        SchedulerStatus::Unclaimed
+    );
+}
+
+#[tokio::test]
+async fn recovery_does_not_count_released_issues_as_running_capacity() {
+    let recovered_workspace = workspace_record("COE-283-A", "/tmp/recovered/COE-283-A");
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-283-b", "COE-283-B", "In Progress", 1)],
+        states: HashMap::from([(
+            "lin-283-a".to_string(),
+            tracker_state_snapshot("lin-283-a", "COE-283-A", "Todo", "unstarted", 100),
+        )]),
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace {
+        recoveries: vec![RecoveryRecord {
+            issue: normalized_issue("lin-283-a", "COE-283-A", "In Progress"),
+            workspace: recovered_workspace,
+            had_in_flight_run: true,
+        }],
+        ..Default::default()
+    };
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config
+        .max_concurrent_agents_by_state
+        .insert("In Progress".to_string(), 1);
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("recovery tick should not reserve running capacity for released issues");
+
+    let recovered = scheduler
+        .execution(&IssueId::new("lin-283-a").expect("issue id should be valid"))
+        .expect("recovered issue should still exist");
+    assert_eq!(recovered.status(), SchedulerStatus::Released);
+    assert_eq!(scheduler.worker().launches.len(), 1);
+    assert_eq!(
+        scheduler.worker().launches[0].issue.identifier.as_str(),
+        "COE-283-B"
+    );
 }
 
 #[tokio::test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,7 +205,7 @@ The repository now exposes three stable foundation contracts that later mileston
   - blocker-aware and hierarchy-aware dispatch eligibility helpers
   - generic scheduler configuration sourced from workflow polling, concurrency, retry, and stall settings
   - explicit `Claimed` / `Running` / `RetryQueued` / `Released` transitions driven only by orchestrator-owned commands and worker reports
-  - fixed continuation retry, exponential failure backoff, bounded global/per-state capacity, running-worker reconciliation, terminal cleanup, and manifest-backed restart recovery for workspace reuse
+  - fixed continuation retry, exponential failure backoff, bounded global/per-state capacity via scheduler-owned cached running counts, running-worker reconciliation, terminal cleanup, and manifest-backed restart recovery for workspace reuse
 
 The other crates are already present at their final ownership boundaries, but for M1 they intentionally expose only thin re-exports or placeholders rather than premature transport logic.
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -76,7 +76,7 @@ Current implementation:
 
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
 - `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
-- `cargo test -p opensymphony-orchestrator` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, and manifest-backed workspace recovery against fake tracker/workspace/worker backends
+- `cargo test -p opensymphony-orchestrator` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, cached per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, active-state reconciliation, and manifest-backed workspace recovery against fake tracker/workspace/worker backends
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`
@@ -190,7 +190,7 @@ Current implementation:
 
 Current repository implementation:
 
-- `crates/opensymphony-orchestrator/tests/scheduler.rs` covers continuation retry, failure backoff, per-state dispatch limits, runtime-event-fed stall detection, terminal reconciliation with cleanup, and manifest-backed workspace recovery using fake backends
+- `crates/opensymphony-orchestrator/tests/scheduler.rs` covers continuation retry, failure backoff, cached per-state dispatch limits across finish/stall/inactive/terminal/reconciliation transitions, runtime-event-fed stall detection, terminal reconciliation with cleanup, and manifest-backed workspace recovery using fake backends
 
 ## 3.5 Control plane and TUI
 


### PR DESCRIPTION
## Summary

Cache scheduler-owned per-state running counts so `max_concurrent_agents_by_state` checks stop rescanning every execution for each ready issue.

## Changes

- add a normalized `running_counts_by_state` cache to the orchestrator scheduler and use cache-aware execution insert/remove helpers
- replace the per-candidate `self.executions.values()` running scan in `dispatch_ready_issues` with cached state-count lookups
- add scheduler regression coverage for finish, stall, tracker-inactive, tracker-terminal, active-state reconciliation, and recovery capacity behavior
- update architecture and testing docs to describe cached per-state capacity tracking and the expanded scheduler test coverage

## Evidence

### Test output

```text
$ cargo test -p opensymphony-orchestrator
8 unit tests passed in src/lib.rs
2 hierarchy_selection integration tests passed
10 scheduler integration tests passed
0 doc tests failed

$ cargo clippy -p opensymphony-orchestrator --tests -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) successfully
```

### Verification

Reproduced the pre-change behavior in `crates/opensymphony-orchestrator/src/scheduler.rs`, where each ready candidate counted running executions by scanning `self.executions.values()` inside `dispatch_ready_issues`. Verified the replacement cache by exercising the state transitions that can drift counters: worker finish, stall retry, tracker-inactive release, tracker-terminal release, active-state reconciliation, and recovery of released issues.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- https://linear.app/trilogy-ai-coe/issue/COE-283/cache-per-state-running-counts-in-the-orchestrator-scheduler

## Additional notes

The repo does not contain the Elixir `mix pr_body.check` workflow referenced by the generic push skill, so the PR body was validated directly against `.github/pull_request_template.md`.
