### PR TITLE
Add configurable OpenHands context condenser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ openhands:
         model: ${LLM_MODEL}
 ```
 
+Optional conversation condensation can be enabled per workflow to reduce long-history context pressure before the agent-server hits the model window:
+
+```yaml
+openhands:
+  conversation:
+    agent:
+      condenser:
+        enabled: true
+        max_size: 240
+        keep_first: 2
+```
+
+When enabled, OpenSymphony forwards an OpenHands `LLMSummarizingCondenser` that reuses the conversation agent's LLM settings. If `max_size` or `keep_first` are omitted, OpenSymphony defaults them to `240` and `2`.
+
 Add a `config.yaml` file next to your target repository `WORKFLOW.md`. A minimal local-supervised config looks like this:
 
 ```yaml

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -80,8 +80,17 @@ openhands:
         # Provider-specific auth/base-url overrides and extra LLM option keys are
         # rejected until the current conversation-create adapter can forward them.
         model: ${LLM_MODEL}
-      # Workflow-owned agent extras such as `log_completions` are rejected until
-      # the current conversation-create payload can actually forward them.
+      condenser:
+        # Disabled by default when omitted. When enabled, OpenSymphony forwards
+        # a fixed `LLMSummarizingCondenser` request that reuses the agent LLM
+        # configuration and defaults to `max_size: 240` plus `keep_first: 2`
+        # if those thresholds are not set explicitly.
+        enabled: true
+        max_size: 240
+        keep_first: 2
+      # Workflow-owned agent extras other than `condenser` such as
+      # `log_completions` are rejected until the current conversation-create
+      # payload can actually forward them.
 
   # Workflow-owned websocket enablement and timeout/reconnect knobs are
   # currently rejected until the runtime readiness/reconnect path consumes them.

--- a/crates/opensymphony-openhands/src/events.rs
+++ b/crates/opensymphony-openhands/src/events.rs
@@ -392,7 +392,9 @@ mod tests {
                     model: "openai/gpt-5.4".to_string(),
                     api_key: None,
                     base_url: None,
+                    usage_id: None,
                 },
+                condenser: None,
             },
         };
         let running = EventEnvelope::new(

--- a/crates/opensymphony-openhands/src/lib.rs
+++ b/crates/opensymphony-openhands/src/lib.rs
@@ -15,9 +15,10 @@ pub use events::{
     TerminalExecutionStatus, UnknownEvent,
 };
 pub use models::{
-    AcceptedResponse, AgentConfig, ConfirmationPolicy, Conversation, ConversationCreateRequest,
-    ConversationRunRequest, ConversationStateUpdatePayload, DoctorProbeConfig, EventEnvelope,
-    LlmConfig, SearchConversationEventsResponse, SendMessageRequest, TextContent, WorkspaceConfig,
+    AcceptedResponse, AgentConfig, CondenserConfig, ConfirmationPolicy, Conversation,
+    ConversationCreateRequest, ConversationRunRequest, ConversationStateUpdatePayload,
+    DoctorProbeConfig, EventEnvelope, LLM_SUMMARIZING_CONDENSER_KIND, LlmConfig,
+    SearchConversationEventsResponse, SendMessageRequest, TextContent, WorkspaceConfig,
 };
 pub use session::{
     ConversationLaunchProfile, IssueConversationManifest, IssueSessionContext, IssueSessionError,

--- a/crates/opensymphony-openhands/src/models.rs
+++ b/crates/opensymphony-openhands/src/models.rs
@@ -7,6 +7,9 @@ fn default_true() -> bool {
     true
 }
 
+pub const LLM_SUMMARIZING_CONDENSER_KIND: &str = "LLMSummarizingCondenser";
+pub const LLM_SUMMARIZING_CONDENSER_USAGE_ID: &str = "condenser";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceConfig {
     pub working_dir: String,
@@ -25,12 +28,43 @@ pub struct LlmConfig {
     pub api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_id: Option<String>,
+}
+
+impl LlmConfig {
+    pub fn with_usage_id(&self, usage_id: impl Into<String>) -> Self {
+        let mut cloned = self.clone();
+        cloned.usage_id = Some(usage_id.into());
+        cloned
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CondenserConfig {
+    pub kind: String,
+    pub llm: LlmConfig,
+    pub max_size: u64,
+    pub keep_first: u64,
+}
+
+impl CondenserConfig {
+    pub fn llm_summarizing(llm: LlmConfig, max_size: u64, keep_first: u64) -> Self {
+        Self {
+            kind: LLM_SUMMARIZING_CONDENSER_KIND.to_string(),
+            llm: llm.with_usage_id(LLM_SUMMARIZING_CONDENSER_USAGE_ID),
+            max_size,
+            keep_first,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentConfig {
     pub kind: String,
     pub llm: LlmConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub condenser: Option<CondenserConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -111,7 +145,9 @@ impl ConversationCreateRequest {
                     model,
                     api_key: config.api_key,
                     base_url: config.base_url,
+                    usage_id: None,
                 },
+                condenser: None,
             },
         }
     }
@@ -383,7 +419,9 @@ mod tests {
                     model: "fake-model".to_string(),
                     api_key: Some("fake-key".to_string()),
                     base_url: None,
+                    usage_id: None,
                 },
+                condenser: None,
             },
         };
 
@@ -420,6 +458,60 @@ mod tests {
             .expect("request should serialize");
 
         assert_eq!(value, json!({}));
+    }
+
+    #[test]
+    fn conversation_create_request_serializes_optional_condenser() {
+        let request = ConversationCreateRequest {
+            conversation_id: Uuid::parse_str("11111111-2222-3333-4444-555555555555")
+                .expect("uuid should parse"),
+            workspace: WorkspaceConfig {
+                working_dir: "/tmp/workspace".to_string(),
+                kind: "LocalWorkspace".to_string(),
+            },
+            persistence_dir: "/tmp/workspace/.opensymphony/openhands".to_string(),
+            max_iterations: 7,
+            stuck_detection: true,
+            confirmation_policy: ConfirmationPolicy {
+                kind: "NeverConfirm".to_string(),
+            },
+            agent: AgentConfig {
+                kind: "Agent".to_string(),
+                llm: LlmConfig {
+                    model: "fake-model".to_string(),
+                    api_key: Some("fake-key".to_string()),
+                    base_url: Some("https://example.com/v1".to_string()),
+                    usage_id: None,
+                },
+                condenser: Some(CondenserConfig::llm_summarizing(
+                    LlmConfig {
+                        model: "fake-model".to_string(),
+                        api_key: Some("fake-key".to_string()),
+                        base_url: Some("https://example.com/v1".to_string()),
+                        usage_id: None,
+                    },
+                    240,
+                    2,
+                )),
+            },
+        };
+
+        let value = serde_json::to_value(&request).expect("request should serialize");
+
+        assert_eq!(
+            value["agent"]["condenser"],
+            json!({
+                "kind": "LLMSummarizingCondenser",
+                "llm": {
+                    "model": "fake-model",
+                    "api_key": "fake-key",
+                    "base_url": "https://example.com/v1",
+                    "usage_id": "condenser",
+                },
+                "max_size": 240,
+                "keep_first": 2,
+            })
+        );
     }
 
     #[test]

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -21,8 +21,8 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::{
-    AgentConfig, ConfirmationPolicy, Conversation, ConversationCreateRequest, EventEnvelope,
-    KnownEvent, LlmConfig, OpenHandsClient, OpenHandsError, RuntimeEventStream,
+    AgentConfig, CondenserConfig, ConfirmationPolicy, Conversation, ConversationCreateRequest,
+    EventEnvelope, KnownEvent, LlmConfig, OpenHandsClient, OpenHandsError, RuntimeEventStream,
     RuntimeStreamConfig, SendMessageRequest, TerminalExecutionStatus, WorkspaceConfig,
 };
 
@@ -111,8 +111,16 @@ pub struct ConversationLaunchProfile {
     pub confirmation_policy_kind: String,
     pub agent_kind: String,
     pub llm_model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub condenser: Option<ConversationLaunchCondenserProfile>,
     pub max_iterations: u32,
     pub stuck_detection: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationLaunchCondenserProfile {
+    pub max_size: u64,
+    pub keep_first: u64,
 }
 
 impl ConversationLaunchProfile {
@@ -140,6 +148,12 @@ impl ConversationLaunchProfile {
             confirmation_policy_kind: conversation.confirmation_policy.kind.clone(),
             agent_kind: conversation.agent.kind.clone(),
             llm_model,
+            condenser: conversation.agent.condenser.as_ref().map(|condenser| {
+                ConversationLaunchCondenserProfile {
+                    max_size: condenser.max_size,
+                    keep_first: condenser.keep_first,
+                }
+            }),
             max_iterations,
             stuck_detection: conversation.stuck_detection,
         })
@@ -151,6 +165,13 @@ impl ConversationLaunchProfile {
         persistence_dir: &Path,
         conversation_id: Option<Uuid>,
     ) -> ConversationCreateRequest {
+        let llm = LlmConfig {
+            model: self.llm_model.clone(),
+            api_key: std::env::var("LLM_API_KEY").ok(),
+            base_url: std::env::var("LLM_BASE_URL").ok(),
+            usage_id: None,
+        };
+
         ConversationCreateRequest {
             conversation_id: conversation_id.unwrap_or_else(Uuid::new_v4),
             workspace: WorkspaceConfig {
@@ -165,11 +186,14 @@ impl ConversationLaunchProfile {
             },
             agent: AgentConfig {
                 kind: self.agent_kind.clone(),
-                llm: LlmConfig {
-                    model: self.llm_model.clone(),
-                    api_key: std::env::var("LLM_API_KEY").ok(),
-                    base_url: std::env::var("LLM_BASE_URL").ok(),
-                },
+                llm: llm.clone(),
+                condenser: self.condenser.as_ref().map(|condenser| {
+                    CondenserConfig::llm_summarizing(
+                        llm.clone(),
+                        condenser.max_size,
+                        condenser.keep_first,
+                    )
+                }),
             },
         }
     }

--- a/crates/opensymphony-openhands/tests/issue_session_runner.rs
+++ b/crates/opensymphony-openhands/tests/issue_session_runner.rs
@@ -6,8 +6,8 @@ use opensymphony_domain::{
 };
 use opensymphony_openhands::{
     ConversationCreateRequest, EventEnvelope, IssueConversationManifest, IssueSessionContext,
-    IssueSessionPromptKind, IssueSessionRunner, IssueSessionRunnerConfig, OpenHandsClient,
-    TransportConfig,
+    IssueSessionPromptKind, IssueSessionRunner, IssueSessionRunnerConfig,
+    LLM_SUMMARIZING_CONDENSER_KIND, OpenHandsClient, TransportConfig,
 };
 use opensymphony_testkit::{FakeOpenHandsConfig, FakeOpenHandsServer};
 use opensymphony_workflow::{ResolvedWorkflow, WorkflowDefinition};
@@ -62,6 +62,48 @@ fn workspace_manager(root: &Path, hooks: HookConfig) -> WorkspaceManager {
 
 fn workflow_for(workspace_root: &Path, base_url: &str) -> ResolvedWorkflow {
     workflow_for_with_persistence_dir(workspace_root, base_url, ".opensymphony/openhands")
+}
+
+fn workflow_for_with_condenser(workspace_root: &Path, base_url: &str) -> ResolvedWorkflow {
+    let workflow = WorkflowDefinition::parse(&format!(
+        r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - In Progress
+  terminal_states:
+    - Done
+workspace:
+  root: {}
+openhands:
+  transport:
+    base_url: {}
+  conversation:
+    agent:
+      condenser:
+        enabled: true
+        max_size: 240
+        keep_first: 2
+---
+
+# Assignment
+
+Issue: {{{{ issue.identifier }}}}
+Title: {{{{ issue.title }}}}
+{{% if attempt %}}Attempt: {{{{ attempt }}}}{{% endif %}}
+"#,
+        workspace_root.display(),
+        base_url,
+    ))
+    .expect("workflow should parse");
+
+    workflow
+        .resolve(
+            workspace_root,
+            &BTreeMap::from([("LINEAR_API_KEY".to_string(), "linear-token".to_string())]),
+        )
+        .expect("workflow should resolve")
 }
 
 fn workflow_for_with_persistence_dir(
@@ -722,6 +764,69 @@ async fn issue_session_runner_rehydrates_a_missing_conversation_without_downgrad
     );
     assert_eq!(messages.len(), 2);
     assert!(messages[1].contains("The original workflow prompt is already present"));
+}
+
+#[tokio::test]
+async fn issue_session_runner_forwards_configured_condenser_to_create_request() {
+    let server = FakeOpenHandsServer::start()
+        .await
+        .expect("fake server should start");
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = workspace_manager(&workspace_root, HookConfig::default());
+    let workflow = workflow_for_with_condenser(&workspace_root, server.base_url());
+    let issue = sample_issue("COE-288");
+    let ensured = manager
+        .ensure(&issue_descriptor(&issue))
+        .await
+        .expect("workspace should exist");
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let runner = IssueSessionRunner::new(client, runner_config(&workflow));
+    let max_turns = u32::try_from(workflow.config.agent.max_turns).expect("max_turns should fit");
+
+    let mut manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-1", 1))
+        .await
+        .expect("run manifest should prepare");
+    let run = run_attempt(
+        &issue,
+        ensured.handle.workspace_path(),
+        "worker-1",
+        None,
+        max_turns,
+    );
+    runner
+        .run(
+            &manager,
+            &ensured.handle,
+            &mut manifest,
+            &issue,
+            &run,
+            &workflow,
+        )
+        .await
+        .expect("issue session run should succeed");
+
+    let create_request = read_create_conversation_request(&manager, &ensured.handle).await;
+    let agent_llm = create_request.agent.llm.clone();
+    let condenser = create_request
+        .agent
+        .condenser
+        .as_ref()
+        .expect("condenser should be forwarded");
+    assert_eq!(condenser.kind, LLM_SUMMARIZING_CONDENSER_KIND);
+    assert_eq!(condenser.max_size, 240);
+    assert_eq!(condenser.keep_first, 2);
+    assert_eq!(&condenser.llm, &agent_llm.with_usage_id("condenser"));
+
+    let persisted_manifest = read_conversation_manifest(&manager, &ensured.handle).await;
+    let persisted_condenser = persisted_manifest
+        .launch_profile
+        .as_ref()
+        .and_then(|profile| profile.condenser.as_ref())
+        .expect("launch profile should persist condenser settings");
+    assert_eq!(persisted_condenser.max_size, 240);
+    assert_eq!(persisted_condenser.keep_first, 2);
 }
 
 #[tokio::test]

--- a/crates/opensymphony-openhands/tests/live_pinned_server.rs
+++ b/crates/opensymphony-openhands/tests/live_pinned_server.rs
@@ -1,22 +1,29 @@
 use std::{
     env,
     net::TcpListener,
+    path::Path,
     path::PathBuf,
     process::{Child, Command, Stdio},
     time::Duration,
 };
 
 use opensymphony_openhands::{
-    ApiKeyAuth, AuthConfig, ConversationCreateRequest, HttpAuth, OpenHandsClient, OpenHandsError,
-    RuntimeStreamConfig, TransportConfig, WebSocketAuth,
+    AgentConfig, ApiKeyAuth, AuthConfig, CondenserConfig, ConfirmationPolicy, Conversation,
+    ConversationCreateRequest, HttpAuth, LlmConfig, OpenHandsClient, OpenHandsError,
+    RuntimeStreamConfig, SendMessageRequest, TransportConfig, WebSocketAuth, WorkspaceConfig,
 };
 use tempfile::TempDir;
-use tokio::time::sleep;
+use tokio::time::{Instant, sleep};
+use uuid::Uuid;
 
 const LIVE_GATE_ENV: &str = "OPENSYMPHONY_LIVE_OPENHANDS";
 const SESSION_API_KEY: &str = "live-secret-token";
 const SESSION_API_KEY_HEADER: &str = "x-session-api-key";
 const SESSION_API_KEY_QUERY_PARAM: &str = "session_api_key";
+const LONG_HISTORY_BATCHES: usize = 6;
+const LONG_HISTORY_BATCH_SIZE: usize = 50;
+const LONG_HISTORY_MAX_SIZE: u64 = 40;
+const LONG_HISTORY_KEEP_FIRST: u64 = 2;
 
 #[tokio::test]
 async fn live_pinned_server_authenticates_external_http_and_websocket_paths() {
@@ -140,6 +147,106 @@ async fn live_pinned_server_rejects_missing_http_auth_and_wrong_websocket_auth()
     );
 }
 
+#[tokio::test]
+#[ignore = "requires a prepared local machine with live OpenHands credentials"]
+async fn live_pinned_server_condenses_long_history_without_prompt_overflow() {
+    if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {
+        eprintln!("skipping live pinned-server test; set {LIVE_GATE_ENV}=1 to enable it");
+        return;
+    }
+
+    let model = env::var("OPENSYMPHONY_OPENHANDS_MODEL")
+        .or_else(|_| env::var("LLM_MODEL"))
+        .expect("live condenser test requires OPENSYMPHONY_OPENHANDS_MODEL or LLM_MODEL");
+    let server = PinnedServer::start(SESSION_API_KEY).await;
+    let workspace = TempDir::new().expect("workspace temp dir should be created");
+    let request = long_history_request(workspace.path(), &model);
+
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()).with_auth(
+        AuthConfig::header_api_key_with_websocket_query_fallback(
+            SESSION_API_KEY_HEADER,
+            SESSION_API_KEY_QUERY_PARAM,
+            SESSION_API_KEY,
+        ),
+    ));
+
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("create conversation should authenticate");
+
+    for batch in 0..LONG_HISTORY_BATCHES {
+        for turn in 0..LONG_HISTORY_BATCH_SIZE {
+            let ordinal = batch * LONG_HISTORY_BATCH_SIZE + turn + 1;
+            let prompt = if turn + 1 == LONG_HISTORY_BATCH_SIZE {
+                format!(
+                    "History marker {ordinal}. Reply with the exact text `batch-{batch}-ok` and then finish."
+                )
+            } else {
+                format!(
+                    "History marker {ordinal}. Do not answer yet; this is backlog context only."
+                )
+            };
+
+            client
+                .send_message(
+                    conversation.conversation_id,
+                    &SendMessageRequest::user_text(prompt),
+                )
+                .await
+                .expect("sending backlog messages should succeed");
+        }
+
+        client
+            .run_conversation(conversation.conversation_id)
+            .await
+            .expect("conversation run should start");
+
+        wait_for_terminal_status(
+            &client,
+            conversation.conversation_id,
+            Duration::from_secs(120),
+        )
+        .await
+        .expect("conversation run should finish cleanly");
+    }
+
+    let events = client
+        .search_all_events(conversation.conversation_id)
+        .await
+        .expect("events should remain searchable after long history");
+    let condensation_events = events
+        .items()
+        .iter()
+        .filter(|event| event.kind.contains("Condensation"))
+        .count();
+    let overflow_errors = events
+        .items()
+        .iter()
+        .filter(|event| event.kind == "ConversationErrorEvent")
+        .filter(|event| event.payload.to_string().contains("prompt is too long"))
+        .count();
+    let message_events = events
+        .items()
+        .iter()
+        .filter(|event| event.kind == "MessageEvent")
+        .count();
+
+    assert!(
+        message_events >= LONG_HISTORY_BATCHES * LONG_HISTORY_BATCH_SIZE,
+        "expected at least {} message events, got {message_events}",
+        LONG_HISTORY_BATCHES * LONG_HISTORY_BATCH_SIZE
+    );
+    assert!(
+        condensation_events > 0,
+        "expected at least one condensation event after long history, got none"
+    );
+    assert_eq!(
+        overflow_errors, 0,
+        "expected no prompt-overflow ConversationErrorEvent, found {overflow_errors}"
+    );
+}
+
 struct PinnedServer {
     child: Child,
     base_url: String,
@@ -206,6 +313,74 @@ fn doctor_probe_request(workspace_root: &std::path::Path) -> ConversationCreateR
         Some("gpt-5.4-mini".to_string()),
         None,
     )
+}
+
+fn long_history_request(workspace_root: &Path, model: &str) -> ConversationCreateRequest {
+    let working_dir = workspace_root.join("repo");
+    let persistence_dir = working_dir.join(".opensymphony/openhands");
+    std::fs::create_dir_all(&persistence_dir).expect("probe directories should be created");
+
+    let llm = LlmConfig {
+        model: model.to_string(),
+        api_key: env::var("LLM_API_KEY").ok(),
+        base_url: env::var("LLM_BASE_URL").ok(),
+        usage_id: None,
+    };
+
+    ConversationCreateRequest {
+        conversation_id: Uuid::new_v4(),
+        workspace: WorkspaceConfig {
+            working_dir: working_dir.display().to_string(),
+            kind: "LocalWorkspace".to_string(),
+        },
+        persistence_dir: persistence_dir.display().to_string(),
+        max_iterations: 20,
+        stuck_detection: true,
+        confirmation_policy: ConfirmationPolicy {
+            kind: "NeverConfirm".to_string(),
+        },
+        agent: AgentConfig {
+            kind: "Agent".to_string(),
+            llm: llm.clone(),
+            condenser: Some(CondenserConfig::llm_summarizing(
+                llm,
+                LONG_HISTORY_MAX_SIZE,
+                LONG_HISTORY_KEEP_FIRST,
+            )),
+        },
+    }
+}
+
+async fn wait_for_terminal_status(
+    client: &OpenHandsClient,
+    conversation_id: Uuid,
+    wait_timeout: Duration,
+) -> Result<Conversation, String> {
+    let deadline = Instant::now() + wait_timeout;
+
+    loop {
+        let conversation = client
+            .get_conversation(conversation_id)
+            .await
+            .map_err(|error| format!("failed to poll conversation state: {error}"))?;
+        match conversation.execution_status.as_str() {
+            "finished" => return Ok(conversation),
+            "error" | "stuck" => {
+                return Err(format!(
+                    "terminal execution_status `{}`",
+                    conversation.execution_status
+                ));
+            }
+            _ => {
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "timed out waiting {wait_timeout:?} for terminal status"
+                    ));
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+        }
+    }
 }
 
 async fn wait_for_ready(base_url: &str, session_api_key: &str, child: &mut Child) {

--- a/crates/opensymphony-workflow/src/lib.rs
+++ b/crates/opensymphony-workflow/src/lib.rs
@@ -13,7 +13,8 @@ pub use model::{
     AgentConfig, AgentFrontMatter, DEFAULT_PROMPT_TEMPLATE, Environment, HooksConfig,
     HooksFrontMatter, IntegerLike, OpenHandsConfig, OpenHandsConfirmationPolicy,
     OpenHandsConfirmationPolicyFrontMatter, OpenHandsConversationAgentConfig,
-    OpenHandsConversationAgentFrontMatter, OpenHandsConversationConfig,
+    OpenHandsConversationAgentFrontMatter, OpenHandsConversationCondenserConfig,
+    OpenHandsConversationCondenserFrontMatter, OpenHandsConversationConfig,
     OpenHandsConversationFrontMatter, OpenHandsFrontMatter, OpenHandsLlmConfig,
     OpenHandsLlmFrontMatter, OpenHandsLocalServerConfig, OpenHandsLocalServerFrontMatter,
     OpenHandsMcpConfig, OpenHandsMcpFrontMatter, OpenHandsStdioServerConfig,
@@ -108,6 +109,7 @@ mod tests {
         model::{
             DEFAULT_HOOK_TIMEOUT_MS, DEFAULT_LINEAR_ENDPOINT, DEFAULT_MAX_CONCURRENT_AGENTS,
             DEFAULT_MAX_RETRY_BACKOFF_MS, DEFAULT_MAX_TURNS, DEFAULT_OPENHANDS_BASE_URL,
+            DEFAULT_OPENHANDS_CONDENSER_KEEP_FIRST, DEFAULT_OPENHANDS_CONDENSER_MAX_SIZE,
             DEFAULT_OPENHANDS_CONFIRMATION_POLICY_KIND, DEFAULT_OPENHANDS_PERSISTENCE_DIR,
             DEFAULT_OPENHANDS_QUERY_PARAM_NAME, DEFAULT_OPENHANDS_READY_TIMEOUT_MS,
             DEFAULT_OPENHANDS_RECONNECT_INITIAL_MS, DEFAULT_OPENHANDS_RECONNECT_MAX_MS,
@@ -415,6 +417,15 @@ tracker:
         assert_eq!(
             resolved.extensions.openhands.conversation.agent.kind,
             "Agent"
+        );
+        assert!(
+            resolved
+                .extensions
+                .openhands
+                .conversation
+                .agent
+                .condenser
+                .is_none()
         );
         assert_eq!(
             resolved.extensions.openhands.websocket.ready_timeout_ms,
@@ -730,6 +741,148 @@ openhands:
         assert_eq!(
             resolved.extensions.openhands.conversation.agent.kind,
             "Agent"
+        );
+        assert!(
+            resolved
+                .extensions
+                .openhands
+                .conversation
+                .agent
+                .condenser
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolves_openhands_condenser_configuration() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  conversation:
+    agent:
+      condenser:
+        enabled: true
+        max_size: 320
+        keep_first: 4
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let resolved = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect("workflow should resolve");
+        let condenser = resolved
+            .extensions
+            .openhands
+            .conversation
+            .agent
+            .condenser
+            .as_ref()
+            .expect("condenser config should exist");
+
+        assert_eq!(condenser.max_size, 320);
+        assert_eq!(condenser.keep_first, 4);
+        assert_eq!(
+            resolved
+                .extensions
+                .openhands
+                .conversation
+                .agent
+                .llm
+                .as_ref()
+                .expect("llm config should exist")
+                .model
+                .as_deref(),
+            Some("openai/gpt-5.4")
+        );
+    }
+
+    #[test]
+    fn defaults_openhands_condenser_thresholds_when_enabled_without_overrides() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  conversation:
+    agent:
+      condenser:
+        enabled: true
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let resolved = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect("workflow should resolve");
+        let condenser = resolved
+            .extensions
+            .openhands
+            .conversation
+            .agent
+            .condenser
+            .as_ref()
+            .expect("condenser config should exist");
+
+        assert_eq!(condenser.max_size, DEFAULT_OPENHANDS_CONDENSER_MAX_SIZE);
+        assert_eq!(condenser.keep_first, DEFAULT_OPENHANDS_CONDENSER_KEEP_FIRST);
+    }
+
+    #[test]
+    fn disables_openhands_condenser_when_flag_is_false() {
+        let workflow = WorkflowDefinition::parse(
+            r#"---
+tracker:
+  kind: linear
+  project_slug: sample-project
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+openhands:
+  conversation:
+    agent:
+      condenser:
+        enabled: false
+        max_size: 320
+        keep_first: 4
+---
+{{ issue.identifier }}
+"#,
+        )
+        .expect("workflow should parse");
+        let env = env([("LINEAR_API_KEY", "linear-token")]);
+
+        let resolved = workflow
+            .resolve(Path::new("/repo"), &env)
+            .expect("workflow should resolve");
+
+        assert!(
+            resolved
+                .extensions
+                .openhands
+                .conversation
+                .agent
+                .condenser
+                .is_none()
         );
     }
 

--- a/crates/opensymphony-workflow/src/model.rs
+++ b/crates/opensymphony-workflow/src/model.rs
@@ -27,6 +27,8 @@ pub const DEFAULT_OPENHANDS_RECONNECT_MAX_MS: u64 = 30_000;
 pub const DEFAULT_OPENHANDS_AUTH_MODE: &str = "auto";
 pub const DEFAULT_OPENHANDS_QUERY_PARAM_NAME: &str = "session_api_key";
 pub const DEFAULT_OPENHANDS_LLM_MODEL: &str = "openai/gpt-5.4";
+pub const DEFAULT_OPENHANDS_CONDENSER_MAX_SIZE: u64 = 240;
+pub const DEFAULT_OPENHANDS_CONDENSER_KEEP_FIRST: u64 = 2;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct WorkflowDefinition {
@@ -159,9 +161,18 @@ pub struct OpenHandsConfirmationPolicy {
 pub struct OpenHandsConversationAgentFrontMatter {
     pub kind: Option<String>,
     pub llm: Option<OpenHandsLlmFrontMatter>,
+    pub condenser: Option<OpenHandsConversationCondenserFrontMatter>,
     pub log_completions: Option<bool>,
     #[serde(flatten)]
     pub options: BTreeMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct OpenHandsConversationCondenserFrontMatter {
+    pub enabled: Option<bool>,
+    pub max_size: Option<IntegerLike>,
+    pub keep_first: Option<IntegerLike>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -306,8 +317,15 @@ pub struct OpenHandsConversationConfig {
 pub struct OpenHandsConversationAgentConfig {
     pub kind: String,
     pub llm: Option<OpenHandsLlmConfig>,
+    pub condenser: Option<OpenHandsConversationCondenserConfig>,
     pub log_completions: bool,
     pub options: BTreeMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenHandsConversationCondenserConfig {
+    pub max_size: u64,
+    pub keep_first: u64,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/opensymphony-workflow/src/resolve.rs
+++ b/crates/opensymphony-workflow/src/resolve.rs
@@ -11,6 +11,7 @@ use crate::{
         AgentConfig, AgentFrontMatter, DEFAULT_HOOK_TIMEOUT_MS, DEFAULT_LINEAR_ENDPOINT,
         DEFAULT_MAX_CONCURRENT_AGENTS, DEFAULT_MAX_RETRY_BACKOFF_MS, DEFAULT_MAX_TURNS,
         DEFAULT_OPENHANDS_AGENT_KIND, DEFAULT_OPENHANDS_AUTH_MODE, DEFAULT_OPENHANDS_BASE_URL,
+        DEFAULT_OPENHANDS_CONDENSER_KEEP_FIRST, DEFAULT_OPENHANDS_CONDENSER_MAX_SIZE,
         DEFAULT_OPENHANDS_CONFIRMATION_POLICY_KIND, DEFAULT_OPENHANDS_LLM_MODEL,
         DEFAULT_OPENHANDS_MAX_ITERATIONS, DEFAULT_OPENHANDS_PERSISTENCE_DIR,
         DEFAULT_OPENHANDS_QUERY_PARAM_NAME, DEFAULT_OPENHANDS_READINESS_PROBE_PATH,
@@ -19,7 +20,8 @@ use crate::{
         DEFAULT_POLL_INTERVAL_MS, DEFAULT_STALL_TIMEOUT_MS, DEFAULT_WORKSPACE_ROOT, Environment,
         HooksConfig, HooksFrontMatter, IntegerLike, OpenHandsConfig, OpenHandsConfirmationPolicy,
         OpenHandsConfirmationPolicyFrontMatter, OpenHandsConversationAgentConfig,
-        OpenHandsConversationAgentFrontMatter, OpenHandsConversationConfig,
+        OpenHandsConversationAgentFrontMatter, OpenHandsConversationCondenserConfig,
+        OpenHandsConversationCondenserFrontMatter, OpenHandsConversationConfig,
         OpenHandsConversationFrontMatter, OpenHandsFrontMatter, OpenHandsLlmConfig,
         OpenHandsLlmFrontMatter, OpenHandsLocalServerConfig, OpenHandsLocalServerFrontMatter,
         OpenHandsMcpConfig, OpenHandsMcpFrontMatter, OpenHandsTransportConfig,
@@ -540,6 +542,7 @@ fn resolve_openhands_conversation<E: Environment>(
                 base_url_env: None,
                 options: BTreeMap::new(),
             }),
+            condenser: None,
             log_completions: false,
             options: BTreeMap::new(),
         },
@@ -616,14 +619,44 @@ fn resolve_openhands_agent<E: Environment>(
 
     Ok(OpenHandsConversationAgentConfig {
         kind,
-        llm: agent
-            .llm
-            .as_ref()
-            .map(|llm| resolve_openhands_llm(llm, env))
-            .transpose()?,
+        llm: match agent.llm.as_ref() {
+            Some(llm) => Some(resolve_openhands_llm(llm, env)?),
+            None => Some(OpenHandsLlmConfig {
+                model: Some(DEFAULT_OPENHANDS_LLM_MODEL.to_owned()),
+                api_key_env: None,
+                base_url_env: None,
+                options: BTreeMap::new(),
+            }),
+        },
+        condenser: resolve_openhands_condenser(agent.condenser.as_ref())?,
         log_completions: false,
         options: BTreeMap::new(),
     })
+}
+
+fn resolve_openhands_condenser(
+    condenser: Option<&OpenHandsConversationCondenserFrontMatter>,
+) -> Result<Option<OpenHandsConversationCondenserConfig>, WorkflowConfigError> {
+    let Some(condenser) = condenser else {
+        return Ok(None);
+    };
+
+    if !condenser.enabled.unwrap_or(false) {
+        return Ok(None);
+    }
+
+    Ok(Some(OpenHandsConversationCondenserConfig {
+        max_size: resolve_positive_u64(
+            condenser.max_size.as_ref(),
+            "openhands.conversation.agent.condenser.max_size",
+            DEFAULT_OPENHANDS_CONDENSER_MAX_SIZE,
+        )?,
+        keep_first: resolve_positive_u64(
+            condenser.keep_first.as_ref(),
+            "openhands.conversation.agent.condenser.keep_first",
+            DEFAULT_OPENHANDS_CONDENSER_KEEP_FIRST,
+        )?,
+    }))
 }
 
 fn resolve_openhands_reuse_policy<E: Environment>(

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -364,7 +364,8 @@ Current workflow defaulting:
 - workflow-owned `websocket.ready_timeout_ms`, `websocket.reconnect_initial_ms`, and `websocket.reconnect_max_ms` overrides now resolve into the runtime stream attach and reconnect budgets
 - `agent.llm.model` is required whenever an `llm` block is present
 - workflow-owned LLM option keys are rejected during workflow resolution until the current request subset can actually forward them
-- workflow-owned agent options such as `log_completions` and extra agent keys are rejected during workflow resolution until the current request subset can actually forward them
+- `openhands.conversation.agent.condenser` is the only workflow-owned agent extension currently forwarded by the conversation-create adapter; it defaults to disabled when omitted, and enabled condensers use the agent LLM config plus `max_size: 240` / `keep_first: 2` unless overridden
+- workflow-owned agent options such as `log_completions` and extra agent keys other than `condenser` are rejected during workflow resolution until the current request subset can actually forward them
 - workflow-owned LLM provider env overrides such as `api_key_env` and `base_url_env` are rejected during workflow resolution until the runtime conversation-create adapter can actually forward them
 - workflow-owned `openhands.mcp.stdio_servers` entries are rejected during workflow resolution until the runtime conversation-create adapter can actually send `mcp_config`
 
@@ -376,7 +377,8 @@ Implementation rule:
 Current repository implementation:
 
 - `ConversationCreateRequest` carries the minimal create payload subset, including `conversation_id`, `workspace.working_dir`, and `persistence_dir`
-- the current request model still serializes `agent` as only `{ kind, llm }`, and `llm` itself as only `{ model, api_key }`, so workflow-owned agent extras plus arbitrary LLM option keys are rejected before runtime launch
+- the current request model serializes `agent` as `{ kind, llm, condenser? }`; when the workflow enables `agent.condenser`, the runtime forwards `agent.condenser` as `{ kind: LLMSummarizingCondenser, llm, max_size, keep_first }` and reuses the conversation agent LLM settings for the summarizer
+- `llm` still serializes as only `{ model, api_key, base_url? }`, so arbitrary LLM option keys plus agent extras other than `condenser` are rejected before runtime launch
 - the current orchestrator/runtime path still uses fixed per-issue conversation reuse, so workflow-owned `reuse_policy` overrides are rejected before runtime launch
 - the current transport layer preserves base-path prefixes across REST endpoints and `/sockets/events/{conversation_id}`, so the same client can target reverse-proxied external servers without code changes outside config
 - the current supervisor readiness probe still owns the local launch path and always uses `/openapi.json`, so explicit `local_server.readiness_probe_path` and `local_server.startup_timeout_ms` overrides are still rejected before runtime launch


### PR DESCRIPTION
## Summary

Add workflow-configurable OpenHands conversation condenser support so long-running issue sessions can summarize history instead of failing on context-window overflow.

## Changes

- add `openhands.conversation.agent.condenser` workflow parsing and resolution, including disabled-by-default behavior plus OpenSymphony defaults for `max_size` and `keep_first`
- extend OpenHands launch/request models to persist condenser settings, forward `LLMSummarizingCondenser`, and emit a distinct condenser LLM `usage_id`
- add unit, integration, and opt-in live pinned-server coverage for enabled/disabled condenser flows and long-history summarization, and document the new workflow shape

## Evidence

### Test output

```text
cargo fmt --all --check
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets --all-features
cargo test -p opensymphony-workflow condenser -- --nocapture
cargo test -p opensymphony-openhands condenser -- --nocapture
OPENSYMPHONY_LIVE_OPENHANDS=1 OPENSYMPHONY_OPENHANDS_MODEL="$LLM_MODEL" cargo test -p opensymphony-openhands live_pinned_server_condenses_long_history_without_prompt_overflow -- --ignored --nocapture
```

### Verification

- Reproduced the pre-change gap by confirming workflow resolution rejected unknown `openhands.conversation.agent.*` keys, which meant `agent.condenser` could not reach the OpenHands create request.
- Verified the workflow now accepts `agent.condenser`, persists it into the launch profile, and serializes the expected OpenHands request shape only when enabled.
- Ran the live pinned-server condenser test with a 300-message history and confirmed the conversation completed without a prompt-overflow error while condensation events appeared in `/events/search`.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: N/A

## Breaking changes

None

## Related issues

- COE-288

## Additional notes

- The live runtime validation exposed one required OpenHands contract detail that was not explicit in the ticket body: the condenser LLM must use its own `usage_id` (`condenser`), or the agent-server rejects the conversation with a duplicate registry entry error.
