### PR TITLE
Show more issues in the TUI issue list

### DIFF
--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -198,13 +198,13 @@ impl TuiState {
                         " "
                     };
                     let line = format!(
-                        "{marker} {} [{} / {}]",
+                        "{marker} {} [{} / {}] {}",
                         issue.identifier,
                         issue.runtime_state.as_str(),
-                        issue.tracker_state
+                        issue.tracker_state,
+                        issue.title
                     );
                     lines.push(fit(&line, width));
-                    lines.push(fit(&format!("  {}", issue.title), width));
                 }
             }
             None => {
@@ -968,7 +968,7 @@ fn fit_section(mut lines: Vec<String>, max_rows: usize, width: usize) -> Vec<Str
 }
 
 fn visible_issue_count(max_rows: usize) -> usize {
-    max(1, max_rows.saturating_sub(1) / 2)
+    max(1, max_rows.saturating_sub(1))
 }
 
 fn issue_window(
@@ -1379,8 +1379,8 @@ mod tests {
     #[test]
     fn visible_issue_count_reserves_header_row() {
         assert_eq!(visible_issue_count(0), 1);
-        assert_eq!(visible_issue_count(4), 1);
-        assert_eq!(visible_issue_count(13), 6);
+        assert_eq!(visible_issue_count(4), 3);
+        assert_eq!(visible_issue_count(13), 12);
     }
 
     #[test]
@@ -1407,6 +1407,20 @@ mod tests {
         assert_eq!(rendered.lines().count(), 22);
         assert!(rendered.contains("first line second line"));
         assert!(!rendered.contains("first line\nsecond line"));
+    }
+
+    #[test]
+    fn compact_issue_rows_show_more_issues_in_default_inline_layout() {
+        let mut state = TuiState::default();
+        state.reduce(TuiAction::SnapshotReceived(Box::new(fixture(8, 12))));
+
+        let lines = state.issue_lines(100, 13);
+
+        assert_eq!(lines.len(), 13);
+        assert!(lines[1].contains("COE-255"));
+        assert!(lines[1].contains("Issue 0"));
+        assert!(lines[12].contains("COE-266"));
+        assert!(lines[12].contains("Issue 11"));
     }
 
     #[test]

--- a/docs/ui-frankentui.md
+++ b/docs/ui-frankentui.md
@@ -126,6 +126,7 @@ Use pane-based layout so future views can expand without redesign.
 
 The implemented inline layout budgets rows per pane instead of truncating one giant body block.
 That keeps the bottom timeline visible under long issue lists, preserves the selected issue when snapshot ordering changes, and windows the issue pane around the current selection so narrower split terminals still keep the selected row and detail visible.
+Issue rows are rendered as compact single-line summaries so the default inline view can keep more issues visible before scrolling, while the detail pane still carries the full per-issue metadata.
 The always-visible status line now leads with daemon and local agent-server health before the
 connection and focus metadata so degraded runtime state is visible even when the issue list is
 otherwise stable.


### PR DESCRIPTION
## Summary

Show more issues in the FrankenTUI issue list without reducing the detail or timeline panes.

## Changes

- render each issue row as a compact single-line summary with identifier, runtime/tracker state, and title
- update the issue-row visibility calculation and add coverage for the denser default inline layout
- document the compact issue-row behavior in `docs/ui-frankentui.md`

## Evidence

### Test output

```text
$ cargo test -p opensymphony-tui
24 unit tests passed
12 reducer tests passed

$ cargo test -p opensymphony-cli --test tui
2 scripted TUI smoke tests passed

$ cargo clippy -p opensymphony-tui -p opensymphony-cli --tests -- -D warnings
Finished without warnings
```

### Verification

Reproduced the prior layout limit from the current renderer math: the default `22`-row inline TUI reserved `13` body rows and only showed `6` issues because each issue consumed two rendered rows. Verified the updated renderer now uses compact single-line issue rows, which raises the default wide-layout issue capacity to `12` visible rows while preserving the timeline and narrow-layout detail behavior covered by the existing tests.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None

## Related issues

- COE-321

## Additional notes

The detail pane remains the source of full per-issue context; this change only makes the issue list itself denser.
