### PR TITLE
fix(openhands): detect and recover from condenser tool-matching errors

### DIFF
--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -1605,7 +1605,7 @@ impl IssueSessionRunner {
         // Simplified conversation resumption: just try to attach directly
         // without checking for LLM config drift or rehydrating.
         // The conversation's stored LLM config in meta.json is used as-is.
-        let stream = match self
+        let mut stream = match self
             .client
             .attach_runtime_stream(conversation_id, self.config.runtime_stream.clone())
             .await
@@ -1618,6 +1618,20 @@ impl IssueSessionRunner {
                 )));
             }
         };
+
+        // Defensive check: if the conversation ended with a condenser tool-matching error,
+        // reset instead of trying to reuse. This prevents reusing corrupted event history.
+        if stream.state_mirror().terminal_status() == Some(TerminalExecutionStatus::Error) {
+            if let Some(error_detail) = extract_error_detail_from_state(stream.state_mirror())
+                && is_condenser_tool_matching_error(&error_detail)
+            {
+                let _ = stream.close().await;
+                return Ok(ReuseSession::Reset(format!(
+                    "previous run ended with condenser tool-matching error (corrupted event history): {}",
+                    error_detail
+                )));
+            }
+        }
 
         let attached_at = Utc::now();
         manifest.fresh_conversation = false;

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -964,6 +964,58 @@ impl IssueSessionRunner {
                         break (active_session, outcome);
                     }
                 }
+            } else if is_condenser_tool_matching_outcome(&outcome)
+                && retry_count < MAX_CONTEXT_OVERFLOW_RETRIES
+            {
+                // Condenser tool-matching errors indicate corrupted event history.
+                // We need a FRESH conversation (not rehydration) since rehydration
+                // would preserve the corrupted events.
+                retry_count += 1;
+                tracing::warn!(
+                    conversation_id = %active_session.manifest.conversation_id,
+                    error = ?outcome.error,
+                    retry_count,
+                    max_retries = MAX_CONTEXT_OVERFLOW_RETRIES,
+                    "condenser tool-matching error detected (corrupted event history), creating fresh conversation"
+                );
+
+                let _ = active_session.stream.close().await;
+
+                match self
+                    .create_fresh_session(
+                        workspace_manager,
+                        workspace,
+                        run_manifest,
+                        &observed_run,
+                        issue,
+                        workflow,
+                        Some("condenser tool-matching error auto-recovery".to_string()),
+                    )
+                    .await
+                {
+                    Ok(Step::Continue(fresh_session)) => {
+                        tracing::info!(
+                            old_conversation_id = %active_session.manifest.conversation_id,
+                            new_conversation_id = %fresh_session.manifest.conversation_id,
+                            "condenser tool-matching recovery: fresh conversation created, re-running turn"
+                        );
+                        current_session = fresh_session;
+                        continue;
+                    }
+                    Ok(Step::EarlyResult(result)) => {
+                        tracing::warn!(
+                            "condenser tool-matching recovery: failed to create fresh session, returning early result"
+                        );
+                        return Ok(*result);
+                    }
+                    Err(fresh_error) => {
+                        tracing::warn!(
+                            %fresh_error,
+                            "condenser tool-matching recovery: failed to create fresh session, returning original failure"
+                        );
+                        break (active_session, outcome);
+                    }
+                }
             } else {
                 break (active_session, outcome);
             }
@@ -2557,6 +2609,29 @@ fn is_context_overflow_outcome(outcome: &NormalizedOutcome) -> bool {
             .is_some_and(is_context_overflow_error)
 }
 
+/// Detect condenser internal errors from OpenHands SDK's ToolCallMatching.
+/// The error appears as a KeyError string representation: the key in single quotes
+/// containing "-tool-" which indicates a tool call ID.
+/// This happens when event history has an ObservationBaseEvent without a corresponding ActionEvent.
+fn is_condenser_tool_matching_error(msg: &str) -> bool {
+    // Pattern: KeyError for a tool call ID from OpenHands SDK's ToolCallMatching.
+    // The error appears as a KeyError string representation: the key in single quotes.
+    //
+    // Known formats:
+    // - OpenAI: 'chatcmpl-tool-{hex}'
+    //
+    // We match the known OpenAI format. Other LLM provider formats can be added as needed.
+    msg.starts_with("'") && msg.ends_with("'") && msg.contains("chatcmpl-tool-")
+}
+
+fn is_condenser_tool_matching_outcome(outcome: &NormalizedOutcome) -> bool {
+    outcome.kind == WorkerOutcomeKind::Failed
+        && outcome
+            .error
+            .as_deref()
+            .is_some_and(is_condenser_tool_matching_error)
+}
+
 fn extract_error_detail_from_state(state: &ConversationStateMirror) -> Option<String> {
     let raw = state.raw_state();
 
@@ -2938,5 +3013,54 @@ mod tests {
         // Expected: 50 + 75 + 300 = 425 output tokens
         assert_eq!(total_input, 300, "input tokens should be 100 + 200 + 0");
         assert_eq!(total_output, 425, "output tokens should be 50 + 75 + 300");
+    }
+
+    #[test]
+    fn condenser_tool_matching_error_detection() {
+        // Valid condenser tool-matching errors from OpenHands SDK's ToolCallMatching
+        // OpenAI-style tool call IDs: 'chatcmpl-tool-{hex}'
+        assert!(is_condenser_tool_matching_error(
+            "'chatcmpl-tool-bcea2761df6a8821'"
+        ));
+        assert!(is_condenser_tool_matching_error("'chatcmpl-tool-abc123'"));
+
+        // Not tool-matching errors
+        assert!(!is_condenser_tool_matching_error(
+            "prompt is too long: 1000"
+        ));
+        assert!(!is_condenser_tool_matching_error("some other error"));
+        assert!(!is_condenser_tool_matching_error(
+            "tool error without quotes"
+        ));
+        assert!(!is_condenser_tool_matching_error(
+            "'not-a-tool-matching-error'"
+        ));
+        assert!(!is_condenser_tool_matching_error("'no-tool-here'"));
+        assert!(!is_condenser_tool_matching_error("'other-tool-id-123'")); // not chatcmpl format
+
+        // Test outcome detection
+        let tool_matching_outcome = NormalizedOutcome {
+            kind: WorkerOutcomeKind::Failed,
+            summary: "test".to_string(),
+            error: Some("'chatcmpl-tool-xyz'".to_string()),
+        };
+        assert!(is_condenser_tool_matching_outcome(&tool_matching_outcome));
+
+        let other_outcome = NormalizedOutcome {
+            kind: WorkerOutcomeKind::Failed,
+            summary: "test".to_string(),
+            error: Some("some other error".to_string()),
+        };
+        assert!(!is_condenser_tool_matching_outcome(&other_outcome));
+
+        let context_overflow_outcome = NormalizedOutcome {
+            kind: WorkerOutcomeKind::Failed,
+            summary: "test".to_string(),
+            error: Some("prompt is too long: 1000".to_string()),
+        };
+        assert!(!is_condenser_tool_matching_outcome(
+            &context_overflow_outcome
+        ));
+        assert!(is_context_overflow_outcome(&context_overflow_outcome));
     }
 }

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -1585,6 +1585,18 @@ impl IssueSessionRunner {
             ));
         }
 
+        // Defensive check: if previous run ended with error status and had activity,
+        // reset to avoid potential corrupted event history.
+        // This is especially important for condenser tool-matching errors which indicate
+        // corrupted state that would fail again on retry.
+        if manifest.last_execution_status.as_deref() == Some("error")
+            && manifest.last_event_id.is_some()
+        {
+            return Ok(ReuseSession::Reset(
+                "previous run ended with error status, resetting to avoid potential corrupted event history".to_string(),
+            ));
+        }
+
         // Simplified conversation resumption: just try to attach directly.
         // The conversation's stored LLM config in meta.json is used as-is.
         // If the API key has changed, the attach will fail naturally and
@@ -1605,7 +1617,7 @@ impl IssueSessionRunner {
         // Simplified conversation resumption: just try to attach directly
         // without checking for LLM config drift or rehydrating.
         // The conversation's stored LLM config in meta.json is used as-is.
-        let mut stream = match self
+        let stream = match self
             .client
             .attach_runtime_stream(conversation_id, self.config.runtime_stream.clone())
             .await
@@ -1618,20 +1630,6 @@ impl IssueSessionRunner {
                 )));
             }
         };
-
-        // Defensive check: if the conversation ended with a condenser tool-matching error,
-        // reset instead of trying to reuse. This prevents reusing corrupted event history.
-        if stream.state_mirror().terminal_status() == Some(TerminalExecutionStatus::Error) {
-            if let Some(error_detail) = extract_error_detail_from_state(stream.state_mirror())
-                && is_condenser_tool_matching_error(&error_detail)
-            {
-                let _ = stream.close().await;
-                return Ok(ReuseSession::Reset(format!(
-                    "previous run ended with condenser tool-matching error (corrupted event history): {}",
-                    error_detail
-                )));
-            }
-        }
 
         let attached_at = Utc::now();
         manifest.fresh_conversation = false;

--- a/crates/opensymphony-openhands/tests/issue_session_runner.rs
+++ b/crates/opensymphony-openhands/tests/issue_session_runner.rs
@@ -2151,3 +2151,122 @@ async fn rehydrate_conversation_deletes_old_and_creates_new_with_token_preservat
         "new conversation should exist on server"
     );
 }
+
+/// Test that the session runner creates a fresh conversation when the previous
+/// run ended with error status, preventing reuse of potentially corrupted event history.
+#[tokio::test]
+async fn issue_session_runner_resets_when_previous_run_ended_with_error_status() {
+    let server = FakeOpenHandsServer::start()
+        .await
+        .expect("fake server should start");
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = workspace_manager(&workspace_root, HookConfig::default());
+    let workflow = workflow_for(&workspace_root, server.base_url());
+    let issue = sample_issue("COE-313-error-reset");
+    let ensured = manager
+        .ensure(&issue_descriptor(&issue))
+        .await
+        .expect("workspace should exist");
+
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let max_turns = u32::try_from(workflow.config.agent.max_turns).expect("max_turns should fit");
+
+    // First, run successfully
+    let mut first_manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-1", 1))
+        .await
+        .expect("first run manifest should prepare");
+    let first_run = run_attempt(
+        &issue,
+        ensured.handle.workspace_path(),
+        "worker-1",
+        None,
+        max_turns,
+    );
+    let first_result = IssueSessionRunner::new(client.clone(), runner_config(&workflow))
+        .run(
+            &manager,
+            &ensured.handle,
+            &mut first_manifest,
+            &issue,
+            &first_run,
+            &workflow,
+        )
+        .await
+        .expect("first run should succeed");
+
+    let first_conversation_id = first_result
+        .conversation
+        .as_ref()
+        .expect("first conversation should exist")
+        .conversation_id
+        .clone();
+
+    // Simulate a previous run that ended with error by modifying the manifest
+    let mut corrupted_manifest = read_conversation_manifest(&manager, &ensured.handle).await;
+    corrupted_manifest.last_execution_status = Some("error".to_string());
+    corrupted_manifest.last_event_id = Some("evt-error-test".to_string());
+    manager
+        .write_json_artifact(
+            &ensured.handle,
+            &ensured.handle.conversation_manifest_path(),
+            &corrupted_manifest,
+        )
+        .await
+        .expect("should write corrupted manifest");
+
+    // Now run again - should reset due to previous error status
+    let mut second_manifest = manager
+        .start_run(&ensured.handle, &RunDescriptor::new("run-2", 2))
+        .await
+        .expect("second run manifest should prepare");
+    let second_run = run_attempt(
+        &issue,
+        ensured.handle.workspace_path(),
+        "worker-2",
+        None,
+        max_turns,
+    );
+    let second_result = IssueSessionRunner::new(client.clone(), runner_config(&workflow))
+        .run(
+            &manager,
+            &ensured.handle,
+            &mut second_manifest,
+            &issue,
+            &second_run,
+            &workflow,
+        )
+        .await
+        .expect("second run should succeed with fresh conversation");
+
+    // Verify it created a fresh conversation (not reused the errored one)
+    let second_conversation_id = second_result
+        .conversation
+        .as_ref()
+        .expect("second conversation should exist")
+        .conversation_id
+        .clone();
+    assert_ne!(
+        first_conversation_id, second_conversation_id,
+        "should create fresh conversation instead of reusing errored one"
+    );
+
+    // Verify full prompt was used (not continuation)
+    assert_eq!(
+        second_result.prompt_kind,
+        IssueSessionPromptKind::Full,
+        "should use full prompt for fresh conversation"
+    );
+
+    // Verify reset reason is recorded
+    let final_manifest = read_conversation_manifest(&manager, &ensured.handle).await;
+    assert!(
+        final_manifest
+            .reset_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("previous run ended with error"),
+        "reset reason should mention previous error status"
+    );
+}


### PR DESCRIPTION
## Summary

Detect and recover from condenser tool-matching errors that occur when OpenHands SDK's `ToolCallMatching` crashes due to corrupted event history.

## Analysis

The error observed was:
```
KeyError: 'chatcmpl-tool-bcea2761df6a8821'
```

This occurs in `openhands/sdk/context/view/properties/tool_call_matching.py:80`:
```python
pending_tool_call_ids.remove(event.tool_call_id)
```

The `ToolCallMatching` class tracks tool calls by maintaining a set of pending tool call IDs:
- When it sees an `ActionEvent`, it adds the tool call ID
- When it sees an `ObservationBaseEvent`, it removes the tool call ID

The crash happens when an `ObservationBaseEvent` (tool result) arrives but the corresponding `ActionEvent` (tool call) is not in the set - indicating corrupted event history.

## Root Cause

The conversation was being reused (`fresh_conversation: false`) with pre-existing event history that had become corrupted - possibly from a previous interrupted run or partial event persistence.

## Solution

Two layers of defense:

### 1. Defensive Reset on Reuse (Primary Protection)
Before attempting to reuse a conversation, check if the previous run ended with `error` status. If so, reset to a fresh conversation. This prevents trying to run with known-bad state.

### 2. Runtime Recovery (Insurance)
If a tool-matching error occurs during a run (unexpected case), create a fresh conversation and retry the turn. Unlike context overflow (where rehydration is appropriate), this error requires a **fresh** conversation because rehydration would preserve the corrupted event history.

## Changes

- Add `is_condenser_tool_matching_error()` to detect OpenAI-style tool call ID KeyErrors
- Add defensive check in `try_reuse_session()` to reset when previous run ended with error
- Add recovery path in `run_with_observer()` for runtime tool-matching errors
- Add test for defensive reset path

## Evidence

### Test output
```
cargo test --package opensymphony-openhands
# 22 passed, 0 failed
```

New test: `issue_session_runner_resets_when_previous_run_ended_with_error_status`

### Verification
- `cargo check` clean
- `cargo clippy` clean

## Testing Gap Acknowledgment

The **runtime recovery path** (creating fresh conversation during a run after tool-matching error) follows the same pattern as context overflow recovery but requires integration test infrastructure to verify end-to-end. 

The **defensive reset in reuse logic** is tested and provides primary protection against recurring corruption. The runtime recovery is insurance for unexpected cases.

## Open Questions

- Should we also match other LLM provider tool call ID formats? (Currently only matching OpenAI `chatcmpl-tool-`)
- Should we log the corrupted conversation ID for debugging?