### PR TITLE
fix(orchestrator): recover startup state before launch

### DIFF
--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -1,6 +1,11 @@
 //! Runtime backend adapters for tracker, workspace, and worker orchestration.
 
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use opensymphony_domain::{
@@ -79,8 +84,8 @@ pub(super) struct RuntimeTrackerBackend {
 
 pub(super) struct RuntimeWorkspaceBackend {
     manager: Arc<WorkspaceManager>,
-    active_states: Vec<String>,
-    terminal_states: Vec<String>,
+    active_states: HashSet<String>,
+    terminal_states: HashSet<String>,
 }
 
 pub(super) struct RuntimeWorkerBackend {
@@ -280,8 +285,20 @@ impl RuntimeWorkspaceBackend {
     pub(super) fn new(manager: Arc<WorkspaceManager>, workflow: &ResolvedWorkflow) -> Self {
         Self {
             manager,
-            active_states: workflow.config.tracker.active_states.clone(),
-            terminal_states: workflow.config.tracker.terminal_states.clone(),
+            active_states: workflow
+                .config
+                .tracker
+                .active_states
+                .iter()
+                .map(|state| normalized_state_name(state))
+                .collect(),
+            terminal_states: workflow
+                .config
+                .tracker
+                .terminal_states
+                .iter()
+                .map(|state| normalized_state_name(state))
+                .collect(),
         }
     }
 }
@@ -711,19 +728,13 @@ fn normalized_state_name(name: &str) -> String {
 
 fn issue_state_category(
     name: &str,
-    active_states: &[String],
-    terminal_states: &[String],
+    active_states: &HashSet<String>,
+    terminal_states: &HashSet<String>,
 ) -> IssueStateCategory {
     let normalized = normalized_state_name(name);
-    if terminal_states
-        .iter()
-        .any(|state| normalized_state_name(state) == normalized)
-    {
+    if terminal_states.contains(&normalized) {
         IssueStateCategory::Terminal
-    } else if active_states
-        .iter()
-        .any(|state| normalized_state_name(state) == normalized)
-    {
+    } else if active_states.contains(&normalized) {
         IssueStateCategory::Active
     } else {
         IssueStateCategory::NonActive
@@ -732,8 +743,8 @@ fn issue_state_category(
 
 fn normalized_issue_from_manifest(
     manifest: &opensymphony_workspace::IssueManifest,
-    active_states: &[String],
-    terminal_states: &[String],
+    active_states: &HashSet<String>,
+    terminal_states: &HashSet<String>,
 ) -> Result<NormalizedIssue, CliWorkspaceError> {
     Ok(NormalizedIssue {
         id: IssueId::new(manifest.issue_id.clone())?,

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -4,8 +4,8 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use opensymphony_domain::{
-    ConversationMetadata, NormalizedIssue, TimestampMs, WorkerOutcomeKind, WorkerOutcomeRecord,
-    WorkspaceKey,
+    ConversationMetadata, IssueId, IssueIdentifier, IssueState, IssueStateCategory,
+    NormalizedIssue, TimestampMs, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey,
 };
 use opensymphony_linear::{LinearClient, LinearConfig, LinearError, WorkpadComment};
 use opensymphony_openhands::{
@@ -20,14 +20,14 @@ use opensymphony_orchestrator::{
 };
 use opensymphony_workflow::{ProcessEnvironment, ResolvedWorkflow};
 use opensymphony_workspace::{
-    CleanupConfig, HookConfig, HookDefinition, IssueDescriptor, RunDescriptor, WorkspaceError,
-    WorkspaceManager, WorkspaceManagerConfig,
+    CleanupConfig, HookConfig, HookDefinition, IssueDescriptor, RunDescriptor, RunStatus,
+    WorkspaceError, WorkspaceManager, WorkspaceManagerConfig,
 };
 use thiserror::Error;
 use tokio::{
     fs,
     sync::{mpsc, oneshot},
-    task::JoinHandle,
+    task::{JoinHandle, JoinSet},
     time::timeout,
 };
 use url::Url;
@@ -79,6 +79,8 @@ pub(super) struct RuntimeTrackerBackend {
 
 pub(super) struct RuntimeWorkspaceBackend {
     manager: Arc<WorkspaceManager>,
+    active_states: Vec<String>,
+    terminal_states: Vec<String>,
 }
 
 pub(super) struct RuntimeWorkerBackend {
@@ -96,6 +98,11 @@ pub(super) struct RuntimeWorkerBackend {
 struct ActiveWorkerTask {
     handle: JoinHandle<()>,
     run: opensymphony_domain::RunAttempt,
+}
+
+struct PendingLaunch {
+    worker_id: String,
+    launch_rx: oneshot::Receiver<LaunchReport>,
 }
 
 struct SchedulerObserver {
@@ -270,8 +277,12 @@ impl TrackerBackend for RuntimeTrackerBackend {
 }
 
 impl RuntimeWorkspaceBackend {
-    pub(super) fn new(manager: Arc<WorkspaceManager>) -> Self {
-        Self { manager }
+    pub(super) fn new(manager: Arc<WorkspaceManager>, workflow: &ResolvedWorkflow) -> Self {
+        Self {
+            manager,
+            active_states: workflow.config.tracker.active_states.clone(),
+            terminal_states: workflow.config.tracker.terminal_states.clone(),
+        }
     }
 }
 
@@ -298,7 +309,36 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
     }
 
     async fn recover_workspaces(&mut self) -> Result<Vec<RecoveryRecord>, Self::Error> {
-        Ok(Vec::new())
+        let mut recoveries = Vec::new();
+        for (handle, manifest) in self.manager.list_all_workspaces().await? {
+            let run_manifest = self.manager.load_run_manifest(&handle).await?;
+            let had_in_flight_run = run_manifest.as_ref().is_some_and(|run| {
+                matches!(
+                    run.status,
+                    RunStatus::Preparing | RunStatus::Prepared | RunStatus::Running
+                )
+            });
+
+            recoveries.push(RecoveryRecord {
+                issue: normalized_issue_from_manifest(
+                    &manifest,
+                    &self.active_states,
+                    &self.terminal_states,
+                )?,
+                workspace: opensymphony_domain::WorkspaceRecord {
+                    path: handle.workspace_path().to_path_buf(),
+                    workspace_key: WorkspaceKey::new(handle.workspace_key().to_string())?,
+                    created_now: false,
+                    created_at: Some(datetime_to_timestamp_ms(manifest.created_at)),
+                    updated_at: Some(datetime_to_timestamp_ms(manifest.updated_at)),
+                    last_seen_tracker_refresh_at: manifest
+                        .last_seen_tracker_refresh_at
+                        .map(datetime_to_timestamp_ms),
+                },
+                had_in_flight_run,
+            });
+        }
+        Ok(recoveries)
     }
 
     async fn cleanup_workspace(
@@ -375,54 +415,8 @@ impl RuntimeWorkerBackend {
             task.handle.abort();
         }
     }
-}
 
-impl Drop for RuntimeWorkerBackend {
-    fn drop(&mut self) {
-        self.abort_all_tracked_tasks();
-    }
-}
-
-fn transport_port_override(url: &Url) -> Result<u16, RunCommandError> {
-    url.port_or_known_default()
-        .ok_or_else(|| RunCommandError::MissingTransportPort {
-            value: url.as_str().to_string(),
-        })
-}
-
-fn report_launch_failure(
-    launch_tx: &mut Option<oneshot::Sender<LaunchReport>>,
-    detail: impl Into<String>,
-) {
-    if let Some(sender) = launch_tx.take() {
-        let _ = sender.send(LaunchReport::Failed(detail.into()));
-    }
-}
-
-fn pending_launch_failure_detail(result: &Result<IssueSessionResult, IssueSessionError>) -> String {
-    match result {
-        Ok(result) => {
-            let detail = result
-                .worker_outcome
-                .error
-                .clone()
-                .or_else(|| result.worker_outcome.summary.clone())
-                .unwrap_or_else(|| {
-                    "worker finished before reporting a conversation launch".to_string()
-                });
-            format!("worker finished before reporting a conversation launch: {detail}")
-        }
-        Err(error) => format!("worker failed before reporting a conversation launch: {error}"),
-    }
-}
-
-impl WorkerBackend for RuntimeWorkerBackend {
-    type Error = CliWorkerError;
-
-    async fn start_worker(
-        &mut self,
-        request: WorkerStartRequest,
-    ) -> Result<WorkerLaunch, Self::Error> {
+    fn spawn_worker_task(&mut self, request: WorkerStartRequest) -> PendingLaunch {
         let mut runner = IssueSessionRunner::new(self.client.clone(), self.runner_config.clone());
         if let Some(source) = self.workpad_comment_source.clone() {
             runner = runner.with_workpad_comment_source(source);
@@ -510,31 +504,144 @@ impl WorkerBackend for RuntimeWorkerBackend {
             worker_id.to_string(),
             ActiveWorkerTask {
                 handle,
-                run: request.run.clone(),
+                run: request.run,
             },
         );
 
-        match timeout(self.launch_timeout, launch_rx).await {
+        PendingLaunch {
+            worker_id: worker_id.to_string(),
+            launch_rx,
+        }
+    }
+
+    async fn resolve_launch_result(
+        &mut self,
+        worker_id: &str,
+        result: Result<
+            Result<LaunchReport, oneshot::error::RecvError>,
+            tokio::time::error::Elapsed,
+        >,
+    ) -> Result<WorkerLaunch, CliWorkerError> {
+        match result {
             Ok(Ok(LaunchReport::Conversation(conversation))) => Ok(WorkerLaunch {
                 conversation: *conversation,
             }),
             Ok(Ok(LaunchReport::Failed(detail))) => {
-                if let Some(task) = self.tasks.remove(worker_id.as_str()) {
+                if let Some(task) = self.tasks.remove(worker_id) {
                     task.handle.await?;
                 }
                 Err(CliWorkerError::LaunchFailed(detail))
             }
             Ok(Err(_)) => {
-                if let Some(task) = self.tasks.remove(worker_id.as_str()) {
+                if let Some(task) = self.tasks.remove(worker_id) {
                     task.handle.await?;
                 }
                 Err(CliWorkerError::LaunchChannelClosed)
             }
             Err(_) => {
-                self.abort_tracked_task(worker_id.as_str());
+                self.abort_tracked_task(worker_id);
                 Err(CliWorkerError::LaunchTimeout(self.launch_timeout))
             }
         }
+    }
+}
+
+impl Drop for RuntimeWorkerBackend {
+    fn drop(&mut self) {
+        self.abort_all_tracked_tasks();
+    }
+}
+
+fn transport_port_override(url: &Url) -> Result<u16, RunCommandError> {
+    url.port_or_known_default()
+        .ok_or_else(|| RunCommandError::MissingTransportPort {
+            value: url.as_str().to_string(),
+        })
+}
+
+fn report_launch_failure(
+    launch_tx: &mut Option<oneshot::Sender<LaunchReport>>,
+    detail: impl Into<String>,
+) {
+    if let Some(sender) = launch_tx.take() {
+        let _ = sender.send(LaunchReport::Failed(detail.into()));
+    }
+}
+
+fn pending_launch_failure_detail(result: &Result<IssueSessionResult, IssueSessionError>) -> String {
+    match result {
+        Ok(result) => {
+            let detail = result
+                .worker_outcome
+                .error
+                .clone()
+                .or_else(|| result.worker_outcome.summary.clone())
+                .unwrap_or_else(|| {
+                    "worker finished before reporting a conversation launch".to_string()
+                });
+            format!("worker finished before reporting a conversation launch: {detail}")
+        }
+        Err(error) => format!("worker failed before reporting a conversation launch: {error}"),
+    }
+}
+
+impl WorkerBackend for RuntimeWorkerBackend {
+    type Error = CliWorkerError;
+
+    async fn start_worker(
+        &mut self,
+        request: WorkerStartRequest,
+    ) -> Result<WorkerLaunch, Self::Error> {
+        let pending = self.spawn_worker_task(request);
+        let worker_id = pending.worker_id.clone();
+        self.resolve_launch_result(
+            &worker_id,
+            timeout(self.launch_timeout, pending.launch_rx).await,
+        )
+        .await
+    }
+
+    async fn start_workers(
+        &mut self,
+        requests: Vec<WorkerStartRequest>,
+    ) -> Vec<Result<WorkerLaunch, Self::Error>> {
+        let pending = requests
+            .into_iter()
+            .map(|request| self.spawn_worker_task(request))
+            .collect::<Vec<_>>();
+        let ordered_worker_ids = pending
+            .iter()
+            .map(|launch| launch.worker_id.clone())
+            .collect::<Vec<_>>();
+
+        let mut join_set = JoinSet::new();
+        for launch in pending {
+            let worker_id = launch.worker_id;
+            let timeout_duration = self.launch_timeout;
+            let rx = launch.launch_rx;
+            join_set.spawn(async move { (worker_id, timeout(timeout_duration, rx).await) });
+        }
+
+        let mut completed = HashMap::new();
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok((worker_id, outcome)) => {
+                    completed.insert(worker_id, outcome);
+                }
+                Err(_) => {}
+            }
+        }
+
+        let mut launches = Vec::with_capacity(ordered_worker_ids.len());
+        for worker_id in ordered_worker_ids {
+            let outcome = completed
+                .remove(&worker_id)
+                .unwrap_or(Ok(Ok(LaunchReport::Failed(
+                    "worker launch waiter finished without a result".to_string(),
+                ))));
+            launches.push(self.resolve_launch_result(&worker_id, outcome).await);
+        }
+        launches
     }
 
     async fn poll_updates(&mut self) -> Result<Vec<WorkerUpdate>, Self::Error> {
@@ -583,6 +690,58 @@ impl WorkerBackend for RuntimeWorkerBackend {
         self.abort_tracked_task(worker_id.as_str());
         Ok(())
     }
+}
+
+fn normalized_state_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+fn issue_state_category(
+    name: &str,
+    active_states: &[String],
+    terminal_states: &[String],
+) -> IssueStateCategory {
+    let normalized = normalized_state_name(name);
+    if terminal_states
+        .iter()
+        .any(|state| normalized_state_name(state) == normalized)
+    {
+        IssueStateCategory::Terminal
+    } else if active_states
+        .iter()
+        .any(|state| normalized_state_name(state) == normalized)
+    {
+        IssueStateCategory::Active
+    } else {
+        IssueStateCategory::NonActive
+    }
+}
+
+fn normalized_issue_from_manifest(
+    manifest: &opensymphony_workspace::IssueManifest,
+    active_states: &[String],
+    terminal_states: &[String],
+) -> Result<NormalizedIssue, CliWorkspaceError> {
+    Ok(NormalizedIssue {
+        id: IssueId::new(manifest.issue_id.clone())?,
+        identifier: IssueIdentifier::new(manifest.identifier.clone())?,
+        title: manifest.title.clone(),
+        description: None,
+        priority: None,
+        state: IssueState {
+            id: None,
+            name: manifest.current_state.clone(),
+            category: issue_state_category(&manifest.current_state, active_states, terminal_states),
+        },
+        branch_name: None,
+        url: None,
+        labels: Vec::new(),
+        parent_id: None,
+        blocked_by: Vec::new(),
+        sub_issues: Vec::new(),
+        created_at: Some(datetime_to_timestamp_ms(manifest.created_at)),
+        updated_at: Some(datetime_to_timestamp_ms(manifest.updated_at)),
+    })
 }
 
 fn issue_descriptor(issue: &NormalizedIssue) -> IssueDescriptor {
@@ -676,6 +835,44 @@ mod tests {
                 .is_empty(),
             "launch failures should be surfaced through start_worker, not queued as runtime updates",
         );
+    }
+
+    #[tokio::test]
+    async fn recover_workspaces_loads_managed_manifests_and_inflight_runs() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspace-root");
+        fs::create_dir_all(&workspace_root).expect("workspace root should be created");
+
+        let workflow = sample_workflow(tempdir.path(), &workspace_root);
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let issue = sample_issue();
+        let ensured = workspace_manager
+            .ensure(&issue_descriptor(&issue))
+            .await
+            .expect("workspace should be created");
+        workspace_manager
+            .start_run(&ensured.handle, &RunDescriptor::new("run-recovery", 2))
+            .await
+            .expect("run manifest should be written");
+
+        let mut backend = RuntimeWorkspaceBackend::new(workspace_manager, &workflow);
+        let recoveries = backend
+            .recover_workspaces()
+            .await
+            .expect("workspace recovery should succeed");
+
+        assert_eq!(recoveries.len(), 1);
+        let recovered = &recoveries[0];
+        assert_eq!(
+            recovered.issue.identifier.to_string(),
+            issue.identifier.to_string()
+        );
+        assert_eq!(recovered.issue.state.category, IssueStateCategory::Active);
+        assert!(recovered.had_in_flight_run);
+        assert_eq!(recovered.workspace.path, ensured.handle.workspace_path());
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -624,8 +624,13 @@ impl WorkerBackend for RuntimeWorkerBackend {
 
         let mut completed = HashMap::new();
         while let Some(result) = join_set.join_next().await {
-            if let Ok((worker_id, outcome)) = result {
-                completed.insert(worker_id, outcome);
+            match result {
+                Ok((worker_id, outcome)) => {
+                    completed.insert(worker_id, outcome);
+                }
+                Err(join_error) => {
+                    tracing::error!(error = %join_error, "worker launch waiter task failed");
+                }
             }
         }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 use tokio::{
     fs,
     sync::{mpsc, oneshot},
-    task::{JoinHandle, JoinSet},
+    task::JoinHandle,
     time::timeout,
 };
 use url::Url;
@@ -614,22 +614,33 @@ impl WorkerBackend for RuntimeWorkerBackend {
             .map(|launch| launch.worker_id.clone())
             .collect::<Vec<_>>();
 
-        let mut join_set = JoinSet::new();
+        let mut waiters = Vec::with_capacity(pending.len());
         for launch in pending {
             let worker_id = launch.worker_id;
             let timeout_duration = self.launch_timeout;
             let rx = launch.launch_rx;
-            join_set.spawn(async move { (worker_id, timeout(timeout_duration, rx).await) });
+            let worker_id_for_task = worker_id.clone();
+            let handle =
+                tokio::spawn(
+                    async move { (worker_id_for_task, timeout(timeout_duration, rx).await) },
+                );
+            waiters.push((worker_id, handle));
         }
 
         let mut completed = HashMap::new();
-        while let Some(result) = join_set.join_next().await {
-            match result {
+        for (worker_id, handle) in waiters {
+            match handle.await {
                 Ok((worker_id, outcome)) => {
                     completed.insert(worker_id, outcome);
                 }
                 Err(join_error) => {
                     tracing::error!(error = %join_error, "worker launch waiter task failed");
+                    completed.insert(
+                        worker_id,
+                        Ok(Ok(LaunchReport::Failed(format!(
+                            "worker launch waiter task failed: {join_error}"
+                        )))),
+                    );
                 }
             }
         }

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -624,11 +624,8 @@ impl WorkerBackend for RuntimeWorkerBackend {
 
         let mut completed = HashMap::new();
         while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok((worker_id, outcome)) => {
-                    completed.insert(worker_id, outcome);
-                }
-                Err(_) => {}
+            if let Ok((worker_id, outcome)) = result {
+                completed.insert(worker_id, outcome);
             }
         }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -125,7 +125,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     let workspace_manager = Arc::new(opensymphony_workspace::WorkspaceManager::new(
         build_workspace_manager_config(&runtime.workflow),
     )?);
-    let workspace = RuntimeWorkspaceBackend::new(workspace_manager.clone());
+    let workspace = RuntimeWorkspaceBackend::new(workspace_manager.clone(), &runtime.workflow);
 
     let (transport, mut supervisor) = build_runtime_transport(&runtime).await?;
     let client = opensymphony_openhands::OpenHandsClient::new(transport);
@@ -152,8 +152,21 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         Utc::now(),
     );
 
+    let bootstrap_snapshot = scheduler.bootstrap(now_timestamp()).await?;
+    push_recent_event(
+        &mut recent_events,
+        RecentEventKind::SnapshotPublished,
+        None,
+        format!(
+            "recovered startup state; running={}, retry_queue={}",
+            bootstrap_snapshot.daemon.running_issue_count,
+            bootstrap_snapshot.daemon.retry_queue_count
+        ),
+        Utc::now(),
+    );
+
     let initial_snapshot = map_snapshot(
-        &scheduler.snapshot(now_timestamp()),
+        &bootstrap_snapshot,
         runtime.workflow.config.workspace.root.as_path(),
         &terminal_state_set(&runtime.workflow),
         current_agent_server_status(&mut supervisor, client.base_url()),

--- a/crates/opensymphony-openhands/src/client.rs
+++ b/crates/opensymphony-openhands/src/client.rs
@@ -729,8 +729,6 @@ impl RuntimeEventStream {
 
     async fn attach(mut self) -> Result<Self, OpenHandsError> {
         self.refresh_conversation().await?;
-        let initial_cache = self.client.search_all_events(self.conversation_id).await?;
-        self.push_new_events(initial_cache.items().iter().cloned(), true);
         self.connect_ready_and_reconcile().await?;
         Ok(self)
     }

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -651,11 +651,12 @@ where
                 continue;
             }
 
+            let state_key = normalized_state_name(&normalized.state.name);
+
             if let Some(limit) = state_limit_for(
                 &self.config.max_concurrent_agents_by_state,
                 &normalized.state.name,
             ) {
-                let state_key = normalized_state_name(&normalized.state.name);
                 let running_in_state = self.running_count_for_state(&normalized.state.name)
                     + planned_running_by_state
                         .get(&state_key)
@@ -708,9 +709,7 @@ where
                 run: claimed_run.clone(),
             };
 
-            *planned_running_by_state
-                .entry(normalized_state_name(&normalized.state.name))
-                .or_default() += 1;
+            *planned_running_by_state.entry(state_key).or_default() += 1;
             pending_launches.push((issue_id, execution, claimed_run, start_request));
         }
 

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -63,8 +63,9 @@ impl SchedulerConfig {
                 .max_concurrent_agents_by_state
                 .iter()
                 .map(|(state, limit)| {
+                    let normalized_state = normalized_state_name(state);
                     u32::try_from(*limit)
-                        .map(|limit| (state.clone(), limit))
+                        .map(|limit| (normalized_state, limit))
                         .map_err(|_| SchedulerError::InvalidConfiguration {
                             detail: format!(
                                 "workflow max_concurrent_agents_by_state[{state}] {limit} exceeds u32::MAX ({})",
@@ -653,10 +654,9 @@ where
 
             let state_key = normalized_state_name(&normalized.state.name);
 
-            if let Some(limit) = state_limit_for(
-                &self.config.max_concurrent_agents_by_state,
-                &normalized.state.name,
-            ) {
+            if let Some(limit) =
+                state_limit_for(&self.config.max_concurrent_agents_by_state, &state_key)
+            {
                 let running_in_state = self.running_count_for_normalized_state(&state_key)
                     + planned_running_by_state
                         .get(&state_key)
@@ -1141,11 +1141,12 @@ fn state_category_from_name(name: &str, config: &SchedulerConfig) -> IssueStateC
     }
 }
 
-fn state_limit_for(limits: &BTreeMap<String, u32>, state_name: &str) -> Option<u32> {
-    let normalized = normalized_state_name(state_name);
-    limits
-        .iter()
-        .find_map(|(state, limit)| (normalized_state_name(state) == normalized).then_some(*limit))
+fn state_limit_for(limits: &BTreeMap<String, u32>, state_key: &str) -> Option<u32> {
+    limits.get(state_key).copied().or_else(|| {
+        limits.iter().find_map(|(configured_state, limit)| {
+            (normalized_state_name(configured_state) == state_key).then_some(*limit)
+        })
+    })
 }
 
 fn non_active_release_reason(category: IssueStateCategory) -> Option<ReleaseReason> {

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -657,7 +657,7 @@ where
                 &self.config.max_concurrent_agents_by_state,
                 &normalized.state.name,
             ) {
-                let running_in_state = self.running_count_for_state(&normalized.state.name)
+                let running_in_state = self.running_count_for_normalized_state(&state_key)
                     + planned_running_by_state
                         .get(&state_key)
                         .copied()
@@ -992,9 +992,9 @@ where
         self.debug_assert_running_counts();
     }
 
-    fn running_count_for_state(&self, state_name: &str) -> usize {
+    fn running_count_for_normalized_state(&self, state_key: &str) -> usize {
         self.running_counts_by_state
-            .get(&normalized_state_name(state_name))
+            .get(state_key)
             .copied()
             .unwrap_or_default()
     }

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -174,6 +174,17 @@ pub trait WorkerBackend {
         request: WorkerStartRequest,
     ) -> Result<WorkerLaunch, Self::Error>;
 
+    async fn start_workers(
+        &mut self,
+        requests: Vec<WorkerStartRequest>,
+    ) -> Vec<Result<WorkerLaunch, Self::Error>> {
+        let mut launches = Vec::with_capacity(requests.len());
+        for request in requests {
+            launches.push(self.start_worker(request).await);
+        }
+        launches
+    }
+
     async fn poll_updates(&mut self) -> Result<Vec<WorkerUpdate>, Self::Error>;
 
     async fn abort_worker(
@@ -317,6 +328,29 @@ where
         );
 
         OrchestratorSnapshot::new(generated_at, daemon, issues)
+    }
+
+    pub async fn bootstrap(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<OrchestratorSnapshot, SchedulerError> {
+        if self.pending_recovery.is_none() {
+            self.pending_recovery =
+                Some(self.workspace.recover_workspaces().await.map_err(|error| {
+                    SchedulerError::Workspace {
+                        detail: error.to_string(),
+                    }
+                })?);
+        }
+
+        let tracker_snapshot = self.load_tracker_snapshot().await?;
+        self.bootstrap_recovery(&tracker_snapshot, observed_at)
+            .await?;
+        self.reconcile_tracker_state(&tracker_snapshot, observed_at)
+            .await?;
+
+        self.last_poll_at = Some(observed_at);
+        Ok(self.snapshot(observed_at))
     }
 
     pub async fn tick(
@@ -585,11 +619,18 @@ where
     ) -> Result<(), SchedulerError> {
         let ready =
             filter_issues_for_dispatch(active_issues.to_vec(), &self.config.terminal_state_set());
+        let available_capacity = usize::try_from(self.config.max_concurrent_agents)
+            .unwrap_or(usize::MAX)
+            .saturating_sub(self.worker_index.len());
+        if available_capacity == 0 {
+            return Ok(());
+        }
+
+        let mut pending_launches = Vec::new();
+        let mut planned_running_by_state: HashMap<String, usize> = HashMap::new();
 
         for tracker_issue in ready {
-            if self.worker_index.len()
-                >= usize::try_from(self.config.max_concurrent_agents).unwrap_or(usize::MAX)
-            {
+            if pending_launches.len() >= available_capacity {
                 break;
             }
 
@@ -614,7 +655,12 @@ where
                 &self.config.max_concurrent_agents_by_state,
                 &normalized.state.name,
             ) {
-                let running_in_state = self.running_count_for_state(&normalized.state.name);
+                let state_key = normalized_state_name(&normalized.state.name);
+                let running_in_state = self.running_count_for_state(&normalized.state.name)
+                    + planned_running_by_state
+                        .get(&state_key)
+                        .copied()
+                        .unwrap_or_default();
                 if running_in_state >= usize::try_from(limit).unwrap_or(usize::MAX) {
                     continue;
                 }
@@ -661,7 +707,27 @@ where
                 workspace,
                 run: claimed_run.clone(),
             };
-            match self.worker.start_worker(start_request).await {
+
+            *planned_running_by_state
+                .entry(normalized_state_name(&normalized.state.name))
+                .or_default() += 1;
+            pending_launches.push((issue_id, execution, claimed_run, start_request));
+        }
+
+        let start_results = self
+            .worker
+            .start_workers(
+                pending_launches
+                    .iter()
+                    .map(|(_, _, _, request)| request.clone())
+                    .collect(),
+            )
+            .await;
+
+        for ((issue_id, mut execution, claimed_run, _), result) in
+            pending_launches.into_iter().zip(start_results.into_iter())
+        {
+            match result {
                 Ok(launch) => {
                     execution = execution.start_running(
                         observed_at,
@@ -669,11 +735,13 @@ where
                         Some(launch.conversation),
                     )?;
                     execution.record_turn_started(observed_at)?;
-                    self.worker_index.insert(worker_id, issue_id.clone());
+                    self.worker_index
+                        .insert(claimed_run.worker_id.clone(), issue_id.clone());
                     debug!(issue_id = %issue_id, "dispatched scheduler worker");
                 }
                 Err(error) => {
                     let detail = error.to_string();
+                    warn!(issue_id = %issue_id, error = %detail, "failed to launch scheduler worker");
                     let outcome = WorkerOutcomeRecord::from_run(
                         &claimed_run,
                         WorkerOutcomeKind::Failed,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,13 @@ The persisted OpenHands state directory is derived from the workflow-owned `open
 The workflow-owned `openhands.conversation.reuse_policy` can override that default with `fresh_each_run`, which forces a new conversation and a full prompt on every worker lifetime. Unsupported policy names now fail from the OpenHands runtime boundary instead of being silently dropped during workflow resolution.
 The persisted conversation manifest also records the owning issue reference, active reuse policy, creation and attach timestamps, the launch profile used to create the thread, and an `llm_config_fingerprint` that tracks the model name for observability. This allows `opensymphony debug <issue-id>` to reattach to the same session with matching runtime settings. Persisting the policy keeps recovery deterministic when the workflow later changes from one policy to another.
 
+Daemon restart recovery is now intentionally split into two phases:
+
+- a startup bootstrap pass restores issue/workspace state from managed workspace metadata and publishes that snapshot before new worker launches begin, so the TUI can repopulate quickly after `opensymphony run` restarts
+- later scheduler ticks handle normal dispatch, retry, and terminal reconciliation
+
+When multiple ready issues need launches in the same tick, the runtime backend also starts those launch waits concurrently up to the scheduler's existing capacity limits instead of serializing every conversation attach behind the first one.
+
 **Simplified conversation resumption**: The runner no longer checks for LLM configuration drift or recreates conversations. Conversations are reused as-is by directly attaching to the existing `conversation_id`. The stored LLM configuration in the conversation's `meta.json` is used without modification. This avoids the complexity and brittleness of the previous delete-and-recreate approach, which was causing issues on every orchestrator restart due to false-positive drift detection.
 
 ### 3.6 The UI only sees the control plane

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -77,6 +77,7 @@ Current implementation:
 - `cargo test --workspace` exercises the fake-server contract suite in `crates/opensymphony-openhands/tests/fake_server_contract.rs`
 - `cargo test -p opensymphony-linear` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `cargo test -p opensymphony-orchestrator` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, cached per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, active-state reconciliation, and manifest-backed workspace recovery against fake tracker/workspace/worker backends
+- `cargo test -p opensymphony-cli orchestrator_run::backends::tests` covers runtime workspace-manifest recovery, in-flight run detection from `run.json`, and launch-path failure handling in the concrete CLI backends
 - `crates/opensymphony-cli/tests/doctor.rs` runs the CLI live-probe path against `opensymphony-testkit`
 - `scripts/smoke_local.sh` runs the static doctor pass
 - `scripts/live_e2e.sh` gates the live doctor run behind `OPENSYMPHONY_LIVE_OPENHANDS=1`
@@ -198,6 +199,7 @@ Current implementation:
 Current repository implementation:
 
 - `crates/opensymphony-orchestrator/tests/scheduler.rs` covers continuation retry, failure backoff, cached per-state dispatch limits across finish/stall/inactive/terminal/reconciliation transitions, runtime-event-fed stall detection, terminal reconciliation with cleanup, and manifest-backed workspace recovery using fake backends
+- local restart validation should confirm that `opensymphony run` publishes a recovered snapshot before the first post-restart launch wave, so the TUI issue list repopulates even when reused conversations still take time to attach
 - `crates/opensymphony-cli/src/orchestrator_run/backends.rs` covers immediate launch-failure cleanup and abort-on-drop cleanup for tracked runtime worker tasks in the production CLI adapter
 
 ## 3.5 Control plane and TUI

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -197,6 +197,13 @@ Use cases:
 
 - restart recovery
 - operator debugging
+- startup bootstrap before new worker launch
+
+Restart recovery should rely on managed workspace metadata only:
+
+- `issue.json` restores the owning issue reference and last known tracker state
+- `run.json` indicates whether the last known worker lifetime was still in `preparing`, `prepared`, or `running` when the daemon stopped
+- startup bootstrap may republish recovered workspace state immediately, but it must not assume any recovered run is still live until a fresh scheduler tick revalidates tracker state and runtime launch status
 - workspace introspection
 - authoritative ownership check for non-injective sanitized workspace keys
 


### PR DESCRIPTION
## Summary

Recover managed workspace state before the first post-restart launch wave, speed reused conversation attaches, and batch worker launch waits so the TUI repopulates quickly after `opensymphony run` restarts.

## Changes

- recover workspaces from `.opensymphony` manifests, including in-flight run detection from `run.json`
- publish a bootstrap snapshot before normal dispatch so recovered issues appear in the control plane and TUI immediately after restart
- batch ready worker launches within existing scheduler capacity limits and remove a redundant OpenHands attach-time event history fetch

## Evidence

### Test output

```text
$ cargo test -p opensymphony-openhands runtime_stream_replays_initial_snapshot_events_on_attach
...
test runtime_stream_replays_initial_snapshot_events_on_attach ... ok

$ cargo test -p opensymphony-cli orchestrator_run::backends::tests
...
test orchestrator_run::backends::tests::recover_workspaces_loads_managed_manifests_and_inflight_runs ... ok

$ cargo test -p opensymphony-orchestrator --test scheduler
...
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Verification

Verified the restart path now restores managed workspace state from metadata before dispatch, the scheduler can launch multiple ready workers concurrently without violating capacity limits, and the OpenHands attach path no longer performs the redundant pre-read that was inflating launch latency for large reused conversations.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] Performance improvement
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Other: n/a

## Breaking changes

None

## Related issues

- COE-316

## Additional notes

This also adds an explicit launch-failure warning in the scheduler so future stuck `retry_queued` cases are easier to diagnose from orchestrator logs.
