### PR TITLE
Add `opensymphony init` for target repo bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opensymphony"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "opensymphony-cli",
  "tokio",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-control"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-domain"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-linear"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-linear-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "opensymphony-domain",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-openhands"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-orchestrator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-testkit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-tui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "ftui",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-workflow"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "liquid",
  "serde",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-workspace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/kumanday/OpenSymphony"
 rust-version = "1.93"
-version = "0.1.0"
+version = "0.1.1"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cd /path/to/target-repo
 opensymphony init
 ```
 
-`opensymphony init` fetches the current bootstrap files from the template repository's raw GitHub URLs at runtime, copies any missing files, merges an existing `AGENTS.md`, prompts before overwriting other conflicts, detects the repo clone URL from `git remote`, and offers to fill in the Linear project slug/key in `WORKFLOW.md`.
+`opensymphony init` fetches the current bootstrap files from the template repository's raw GitHub URLs at runtime, copies any missing files, merges an existing `AGENTS.md`, prompts before overwriting other conflicts, detects the repo clone URL from `git remote`, offers to fill in the Linear project slug/key in `WORKFLOW.md`, and can optionally scaffold automated OpenHands AI PR review.
 
 The copied bootstrap payload currently includes:
 
@@ -79,8 +79,13 @@ The copied bootstrap payload currently includes:
 - `.agents/skills/`
 - `.github/CODEOWNERS`
 - `.github/pull_request_template.md`
-- `.github/workflows/ai-pr-review.yml`
 - `docs/tasks/README.md`
+
+If you opt into AI PR review during `init`, it also adds:
+
+- `.github/workflows/ai-pr-review.yml`
+- `.agents/skills/custom-codereview-guide.md`
+- `docs/ai-pr-review-human-setup.md`
 
 If you want to inspect the exact upstream source, `init` pulls from the raw template base at [raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main](https://raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main/WORKFLOW.md).
 

--- a/README.md
+++ b/README.md
@@ -61,56 +61,52 @@ opensymphony --help
 
 For new projects, use the [OpenSymphony-template](https://github.com/kumanday/OpenSymphony-template) repository as a starting point.
 
-For existing projects, copy these files from the template repo:
+For an existing repository, bootstrap it in place:
 
 ```bash
-# From your target repository:
+cd /path/to/target-repo
+opensymphony init
+```
 
-# 1. WORKFLOW.md (orchestration configuration)
-curl -o WORKFLOW.md https://raw.githubusercontent.com/kumanday/OpenSymphony-template/main/WORKFLOW.md
+`opensymphony init` fetches the current bootstrap files from the template repository's raw GitHub URLs at runtime, copies any missing files, merges an existing `AGENTS.md`, prompts before overwriting other conflicts, detects the repo clone URL from `git remote`, and offers to fill in the Linear project slug/key in `WORKFLOW.md`.
 
-# 2. Skills directory (commit, push, pull, land, linear, convert-tasks-to-linear, create-implementation-plan)
-mkdir -p .agents/skills
-for skill in commit land pull push linear convert-tasks-to-linear create-implementation-plan; do
-  mkdir -p ".agents/skills/$skill"
-  curl -o ".agents/skills/$skill/SKILL.md" \
-    "https://raw.githubusercontent.com/kumanday/OpenSymphony-template/main/.agents/skills/$skill/SKILL.md"
-done
+The copied bootstrap payload currently includes:
 
-# 3. GitHub workflows (AI PR review)
-mkdir -p .github/workflows
-curl -o .github/workflows/ai-pr-review.yml \
-  https://raw.githubusercontent.com/kumanday/OpenSymphony-template/main/.github/workflows/ai-pr-review.yml
+- `WORKFLOW.md`
+- `AGENTS.md`
+- `config.yaml`
+- `.gitignore`
+- `.agents/skills/`
+- `.github/CODEOWNERS`
+- `.github/pull_request_template.md`
+- `.github/workflows/ai-pr-review.yml`
+- `docs/tasks/README.md`
 
-# 4. PR template and CODEOWNERS
-curl -o .github/pull_request_template.md \
-  https://raw.githubusercontent.com/kumanday/OpenSymphony-template/main/.github/pull_request_template.md
-curl -o .github/CODEOWNERS \
-  https://raw.githubusercontent.com/kumanday/OpenSymphony-template/main/.github/CODEOWNERS
+If you want to inspect the exact upstream source, `init` pulls from the raw template base at [raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main](https://raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main/WORKFLOW.md).
 
-# 5. Create required labels
+If you want the template's GitHub label conventions, create them once per repository:
+
+```bash
 gh label create "symphony" --description "PR created by OpenSymphony" --color "1f77b4" || true
 gh label create "review-this" --description "Trigger AI PR review" --color "d73a4a" || true
 ```
 
-Then edit `WORKFLOW.md` to set your project details:
+Then review the copied `WORKFLOW.md` and `config.yaml`:
 
 | Field | Description | Env Var | Example |
 |-------|-------------|---------|---------|
 | `tracker.project_slug` | Your Linear project identifier | - | `my-team/my-project` |
 | `workspace.root` | Where to store per-issue workspaces | - | `~/.opensymphony/workspaces` |
-| `openhands.conversation.agent.llm.model` | LLM model to use | `LLM_MODEL` | `openai/gpt-5.4` |
+| `openhands.conversation.agent.llm.model` | LLM model to use | `LLM_MODEL` | `openai/accounts/fireworks/models/glm-5p1` |
 
 **Environment Variables**
 
 OpenSymphony uses standard OpenHands environment variable names:
 
 ```bash
-# Required: LLM configuration
-export LLM_MODEL="openai/gpt-5.4"
-export LLM_API_KEY="sk-..."
-
-# Optional: Custom base URL for non-OpenAI providers (e.g., Fireworks)
+# Fireworks example via the OpenAI-compatible provider adapter
+export LLM_MODEL="openai/accounts/fireworks/models/glm-5p1"
+export LLM_API_KEY="fw-..."
 export LLM_BASE_URL="https://api.fireworks.ai/inference/v1"
 ```
 
@@ -137,7 +133,7 @@ openhands:
 
 OpenSymphony forwards an OpenHands `LLMSummarizingCondenser` that reuses the conversation agent's LLM settings. The condenser is enabled by default with `max_size: 240` and `keep_first: 2`. To disable it, set `enabled: false`.
 
-Add a root-level `config.yaml` file next to your target repository `WORKFLOW.md`. A minimal local-supervised config looks like this:
+`opensymphony init` also copies a starter `config.yaml` next to the target repository `WORKFLOW.md`. A minimal local-supervised config looks like this:
 
 ```yaml
 control_plane:
@@ -159,8 +155,11 @@ Note: [`examples/configs/local-dev.yaml`](examples/configs/local-dev.yaml) is fo
 # Run preflight checks from the OpenSymphony checkout
 opensymphony doctor --config examples/configs/local-dev.yaml
 
-# Start the orchestrator from the target repository
+# Bootstrap an existing target repository once
 cd /path/to/target-repo
+opensymphony init
+
+# Start the orchestrator from the target repository
 opensymphony run
 
 # Or point at an explicit runtime config file
@@ -226,7 +225,7 @@ The legacy `opensymphony daemon` command is still available as a demo control-pl
 | `opensymphony-workspace` | Workspace lifecycle, hooks, containment |
 | `opensymphony-control` | Control plane API and snapshot derivation |
 | `opensymphony-tui` | FrankenTUI operator client |
-| `opensymphony-cli` | CLI entrypoints: run, daemon (demo), tui, doctor, linear-mcp |
+| `opensymphony-cli` | CLI entrypoints: init, run, debug, daemon (demo), tui, doctor, linear-mcp, rehydrate |
 
 ## Deployment Modes
 

--- a/crates/opensymphony-cli/Cargo.toml
+++ b/crates/opensymphony-cli/Cargo.toml
@@ -28,6 +28,7 @@ opensymphony-orchestrator = { path = "../opensymphony-orchestrator" }
 opensymphony-workflow = { path = "../opensymphony-workflow" }
 opensymphony-tui = { path = "../opensymphony-tui" }
 opensymphony-workspace = { path = "../opensymphony-workspace" }
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -1,0 +1,983 @@
+use std::{
+    env, fs,
+    io::{self, BufRead, Write},
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
+
+use clap::Args;
+use reqwest::{Client, StatusCode, Url};
+use thiserror::Error;
+
+const DEFAULT_TEMPLATE_BASE_URL: &str =
+    "https://raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main/";
+const DEFAULT_LLM_MODEL: &str = "openai/accounts/fireworks/models/glm-5p1";
+const DEFAULT_LLM_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
+const PRESERVED_AGENTS_MARKER: &str = "## Preserved Existing AGENTS.md";
+const WORKFLOW_PROJECT_SLUG_PLACEHOLDER: &str = "\"YOUR-PROJECT-SLUG\"";
+const WORKFLOW_GIT_REMOTE_PLACEHOLDER: &str = "https://github.com/YOUR-ORG/YOUR-REPO.git";
+
+#[derive(Debug, Args, Clone)]
+pub struct InitArgs {}
+
+#[derive(Debug, Error)]
+enum InitCommandError {
+    #[error("failed to determine the current working directory: {0}")]
+    CurrentDir(#[source] io::Error),
+    #[error("failed to build the template fetch client: {0}")]
+    HttpClient(#[source] reqwest::Error),
+    #[error("invalid template base URL `{value}`: {source}")]
+    InvalidTemplateBaseUrl {
+        value: String,
+        #[source]
+        source: url::ParseError,
+    },
+    #[error("failed to fetch template asset {path} from {url}: {source}")]
+    FetchTemplate {
+        path: &'static str,
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("failed to fetch template asset {path} from {url}: HTTP {status}")]
+    FetchTemplateStatus {
+        path: &'static str,
+        url: String,
+        status: StatusCode,
+    },
+    #[error("template asset {path} from {url} was not valid UTF-8: {source}")]
+    DecodeTemplate {
+        path: &'static str,
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("failed to read {path}: {source}")]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to create {path}: {source}")]
+    CreateDir {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to write {path}: {source}")]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to read interactive input: {0}")]
+    PromptIo(#[source] io::Error),
+    #[error("input closed while waiting for a response")]
+    PromptClosed,
+    #[error("initialization aborted")]
+    AbortedByUser,
+}
+
+#[derive(Clone, Copy)]
+struct TemplateAsset {
+    path: &'static str,
+    kind: AssetKind,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AssetKind {
+    Standard,
+    Agents,
+    Workflow,
+}
+
+#[derive(Clone)]
+struct FetchedAsset {
+    definition: TemplateAsset,
+    contents: String,
+}
+
+enum PlannedAction {
+    Create,
+    Prompt,
+    Overwrite,
+    Skip,
+    Unchanged,
+    MergeAgents,
+    CustomizeWorkflow,
+}
+
+struct PlannedAsset {
+    asset: FetchedAsset,
+    existing: Option<String>,
+    action: PlannedAction,
+}
+
+enum AppliedChange {
+    Created,
+    Overwritten,
+    Updated,
+    Merged,
+    Skipped,
+    Unchanged,
+}
+
+enum GitRemoteDetection {
+    Selected { remote_name: String, url: String },
+    None,
+    Ambiguous(Vec<String>),
+}
+
+trait EnvLookup {
+    fn get(&self, name: &str) -> Option<String>;
+}
+
+struct ProcessEnvironment;
+
+impl EnvLookup for ProcessEnvironment {
+    fn get(&self, name: &str) -> Option<String> {
+        env::var(name)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    }
+}
+
+struct PromptUi<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> PromptUi<R, W>
+where
+    R: BufRead,
+    W: Write,
+{
+    fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+
+    fn line(&mut self, message: impl AsRef<str>) -> Result<(), InitCommandError> {
+        writeln!(self.writer, "{}", message.as_ref()).map_err(InitCommandError::PromptIo)
+    }
+
+    fn blank_line(&mut self) -> Result<(), InitCommandError> {
+        writeln!(self.writer).map_err(InitCommandError::PromptIo)
+    }
+
+    fn prompt(&mut self, prompt: &str) -> Result<String, InitCommandError> {
+        write!(self.writer, "{prompt}").map_err(InitCommandError::PromptIo)?;
+        self.writer.flush().map_err(InitCommandError::PromptIo)?;
+
+        let mut response = String::new();
+        let bytes = self
+            .reader
+            .read_line(&mut response)
+            .map_err(InitCommandError::PromptIo)?;
+        if bytes == 0 {
+            return Err(InitCommandError::PromptClosed);
+        }
+
+        while response.ends_with('\n') || response.ends_with('\r') {
+            response.pop();
+        }
+        Ok(response)
+    }
+}
+
+const TEMPLATE_ASSETS: &[TemplateAsset] = &[
+    TemplateAsset {
+        path: "WORKFLOW.md",
+        kind: AssetKind::Workflow,
+    },
+    TemplateAsset {
+        path: "AGENTS.md",
+        kind: AssetKind::Agents,
+    },
+    TemplateAsset {
+        path: "config.yaml",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".gitignore",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/commit/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/convert-tasks-to-linear/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/create-implementation-plan/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/land/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/linear/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/pull/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".agents/skills/push/SKILL.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".github/CODEOWNERS",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".github/pull_request_template.md",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: ".github/workflows/ai-pr-review.yml",
+        kind: AssetKind::Standard,
+    },
+    TemplateAsset {
+        path: "docs/tasks/README.md",
+        kind: AssetKind::Standard,
+    },
+];
+
+pub async fn run_command(args: InitArgs) -> ExitCode {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut ui = PromptUi::new(stdin.lock(), stdout.lock());
+
+    match run_init(args, &ProcessEnvironment, &mut ui).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            let _ = ui.blank_line();
+            let _ = ui.line(format!("opensymphony init failed: {error}"));
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run_init<R, W, E>(
+    args: InitArgs,
+    env_lookup: &E,
+    ui: &mut PromptUi<R, W>,
+) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+    E: EnvLookup,
+{
+    let _ = args;
+
+    let target_repo = env::current_dir().map_err(InitCommandError::CurrentDir)?;
+    let client = Client::builder()
+        .user_agent(concat!("opensymphony-cli/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(InitCommandError::HttpClient)?;
+
+    ui.line(format!(
+        "Initializing OpenSymphony files in {}",
+        target_repo.display()
+    ))?;
+    ui.line("Fetching the current template payload from GitHub...")?;
+
+    let fetched_assets = fetch_template_assets(&client).await?;
+    let mut planned_assets = plan_assets(&target_repo, fetched_assets)?;
+    resolve_conflicts(&mut planned_assets, ui)?;
+
+    let workflow_will_change = planned_assets.iter().any(|planned| {
+        planned.asset.definition.kind == AssetKind::Workflow
+            && matches!(
+                planned.action,
+                PlannedAction::Create | PlannedAction::Overwrite | PlannedAction::CustomizeWorkflow
+            )
+    });
+
+    let git_remote = detect_git_remote_url(&target_repo);
+    match &git_remote {
+        GitRemoteDetection::Selected { remote_name, url } => {
+            ui.line(format!(
+                "Detected git remote `{remote_name}` -> {url}; `WORKFLOW.md` will use it for the clone hook."
+            ))?;
+        }
+        GitRemoteDetection::None => {
+            ui.line(
+                "No git remote URL detected; `WORKFLOW.md` will keep its clone URL placeholder.",
+            )?;
+        }
+        GitRemoteDetection::Ambiguous(remotes) => {
+            ui.line(format!(
+                "Found multiple git remotes without `origin` ({}); `WORKFLOW.md` will keep its clone URL placeholder.",
+                remotes.join(", ")
+            ))?;
+        }
+    }
+
+    let linear_project_slug = if workflow_will_change {
+        let response =
+            ui.prompt("Enter your Linear project slug/key (leave blank to set it later): ")?;
+        let response = response.trim();
+        (!response.is_empty()).then(|| response.to_owned())
+    } else {
+        None
+    };
+
+    let mut created = Vec::new();
+    let mut overwritten = Vec::new();
+    let mut updated = Vec::new();
+    let mut merged = Vec::new();
+    let mut skipped = Vec::new();
+    let mut unchanged = Vec::new();
+    let mut wrote_config = false;
+
+    for planned in planned_assets {
+        let destination = target_repo.join(planned.asset.definition.path);
+        let relative_path = planned.asset.definition.path.to_owned();
+
+        let final_result = apply_asset(
+            &destination,
+            planned,
+            git_remote_url(&git_remote),
+            linear_project_slug.as_deref(),
+        )?;
+
+        match final_result {
+            AppliedChange::Created => {
+                if relative_path == "config.yaml" {
+                    wrote_config = true;
+                }
+                created.push(relative_path);
+            }
+            AppliedChange::Overwritten => {
+                if relative_path == "config.yaml" {
+                    wrote_config = true;
+                }
+                overwritten.push(relative_path);
+            }
+            AppliedChange::Updated => {
+                if relative_path == "config.yaml" {
+                    wrote_config = true;
+                }
+                updated.push(relative_path);
+            }
+            AppliedChange::Merged => merged.push(relative_path),
+            AppliedChange::Skipped => skipped.push(relative_path),
+            AppliedChange::Unchanged => unchanged.push(relative_path),
+        }
+    }
+
+    ui.blank_line()?;
+    ui.line("Initialization summary:")?;
+    print_group(ui, "Created", &created)?;
+    print_group(ui, "Overwritten", &overwritten)?;
+    print_group(ui, "Updated", &updated)?;
+    print_group(ui, "Merged", &merged)?;
+    print_group(ui, "Skipped", &skipped)?;
+    print_group(ui, "Unchanged", &unchanged)?;
+
+    if wrote_config {
+        ui.blank_line()?;
+        ui.line(
+            "Review `config.yaml` and update `openhands.tool_dir` if the copied template path does not match your machine.",
+        )?;
+    }
+
+    prompt_for_missing_llm_env(env_lookup, ui)?;
+
+    ui.blank_line()?;
+    ui.line("OpenSymphony init complete.")?;
+    Ok(())
+}
+
+async fn fetch_template_assets(client: &Client) -> Result<Vec<FetchedAsset>, InitCommandError> {
+    let base_url = env::var("OPENSYMPHONY_TEMPLATE_BASE_URL")
+        .unwrap_or_else(|_| DEFAULT_TEMPLATE_BASE_URL.to_string());
+    let base_url =
+        Url::parse(&base_url).map_err(|source| InitCommandError::InvalidTemplateBaseUrl {
+            value: base_url.clone(),
+            source,
+        })?;
+
+    let mut fetched = Vec::with_capacity(TEMPLATE_ASSETS.len());
+    for definition in TEMPLATE_ASSETS {
+        let url = base_url.join(definition.path).map_err(|source| {
+            InitCommandError::InvalidTemplateBaseUrl {
+                value: format!("{base_url}{}", definition.path),
+                source,
+            }
+        })?;
+        let response = client.get(url.clone()).send().await.map_err(|source| {
+            InitCommandError::FetchTemplate {
+                path: definition.path,
+                url: url.to_string(),
+                source,
+            }
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(InitCommandError::FetchTemplateStatus {
+                path: definition.path,
+                url: url.to_string(),
+                status,
+            });
+        }
+
+        let contents =
+            response
+                .text()
+                .await
+                .map_err(|source| InitCommandError::DecodeTemplate {
+                    path: definition.path,
+                    url: url.to_string(),
+                    source,
+                })?;
+
+        fetched.push(FetchedAsset {
+            definition: *definition,
+            contents,
+        });
+    }
+
+    Ok(fetched)
+}
+
+fn plan_assets(
+    target_repo: &Path,
+    assets: Vec<FetchedAsset>,
+) -> Result<Vec<PlannedAsset>, InitCommandError> {
+    let mut planned = Vec::with_capacity(assets.len());
+
+    for asset in assets {
+        let destination = target_repo.join(asset.definition.path);
+        match fs::read_to_string(&destination) {
+            Ok(existing) => {
+                let action = match asset.definition.kind {
+                    AssetKind::Agents => {
+                        if comparable_text(&existing) == comparable_text(&asset.contents)
+                            || agents_already_initialized(&existing, &asset.contents)
+                        {
+                            PlannedAction::Unchanged
+                        } else {
+                            PlannedAction::MergeAgents
+                        }
+                    }
+                    AssetKind::Workflow => {
+                        if comparable_text(&existing) == comparable_text(&asset.contents) {
+                            PlannedAction::CustomizeWorkflow
+                        } else {
+                            PlannedAction::Prompt
+                        }
+                    }
+                    AssetKind::Standard => {
+                        if comparable_text(&existing) == comparable_text(&asset.contents) {
+                            PlannedAction::Unchanged
+                        } else {
+                            PlannedAction::Prompt
+                        }
+                    }
+                };
+
+                planned.push(PlannedAsset {
+                    asset,
+                    existing: Some(existing),
+                    action,
+                });
+            }
+            Err(source) if source.kind() == io::ErrorKind::NotFound => {
+                planned.push(PlannedAsset {
+                    asset,
+                    existing: None,
+                    action: PlannedAction::Create,
+                });
+            }
+            Err(source) => {
+                return Err(InitCommandError::ReadFile {
+                    path: destination,
+                    source,
+                });
+            }
+        }
+    }
+
+    Ok(planned)
+}
+
+fn resolve_conflicts<R, W>(
+    planned_assets: &mut [PlannedAsset],
+    ui: &mut PromptUi<R, W>,
+) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    for planned in planned_assets {
+        if !matches!(planned.action, PlannedAction::Prompt) {
+            continue;
+        }
+
+        let relative_path = Path::new(planned.asset.definition.path);
+        let display_path = relative_path.display();
+
+        loop {
+            ui.blank_line()?;
+            ui.line(format!("`{display_path}` already exists."))?;
+            let response = ui.prompt("Choose [s]kip, [o]verwrite, or [a]bort: ")?;
+            match response.trim().to_ascii_lowercase().as_str() {
+                "s" | "skip" => {
+                    planned.action = PlannedAction::Skip;
+                    break;
+                }
+                "o" | "overwrite" => {
+                    planned.action = PlannedAction::Overwrite;
+                    break;
+                }
+                "a" | "abort" => return Err(InitCommandError::AbortedByUser),
+                _ => {
+                    ui.line("Please answer with `skip`, `overwrite`, or `abort`.")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_asset(
+    destination: &Path,
+    planned: PlannedAsset,
+    git_remote_url: Option<&str>,
+    linear_project_slug: Option<&str>,
+) -> Result<AppliedChange, InitCommandError> {
+    let existing = planned.existing.as_deref();
+
+    let Some(final_contents) = build_final_contents(
+        &planned.asset,
+        &planned.action,
+        existing,
+        git_remote_url,
+        linear_project_slug,
+    ) else {
+        return Ok(match planned.action {
+            PlannedAction::Skip => AppliedChange::Skipped,
+            PlannedAction::Unchanged => AppliedChange::Unchanged,
+            PlannedAction::Create
+            | PlannedAction::Overwrite
+            | PlannedAction::MergeAgents
+            | PlannedAction::CustomizeWorkflow
+            | PlannedAction::Prompt => AppliedChange::Unchanged,
+        });
+    };
+
+    if let Some(existing) = existing
+        && comparable_text(existing) == comparable_text(&final_contents)
+    {
+        return Ok(AppliedChange::Unchanged);
+    }
+
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|source| InitCommandError::CreateDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::write(destination, final_contents).map_err(|source| InitCommandError::WriteFile {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+
+    Ok(match planned.action {
+        PlannedAction::Create => AppliedChange::Created,
+        PlannedAction::Overwrite => AppliedChange::Overwritten,
+        PlannedAction::CustomizeWorkflow => AppliedChange::Updated,
+        PlannedAction::MergeAgents => AppliedChange::Merged,
+        PlannedAction::Skip => AppliedChange::Skipped,
+        PlannedAction::Unchanged => AppliedChange::Unchanged,
+        PlannedAction::Prompt => unreachable!("conflicts should be resolved before apply"),
+    })
+}
+
+fn build_final_contents(
+    asset: &FetchedAsset,
+    action: &PlannedAction,
+    existing: Option<&str>,
+    git_remote_url: Option<&str>,
+    linear_project_slug: Option<&str>,
+) -> Option<String> {
+    match action {
+        PlannedAction::Create | PlannedAction::Overwrite => Some(match asset.definition.kind {
+            AssetKind::Workflow => {
+                customize_workflow(&asset.contents, git_remote_url, linear_project_slug)
+            }
+            _ => asset.contents.clone(),
+        }),
+        PlannedAction::CustomizeWorkflow => Some(customize_workflow(
+            &asset.contents,
+            git_remote_url,
+            linear_project_slug,
+        )),
+        PlannedAction::MergeAgents => Some(match existing {
+            Some(existing) if !existing.trim().is_empty() => {
+                merge_agents(&asset.contents, existing)
+            }
+            _ => asset.contents.clone(),
+        }),
+        PlannedAction::Skip | PlannedAction::Unchanged => None,
+        PlannedAction::Prompt => None,
+    }
+}
+
+fn prompt_for_missing_llm_env<R, W, E>(
+    env_lookup: &E,
+    ui: &mut PromptUi<R, W>,
+) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+    E: EnvLookup,
+{
+    let mut exports = Vec::new();
+
+    if env_lookup.get("LLM_MODEL").is_none() {
+        let response = ui.prompt(&format!(
+            "LLM_MODEL is not set. Enter a model now, or press Enter to use `{DEFAULT_LLM_MODEL}`: "
+        ))?;
+        let value = match response.trim() {
+            "" => DEFAULT_LLM_MODEL.to_string(),
+            custom => custom.to_string(),
+        };
+        exports.push(("LLM_MODEL", value));
+    }
+
+    if env_lookup.get("LLM_API_KEY").is_none() {
+        let response = ui.prompt(
+            "LLM_API_KEY is not set. Press Enter to use the placeholder `<your-llm-api-key>` in the export snippet, or type a different placeholder label: ",
+        )?;
+        let value = match response.trim() {
+            "" => "<your-llm-api-key>".to_string(),
+            custom => custom.to_string(),
+        };
+        exports.push(("LLM_API_KEY", value));
+    }
+
+    if env_lookup.get("LLM_BASE_URL").is_none() {
+        let response = ui.prompt(&format!(
+            "LLM_BASE_URL is not set. Enter a base URL now, or press Enter to use `{DEFAULT_LLM_BASE_URL}`: "
+        ))?;
+        let value = match response.trim() {
+            "" => DEFAULT_LLM_BASE_URL.to_string(),
+            custom => custom.to_string(),
+        };
+        exports.push(("LLM_BASE_URL", value));
+    }
+
+    if exports.is_empty() {
+        return Ok(());
+    }
+
+    ui.blank_line()?;
+    ui.line("Before `opensymphony run`, export these in your shell:")?;
+    for (name, value) in exports {
+        ui.line(format!("export {name}={}", shell_single_quote(&value)))?;
+    }
+    Ok(())
+}
+
+fn detect_git_remote_url(target_repo: &Path) -> GitRemoteDetection {
+    let output = std::process::Command::new("git")
+        .args(["remote"])
+        .current_dir(target_repo)
+        .output();
+    let Ok(output) = output else {
+        return GitRemoteDetection::None;
+    };
+    if !output.status.success() {
+        return GitRemoteDetection::None;
+    }
+
+    let remotes = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let Some(remote_name) = select_remote_name(&remotes) else {
+        return if remotes.len() > 1 {
+            GitRemoteDetection::Ambiguous(remotes)
+        } else {
+            GitRemoteDetection::None
+        };
+    };
+
+    let get_url = std::process::Command::new("git")
+        .args(["remote", "get-url", &remote_name])
+        .current_dir(target_repo)
+        .output();
+    let Ok(get_url) = get_url else {
+        return GitRemoteDetection::None;
+    };
+    if !get_url.status.success() {
+        return GitRemoteDetection::None;
+    }
+
+    let url = String::from_utf8_lossy(&get_url.stdout).trim().to_owned();
+    if url.is_empty() {
+        GitRemoteDetection::None
+    } else {
+        GitRemoteDetection::Selected { remote_name, url }
+    }
+}
+
+fn select_remote_name(remotes: &[String]) -> Option<String> {
+    if remotes.iter().any(|remote| remote == "origin") {
+        Some("origin".to_string())
+    } else if remotes.len() == 1 {
+        remotes.first().cloned()
+    } else {
+        None
+    }
+}
+
+fn git_remote_url(detection: &GitRemoteDetection) -> Option<&str> {
+    match detection {
+        GitRemoteDetection::Selected { url, .. } => Some(url.as_str()),
+        GitRemoteDetection::None | GitRemoteDetection::Ambiguous(_) => None,
+    }
+}
+
+fn agents_already_initialized(existing: &str, template: &str) -> bool {
+    comparable_text(existing).starts_with(&comparable_text(template))
+        || existing.contains(PRESERVED_AGENTS_MARKER)
+}
+
+fn merge_agents(template: &str, existing: &str) -> String {
+    let mut merged = template.trim_end().to_string();
+    if existing.trim().is_empty() {
+        merged.push('\n');
+        return merged;
+    }
+
+    merged.push_str("\n\n");
+    merged.push_str(PRESERVED_AGENTS_MARKER);
+    merged.push_str("\n\n");
+    merged.push_str(
+        "The following content was preserved from the repository's previous `AGENTS.md` during `opensymphony init`.\n\n",
+    );
+    merged.push_str(existing.trim());
+    merged.push('\n');
+    merged
+}
+
+fn customize_workflow(
+    template: &str,
+    git_remote_url: Option<&str>,
+    linear_project_slug: Option<&str>,
+) -> String {
+    let mut customized = template.to_string();
+
+    if let Some(url) = git_remote_url {
+        customized = customized.replace(WORKFLOW_GIT_REMOTE_PLACEHOLDER, &shell_single_quote(url));
+    }
+
+    if let Some(slug) = linear_project_slug
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty())
+    {
+        customized =
+            customized.replace(WORKFLOW_PROJECT_SLUG_PLACEHOLDER, &yaml_double_quote(slug));
+    }
+
+    customized
+}
+
+fn comparable_text(value: &str) -> String {
+    value.replace("\r\n", "\n").trim_end().to_owned()
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn yaml_double_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn print_group<R, W>(
+    ui: &mut PromptUi<R, W>,
+    label: &str,
+    items: &[String],
+) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    ui.line(format!("{label}:"))?;
+    for item in items {
+        ui.line(format!("- {item}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::{
+        DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL, GitRemoteDetection, PRESERVED_AGENTS_MARKER,
+        PromptUi, agents_already_initialized, comparable_text, customize_workflow, git_remote_url,
+        merge_agents, prompt_for_missing_llm_env, select_remote_name, shell_single_quote,
+    };
+
+    struct StubEnvironment {
+        values: BTreeMap<String, String>,
+    }
+
+    impl super::EnvLookup for StubEnvironment {
+        fn get(&self, name: &str) -> Option<String> {
+            self.values.get(name).cloned()
+        }
+    }
+
+    #[test]
+    fn customize_workflow_replaces_repo_url_and_project_slug() {
+        let workflow = r#"---
+tracker:
+  project_slug: "YOUR-PROJECT-SLUG"
+hooks:
+  after_create: |
+    git clone --depth 1 https://github.com/YOUR-ORG/YOUR-REPO.git .
+---
+"#;
+
+        let customized = customize_workflow(
+            workflow,
+            Some("git@github.com:kumanday/demo.git"),
+            Some("demo-project"),
+        );
+
+        assert!(customized.contains("project_slug: \"demo-project\""));
+        assert!(customized.contains("git clone --depth 1 'git@github.com:kumanday/demo.git' ."));
+    }
+
+    #[test]
+    fn customize_workflow_replaces_placeholders_without_exact_line_matching() {
+        let workflow = r#"---
+tracker:
+  project_slug:    "YOUR-PROJECT-SLUG"
+hooks:
+  after_create: |
+        if [ ! -d .git ]; then git clone --depth 1 https://github.com/YOUR-ORG/YOUR-REPO.git .; fi
+---
+"#;
+
+        let customized = customize_workflow(
+            workflow,
+            Some("https://github.com/example/demo.git"),
+            Some("demo-project"),
+        );
+
+        assert!(customized.contains("project_slug:    \"demo-project\""));
+        assert!(customized.contains("git clone --depth 1 'https://github.com/example/demo.git' ."));
+    }
+
+    #[test]
+    fn merge_agents_appends_existing_content_under_marker() {
+        let template = "# AGENTS.md\n\nTemplate\n";
+        let existing = "# Existing\n\nRules";
+
+        let merged = merge_agents(template, existing);
+
+        assert!(merged.starts_with("# AGENTS.md"));
+        assert!(merged.contains(PRESERVED_AGENTS_MARKER));
+        assert!(merged.contains("# Existing\n\nRules"));
+    }
+
+    #[test]
+    fn agents_initialized_detection_handles_prefixed_template_content() {
+        let template = "# AGENTS.md\n\nTemplate\n";
+        let existing = format!("{template}\n\n## More Notes\n\nCustom");
+
+        assert!(agents_already_initialized(&existing, template));
+    }
+
+    #[test]
+    fn comparable_text_ignores_crlf_and_trailing_newlines() {
+        assert_eq!(comparable_text("a\r\nb\r\n"), comparable_text("a\nb\n\n"));
+    }
+
+    #[test]
+    fn select_remote_prefers_origin_then_single_remote() {
+        assert_eq!(
+            select_remote_name(&["fork".to_string(), "origin".to_string()]),
+            Some("origin".to_string())
+        );
+        assert_eq!(
+            select_remote_name(&["upstream".to_string()]),
+            Some("upstream".to_string())
+        );
+        assert_eq!(
+            select_remote_name(&["fork".to_string(), "upstream".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn git_remote_url_returns_selected_only() {
+        assert_eq!(
+            git_remote_url(&GitRemoteDetection::Selected {
+                remote_name: "origin".to_string(),
+                url: "https://github.com/kumanday/OpenSymphony-template.git".to_string(),
+            }),
+            Some("https://github.com/kumanday/OpenSymphony-template.git")
+        );
+        assert_eq!(git_remote_url(&GitRemoteDetection::None), None);
+        assert_eq!(
+            git_remote_url(&GitRemoteDetection::Ambiguous(vec!["fork".to_string()])),
+            None
+        );
+    }
+
+    #[test]
+    fn shell_single_quote_escapes_embedded_single_quotes() {
+        assert_eq!(shell_single_quote("abc'def"), "'abc'\\''def'");
+    }
+
+    #[test]
+    fn llm_defaults_match_fireworks_examples() {
+        assert_eq!(
+            DEFAULT_LLM_MODEL,
+            "openai/accounts/fireworks/models/glm-5p1"
+        );
+        assert_eq!(
+            DEFAULT_LLM_BASE_URL,
+            "https://api.fireworks.ai/inference/v1"
+        );
+    }
+
+    #[test]
+    fn missing_llm_env_prompts_render_fireworks_defaults() {
+        let env = StubEnvironment {
+            values: BTreeMap::new(),
+        };
+        let mut output = Vec::new();
+        let mut ui = PromptUi::new(&b"\n\n\n"[..], &mut output);
+
+        prompt_for_missing_llm_env(&env, &mut ui).expect("prompt should succeed");
+
+        let rendered = String::from_utf8(output).expect("prompt output should be utf-8");
+        assert!(rendered.contains("LLM_MODEL is not set."));
+        assert!(rendered.contains("openai/accounts/fireworks/models/glm-5p1"));
+        assert!(rendered.contains("https://api.fireworks.ai/inference/v1"));
+        assert!(rendered.contains("export LLM_API_KEY='<your-llm-api-key>'"));
+    }
+}

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -3,6 +3,7 @@ use std::{
     io::{self, BufRead, Write},
     path::{Path, PathBuf},
     process::ExitCode,
+    time::Duration,
 };
 
 use clap::Args;
@@ -11,8 +12,15 @@ use thiserror::Error;
 
 const DEFAULT_TEMPLATE_BASE_URL: &str =
     "https://raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main/";
+const DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_LLM_MODEL: &str = "openai/accounts/fireworks/models/glm-5p1";
 const DEFAULT_LLM_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
+const DEFAULT_AI_REVIEW_PROVIDER_KIND: &str = "openai-compatible";
+const DEFAULT_AI_REVIEW_MODEL_ID: &str = "accounts/fireworks/models/glm-5p1";
+const DEFAULT_AI_REVIEW_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
+const DEFAULT_AI_REVIEW_STYLE: &str = "standard";
+const DEFAULT_AI_REVIEW_REQUIRE_EVIDENCE: &str = "true";
+const AI_REVIEW_LABEL_NAME: &str = "review-this";
 const PRESERVED_AGENTS_MARKER: &str = "## Preserved Existing AGENTS.md";
 const WORKFLOW_PROJECT_SLUG_PLACEHOLDER: &str = "\"YOUR-PROJECT-SLUG\"";
 const WORKFLOW_GIT_REMOTE_PLACEHOLDER: &str = "https://github.com/YOUR-ORG/YOUR-REPO.git";
@@ -185,7 +193,7 @@ where
     }
 }
 
-const TEMPLATE_ASSETS: &[TemplateAsset] = &[
+const CORE_TEMPLATE_ASSETS: &[TemplateAsset] = &[
     TemplateAsset {
         path: "WORKFLOW.md",
         kind: AssetKind::Workflow,
@@ -239,14 +247,25 @@ const TEMPLATE_ASSETS: &[TemplateAsset] = &[
         kind: AssetKind::Standard,
     },
     TemplateAsset {
-        path: ".github/workflows/ai-pr-review.yml",
-        kind: AssetKind::Standard,
-    },
-    TemplateAsset {
         path: "docs/tasks/README.md",
         kind: AssetKind::Standard,
     },
 ];
+
+const AI_REVIEW_TEMPLATE_ASSETS: &[TemplateAsset] = &[TemplateAsset {
+    path: ".github/workflows/ai-pr-review.yml",
+    kind: AssetKind::Standard,
+}];
+
+const AI_REVIEW_SETUP_DOC_ASSET: TemplateAsset = TemplateAsset {
+    path: "docs/ai-pr-review-human-setup.md",
+    kind: AssetKind::Standard,
+};
+
+const AI_REVIEW_CUSTOM_GUIDE_ASSET: TemplateAsset = TemplateAsset {
+    path: ".agents/skills/custom-codereview-guide.md",
+    kind: AssetKind::Standard,
+};
 
 pub async fn run_command(args: InitArgs) -> ExitCode {
     let stdin = io::stdin();
@@ -276,18 +295,27 @@ where
     let _ = args;
 
     let target_repo = env::current_dir().map_err(InitCommandError::CurrentDir)?;
-    let client = Client::builder()
-        .user_agent(concat!("opensymphony-cli/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .map_err(InitCommandError::HttpClient)?;
-
     ui.line(format!(
         "Initializing OpenSymphony files in {}",
         target_repo.display()
     ))?;
+    let enable_ai_pr_review = prompt_yes_no(
+        ui,
+        "Also scaffold automated OpenHands AI PR review? [y/N]: ",
+        false,
+    )?;
+    let client = Client::builder()
+        .user_agent(concat!("opensymphony-cli/", env!("CARGO_PKG_VERSION")))
+        .timeout(template_fetch_timeout())
+        .build()
+        .map_err(InitCommandError::HttpClient)?;
     ui.line("Fetching the current template payload from GitHub...")?;
 
-    let fetched_assets = fetch_template_assets(&client).await?;
+    let mut fetched_assets = fetch_template_assets(&client, CORE_TEMPLATE_ASSETS).await?;
+    if enable_ai_pr_review {
+        fetched_assets.extend(fetch_template_assets(&client, AI_REVIEW_TEMPLATE_ASSETS).await?);
+        fetched_assets.extend(generated_ai_review_assets());
+    }
     let mut planned_assets = plan_assets(&target_repo, fetched_assets)?;
     resolve_conflicts(&mut planned_assets, ui)?;
 
@@ -388,6 +416,10 @@ where
         )?;
     }
 
+    if enable_ai_pr_review {
+        print_ai_pr_review_guidance(ui)?;
+    }
+
     prompt_for_missing_llm_env(env_lookup, ui)?;
 
     ui.blank_line()?;
@@ -395,7 +427,10 @@ where
     Ok(())
 }
 
-async fn fetch_template_assets(client: &Client) -> Result<Vec<FetchedAsset>, InitCommandError> {
+async fn fetch_template_assets(
+    client: &Client,
+    assets: &[TemplateAsset],
+) -> Result<Vec<FetchedAsset>, InitCommandError> {
     let base_url = env::var("OPENSYMPHONY_TEMPLATE_BASE_URL")
         .unwrap_or_else(|_| DEFAULT_TEMPLATE_BASE_URL.to_string());
     let base_url =
@@ -404,8 +439,8 @@ async fn fetch_template_assets(client: &Client) -> Result<Vec<FetchedAsset>, Ini
             source,
         })?;
 
-    let mut fetched = Vec::with_capacity(TEMPLATE_ASSETS.len());
-    for definition in TEMPLATE_ASSETS {
+    let mut fetched = Vec::with_capacity(assets.len());
+    for definition in assets {
         let url = base_url.join(definition.path).map_err(|source| {
             InitCommandError::InvalidTemplateBaseUrl {
                 value: format!("{base_url}{}", definition.path),
@@ -446,6 +481,19 @@ async fn fetch_template_assets(client: &Client) -> Result<Vec<FetchedAsset>, Ini
     }
 
     Ok(fetched)
+}
+
+fn generated_ai_review_assets() -> Vec<FetchedAsset> {
+    vec![
+        FetchedAsset {
+            definition: AI_REVIEW_SETUP_DOC_ASSET,
+            contents: ai_pr_review_setup_doc_contents(),
+        },
+        FetchedAsset {
+            definition: AI_REVIEW_CUSTOM_GUIDE_ASSET,
+            contents: custom_codereview_guide_contents(),
+        },
+    ]
 }
 
 fn plan_assets(
@@ -689,6 +737,44 @@ where
     Ok(())
 }
 
+fn prompt_yes_no<R, W>(
+    ui: &mut PromptUi<R, W>,
+    prompt: &str,
+    default: bool,
+) -> Result<bool, InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    loop {
+        let response = ui.prompt(prompt)?;
+        match response.trim().to_ascii_lowercase().as_str() {
+            "" => return Ok(default),
+            "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => {
+                ui.line("Please answer with `yes` or `no`.")?;
+            }
+        }
+    }
+}
+
+fn template_fetch_timeout() -> Duration {
+    template_fetch_timeout_from_env(
+        env::var("OPENSYMPHONY_TEMPLATE_FETCH_TIMEOUT_MS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn template_fetch_timeout_from_env(value: Option<&str>) -> Duration {
+    value
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|timeout_ms| *timeout_ms > 0)
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| Duration::from_millis(DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS))
+}
+
 fn detect_git_remote_url(target_repo: &Path) -> GitRemoteDetection {
     let output = std::process::Command::new("git")
         .args(["remote"])
@@ -808,6 +894,168 @@ fn yaml_double_quote(value: &str) -> String {
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
+fn ai_pr_review_setup_doc_contents() -> String {
+    format!(
+        r#"# OpenHands AI PR Review Setup
+
+This repository was bootstrapped with OpenHands AI PR review support via `opensymphony init`.
+
+## Files Added
+
+- `.github/workflows/ai-pr-review.yml`
+- `.agents/skills/custom-codereview-guide.md`
+
+## GitHub Actions Secret
+
+Add this repository secret under **Settings -> Secrets and variables -> Actions**:
+
+| Name | Value |
+|------|-------|
+| `FIREWORKS_API_KEY` | Your Fireworks API key |
+
+## GitHub Actions Variables
+
+Add these repository variables under **Settings -> Secrets and variables -> Actions -> Variables**:
+
+| Name | Value |
+|------|-------|
+| `AI_REVIEW_PROVIDER_KIND` | `{provider_kind}` |
+| `AI_REVIEW_MODEL_ID` | `{model_id}` |
+| `AI_REVIEW_BASE_URL` | `{base_url}` |
+| `AI_REVIEW_STYLE` | `{style}` |
+| `AI_REVIEW_REQUIRE_EVIDENCE` | `{require_evidence}` |
+
+## Label
+
+Create the `{label}` label so maintainers can retrigger review on demand.
+
+```bash
+gh label create {quoted_label} --description 'Trigger AI PR review' --color 'd73a4a' || true
+```
+
+## Optional GitHub CLI Commands
+
+```bash
+gh variable set AI_REVIEW_PROVIDER_KIND --body {quoted_provider_kind}
+gh variable set AI_REVIEW_MODEL_ID --body {quoted_model_id}
+gh variable set AI_REVIEW_BASE_URL --body {quoted_base_url}
+gh variable set AI_REVIEW_STYLE --body {quoted_style}
+gh variable set AI_REVIEW_REQUIRE_EVIDENCE --body {quoted_require_evidence}
+gh secret set FIREWORKS_API_KEY
+```
+
+## Notes
+
+- If your organization restricts Actions, allow `OpenHands/extensions`.
+- Do not make the AI review workflow a required status check.
+- Keep the workflow on GitHub-hosted runners unless you have separately reviewed the risk model for untrusted PR content.
+"#,
+        provider_kind = DEFAULT_AI_REVIEW_PROVIDER_KIND,
+        model_id = DEFAULT_AI_REVIEW_MODEL_ID,
+        base_url = DEFAULT_AI_REVIEW_BASE_URL,
+        style = DEFAULT_AI_REVIEW_STYLE,
+        require_evidence = DEFAULT_AI_REVIEW_REQUIRE_EVIDENCE,
+        label = AI_REVIEW_LABEL_NAME,
+        quoted_label = shell_single_quote(AI_REVIEW_LABEL_NAME),
+        quoted_provider_kind = shell_single_quote(DEFAULT_AI_REVIEW_PROVIDER_KIND),
+        quoted_model_id = shell_single_quote(DEFAULT_AI_REVIEW_MODEL_ID),
+        quoted_base_url = shell_single_quote(DEFAULT_AI_REVIEW_BASE_URL),
+        quoted_style = shell_single_quote(DEFAULT_AI_REVIEW_STYLE),
+        quoted_require_evidence = shell_single_quote(DEFAULT_AI_REVIEW_REQUIRE_EVIDENCE),
+    )
+}
+
+fn custom_codereview_guide_contents() -> String {
+    r#"---
+name: custom-codereview-guide
+description: |
+  Repository-specific code review guidance for this project.
+  Update this file so OpenHands PR review focuses on the right risks.
+---
+
+# Custom Code Review Guide
+
+OpenHands PR review will load this file when it is present. Replace this starter content with repository-specific expectations.
+
+## Default Priorities
+
+- Prioritize correctness, regressions, security risks, and missing tests ahead of style-only feedback.
+- Treat behavior changes as incomplete unless the PR includes concrete verification or evidence.
+- Call out risky data migrations, auth changes, concurrency hazards, and production operability regressions explicitly.
+
+## Customize For This Repository
+
+- List the most security-sensitive paths or subsystems.
+- List required validation commands reviewers should expect to see.
+- Describe any architecture invariants that must not be broken.
+- Add framework- or language-specific review heuristics that matter here.
+
+## Evidence Expectations
+
+- Behavior changes should include test or reproduction output.
+- UI changes should include screenshots or recordings.
+- Performance-sensitive changes should include benchmark data or timing notes.
+"#
+    .to_string()
+}
+
+fn print_ai_pr_review_guidance<R, W>(ui: &mut PromptUi<R, W>) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    ui.blank_line()?;
+    ui.line("OpenHands AI PR review scaffolding was added.")?;
+    ui.line("Next steps for GitHub Actions setup:")?;
+    ui.line("- secret: FIREWORKS_API_KEY=<your-fireworks-api-key>")?;
+    ui.line(format!(
+        "- variable: AI_REVIEW_PROVIDER_KIND={DEFAULT_AI_REVIEW_PROVIDER_KIND}"
+    ))?;
+    ui.line(format!(
+        "- variable: AI_REVIEW_MODEL_ID={DEFAULT_AI_REVIEW_MODEL_ID}"
+    ))?;
+    ui.line(format!(
+        "- variable: AI_REVIEW_BASE_URL={DEFAULT_AI_REVIEW_BASE_URL}"
+    ))?;
+    ui.line(format!(
+        "- variable: AI_REVIEW_STYLE={DEFAULT_AI_REVIEW_STYLE}"
+    ))?;
+    ui.line(format!(
+        "- variable: AI_REVIEW_REQUIRE_EVIDENCE={DEFAULT_AI_REVIEW_REQUIRE_EVIDENCE}"
+    ))?;
+    ui.line(format!(
+        "- label: `{AI_REVIEW_LABEL_NAME}` for manual reruns"
+    ))?;
+    ui.line("GitHub CLI examples:")?;
+    ui.line(format!(
+        "gh variable set AI_REVIEW_PROVIDER_KIND --body {}",
+        shell_single_quote(DEFAULT_AI_REVIEW_PROVIDER_KIND)
+    ))?;
+    ui.line(format!(
+        "gh variable set AI_REVIEW_MODEL_ID --body {}",
+        shell_single_quote(DEFAULT_AI_REVIEW_MODEL_ID)
+    ))?;
+    ui.line(format!(
+        "gh variable set AI_REVIEW_BASE_URL --body {}",
+        shell_single_quote(DEFAULT_AI_REVIEW_BASE_URL)
+    ))?;
+    ui.line(format!(
+        "gh variable set AI_REVIEW_STYLE --body {}",
+        shell_single_quote(DEFAULT_AI_REVIEW_STYLE)
+    ))?;
+    ui.line(format!(
+        "gh variable set AI_REVIEW_REQUIRE_EVIDENCE --body {}",
+        shell_single_quote(DEFAULT_AI_REVIEW_REQUIRE_EVIDENCE)
+    ))?;
+    ui.line("gh secret set FIREWORKS_API_KEY")?;
+    ui.line(format!(
+        "gh label create {} --description 'Trigger AI PR review' --color 'd73a4a' || true",
+        shell_single_quote(AI_REVIEW_LABEL_NAME)
+    ))?;
+    ui.line("See `docs/ai-pr-review-human-setup.md` for the full setup checklist.")?;
+    Ok(())
+}
+
 fn print_group<R, W>(
     ui: &mut PromptUi<R, W>,
     label: &str,
@@ -831,11 +1079,16 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::time::Duration;
 
     use super::{
-        DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL, GitRemoteDetection, PRESERVED_AGENTS_MARKER,
-        PromptUi, agents_already_initialized, comparable_text, customize_workflow, git_remote_url,
-        merge_agents, prompt_for_missing_llm_env, select_remote_name, shell_single_quote,
+        AI_REVIEW_LABEL_NAME, DEFAULT_AI_REVIEW_BASE_URL, DEFAULT_AI_REVIEW_MODEL_ID,
+        DEFAULT_AI_REVIEW_PROVIDER_KIND, DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL,
+        DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS, GitRemoteDetection, PRESERVED_AGENTS_MARKER, PromptUi,
+        agents_already_initialized, ai_pr_review_setup_doc_contents, comparable_text,
+        custom_codereview_guide_contents, customize_workflow, git_remote_url, merge_agents,
+        prompt_for_missing_llm_env, prompt_yes_no, select_remote_name, shell_single_quote,
+        template_fetch_timeout_from_env,
     };
 
     struct StubEnvironment {
@@ -979,5 +1232,51 @@ hooks:
         assert!(rendered.contains("openai/accounts/fireworks/models/glm-5p1"));
         assert!(rendered.contains("https://api.fireworks.ai/inference/v1"));
         assert!(rendered.contains("export LLM_API_KEY='<your-llm-api-key>'"));
+    }
+
+    #[test]
+    fn prompt_yes_no_accepts_blank_as_default() {
+        let mut output = Vec::new();
+        let mut ui = PromptUi::new(&b"\n"[..], &mut output);
+
+        let accepted =
+            prompt_yes_no(&mut ui, "Enable? [y/N]: ", false).expect("prompt should succeed");
+
+        assert!(!accepted);
+    }
+
+    #[test]
+    fn template_fetch_timeout_uses_default_and_override() {
+        assert_eq!(
+            template_fetch_timeout_from_env(None),
+            Duration::from_millis(DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS)
+        );
+        assert_eq!(
+            template_fetch_timeout_from_env(Some("250")),
+            Duration::from_millis(250)
+        );
+        assert_eq!(
+            template_fetch_timeout_from_env(Some("not-a-number")),
+            Duration::from_millis(DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS)
+        );
+    }
+
+    #[test]
+    fn ai_pr_review_setup_doc_uses_fireworks_p1_defaults() {
+        let doc = ai_pr_review_setup_doc_contents();
+
+        assert!(doc.contains(DEFAULT_AI_REVIEW_PROVIDER_KIND));
+        assert!(doc.contains(DEFAULT_AI_REVIEW_MODEL_ID));
+        assert!(doc.contains(DEFAULT_AI_REVIEW_BASE_URL));
+        assert!(doc.contains(AI_REVIEW_LABEL_NAME));
+    }
+
+    #[test]
+    fn custom_codereview_guide_contains_starter_skill_metadata() {
+        let guide = custom_codereview_guide_contents();
+
+        assert!(guide.contains("name: custom-codereview-guide"));
+        assert!(guide.contains("Default Priorities"));
+        assert!(guide.contains("Evidence Expectations"));
     }
 }

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1,4 +1,5 @@
 mod debug_session;
+mod init_repo;
 mod orchestrator_run;
 
 use std::{
@@ -48,6 +49,8 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    #[command(about = "Initialize the current target repository with OpenSymphony files")]
+    Init(init_repo::InitArgs),
     #[command(about = "Run the real orchestrator against the current project workflow")]
     Run(orchestrator_run::RunArgs),
     #[command(about = "Resume an issue conversation for interactive debugging")]
@@ -278,6 +281,7 @@ pub async fn run() -> ExitCode {
     init_tracing();
     let cli = Cli::parse();
     match cli.command {
+        Command::Init(args) => init_repo::run_command(args).await,
         Command::Run(args) => orchestrator_run::run_command(args).await,
         Command::Debug(args) => debug_session::run_command(args).await,
         Command::Doctor(args) => run_doctor(args).await,
@@ -2191,6 +2195,7 @@ mod tests {
             .expect("CLI fixture should parse");
 
         match cli.command {
+            Command::Init(_) => panic!("expected daemon command"),
             Command::Daemon(args) => assert_eq!(args.sample_interval_ms.get(), 250),
             Command::Run(_)
             | Command::Debug(_)

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -2060,9 +2060,17 @@ async fn resolve_rehydrate_runtime(current_dir: &Path) -> Result<RehydrateRuntim
         .map_err(|e| format!("failed to read WORKFLOW.md: {}", e))?;
     let workflow_def = WorkflowDefinition::parse(&workflow_content)
         .map_err(|e| format!("failed to parse WORKFLOW.md: {}", e))?;
-    let workflow = workflow_def
-        .resolve_with_process_env(&target_repo)
-        .map_err(|e| format!("failed to resolve workflow: {}", e))?;
+    let workflow = if workflow_def.front_matter.tracker.api_key.is_some() {
+        workflow_def.resolve_with_process_env(&target_repo)
+    } else {
+        workflow_def.resolve(
+            &target_repo,
+            &DoctorWorkflowEnvironment {
+                fallback_linear_api_key: true,
+            },
+        )
+    }
+    .map_err(|e| format!("failed to resolve workflow: {}", e))?;
 
     Ok(RehydrateRuntimeConfig { workflow, tool_dir })
 }

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -16,6 +16,7 @@ fn top_level_help_describes_commands_and_safety_posture() {
     for snippet in [
         "Operate the OpenSymphony local MVP on a trusted machine",
         "process-level isolation only",
+        "Initialize the current target repository with OpenSymphony files",
         "Run the real orchestrator against the current project workflow",
         "Resume an issue conversation for interactive debugging",
         "Serve the local control-plane demo stream",

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -1,0 +1,308 @@
+use std::{collections::BTreeMap, process::Stdio, sync::Arc};
+
+use axum::{
+    Router,
+    extract::{Request, State},
+    http::{StatusCode, Uri},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use tempfile::TempDir;
+use tokio::{io::AsyncWriteExt, net::TcpListener, process::Command};
+
+#[tokio::test]
+async fn init_copies_template_files_and_customizes_workflow() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
+    write_stdin(&mut child, "demo-project\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+
+    let workflow =
+        std::fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+    assert!(workflow.contains("project_slug: \"demo-project\""));
+    assert!(workflow.contains("git clone --depth 1 'https://github.com/example/demo.git' ."));
+
+    assert!(
+        repo.path().join("AGENTS.md").is_file(),
+        "AGENTS.md should be created"
+    );
+    assert!(
+        repo.path().join(".agents/skills/pull/SKILL.md").is_file(),
+        "skill file should be created"
+    );
+    assert!(
+        repo.path().join("config.yaml").is_file(),
+        "config.yaml should be created"
+    );
+    assert!(
+        stdout.contains("Initialization summary"),
+        "stdout should contain a summary: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_merges_agents_and_skips_conflicting_file_when_requested() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    std::fs::write(
+        repo.path().join("AGENTS.md"),
+        "# Existing Agents\n\nKeep me.\n",
+    )
+    .expect("existing AGENTS should write");
+    std::fs::create_dir_all(repo.path().join(".github")).expect(".github should exist");
+    std::fs::write(
+        repo.path().join(".github/pull_request_template.md"),
+        "keep this template\n",
+    )
+    .expect("existing PR template should write");
+
+    let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
+    write_stdin(&mut child, "skip\ndemo-project\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+
+    let agents =
+        std::fs::read_to_string(repo.path().join("AGENTS.md")).expect("AGENTS.md should exist");
+    assert!(
+        agents.contains("## Preserved Existing AGENTS.md"),
+        "existing AGENTS content should be preserved: {agents}",
+    );
+    assert!(
+        agents.contains("# Existing Agents\n\nKeep me."),
+        "existing AGENTS text should be appended: {agents}",
+    );
+
+    let pr_template = std::fs::read_to_string(repo.path().join(".github/pull_request_template.md"))
+        .expect("PR template should exist");
+    assert_eq!(pr_template, "keep this template\n");
+    assert!(
+        stdout.contains("- .github/pull_request_template.md"),
+        "skipped file should appear in summary: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_aborts_before_writing_when_user_requests_abort() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    std::fs::write(repo.path().join("WORKFLOW.md"), "user workflow\n")
+        .expect("existing workflow should write");
+
+    let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
+    write_stdin(&mut child, "abort\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "init should fail when aborted: stdout={stdout}, stderr={stderr}",
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.path().join("WORKFLOW.md"))
+            .expect("workflow should still exist"),
+        "user workflow\n"
+    );
+    assert!(
+        !repo.path().join("AGENTS.md").exists(),
+        "no additional files should be written after abort",
+    );
+}
+
+fn spawn_init_child(
+    repo_root: &std::path::Path,
+    template_base_url: &str,
+    extra_args: &[&str],
+) -> tokio::process::Child {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_opensymphony"));
+    command
+        .arg("init")
+        .args(extra_args)
+        .current_dir(repo_root)
+        .env("OPENSYMPHONY_TEMPLATE_BASE_URL", template_base_url)
+        .env("LLM_MODEL", "already-set-model")
+        .env("LLM_API_KEY", "already-set-key")
+        .env("LLM_BASE_URL", "https://example.com/llm")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command.spawn().expect("init command should spawn")
+}
+
+async fn write_stdin(child: &mut tokio::process::Child, input: &str) {
+    let mut stdin = child.stdin.take().expect("stdin should exist");
+    stdin
+        .write_all(input.as_bytes())
+        .await
+        .expect("stdin should accept scripted input");
+    drop(stdin);
+}
+
+fn init_git_repo(repo_root: &std::path::Path, remote_url: &str) {
+    run_git(repo_root, &["init", "-q"]);
+    run_git(repo_root, &["remote", "add", "origin", remote_url]);
+}
+
+fn run_git(repo_root: &std::path::Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo_root)
+        .status()
+        .expect("git should run");
+    assert!(status.success(), "git {:?} should succeed", args);
+}
+
+struct TemplateServer {
+    base_url: String,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl TemplateServer {
+    async fn start() -> Self {
+        let assets = Arc::new(template_assets());
+        let app = Router::new()
+            .fallback(get(template_handler))
+            .with_state(assets);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("template server should bind");
+        let address = listener
+            .local_addr()
+            .expect("template server should have an address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("template server should run");
+        });
+
+        Self {
+            base_url: format!("http://{address}/"),
+            task,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for TemplateServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn template_handler(
+    State(assets): State<Arc<BTreeMap<String, String>>>,
+    uri: Uri,
+    _request: Request,
+) -> Response {
+    let path = uri.path().trim_start_matches('/');
+    match assets.get(path) {
+        Some(content) => (StatusCode::OK, content.clone()).into_response(),
+        None => (StatusCode::NOT_FOUND, format!("missing asset {path}")).into_response(),
+    }
+}
+
+fn template_assets() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "WORKFLOW.md".to_string(),
+            r#"---
+tracker:
+  kind: linear
+  project_slug: "YOUR-PROJECT-SLUG"
+hooks:
+  after_create: |
+    git clone --depth 1 https://github.com/YOUR-ORG/YOUR-REPO.git .
+openhands:
+  conversation:
+    agent:
+      llm:
+        model: ${LLM_MODEL}
+---
+"#
+            .to_string(),
+        ),
+        (
+            "AGENTS.md".to_string(),
+            "# AGENTS.md\n\nTemplate agents.\n".to_string(),
+        ),
+        (
+            "config.yaml".to_string(),
+            "control_plane:\n  bind: 127.0.0.1:2468\n".to_string(),
+        ),
+        (".gitignore".to_string(), ".opensymphony/\n".to_string()),
+        (
+            ".agents/skills/commit/SKILL.md".to_string(),
+            "# commit\n".to_string(),
+        ),
+        (
+            ".agents/skills/convert-tasks-to-linear/SKILL.md".to_string(),
+            "# convert\n".to_string(),
+        ),
+        (
+            ".agents/skills/create-implementation-plan/SKILL.md".to_string(),
+            "# plan\n".to_string(),
+        ),
+        (
+            ".agents/skills/land/SKILL.md".to_string(),
+            "# land\n".to_string(),
+        ),
+        (
+            ".agents/skills/linear/SKILL.md".to_string(),
+            "# linear\n".to_string(),
+        ),
+        (
+            ".agents/skills/pull/SKILL.md".to_string(),
+            "# pull\n".to_string(),
+        ),
+        (
+            ".agents/skills/push/SKILL.md".to_string(),
+            "# push\n".to_string(),
+        ),
+        (".github/CODEOWNERS".to_string(), "* @example\n".to_string()),
+        (
+            ".github/pull_request_template.md".to_string(),
+            "template body\n".to_string(),
+        ),
+        (
+            ".github/workflows/ai-pr-review.yml".to_string(),
+            "name: ai-pr-review\n".to_string(),
+        ),
+        ("docs/tasks/README.md".to_string(), "# Tasks\n".to_string()),
+    ])
+}

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, process::Stdio, sync::Arc};
+use std::{collections::BTreeMap, process::Stdio, sync::Arc, time::Duration};
 
 use axum::{
     Router,
@@ -17,7 +17,7 @@ async fn init_copies_template_files_and_customizes_workflow() {
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "demo-project\n").await;
+    write_stdin(&mut child, "\ndemo-project\n").await;
 
     let output = child
         .wait_with_output()
@@ -49,8 +49,65 @@ async fn init_copies_template_files_and_customizes_workflow() {
         "config.yaml should be created"
     );
     assert!(
+        !repo
+            .path()
+            .join(".github/workflows/ai-pr-review.yml")
+            .exists(),
+        "AI PR review workflow should not be added unless requested"
+    );
+    assert!(
         stdout.contains("Initialization summary"),
         "stdout should contain a summary: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_can_scaffold_ai_pr_review_and_print_setup_guidance() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
+    write_stdin(&mut child, "yes\ndemo-project\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        repo.path()
+            .join(".github/workflows/ai-pr-review.yml")
+            .is_file(),
+        "AI PR review workflow should be created"
+    );
+    assert!(
+        repo.path()
+            .join(".agents/skills/custom-codereview-guide.md")
+            .is_file(),
+        "starter review guide should be created"
+    );
+    assert!(
+        repo.path()
+            .join("docs/ai-pr-review-human-setup.md")
+            .is_file(),
+        "setup guide should be created"
+    );
+    assert!(
+        stdout.contains("OpenHands AI PR review scaffolding was added."),
+        "stdout should contain AI review guidance: {stdout}",
+    );
+    assert!(
+        stdout.contains(
+            "gh variable set AI_REVIEW_MODEL_ID --body 'accounts/fireworks/models/glm-5p1'"
+        ),
+        "stdout should contain GitHub variable commands: {stdout}",
     );
 }
 
@@ -73,7 +130,7 @@ async fn init_merges_agents_and_skips_conflicting_file_when_requested() {
     .expect("existing PR template should write");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "skip\ndemo-project\n").await;
+    write_stdin(&mut child, "\nskip\ndemo-project\n").await;
 
     let output = child
         .wait_with_output()
@@ -117,7 +174,7 @@ async fn init_aborts_before_writing_when_user_requests_abort() {
         .expect("existing workflow should write");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "abort\n").await;
+    write_stdin(&mut child, "\nabort\n").await;
 
     let output = child
         .wait_with_output()
@@ -141,10 +198,54 @@ async fn init_aborts_before_writing_when_user_requests_abort() {
     );
 }
 
+#[tokio::test]
+async fn init_fails_when_template_fetch_times_out() {
+    let server = TemplateServer::start_with_delay(Duration::from_millis(250)).await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child_with_env(
+        repo.path(),
+        server.base_url(),
+        &[],
+        &[("OPENSYMPHONY_TEMPLATE_FETCH_TIMEOUT_MS", "50")],
+    );
+    write_stdin(&mut child, "\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "init should fail on template fetch timeout: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("opensymphony init failed: failed to fetch template asset"),
+        "stdout should report the fetch failure: {stdout}",
+    );
+    assert!(
+        !repo.path().join("WORKFLOW.md").exists(),
+        "no files should be written when the template fetch times out",
+    );
+}
+
 fn spawn_init_child(
     repo_root: &std::path::Path,
     template_base_url: &str,
     extra_args: &[&str],
+) -> tokio::process::Child {
+    spawn_init_child_with_env(repo_root, template_base_url, extra_args, &[])
+}
+
+fn spawn_init_child_with_env(
+    repo_root: &std::path::Path,
+    template_base_url: &str,
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
 ) -> tokio::process::Child {
     let mut command = Command::new(env!("CARGO_BIN_EXE_opensymphony"));
     command
@@ -159,6 +260,9 @@ fn spawn_init_child(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    for (name, value) in extra_env {
+        command.env(name, value);
+    }
     command.spawn().expect("init command should spawn")
 }
 
@@ -192,10 +296,14 @@ struct TemplateServer {
 
 impl TemplateServer {
     async fn start() -> Self {
+        Self::start_with_delay(Duration::ZERO).await
+    }
+
+    async fn start_with_delay(delay: Duration) -> Self {
         let assets = Arc::new(template_assets());
         let app = Router::new()
             .fallback(get(template_handler))
-            .with_state(assets);
+            .with_state((assets, delay));
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("template server should bind");
@@ -226,10 +334,13 @@ impl Drop for TemplateServer {
 }
 
 async fn template_handler(
-    State(assets): State<Arc<BTreeMap<String, String>>>,
+    State((assets, delay)): State<(Arc<BTreeMap<String, String>>, Duration)>,
     uri: Uri,
     _request: Request,
 ) -> Response {
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
     let path = uri.path().trim_start_matches('/');
     match assets.get(path) {
         Some(content) => (StatusCode::OK, content.clone()).into_response(),

--- a/docs/ai-pr-review-human-setup.md
+++ b/docs/ai-pr-review-human-setup.md
@@ -29,7 +29,7 @@ Add the following **Variables**:
 | Name | Value | Description |
 |------|-------|-------------|
 | `AI_REVIEW_PROVIDER_KIND` | `openai-compatible` | Provider type |
-| `AI_REVIEW_MODEL_ID` | `accounts/fireworks/models/glm-5` | Model identifier |
+| `AI_REVIEW_MODEL_ID` | `accounts/fireworks/models/glm-5p1` | Model identifier |
 | `AI_REVIEW_BASE_URL` | `https://api.fireworks.ai/inference/v1` | API base URL |
 | `AI_REVIEW_STYLE` | `standard` | Review style (standard, strict, lenient) |
 | `AI_REVIEW_REQUIRE_EVIDENCE` | `true` | Require Evidence section in PRs |
@@ -199,7 +199,7 @@ To use a native LiteLLM provider route instead of OpenAI-compatible:
 
 Example for native Fireworks:
 - `AI_REVIEW_PROVIDER_KIND` = `litellm-native`
-- `AI_REVIEW_MODEL_ID` = `fireworks_ai/accounts/fireworks/models/glm-5`
+- `AI_REVIEW_MODEL_ID` = `fireworks_ai/accounts/fireworks/models/glm-5p1`
 - `AI_REVIEW_BASE_URL` = (empty)
 
 ## Future Enhancements (Not Implemented)

--- a/docs/ai-pr-review-system-spec.md
+++ b/docs/ai-pr-review-system-spec.md
@@ -391,7 +391,7 @@ Settings → Secrets and variables → Actions → Variables
 Create these repository variables:
 
 - `AI_REVIEW_PROVIDER_KIND` = `openai-compatible`
-- `AI_REVIEW_MODEL_ID` = `accounts/fireworks/models/glm-5`
+- `AI_REVIEW_MODEL_ID` = `accounts/fireworks/models/glm-5p1`
 - `AI_REVIEW_BASE_URL` = `https://api.fireworks.ai/inference/v1`
 - `AI_REVIEW_STYLE` = `standard`
 - `AI_REVIEW_REQUIRE_EVIDENCE` = `true`
@@ -503,7 +503,7 @@ If you want to use a native LiteLLM provider route instead of the generic OpenAI
 Example for native Fireworks through LiteLLM:
 
 - `AI_REVIEW_PROVIDER_KIND` = `litellm-native`
-- `AI_REVIEW_MODEL_ID` = `fireworks_ai/accounts/fireworks/models/glm-5`
+- `AI_REVIEW_MODEL_ID` = `fireworks_ai/accounts/fireworks/models/glm-5p1`
 - `AI_REVIEW_BASE_URL` = empty
 
 ## Local developer note
@@ -513,7 +513,7 @@ If you want to test the provider configuration locally with OpenHands tooling, t
 ```bash
 export FIREWORKS_API_KEY="<your-fireworks-key>"
 export LLM_API_KEY="$FIREWORKS_API_KEY"
-export LLM_MODEL="openai/accounts/fireworks/models/glm-5"
+export LLM_MODEL="openai/accounts/fireworks/models/glm-5p1"
 export LLM_BASE_URL="https://api.fireworks.ai/inference/v1"
 ```
 ```
@@ -608,7 +608,6 @@ Before finishing, verify all of the following:
 - [ ] no `pull_request_target` workflow was added by default
 - [ ] no auto-approval logic was added
 - [ ] the Fireworks configuration is documented exactly with:
-  - model id `accounts/fireworks/models/glm-5`
+  - model id `accounts/fireworks/models/glm-5p1`
   - base URL `https://api.fireworks.ai/inference/v1`
   - secret name `FIREWORKS_API_KEY`
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,10 +182,13 @@ Current crate boundaries:
   - snapshot store
   - local HTTP and WebSocket control-plane API
 - `opensymphony-cli`
+  - `init` target-repo bootstrap from template-hosted raw assets
   - `run` orchestrator startup
+  - `debug` conversation resume
   - `daemon` demo control-plane startup
   - doctor command
   - target-repo `WORKFLOW.md` resolution and prompt preflight for doctor
+  - rehydrate command
   - repo-root OpenHands preflight checks
   - linear-mcp command
   - config entrypoints

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -122,10 +122,14 @@ Purpose:
 
 Purpose:
 
+- `init`
+- `run`
+- `debug`
 - `daemon`
 - `tui`
 - `doctor`
 - `linear-mcp`
+- `rehydrate`
 - config and path resolution entrypoints
 
 ## 2.10 `opensymphony-tui`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -365,7 +365,7 @@ Recommended first-run sequence:
 Current workspace commands:
 
 - `cd /path/to/target-repo && opensymphony init`
-- `opensymphony init` fetches the current bootstrap payload from the template repo's raw GitHub URLs, merges an existing `AGENTS.md`, and prompts before overwriting other repo-owned files
+- `opensymphony init` fetches the current bootstrap payload from the template repo's raw GitHub URLs, merges an existing `AGENTS.md`, prompts before overwriting other repo-owned files, and can optionally scaffold OpenHands AI PR review plus a local setup guide
 - `cd /path/to/target-repo && opensymphony run`
 - `cd /path/to/target-repo && opensymphony run --config ./config.yaml`
 - `cd /path/to/target-repo && opensymphony debug COE-284`
@@ -381,6 +381,7 @@ Current validation commands for the implemented orchestrator and observability s
 
 - `cargo test`
 - `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p opensymphony-cli --lib resolve_rehydrate_runtime_honors_root_config_tool_dir -- --nocapture`
 - `cargo test -p opensymphony-cli --test init`
 - `cargo test -p opensymphony-cli --test debug`
 - `cargo install --path . --locked --root /tmp/opensymphony-install-check`

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -345,25 +345,31 @@ Expected assertions:
 
 Recommended CLI commands for the repo:
 
+- `opensymphony init`
 - `opensymphony run`
 - `opensymphony debug <issue-id>`
 - `opensymphony tui`
 - `opensymphony doctor`
 - `opensymphony linear-mcp`
+- `opensymphony rehydrate <issue-id> --reason "..."`
 
 Recommended first-run sequence:
 
 - `cargo install --path .`
 - `./tools/openhands-server/install.sh`
 - `opensymphony --help`
+- `cd /path/to/target-repo && opensymphony init`
+- review the copied `config.yaml` and update `openhands.tool_dir` if the template path does not match your machine
 - `opensymphony doctor --config examples/configs/local-dev.yaml`
 
 Current workspace commands:
 
+- `cd /path/to/target-repo && opensymphony init`
+- `opensymphony init` fetches the current bootstrap payload from the template repo's raw GitHub URLs, merges an existing `AGENTS.md`, and prompts before overwriting other repo-owned files
 - `cd /path/to/target-repo && opensymphony run`
 - `cd /path/to/target-repo && opensymphony run --config ./config.yaml`
-- copy `examples/target-repo/config.yaml` into the target repo root as `config.yaml` before first run; `examples/configs/local-dev.yaml` is only for doctor/preflight against this repo checkout
 - `cd /path/to/target-repo && opensymphony debug COE-284`
+- `cd /path/to/target-repo && opensymphony rehydrate COE-284 --reason "API key rotation"`
 - `opensymphony tui --url http://127.0.0.1:2468/`
 
 Possible helper commands later:
@@ -375,8 +381,10 @@ Current validation commands for the implemented orchestrator and observability s
 
 - `cargo test`
 - `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p opensymphony-cli --test init`
 - `cargo test -p opensymphony-cli --test debug`
 - `cargo install --path . --locked --root /tmp/opensymphony-install-check`
+- `cd /path/to/target-repo && /tmp/opensymphony-install-check/bin/opensymphony init`
 - `cd /path/to/target-repo && /tmp/opensymphony-install-check/bin/opensymphony run`
 - `cd /path/to/target-repo && /tmp/opensymphony-install-check/bin/opensymphony debug COE-284`
 - `curl http://127.0.0.1:2468/api/v1/snapshot`


### PR DESCRIPTION
## Summary

Add a new `opensymphony init` command to bootstrap an existing target repository from the current OpenSymphony template, then harden that bootstrap flow with fetch timeouts and optional OpenHands AI PR review scaffolding.

## Changes

- add `opensymphony init` to fetch template bootstrap files from raw GitHub URLs at runtime, detect clobbers, merge existing `AGENTS.md`, prompt for overwrite/skip/abort decisions, and customize `WORKFLOW.md` from the local git remote plus optional Linear project input
- harden template fetching with a client timeout so `init` does not hang indefinitely when GitHub raw is slow or unreachable
- make OpenHands AI PR review scaffolding opt-in during `init`, add a starter `.agents/skills/custom-codereview-guide.md`, add `docs/ai-pr-review-human-setup.md`, and print GitHub variable/secret/label guidance when enabled
- relax rehydrate workflow resolution when tracker credentials are not actually needed, so the root-config tool-dir path resolves deterministically in CI
- update setup and operations docs to replace the old manual curl/copy flow with `opensymphony init`, and align Fireworks examples on `glm-5p1`

## Evidence

### Test output

```text
$ cargo test -p opensymphony-cli
...
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
...
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
...
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
...
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
...
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.14s

$ cargo clippy -p opensymphony-cli --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.80s
```

### Verification

- Ran the new `init` integration suite against a local mock HTTP server that stands in for the template raw-file host.
- Confirmed `init` now fails cleanly on fetch timeout instead of hanging, fills `WORKFLOW.md` from `git remote`, preserves existing `AGENTS.md`, and stops cleanly on abort before writing other files.
- Verified opting into AI PR review adds the workflow plus the starter local guidance files and prints the GitHub Actions configuration commands needed to finish setup.
- Verified the rehydrate runtime test path resolves successfully without depending on ambient `LINEAR_API_KEY` state.

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

None linked.

## Additional notes

The bootstrap command still pulls template assets from GitHub raw URLs at runtime instead of embedding a local snapshot into the CLI binary. The AI PR review workflow is now opt-in during `opensymphony init` rather than always being copied into every target repo.
