### PR TITLE
fix(init): automate GitHub review setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opensymphony"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "opensymphony-cli",
  "tokio",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-control"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-domain"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-linear"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-openhands"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-orchestrator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-testkit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-tui"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "ftui",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-workflow"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "liquid",
  "serde",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-workspace"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/kumanday/OpenSymphony"
 rust-version = "1.93"
-version = "1.0.0"
+version = "1.0.1"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ opensymphony init
 ```
 
 `opensymphony init` guides the bootstrap flow, customizes `WORKFLOW.md`, and
-can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review).
+can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review), including GitHub setup through `gh` when it is installed and authorized for the target repo.
 
 ### Running the Orchestrator
 

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -2,7 +2,7 @@ use std::{
     env, fs,
     io::{self, BufRead, Write},
     path::{Path, PathBuf},
-    process::ExitCode,
+    process::{ExitCode, Output},
     time::Duration,
 };
 
@@ -24,6 +24,7 @@ const DEFAULT_AI_REVIEW_BASE_URL: &str = "https://api.fireworks.ai/inference/v1"
 const DEFAULT_AI_REVIEW_STYLE: &str = "standard";
 const DEFAULT_AI_REVIEW_REQUIRE_EVIDENCE: &str = "true";
 const DEFAULT_AI_REVIEW_SECRET_NAME: &str = "AI_REVIEW_API_KEY";
+const AI_REVIEW_LABEL_DESCRIPTION: &str = "Trigger AI PR review";
 const OPENHANDS_PR_REVIEW_PLUGIN_URL: &str =
     "https://github.com/OpenHands/extensions/tree/main/plugins/pr-review";
 const OPENHANDS_PR_REVIEW_DOCS_URL: &str =
@@ -205,6 +206,16 @@ enum AppliedChange {
     Unchanged,
 }
 
+enum GhRepoAutomationStatus {
+    Ready,
+    MissingCli,
+    RepoAccessUnavailable { details: String },
+}
+
+struct AiReviewGhAutomationResult {
+    secret_updated: bool,
+}
+
 enum GitRemoteDetection {
     Selected { remote_name: String, url: String },
     None,
@@ -279,10 +290,6 @@ const CORE_TEMPLATE_ASSETS: &[TemplateAsset] = &[
     },
     TemplateAsset {
         path: "config.yaml",
-        kind: AssetKind::Standard,
-    },
-    TemplateAsset {
-        path: ".gitignore",
         kind: AssetKind::Standard,
     },
     TemplateAsset {
@@ -476,7 +483,7 @@ where
     }
 
     if let Some(config) = ai_review_config.as_ref() {
-        print_ai_pr_review_guidance(ui, config)?;
+        handle_ai_pr_review_setup(ui, env_lookup, &target_repo, &git_remote, config)?;
     }
 
     prompt_for_missing_llm_env(env_lookup, ui)?;
@@ -1151,6 +1158,10 @@ fn ai_pr_review_setup_doc_contents(config: &AiReviewConfig) -> String {
 
 This repository was bootstrapped with OpenHands PR review support via `opensymphony init`.
 
+If `opensymphony init` was able to use `gh`, it may already have configured the
+repository variables, label, and optional secret. Use this document to verify
+that setup, fill in anything you skipped, or finish the manual fallback path.
+
 Useful references:
 
 - Plugin page: {plugin_url}
@@ -1163,7 +1174,7 @@ Useful references:
 
 ## GitHub Actions Secret
 
-Add this repository secret under **Settings -> Secrets and variables -> Actions**:
+Verify or add this repository secret under **Settings -> Secrets and variables -> Actions**:
 
 | Name | Value |
 |------|-------|
@@ -1174,7 +1185,7 @@ configuration for new repos; any compatible provider/model is fine.
 
 ## GitHub Actions Variables
 
-Add these repository variables under **Settings -> Secrets and variables -> Actions -> Variables**:
+Verify or add these repository variables under **Settings -> Secrets and variables -> Actions -> Variables**:
 
 | Name | Value |
 |------|-------|
@@ -1185,13 +1196,16 @@ Add these repository variables under **Settings -> Secrets and variables -> Acti
 
 ## Label
 
-Create the `{label}` label so maintainers can retrigger review on demand.
+Make sure the `{label}` label exists so maintainers can retrigger review on demand.
 
 ```bash
-gh label create {quoted_label} --description 'Trigger AI PR review' --color 'd73a4a' || true
+gh label create {quoted_label} --description 'Trigger AI PR review' --color 'd73a4a' --force
 ```
 
 ## Optional GitHub CLI Commands
+
+Run these from the target repo root if you want to configure or verify the
+repository with `gh` manually:
 
 ```bash
 gh variable set AI_REVIEW_PROVIDER_KIND --body {quoted_provider_kind}
@@ -1199,6 +1213,7 @@ gh variable set AI_REVIEW_MODEL_ID --body {quoted_model_id}
 {base_url_command}gh variable set AI_REVIEW_STYLE --body {quoted_style}
 gh variable set AI_REVIEW_REQUIRE_EVIDENCE --body {quoted_require_evidence}
 gh secret set {secret_name}
+gh label create {quoted_label} --description 'Trigger AI PR review' --color 'd73a4a' --force
 ```
 
 ## Notes
@@ -1264,69 +1279,416 @@ OpenHands PR review will load this file when it is present. Replace this starter
     .to_string()
 }
 
-fn print_ai_pr_review_guidance<R, W>(
+fn handle_ai_pr_review_setup<R, W, E>(
     ui: &mut PromptUi<R, W>,
+    env_lookup: &E,
+    target_repo: &Path,
+    git_remote: &GitRemoteDetection,
+    config: &AiReviewConfig,
+) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+    E: EnvLookup,
+{
+    ui.blank_line()?;
+    ui.line("OpenHands PR review scaffolding was added.")?;
+    let Some(repo_slug) = git_remote_url(git_remote).and_then(github_repo_slug_from_remote) else {
+        ui.line(
+            "GitHub automation was skipped because the detected git remote is missing or is not a GitHub repository URL.",
+        )?;
+        ui.line("See `docs/ai-pr-review-human-setup.md` for the remaining setup checklist.")?;
+        return Ok(());
+    };
+
+    match check_gh_repo_automation(target_repo, &repo_slug) {
+        GhRepoAutomationStatus::Ready => {}
+        GhRepoAutomationStatus::MissingCli => {
+            ui.line(
+                "GitHub automation was skipped because `gh` is not installed or is not available on `PATH`.",
+            )?;
+            ui.line(
+                "Install GitHub CLI, run `gh auth login`, and then run these commands when you're ready:",
+            )?;
+            print_ai_review_cli_fallback(ui, &repo_slug, config)?;
+            return Ok(());
+        }
+        GhRepoAutomationStatus::RepoAccessUnavailable { details } => {
+            ui.line(format!(
+                "GitHub automation was skipped because `gh` could not access `{repo_slug}`."
+            ))?;
+            if !details.is_empty() {
+                ui.line(format!("`gh` reported: {details}"))?;
+            }
+            ui.line(
+                "Run `gh auth login` with an account that can manage this repository, then run these commands when you're ready:",
+            )?;
+            print_ai_review_cli_fallback(ui, &repo_slug, config)?;
+            return Ok(());
+        }
+    }
+
+    if !prompt_yes_no(
+        ui,
+        &format!(
+            "Configure GitHub Actions variables, the optional secret, and the `{AI_REVIEW_LABEL_NAME}` label for `{repo_slug}` now with `gh`? [Y/n]: "
+        ),
+        true,
+    )? {
+        ui.line("Skipped GitHub automation for now.")?;
+        ui.line("See `docs/ai-pr-review-human-setup.md` for the checklist and validation steps.")?;
+        return Ok(());
+    }
+
+    let secret_value = prompt_ai_review_secret(ui, env_lookup)?;
+    match configure_ai_review_with_gh(target_repo, &repo_slug, config, secret_value.as_deref()) {
+        Ok(result) => {
+            ui.line(format!(
+                "GitHub Actions settings for `{repo_slug}` were configured with `gh`."
+            ))?;
+            ui.line("- variables: AI_REVIEW_PROVIDER_KIND, AI_REVIEW_MODEL_ID, AI_REVIEW_BASE_URL, AI_REVIEW_STYLE, AI_REVIEW_REQUIRE_EVIDENCE")?;
+            ui.line(format!("- label: `{AI_REVIEW_LABEL_NAME}` ensured"))?;
+            if result.secret_updated {
+                ui.line(format!(
+                    "- secret: `{DEFAULT_AI_REVIEW_SECRET_NAME}` updated"
+                ))?;
+            } else {
+                ui.line(format!(
+                    "- secret: `{DEFAULT_AI_REVIEW_SECRET_NAME}` was left unchanged; set it later if needed"
+                ))?;
+            }
+        }
+        Err(error) => {
+            ui.line(format!(
+                "GitHub automation could not finish automatically: {error}"
+            ))?;
+            ui.line(
+                "Make sure your account can manage repository variables, secrets, and labels, then finish the checklist in `docs/ai-pr-review-human-setup.md`.",
+            )?;
+        }
+    }
+
+    ui.line(format!("Plugin: {OPENHANDS_PR_REVIEW_PLUGIN_URL}"))?;
+    ui.line(format!("Docs: {OPENHANDS_PR_REVIEW_DOCS_URL}"))?;
+    Ok(())
+}
+
+fn prompt_ai_review_secret<R, W, E>(
+    ui: &mut PromptUi<R, W>,
+    env_lookup: &E,
+) -> Result<Option<String>, InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+    E: EnvLookup,
+{
+    if let Some(llm_api_key) = env_lookup.get("LLM_API_KEY")
+        && prompt_yes_no(
+            ui,
+            &format!(
+                "Reuse the current `LLM_API_KEY` value for GitHub secret `{DEFAULT_AI_REVIEW_SECRET_NAME}`? [Y/n]: "
+            ),
+            true,
+        )?
+    {
+        return Ok(Some(llm_api_key));
+    }
+
+    ui.line(format!(
+        "`{DEFAULT_AI_REVIEW_SECRET_NAME}` is the provider key the GitHub Actions review workflow will use."
+    ))?;
+    let response = ui.prompt(&format!(
+        "Enter a value for `{DEFAULT_AI_REVIEW_SECRET_NAME}` now (input is visible; leave blank to skip this step for now): "
+    ))?;
+    let response = response.trim();
+    if response.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(response.to_string()))
+    }
+}
+
+fn github_repo_slug_from_remote(remote_url: &str) -> Option<String> {
+    if let Ok(url) = Url::parse(remote_url)
+        && matches!(url.host_str(), Some("github.com" | "www.github.com"))
+    {
+        return normalize_github_repo_slug(url.path());
+    }
+
+    remote_url
+        .strip_prefix("git@github.com:")
+        .or_else(|| remote_url.strip_prefix("ssh://git@github.com/"))
+        .and_then(normalize_github_repo_slug)
+}
+
+fn normalize_github_repo_slug(path: &str) -> Option<String> {
+    let trimmed = path.trim_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let mut parts = trimmed.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+fn check_gh_repo_automation(target_repo: &Path, repo_slug: &str) -> GhRepoAutomationStatus {
+    match run_gh_command(target_repo, &["--version"]) {
+        Ok(output) if output.status.success() => {}
+        Ok(_) => return GhRepoAutomationStatus::MissingCli,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            return GhRepoAutomationStatus::MissingCli;
+        }
+        Err(source) => {
+            return GhRepoAutomationStatus::RepoAccessUnavailable {
+                details: source.to_string(),
+            };
+        }
+    }
+
+    match run_gh_command(
+        target_repo,
+        &[
+            "repo",
+            "view",
+            "--repo",
+            repo_slug,
+            "--json",
+            "nameWithOwner",
+        ],
+    ) {
+        Ok(output) if output.status.success() => GhRepoAutomationStatus::Ready,
+        Ok(output) => GhRepoAutomationStatus::RepoAccessUnavailable {
+            details: summarize_command_output(&output),
+        },
+        Err(source) => GhRepoAutomationStatus::RepoAccessUnavailable {
+            details: source.to_string(),
+        },
+    }
+}
+
+fn configure_ai_review_with_gh(
+    target_repo: &Path,
+    repo_slug: &str,
+    config: &AiReviewConfig,
+    secret_value: Option<&str>,
+) -> Result<AiReviewGhAutomationResult, String> {
+    run_gh_command_checked(
+        target_repo,
+        &[
+            "variable",
+            "set",
+            "AI_REVIEW_PROVIDER_KIND",
+            "--repo",
+            repo_slug,
+            "--body",
+            &config.provider_kind,
+        ],
+    )?;
+    run_gh_command_checked(
+        target_repo,
+        &[
+            "variable",
+            "set",
+            "AI_REVIEW_MODEL_ID",
+            "--repo",
+            repo_slug,
+            "--body",
+            &config.model_id,
+        ],
+    )?;
+    run_gh_command_checked(
+        target_repo,
+        &[
+            "variable",
+            "set",
+            "AI_REVIEW_BASE_URL",
+            "--repo",
+            repo_slug,
+            "--body",
+            config.base_url.as_deref().unwrap_or(""),
+        ],
+    )?;
+    run_gh_command_checked(
+        target_repo,
+        &[
+            "variable",
+            "set",
+            "AI_REVIEW_STYLE",
+            "--repo",
+            repo_slug,
+            "--body",
+            &config.style,
+        ],
+    )?;
+    run_gh_command_checked(
+        target_repo,
+        &[
+            "variable",
+            "set",
+            "AI_REVIEW_REQUIRE_EVIDENCE",
+            "--repo",
+            repo_slug,
+            "--body",
+            config.require_evidence_value(),
+        ],
+    )?;
+    run_gh_command_checked(
+        target_repo,
+        &[
+            "label",
+            "create",
+            AI_REVIEW_LABEL_NAME,
+            "--repo",
+            repo_slug,
+            "--description",
+            AI_REVIEW_LABEL_DESCRIPTION,
+            "--color",
+            "d73a4a",
+            "--force",
+        ],
+    )?;
+
+    let secret_updated = if let Some(secret_value) = secret_value {
+        run_gh_secret_set(
+            target_repo,
+            repo_slug,
+            DEFAULT_AI_REVIEW_SECRET_NAME,
+            secret_value,
+        )?;
+        true
+    } else {
+        false
+    };
+
+    Ok(AiReviewGhAutomationResult { secret_updated })
+}
+
+fn print_ai_review_cli_fallback<R, W>(
+    ui: &mut PromptUi<R, W>,
+    repo_slug: &str,
     config: &AiReviewConfig,
 ) -> Result<(), InitCommandError>
 where
     R: BufRead,
     W: Write,
 {
-    ui.blank_line()?;
-    ui.line("OpenHands PR review scaffolding was added.")?;
-    ui.line("Next steps for GitHub Actions setup:")?;
-    ui.line("- secret: AI_REVIEW_API_KEY=<your-ai-review-provider-key>")?;
     ui.line(format!(
-        "- variable: AI_REVIEW_PROVIDER_KIND={}",
-        config.provider_kind
-    ))?;
-    ui.line(format!(
-        "- variable: AI_REVIEW_MODEL_ID={}",
-        config.model_id
-    ))?;
-    if let Some(base_url) = config.base_url.as_ref() {
-        ui.line(format!("- variable: AI_REVIEW_BASE_URL={base_url}"))?;
-    }
-    ui.line(format!("- variable: AI_REVIEW_STYLE={}", config.style))?;
-    ui.line(format!(
-        "- variable: AI_REVIEW_REQUIRE_EVIDENCE={}",
-        config.require_evidence_value()
-    ))?;
-    ui.line(format!(
-        "- label: `{AI_REVIEW_LABEL_NAME}` for manual reruns"
-    ))?;
-    ui.line("GitHub CLI examples:")?;
-    ui.line(format!(
-        "gh variable set AI_REVIEW_PROVIDER_KIND --body {}",
+        "gh variable set AI_REVIEW_PROVIDER_KIND --repo {repo_slug} --body {}",
         shell_single_quote(&config.provider_kind)
     ))?;
     ui.line(format!(
-        "gh variable set AI_REVIEW_MODEL_ID --body {}",
+        "gh variable set AI_REVIEW_MODEL_ID --repo {repo_slug} --body {}",
         shell_single_quote(&config.model_id)
     ))?;
-    if let Some(base_url) = config.base_url.as_ref() {
-        ui.line(format!(
-            "gh variable set AI_REVIEW_BASE_URL --body {}",
-            shell_single_quote(base_url)
-        ))?;
-    }
     ui.line(format!(
-        "gh variable set AI_REVIEW_STYLE --body {}",
+        "gh variable set AI_REVIEW_BASE_URL --repo {repo_slug} --body {}",
+        shell_single_quote(config.base_url.as_deref().unwrap_or(""))
+    ))?;
+    ui.line(format!(
+        "gh variable set AI_REVIEW_STYLE --repo {repo_slug} --body {}",
         shell_single_quote(&config.style)
     ))?;
     ui.line(format!(
-        "gh variable set AI_REVIEW_REQUIRE_EVIDENCE --body {}",
+        "gh variable set AI_REVIEW_REQUIRE_EVIDENCE --repo {repo_slug} --body {}",
         shell_single_quote(config.require_evidence_value())
     ))?;
-    ui.line("gh secret set AI_REVIEW_API_KEY")?;
     ui.line(format!(
-        "gh label create {} --description 'Trigger AI PR review' --color 'd73a4a' || true",
-        shell_single_quote(AI_REVIEW_LABEL_NAME)
+        "gh secret set {DEFAULT_AI_REVIEW_SECRET_NAME} --repo {repo_slug}"
     ))?;
-    ui.line(format!("Plugin: {OPENHANDS_PR_REVIEW_PLUGIN_URL}"))?;
-    ui.line(format!("Docs: {OPENHANDS_PR_REVIEW_DOCS_URL}"))?;
-    ui.line("See `docs/ai-pr-review-human-setup.md` for the full setup checklist.")?;
+    ui.line(format!(
+        "gh label create {AI_REVIEW_LABEL_NAME} --repo {repo_slug} --description {} --color d73a4a --force",
+        shell_single_quote(AI_REVIEW_LABEL_DESCRIPTION)
+    ))?;
+    ui.line(
+        "You can reuse the same value as `LLM_API_KEY` for `AI_REVIEW_API_KEY` if that is the provider key you want the review workflow to use.",
+    )?;
+    ui.line("See `docs/ai-pr-review-human-setup.md` for the full checklist.")?;
     Ok(())
+}
+
+fn run_gh_command(target_repo: &Path, args: &[&str]) -> io::Result<Output> {
+    std::process::Command::new("gh")
+        .args(args)
+        .current_dir(target_repo)
+        .output()
+}
+
+fn run_gh_command_checked(target_repo: &Path, args: &[&str]) -> Result<(), String> {
+    let output = run_gh_command(target_repo, args)
+        .map_err(|source| format!("failed to run `gh {}`: {source}", args.join(" ")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "`gh {}` failed: {}",
+            args.join(" "),
+            summarize_command_output(&output)
+        ))
+    }
+}
+
+fn run_gh_secret_set(
+    target_repo: &Path,
+    repo_slug: &str,
+    secret_name: &str,
+    secret_value: &str,
+) -> Result<(), String> {
+    let mut child = std::process::Command::new("gh")
+        .args(["secret", "set", secret_name, "--repo", repo_slug])
+        .current_dir(target_repo)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|source| format!("failed to run `gh secret set {secret_name}`: {source}"))?;
+
+    let Some(mut stdin) = child.stdin.take() else {
+        return Err(format!(
+            "failed to provide a value for `gh secret set {secret_name}`"
+        ));
+    };
+    stdin
+        .write_all(secret_value.as_bytes())
+        .map_err(|source| format!("failed to write `{secret_name}` to `gh`: {source}"))?;
+    drop(stdin);
+
+    let output = child
+        .wait_with_output()
+        .map_err(|source| format!("failed to wait for `gh secret set {secret_name}`: {source}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "`gh secret set {secret_name}` failed: {}",
+            summarize_command_output(&output)
+        ))
+    }
+}
+
+fn summarize_command_output(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return summarize_line(&stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return summarize_line(&stdout);
+    }
+
+    "command returned no output".to_string()
+}
+
+fn summarize_line(value: &str) -> String {
+    const MAX_LEN: usize = 200;
+    let first_line = value.lines().next().unwrap_or(value).trim();
+    if first_line.len() > MAX_LEN {
+        format!("{}...", &first_line[..MAX_LEN])
+    } else {
+        first_line.to_string()
+    }
 }
 
 fn print_group<R, W>(
@@ -1360,9 +1722,9 @@ mod tests {
         DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL, DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS,
         GitRemoteDetection, PRESERVED_AGENTS_MARKER, PromptUi, agents_already_initialized,
         ai_pr_review_setup_doc_contents, comparable_text, custom_codereview_guide_contents,
-        customize_workflow, git_remote_url, merge_agents, prompt_ai_review_config,
-        prompt_for_missing_llm_env, prompt_yes_no, select_remote_name, shell_single_quote,
-        template_fetch_timeout_from_env,
+        customize_workflow, git_remote_url, github_repo_slug_from_remote, merge_agents,
+        normalize_github_repo_slug, prompt_ai_review_config, prompt_for_missing_llm_env,
+        prompt_yes_no, select_remote_name, shell_single_quote, template_fetch_timeout_from_env,
     };
 
     struct StubEnvironment {
@@ -1470,6 +1832,35 @@ hooks:
         assert_eq!(git_remote_url(&GitRemoteDetection::None), None);
         assert_eq!(
             git_remote_url(&GitRemoteDetection::Ambiguous(vec!["fork".to_string()])),
+            None
+        );
+    }
+
+    #[test]
+    fn github_repo_slug_parser_supports_https_and_ssh_remotes() {
+        assert_eq!(
+            github_repo_slug_from_remote("https://github.com/kumanday/OpenSymphony.git"),
+            Some("kumanday/OpenSymphony".to_string())
+        );
+        assert_eq!(
+            github_repo_slug_from_remote("git@github.com:kumanday/OpenSymphony.git"),
+            Some("kumanday/OpenSymphony".to_string())
+        );
+        assert_eq!(
+            github_repo_slug_from_remote("https://gitlab.com/kumanday/OpenSymphony.git"),
+            None
+        );
+    }
+
+    #[test]
+    fn normalize_github_repo_slug_rejects_invalid_paths() {
+        assert_eq!(
+            normalize_github_repo_slug("/kumanday/OpenSymphony.git"),
+            Some("kumanday/OpenSymphony".to_string())
+        );
+        assert_eq!(normalize_github_repo_slug("/kumanday"), None);
+        assert_eq!(
+            normalize_github_repo_slug("/kumanday/OpenSymphony/extra"),
             None
         );
     }

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, process::Stdio, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, fs, process::Stdio, sync::Arc, time::Duration};
 
 use axum::{
     Router,
@@ -32,7 +32,7 @@ async fn init_copies_template_files_and_customizes_workflow() {
     );
 
     let workflow =
-        std::fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
     assert!(workflow.contains("project_slug: \"demo-project\""));
     assert!(workflow.contains("git clone --depth 1 'https://github.com/example/demo.git' ."));
 
@@ -61,6 +61,10 @@ async fn init_copies_template_files_and_customizes_workflow() {
         "config.yaml should be created"
     );
     assert!(
+        !repo.path().join(".gitignore").exists(),
+        "target repos should not receive the template .gitignore"
+    );
+    assert!(
         !repo
             .path()
             .join(".github/workflows/ai-pr-review.yml")
@@ -74,7 +78,7 @@ async fn init_copies_template_files_and_customizes_workflow() {
 }
 
 #[tokio::test]
-async fn init_can_scaffold_ai_pr_review_and_print_setup_guidance() {
+async fn init_can_scaffold_ai_pr_review_and_print_fallback_commands_when_gh_cannot_access_repo() {
     let server = TemplateServer::start().await;
     let repo = TempDir::new().expect("temp repo should exist");
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
@@ -117,13 +121,79 @@ async fn init_can_scaffold_ai_pr_review_and_print_setup_guidance() {
     );
     assert!(
         stdout.contains(
-            "gh variable set AI_REVIEW_MODEL_ID --body 'accounts/fireworks/models/glm-5p1'"
+            "gh variable set AI_REVIEW_MODEL_ID --repo example/demo --body 'accounts/fireworks/models/glm-5p1'"
         ),
         "stdout should contain GitHub variable commands: {stdout}",
     );
     assert!(
-        stdout.contains("gh secret set AI_REVIEW_API_KEY"),
-        "stdout should contain the generic AI review secret guidance: {stdout}",
+        stdout.contains("`gh` could not access `example/demo`"),
+        "stdout should explain why automation fell back to manual commands: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_can_scaffold_ai_pr_review_and_configure_github_with_gh() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    let gh_log = repo.path().join("gh.log");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child_with_env(
+        repo.path(),
+        server.base_url(),
+        &[],
+        &[
+            ("OPENSYMPHONY_TEST_GH_MODE", "success"),
+            (
+                "OPENSYMPHONY_TEST_GH_LOG",
+                gh_log.to_str().expect("gh log path should be valid"),
+            ),
+        ],
+    );
+    write_stdin(&mut child, "yes\n\n\n\n\n\ndemo-project\nyes\nyes\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("GitHub Actions settings for `example/demo` were configured with `gh`."),
+        "stdout should confirm GitHub automation: {stdout}",
+    );
+    assert!(
+        !stdout.contains("gh variable set AI_REVIEW_MODEL_ID"),
+        "successful automation should not dump fallback gh commands: {stdout}",
+    );
+
+    let gh_log = fs::read_to_string(&gh_log).expect("gh log should exist");
+    assert!(
+        gh_log.contains("gh --version"),
+        "preflight should verify gh exists: {gh_log}",
+    );
+    assert!(
+        gh_log.contains("gh repo view --repo example/demo --json nameWithOwner"),
+        "preflight should verify repo access: {gh_log}",
+    );
+    assert!(
+        gh_log.contains(
+            "gh variable set AI_REVIEW_PROVIDER_KIND --repo example/demo --body openai-compatible"
+        ),
+        "provider variable should be configured: {gh_log}",
+    );
+    assert!(
+        gh_log.contains("gh label create review-this --repo example/demo --description Trigger AI PR review --color d73a4a --force"),
+        "label should be ensured: {gh_log}",
+    );
+    assert!(
+        gh_log.contains("gh secret set AI_REVIEW_API_KEY --repo example/demo"),
+        "secret should be configured when the user reuses LLM_API_KEY: {gh_log}",
     );
 }
 
@@ -133,13 +203,13 @@ async fn init_merges_agents_and_skips_conflicting_file_when_requested() {
     let repo = TempDir::new().expect("temp repo should exist");
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
-    std::fs::write(
+    fs::write(
         repo.path().join("AGENTS.md"),
         "# Existing Agents\n\nKeep me.\n",
     )
     .expect("existing AGENTS should write");
-    std::fs::create_dir_all(repo.path().join(".github")).expect(".github should exist");
-    std::fs::write(
+    fs::create_dir_all(repo.path().join(".github")).expect(".github should exist");
+    fs::write(
         repo.path().join(".github/pull_request_template.md"),
         "keep this template\n",
     )
@@ -160,8 +230,7 @@ async fn init_merges_agents_and_skips_conflicting_file_when_requested() {
         "init should succeed: stdout={stdout}, stderr={stderr}",
     );
 
-    let agents =
-        std::fs::read_to_string(repo.path().join("AGENTS.md")).expect("AGENTS.md should exist");
+    let agents = fs::read_to_string(repo.path().join("AGENTS.md")).expect("AGENTS.md should exist");
     assert!(
         agents.contains("## Preserved Existing AGENTS.md"),
         "existing AGENTS content should be preserved: {agents}",
@@ -171,7 +240,7 @@ async fn init_merges_agents_and_skips_conflicting_file_when_requested() {
         "existing AGENTS text should be appended: {agents}",
     );
 
-    let pr_template = std::fs::read_to_string(repo.path().join(".github/pull_request_template.md"))
+    let pr_template = fs::read_to_string(repo.path().join(".github/pull_request_template.md"))
         .expect("PR template should exist");
     assert_eq!(pr_template, "keep this template\n");
     assert!(
@@ -186,7 +255,7 @@ async fn init_aborts_before_writing_when_user_requests_abort() {
     let repo = TempDir::new().expect("temp repo should exist");
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
-    std::fs::write(repo.path().join("WORKFLOW.md"), "user workflow\n")
+    fs::write(repo.path().join("WORKFLOW.md"), "user workflow\n")
         .expect("existing workflow should write");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
@@ -204,8 +273,7 @@ async fn init_aborts_before_writing_when_user_requests_abort() {
         "init should fail when aborted: stdout={stdout}, stderr={stderr}",
     );
     assert_eq!(
-        std::fs::read_to_string(repo.path().join("WORKFLOW.md"))
-            .expect("workflow should still exist"),
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should still exist"),
         "user workflow\n"
     );
     assert!(
@@ -263,12 +331,34 @@ fn spawn_init_child_with_env(
     extra_args: &[&str],
     extra_env: &[(&str, &str)],
 ) -> tokio::process::Child {
+    let gh_bin_dir = repo_root.join(".test-bin");
+    fs::create_dir_all(&gh_bin_dir).expect("fake gh bin dir should exist");
+    let gh_bin = gh_bin_dir.join("gh");
+    fs::write(&gh_bin, fake_gh_script()).expect("fake gh should be written");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&gh_bin)
+            .expect("fake gh metadata should exist")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&gh_bin, permissions).expect("fake gh should be executable");
+    }
+    let path = format!(
+        "{}:{}",
+        gh_bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
     let mut command = Command::new(env!("CARGO_BIN_EXE_opensymphony"));
     command
         .arg("init")
         .args(extra_args)
         .current_dir(repo_root)
+        .env("PATH", path)
         .env("OPENSYMPHONY_TEMPLATE_BASE_URL", template_base_url)
+        .env("OPENSYMPHONY_TEST_GH_MODE", "deny-repo")
         .env("LLM_MODEL", "already-set-model")
         .env("LLM_API_KEY", "already-set-key")
         .env("LLM_BASE_URL", "https://example.com/llm")
@@ -403,7 +493,6 @@ openhands:
             "config.yaml".to_string(),
             "control_plane:\n  bind: 127.0.0.1:2468\n".to_string(),
         ),
-        (".gitignore".to_string(), ".opensymphony/\n".to_string()),
         (
             ".agents/skills/commit/SKILL.md".to_string(),
             "# commit\n".to_string(),
@@ -467,4 +556,66 @@ openhands:
         ),
         ("docs/tasks/README.md".to_string(), "# Tasks\n".to_string()),
     ])
+}
+
+fn fake_gh_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+mode="${OPENSYMPHONY_TEST_GH_MODE:-deny-repo}"
+log_path="${OPENSYMPHONY_TEST_GH_LOG:-}"
+
+log_command() {
+  if [ -n "$log_path" ]; then
+    printf 'gh %s\n' "$*" >> "$log_path"
+  fi
+}
+
+case "${1-}" in
+  --version)
+    log_command "$*"
+    printf 'gh version test\n'
+    exit 0
+    ;;
+  repo)
+    log_command "$*"
+    if [ "$mode" = "success" ]; then
+      printf '{"nameWithOwner":"example/demo"}\n'
+      exit 0
+    fi
+    printf 'authentication required or repository access denied\n' >&2
+    exit 1
+    ;;
+  variable)
+    log_command "$*"
+    if [ "$mode" = "success" ]; then
+      exit 0
+    fi
+    printf 'repository settings access denied\n' >&2
+    exit 1
+    ;;
+  label)
+    log_command "$*"
+    if [ "$mode" = "success" ]; then
+      exit 0
+    fi
+    printf 'label write access denied\n' >&2
+    exit 1
+    ;;
+  secret)
+    log_command "$*"
+    cat >/dev/null
+    if [ "$mode" = "success" ]; then
+      exit 0
+    fi
+    printf 'secret write access denied\n' >&2
+    exit 1
+    ;;
+  *)
+    log_command "$*"
+    printf 'unexpected gh invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+"#
 }

--- a/docs/ai-pr-review-human-setup.md
+++ b/docs/ai-pr-review-human-setup.md
@@ -1,6 +1,12 @@
 # OpenHands PR Review - Human Setup Guide
 
-This document describes the manual setup steps required to activate the OpenHands PR review workflow.
+This document covers the remaining human checks for the OpenHands PR review
+workflow.
+
+`opensymphony init` now tries to configure the GitHub Actions variables, label,
+and optional review secret automatically when `gh` is installed and can access
+the target repository. Use this guide to verify that setup, finish anything you
+skipped, or complete the fallback path when GitHub automation was unavailable.
 
 Useful references:
 
@@ -19,7 +25,7 @@ Useful references:
 
 Go to: **Settings → Secrets and variables → Actions**
 
-Add the following **Secret**:
+Verify or add the following **Secret**:
 
 | Name | Value |
 |------|-------|
@@ -32,7 +38,7 @@ name.
 
 Go to: **Settings → Secrets and variables → Actions → Variables tab**
 
-Add the following **Variables**:
+Verify or add the following **Variables**:
 
 | Name | Value | Description |
 |------|-------|-------------|
@@ -52,7 +58,9 @@ Create:
 - **Description:** `Trigger AI PR review`
 - **Color:** Any (suggested: `#0052CC` blue)
 
-Adding this label to a same-repo PR will retrigger the review workflow.
+Adding this label to a same-repo PR will retrigger the review workflow. If
+`opensymphony init` had working `gh` access, it may already have created or
+updated this label for you.
 
 ### 4. Allow the OpenHands Action (if restricted)
 
@@ -144,6 +152,15 @@ After setup, verify the system works:
 - Check that the PR is from the same repository (not a fork)
 - Check that the author is not Dependabot
 - Check that Actions are enabled in repository settings
+
+### `opensymphony init` could not automate GitHub setup
+
+- Install GitHub CLI if `gh` is missing: https://cli.github.com/
+- Sign in with `gh auth login`
+- Make sure the signed-in account can manage repository Actions settings and
+  labels
+- Re-run `opensymphony init` or use the printed fallback `gh` commands from the
+  target repo root
 
 ### "Missing repository variable" errors
 

--- a/docs/ai-pr-review-system-spec.md
+++ b/docs/ai-pr-review-system-spec.md
@@ -57,7 +57,9 @@ Do **not** create a fork-secret workflow by default.
 
 Do **not** enable `pull_request_target` by default.
 
-Do **not** create or modify branch protection or labels through code. Put those steps in the human setup document.
+Do **not** create or modify branch protection through code. Labels may be
+bootstrapped by repository setup tooling when `gh` is available, but the human
+setup document must still cover the manual fallback path.
 
 Do **not** invent `CODEOWNERS` entries if real owners are not obvious from the repository. Put a TODO and an example in the human setup document instead.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,8 @@ opensymphony init
 - fills the `WORKFLOW.md` clone hook from `git remote` when possible
 - offers to fill the Linear project slug/key in `WORKFLOW.md`
 - can optionally scaffold OpenHands AI PR review
+- can configure the GitHub Actions variables, label, and optional review secret
+  automatically when `gh` is installed and can access the repository
 
 The template repository is still the upstream source of those starter assets,
 but it is an implementation detail of `opensymphony init`, not a required
@@ -36,7 +38,6 @@ Core bootstrap payload:
 - `WORKFLOW.md`
 - `AGENTS.md`
 - `config.yaml`
-- `.gitignore`
 - `.agents/skills/` copied recursively, including skill-local `references/`, `scripts/`, and similar helper files
 - `.agents/skills/linear/references/`
 - `.github/CODEOWNERS`
@@ -51,12 +52,12 @@ Optional AI PR review scaffolding:
 
 ## Labels
 
-If you want the template's GitHub label conventions, create them once per
-repository:
+If you enable AI PR review and `gh` is available with repository access,
+`opensymphony init` can create the `review-this` label for you. If automation is
+skipped, create it once per repository:
 
 ```bash
-gh label create "symphony" --description "PR created by OpenSymphony" --color "1f77b4" || true
-gh label create "review-this" --description "Trigger AI PR review" --color "d73a4a" || true
+gh label create "review-this" --description "Trigger AI PR review" --color "d73a4a" --force
 ```
 
 ## Review The Generated Workflow
@@ -143,5 +144,14 @@ config that `opensymphony run` looks for in a target repo.
 
 ## OpenHands PR Review
 
-If you opt into OpenHands PR review during `init`, finish the GitHub Actions
-setup described in [ai-pr-review-human-setup.md](ai-pr-review-human-setup.md).
+If you opt into OpenHands PR review during `init`, the CLI will try to
+configure the GitHub Actions variables, label, and optional review secret for
+you when:
+
+- `gh` is installed
+- `gh` can access the target repository
+- you approve the automation prompt
+
+If any of those are missing, `init` falls back to a short checklist plus the
+manual `gh` commands. The full verification and branch-protection guidance
+lives in [ai-pr-review-human-setup.md](ai-pr-review-human-setup.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -32,6 +32,9 @@ Important `init` behavior:
 - merges an existing `AGENTS.md`
 - prompts before overwriting repo-owned files
 - optionally scaffolds AI PR review assets
+- can configure GitHub Actions variables, the `review-this` label, and the
+  optional AI review secret automatically when `gh` is installed and can access
+  the target repository
 - copies `.agents/skills/` recursively so helper scripts, query files, and
   reference docs all arrive together
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -280,7 +280,7 @@ The repository-owned script performs the full live flow:
 
 ### Scenario A: checklist-driven issue lifecycle
 
-- generate a temp target repo with repo-owned `WORKFLOW.md`, `AGENTS.md`, `.gitignore`, and a two-step checklist
+- generate a temp target repo with repo-owned `WORKFLOW.md`, `AGENTS.md`, and a two-step checklist
 - populate the issue workspace through the documented `after_create` clone hook
 - run one issue through the real `WorkspaceManager` plus `IssueSessionRunner` path
 - verify workspace creation, prompt capture, conversation creation, and a deterministic first-run assistant reply


### PR DESCRIPTION
## Summary

Tighten `opensymphony init` around two rough edges from real target-repo usage.

## Changes

- stop copying the template `.gitignore` into initialized target repos
- check for `gh` and GitHub repo access before attempting PR review setup, then automate repository variables, the `review-this` label, and the optional `AI_REVIEW_API_KEY` secret when possible
- fall back to concise manual `gh` commands only when `gh` is missing or cannot access the repo, and update the docs/tests plus bump the workspace version to `1.0.1`

## Evidence

### Test output

```text
$ cargo test -p opensymphony-cli
33 unit tests passed
1 debug integration test passed
9 doctor integration tests passed
4 help integration tests passed
6 init integration tests passed
3 run integration tests passed
2 tui integration tests passed

$ cargo clippy -p opensymphony-cli --all-targets -- -D warnings
Finished dev profile without warnings
```

### Verification

Verified the new `init` coverage for both AI review setup branches:
- fallback output when `gh` is unavailable for the target repo
- successful `gh` automation of repo variables, label creation, and secret reuse from `LLM_API_KEY`
- no template `.gitignore` copied into initialized target repos

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None

## Related issues

None

## Additional notes

The AI review automation intentionally keeps branch protection and wider GitHub policy decisions in the human setup docs; only repo-scoped variables, the optional secret, and the rerun label are automated.
