### PR TITLE
Fix init bootstrap payload and gh setup

### DIFF
--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -29,7 +29,8 @@ const OPENHANDS_PR_REVIEW_PLUGIN_URL: &str =
     "https://github.com/OpenHands/extensions/tree/main/plugins/pr-review";
 const OPENHANDS_PR_REVIEW_DOCS_URL: &str =
     "https://docs.openhands.dev/sdk/guides/github-workflows/pr-review";
-const OPENHANDS_EXTENSIONS_PINNED_SHA: &str = "9e5bb49dbe61bdb364c89c10c7307c38139e9532";
+const OPENHANDS_PR_REVIEW_SETUP_GUIDE_URL: &str =
+    "https://github.com/kumanday/OpenSymphony/blob/main/docs/ai-pr-review-human-setup.md";
 const AI_REVIEW_LABEL_NAME: &str = "review-this";
 const PRESERVED_AGENTS_MARKER: &str = "## Preserved Existing AGENTS.md";
 const WORKFLOW_PROJECT_SLUG_PLACEHOLDER: &str = "\"YOUR-PROJECT-SLUG\"";
@@ -300,10 +301,6 @@ const CORE_TEMPLATE_ASSETS: &[TemplateAsset] = &[
         path: ".github/pull_request_template.md",
         kind: AssetKind::Standard,
     },
-    TemplateAsset {
-        path: "docs/tasks/README.md",
-        kind: AssetKind::Standard,
-    },
 ];
 
 const CORE_TEMPLATE_DIRECTORIES: &[TemplateDirectory] = &[TemplateDirectory {
@@ -315,11 +312,6 @@ const AI_REVIEW_TEMPLATE_ASSETS: &[TemplateAsset] = &[TemplateAsset {
     path: ".github/workflows/ai-pr-review.yml",
     kind: AssetKind::Standard,
 }];
-
-const AI_REVIEW_SETUP_DOC_ASSET: TemplateAsset = TemplateAsset {
-    path: "docs/ai-pr-review-human-setup.md",
-    kind: AssetKind::Standard,
-};
 
 const AI_REVIEW_CUSTOM_GUIDE_ASSET: TemplateAsset = TemplateAsset {
     path: ".agents/skills/custom-codereview-guide.md",
@@ -377,10 +369,10 @@ where
 
     let mut fetched_assets =
         fetch_template_assets(&client, CORE_TEMPLATE_ASSETS, CORE_TEMPLATE_DIRECTORIES).await?;
-    if let Some(config) = ai_review_config.as_ref() {
+    if ai_review_config.is_some() {
         fetched_assets
             .extend(fetch_template_assets(&client, AI_REVIEW_TEMPLATE_ASSETS, &[]).await?);
-        fetched_assets.extend(generated_ai_review_assets(config));
+        fetched_assets.extend(generated_ai_review_assets());
     }
     let mut planned_assets = plan_assets(&target_repo, fetched_assets)?;
     resolve_conflicts(&mut planned_assets, ui)?;
@@ -478,7 +470,7 @@ where
     if wrote_config {
         ui.blank_line()?;
         ui.line(
-            "If you use the managed local OpenHands runtime, run `opensymphony install openhands` to provision the pinned tooling into the configured `openhands.tool_dir`.",
+            "For the managed local OpenHands server, run `opensymphony install openhands` to provision the pinned tooling into the configured `openhands.tool_dir`.",
         )?;
     }
 
@@ -644,19 +636,12 @@ async fn fetch_template_file(
     })
 }
 
-fn generated_ai_review_assets(config: &AiReviewConfig) -> Vec<FetchedAsset> {
-    vec![
-        FetchedAsset {
-            path: AI_REVIEW_SETUP_DOC_ASSET.path.to_string(),
-            kind: AI_REVIEW_SETUP_DOC_ASSET.kind,
-            contents: ai_pr_review_setup_doc_contents(config),
-        },
-        FetchedAsset {
-            path: AI_REVIEW_CUSTOM_GUIDE_ASSET.path.to_string(),
-            kind: AI_REVIEW_CUSTOM_GUIDE_ASSET.kind,
-            contents: custom_codereview_guide_contents(),
-        },
-    ]
+fn generated_ai_review_assets() -> Vec<FetchedAsset> {
+    vec![FetchedAsset {
+        path: AI_REVIEW_CUSTOM_GUIDE_ASSET.path.to_string(),
+        kind: AI_REVIEW_CUSTOM_GUIDE_ASSET.kind,
+        contents: custom_codereview_guide_contents(),
+    }]
 }
 
 fn plan_assets(
@@ -1136,115 +1121,6 @@ fn yaml_double_quote(value: &str) -> String {
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
-fn ai_pr_review_setup_doc_contents(config: &AiReviewConfig) -> String {
-    let base_url_row = config.base_url.as_ref().map_or(String::new(), |base_url| {
-        format!("| `AI_REVIEW_BASE_URL` | `{base_url}` |\n")
-    });
-    let base_url_command = config.base_url.as_ref().map_or(String::new(), |base_url| {
-        format!(
-            "gh variable set AI_REVIEW_BASE_URL --body {}\n",
-            shell_single_quote(base_url)
-        )
-    });
-    let base_url_note = if config.base_url.is_some() {
-        String::new()
-    } else {
-        "- `AI_REVIEW_BASE_URL` is optional for the selected provider and may be left unset.\n"
-            .to_string()
-    };
-
-    format!(
-        r#"# OpenHands PR Review Setup
-
-This repository was bootstrapped with OpenHands PR review support via `opensymphony init`.
-
-If `opensymphony init` was able to use `gh`, it may already have configured the
-repository variables, label, and optional secret. Use this document to verify
-that setup, fill in anything you skipped, or finish the manual fallback path.
-
-Useful references:
-
-- Plugin page: {plugin_url}
-- Official docs: {docs_url}
-
-## Files Added
-
-- `.github/workflows/ai-pr-review.yml`
-- `.agents/skills/custom-codereview-guide.md`
-
-## GitHub Actions Secret
-
-Verify or add this repository secret under **Settings -> Secrets and variables -> Actions**:
-
-| Name | Value |
-|------|-------|
-| `{secret_name}` | Your AI review provider API key |
-
-The secret name is provider-agnostic. Fireworks is only the default example
-configuration for new repos; any compatible provider/model is fine.
-
-## GitHub Actions Variables
-
-Verify or add these repository variables under **Settings -> Secrets and variables -> Actions -> Variables**:
-
-| Name | Value |
-|------|-------|
-| `AI_REVIEW_PROVIDER_KIND` | `{provider_kind}` |
-| `AI_REVIEW_MODEL_ID` | `{model_id}` |
-{base_url_row}| `AI_REVIEW_STYLE` | `{style}` |
-| `AI_REVIEW_REQUIRE_EVIDENCE` | `{require_evidence}` |
-
-## Label
-
-Make sure the `{label}` label exists so maintainers can retrigger review on demand.
-
-```bash
-gh label create {quoted_label} --description 'Trigger AI PR review' --color 'd73a4a' --force
-```
-
-## Optional GitHub CLI Commands
-
-Run these from the target repo root if you want to configure or verify the
-repository with `gh` manually:
-
-```bash
-gh variable set AI_REVIEW_PROVIDER_KIND --body {quoted_provider_kind}
-gh variable set AI_REVIEW_MODEL_ID --body {quoted_model_id}
-{base_url_command}gh variable set AI_REVIEW_STYLE --body {quoted_style}
-gh variable set AI_REVIEW_REQUIRE_EVIDENCE --body {quoted_require_evidence}
-gh secret set {secret_name}
-gh label create {quoted_label} --description 'Trigger AI PR review' --color 'd73a4a' --force
-```
-
-## Notes
-
-- Fireworks is the default example only; swap in your preferred provider/model if needed.
-{base_url_note}- If your provider uses an OpenAI-compatible endpoint, `AI_REVIEW_BASE_URL` must be set.
-- If your organization restricts Actions, allow `OpenHands/extensions`.
-- The generated workflow should already pin the plugin to `{pinned_sha}` in both the `uses:` line and the `extensions-version:` input.
-- Do not make the AI review workflow a required status check.
-- Keep the workflow on GitHub-hosted runners unless you have separately reviewed the risk model for untrusted PR content.
-"#,
-        provider_kind = config.provider_kind,
-        model_id = config.model_id,
-        style = config.style,
-        require_evidence = config.require_evidence_value(),
-        label = AI_REVIEW_LABEL_NAME,
-        base_url_row = base_url_row,
-        base_url_command = base_url_command,
-        base_url_note = base_url_note,
-        quoted_label = shell_single_quote(AI_REVIEW_LABEL_NAME),
-        quoted_provider_kind = shell_single_quote(&config.provider_kind),
-        quoted_model_id = shell_single_quote(&config.model_id),
-        quoted_style = shell_single_quote(&config.style),
-        quoted_require_evidence = shell_single_quote(config.require_evidence_value()),
-        secret_name = DEFAULT_AI_REVIEW_SECRET_NAME,
-        plugin_url = OPENHANDS_PR_REVIEW_PLUGIN_URL,
-        docs_url = OPENHANDS_PR_REVIEW_DOCS_URL,
-        pinned_sha = OPENHANDS_EXTENSIONS_PINNED_SHA,
-    )
-}
-
 fn custom_codereview_guide_contents() -> String {
     r#"---
 name: custom-codereview-guide
@@ -1297,7 +1173,7 @@ where
         ui.line(
             "GitHub automation was skipped because the detected git remote is missing or is not a GitHub repository URL.",
         )?;
-        ui.line("See `docs/ai-pr-review-human-setup.md` for the remaining setup checklist.")?;
+        print_ai_review_setup_links(ui)?;
         return Ok(());
     };
 
@@ -1336,7 +1212,7 @@ where
         true,
     )? {
         ui.line("Skipped GitHub automation for now.")?;
-        ui.line("See `docs/ai-pr-review-human-setup.md` for the checklist and validation steps.")?;
+        print_ai_review_setup_links(ui)?;
         return Ok(());
     }
 
@@ -1363,13 +1239,13 @@ where
                 "GitHub automation could not finish automatically: {error}"
             ))?;
             ui.line(
-                "Make sure your account can manage repository variables, secrets, and labels, then finish the checklist in `docs/ai-pr-review-human-setup.md`.",
+                "Make sure your account can manage repository variables, secrets, and labels, then finish the setup with the printed commands or the upstream guide.",
             )?;
+            print_ai_review_setup_links(ui)?;
         }
     }
 
-    ui.line(format!("Plugin: {OPENHANDS_PR_REVIEW_PLUGIN_URL}"))?;
-    ui.line(format!("Docs: {OPENHANDS_PR_REVIEW_DOCS_URL}"))?;
+    print_ai_review_setup_links(ui)?;
     Ok(())
 }
 
@@ -1449,14 +1325,7 @@ fn check_gh_repo_automation(target_repo: &Path, repo_slug: &str) -> GhRepoAutoma
 
     match run_gh_command(
         target_repo,
-        &[
-            "repo",
-            "view",
-            "--repo",
-            repo_slug,
-            "--json",
-            "nameWithOwner",
-        ],
+        &["repo", "view", repo_slug, "--json", "nameWithOwner"],
     ) {
         Ok(output) if output.status.success() => GhRepoAutomationStatus::Ready,
         Ok(output) => GhRepoAutomationStatus::RepoAccessUnavailable {
@@ -1480,7 +1349,7 @@ fn configure_ai_review_with_gh(
             "variable",
             "set",
             "AI_REVIEW_PROVIDER_KIND",
-            "--repo",
+            "-R",
             repo_slug,
             "--body",
             &config.provider_kind,
@@ -1492,7 +1361,7 @@ fn configure_ai_review_with_gh(
             "variable",
             "set",
             "AI_REVIEW_MODEL_ID",
-            "--repo",
+            "-R",
             repo_slug,
             "--body",
             &config.model_id,
@@ -1504,7 +1373,7 @@ fn configure_ai_review_with_gh(
             "variable",
             "set",
             "AI_REVIEW_BASE_URL",
-            "--repo",
+            "-R",
             repo_slug,
             "--body",
             config.base_url.as_deref().unwrap_or(""),
@@ -1516,7 +1385,7 @@ fn configure_ai_review_with_gh(
             "variable",
             "set",
             "AI_REVIEW_STYLE",
-            "--repo",
+            "-R",
             repo_slug,
             "--body",
             &config.style,
@@ -1528,7 +1397,7 @@ fn configure_ai_review_with_gh(
             "variable",
             "set",
             "AI_REVIEW_REQUIRE_EVIDENCE",
-            "--repo",
+            "-R",
             repo_slug,
             "--body",
             config.require_evidence_value(),
@@ -1540,7 +1409,7 @@ fn configure_ai_review_with_gh(
             "label",
             "create",
             AI_REVIEW_LABEL_NAME,
-            "--repo",
+            "-R",
             repo_slug,
             "--description",
             AI_REVIEW_LABEL_DESCRIPTION,
@@ -1575,36 +1444,49 @@ where
     W: Write,
 {
     ui.line(format!(
-        "gh variable set AI_REVIEW_PROVIDER_KIND --repo {repo_slug} --body {}",
+        "gh variable set AI_REVIEW_PROVIDER_KIND -R {repo_slug} --body {}",
         shell_single_quote(&config.provider_kind)
     ))?;
     ui.line(format!(
-        "gh variable set AI_REVIEW_MODEL_ID --repo {repo_slug} --body {}",
+        "gh variable set AI_REVIEW_MODEL_ID -R {repo_slug} --body {}",
         shell_single_quote(&config.model_id)
     ))?;
     ui.line(format!(
-        "gh variable set AI_REVIEW_BASE_URL --repo {repo_slug} --body {}",
+        "gh variable set AI_REVIEW_BASE_URL -R {repo_slug} --body {}",
         shell_single_quote(config.base_url.as_deref().unwrap_or(""))
     ))?;
     ui.line(format!(
-        "gh variable set AI_REVIEW_STYLE --repo {repo_slug} --body {}",
+        "gh variable set AI_REVIEW_STYLE -R {repo_slug} --body {}",
         shell_single_quote(&config.style)
     ))?;
     ui.line(format!(
-        "gh variable set AI_REVIEW_REQUIRE_EVIDENCE --repo {repo_slug} --body {}",
+        "gh variable set AI_REVIEW_REQUIRE_EVIDENCE -R {repo_slug} --body {}",
         shell_single_quote(config.require_evidence_value())
     ))?;
     ui.line(format!(
-        "gh secret set {DEFAULT_AI_REVIEW_SECRET_NAME} --repo {repo_slug}"
+        "gh secret set {DEFAULT_AI_REVIEW_SECRET_NAME} -R {repo_slug}"
     ))?;
     ui.line(format!(
-        "gh label create {AI_REVIEW_LABEL_NAME} --repo {repo_slug} --description {} --color d73a4a --force",
+        "gh label create {AI_REVIEW_LABEL_NAME} -R {repo_slug} --description {} --color d73a4a --force",
         shell_single_quote(AI_REVIEW_LABEL_DESCRIPTION)
     ))?;
     ui.line(
         "You can reuse the same value as `LLM_API_KEY` for `AI_REVIEW_API_KEY` if that is the provider key you want the review workflow to use.",
     )?;
-    ui.line("See `docs/ai-pr-review-human-setup.md` for the full checklist.")?;
+    print_ai_review_setup_links(ui)?;
+    Ok(())
+}
+
+fn print_ai_review_setup_links<R, W>(ui: &mut PromptUi<R, W>) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    ui.line(format!(
+        "Manual setup guide: {OPENHANDS_PR_REVIEW_SETUP_GUIDE_URL}"
+    ))?;
+    ui.line(format!("Plugin: {OPENHANDS_PR_REVIEW_PLUGIN_URL}"))?;
+    ui.line(format!("Docs: {OPENHANDS_PR_REVIEW_DOCS_URL}"))?;
     Ok(())
 }
 
@@ -1636,7 +1518,7 @@ fn run_gh_secret_set(
     secret_value: &str,
 ) -> Result<(), String> {
     let mut child = std::process::Command::new("gh")
-        .args(["secret", "set", secret_name, "--repo", repo_slug])
+        .args(["secret", "set", secret_name, "-R", repo_slug])
         .current_dir(target_repo)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -1717,14 +1599,12 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AI_REVIEW_LABEL_NAME, AiReviewConfig, DEFAULT_AI_REVIEW_BASE_URL,
-        DEFAULT_AI_REVIEW_MODEL_ID, DEFAULT_AI_REVIEW_PROVIDER_KIND, DEFAULT_AI_REVIEW_SECRET_NAME,
         DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL, DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS,
         GitRemoteDetection, PRESERVED_AGENTS_MARKER, PromptUi, agents_already_initialized,
-        ai_pr_review_setup_doc_contents, comparable_text, custom_codereview_guide_contents,
-        customize_workflow, git_remote_url, github_repo_slug_from_remote, merge_agents,
-        normalize_github_repo_slug, prompt_ai_review_config, prompt_for_missing_llm_env,
-        prompt_yes_no, select_remote_name, shell_single_quote, template_fetch_timeout_from_env,
+        comparable_text, custom_codereview_guide_contents, customize_workflow, git_remote_url,
+        github_repo_slug_from_remote, merge_agents, normalize_github_repo_slug,
+        prompt_ai_review_config, prompt_for_missing_llm_env, prompt_yes_no, select_remote_name,
+        shell_single_quote, template_fetch_timeout_from_env,
     };
 
     struct StubEnvironment {
@@ -1924,17 +1804,6 @@ hooks:
             template_fetch_timeout_from_env(Some("not-a-number")),
             Duration::from_millis(DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS)
         );
-    }
-
-    #[test]
-    fn ai_pr_review_setup_doc_uses_generic_secret_and_fireworks_defaults() {
-        let doc = ai_pr_review_setup_doc_contents(&AiReviewConfig::default());
-
-        assert!(doc.contains(DEFAULT_AI_REVIEW_SECRET_NAME));
-        assert!(doc.contains(DEFAULT_AI_REVIEW_PROVIDER_KIND));
-        assert!(doc.contains(DEFAULT_AI_REVIEW_MODEL_ID));
-        assert!(doc.contains(DEFAULT_AI_REVIEW_BASE_URL));
-        assert!(doc.contains(AI_REVIEW_LABEL_NAME));
     }
 
     #[test]

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -63,6 +63,10 @@ async fn init_copies_template_files_and_customizes_workflow() {
         "config.yaml should be created"
     );
     assert!(
+        !repo.path().join("docs/tasks/README.md").exists(),
+        "target repos should not receive docs/tasks bootstrap files"
+    );
+    assert!(
         !repo.path().join(".gitignore").exists(),
         "target repos should not receive the template .gitignore"
     );
@@ -112,10 +116,17 @@ async fn init_can_scaffold_ai_pr_review_and_print_fallback_commands_when_gh_cann
         "starter review guide should be created"
     );
     assert!(
-        repo.path()
+        !repo
+            .path()
             .join("docs/ai-pr-review-human-setup.md")
-            .is_file(),
-        "setup guide should be created"
+            .exists(),
+        "AI PR review should not create repo-local docs setup files"
+    );
+    assert!(
+        stdout.contains(
+            "For the managed local OpenHands server, run `opensymphony install openhands`"
+        ),
+        "stdout should present managed local OpenHands as the normal path: {stdout}",
     );
     assert!(
         stdout.contains("OpenHands PR review scaffolding was added."),
@@ -123,9 +134,15 @@ async fn init_can_scaffold_ai_pr_review_and_print_fallback_commands_when_gh_cann
     );
     assert!(
         stdout.contains(
-            "gh variable set AI_REVIEW_MODEL_ID --repo example/demo --body 'accounts/fireworks/models/glm-5p1'"
+            "gh variable set AI_REVIEW_MODEL_ID -R example/demo --body 'accounts/fireworks/models/glm-5p1'"
         ),
         "stdout should contain GitHub variable commands: {stdout}",
+    );
+    assert!(
+        stdout.contains(
+            "Manual setup guide: https://github.com/kumanday/OpenSymphony/blob/main/docs/ai-pr-review-human-setup.md"
+        ),
+        "stdout should point to the upstream setup guide: {stdout}",
     );
     assert!(
         stdout.contains("`gh` could not access `example/demo`"),
@@ -180,21 +197,21 @@ async fn init_can_scaffold_ai_pr_review_and_configure_github_with_gh() {
         "preflight should verify gh exists: {gh_log}",
     );
     assert!(
-        gh_log.contains("gh repo view --repo example/demo --json nameWithOwner"),
+        gh_log.contains("gh repo view example/demo --json nameWithOwner"),
         "preflight should verify repo access: {gh_log}",
     );
     assert!(
         gh_log.contains(
-            "gh variable set AI_REVIEW_PROVIDER_KIND --repo example/demo --body openai-compatible"
+            "gh variable set AI_REVIEW_PROVIDER_KIND -R example/demo --body openai-compatible"
         ),
         "provider variable should be configured: {gh_log}",
     );
     assert!(
-        gh_log.contains("gh label create review-this --repo example/demo --description Trigger AI PR review --color d73a4a --force"),
+        gh_log.contains("gh label create review-this -R example/demo --description Trigger AI PR review --color d73a4a --force"),
         "label should be ensured: {gh_log}",
     );
     assert!(
-        gh_log.contains("gh secret set AI_REVIEW_API_KEY --repo example/demo"),
+        gh_log.contains("gh secret set AI_REVIEW_API_KEY -R example/demo"),
         "secret should be configured when the user reuses LLM_API_KEY: {gh_log}",
     );
 }
@@ -556,7 +573,6 @@ openhands:
             ".github/workflows/ai-pr-review.yml".to_string(),
             "name: ai-pr-review\n".to_string(),
         ),
-        ("docs/tasks/README.md".to_string(), "# Tasks\n".to_string()),
     ])
 }
 

--- a/docs/ai-pr-review-system-spec.md
+++ b/docs/ai-pr-review-system-spec.md
@@ -51,7 +51,7 @@ Create or update the following:
 2. `.agents/skills/custom-codereview-guide.md`
 3. `AGENTS.md` (append an additive AI-review section, or create one if it does not exist)
 4. `.github/pull_request_template.md` or the repository’s existing PR template(s)
-5. `docs/ai-pr-review-human-setup.md`
+5. the central setup guide at `docs/ai-pr-review-human-setup.md` in OpenSymphony itself
 
 Do **not** create a fork-secret workflow by default.
 
@@ -61,19 +61,19 @@ Do **not** create or modify branch protection through code. Labels may be
 bootstrapped by repository setup tooling when `gh` is available, but the human
 setup document must still cover the manual fallback path.
 
-Do **not** invent `CODEOWNERS` entries if real owners are not obvious from the repository. Put a TODO and an example in the human setup document instead.
+Do **not** invent `CODEOWNERS` entries if real owners are not obvious from the repository. Put a TODO and an example in the central human setup guide instead.
 
 ## Coding-agent implementation rules
 
 1. Preserve existing files and merge changes additively.
 2. If `AGENTS.md` already exists, append a clearly labeled section instead of overwriting it.
 3. If `.github/pull_request_template.md` already exists, merge the `Evidence` section into the existing template instead of replacing the whole file.
-4. If the repo uses `.github/PULL_REQUEST_TEMPLATE/` multiple templates, update the default or the most relevant template and document the rest in the human setup file.
+4. If the repo uses `.github/PULL_REQUEST_TEMPLATE/` multiple templates, update the default or the most relevant template and document the rest in the central human setup guide.
 5. If the repo already has `.agents/skills/` or `.openhands/skills/`, use `.agents/skills/` and avoid conflicting duplicate skill names.
 6. Use a **unique** skill name like `custom-codereview-guide`, not `code-review`, so the repo skill **supplements** the default OpenHands review skill instead of overriding it.
 7. Pin the OpenHands action to a **full commit SHA** before finalizing the implementation.
 8. Use the **same SHA** for the action ref and for the `extensions-version` input.
-9. Do not ask humans for follow-up information during implementation. Infer what is safe to infer from the repository. Put everything else into `docs/ai-pr-review-human-setup.md`.
+9. Do not ask humans for follow-up information during implementation. Infer what is safe to infer from the repository. Put everything else into the central `docs/ai-pr-review-human-setup.md` guide.
 
 ## File 1: `.github/workflows/ai-pr-review.yml`
 
@@ -351,9 +351,9 @@ Call out any specific files, invariants, migrations, compatibility concerns, or 
 - [ ] Evidence section is complete
 ```
 
-## File 5: `docs/ai-pr-review-human-setup.md`
+## File 5: central `docs/ai-pr-review-human-setup.md`
 
-Create this documentation file for humans.
+Create or update this documentation file for humans in OpenSymphony itself. `opensymphony init` should link to it rather than copying it into target repositories.
 
 Use the following content, updating any repo-specific references or notes you discover during implementation.
 
@@ -594,7 +594,7 @@ The coding agent should inspect the repository and enrich the following where sa
 - generated or vendored paths
 - sensitive areas like auth, payments, migrations, queues, background jobs, schema, API contracts, rollout flags
 
-If a fact is not safely inferable, put it in `docs/ai-pr-review-human-setup.md` as a TODO.
+If a fact is not safely inferable, put it in the central `docs/ai-pr-review-human-setup.md` guide as a TODO.
 
 ## Final checklist for the coding agent
 
@@ -606,7 +606,7 @@ Before finishing, verify all of the following:
 - [ ] `.agents/skills/custom-codereview-guide.md` exists with a **unique** skill name
 - [ ] `AGENTS.md` exists and includes the AI review overlay
 - [ ] the PR template contains an `Evidence` section
-- [ ] `docs/ai-pr-review-human-setup.md` exists
+- [ ] the central `docs/ai-pr-review-human-setup.md` guide exists
 - [ ] no fork-secret workflow was added by default
 - [ ] no `pull_request_target` workflow was added by default
 - [ ] no auto-approval logic was added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,13 +42,11 @@ Core bootstrap payload:
 - `.agents/skills/linear/references/`
 - `.github/CODEOWNERS`
 - `.github/pull_request_template.md`
-- `docs/tasks/README.md`
 
 Optional AI PR review scaffolding:
 
 - `.github/workflows/ai-pr-review.yml`
 - `.agents/skills/custom-codereview-guide.md`
-- `docs/ai-pr-review-human-setup.md`
 
 ## Labels
 
@@ -160,4 +158,6 @@ you when:
 
 If any of those are missing, `init` falls back to a short checklist plus the
 manual `gh` commands. The full verification and branch-protection guidance
-lives in [ai-pr-review-human-setup.md](ai-pr-review-human-setup.md).
+lives in the OpenSymphony docs at
+[ai-pr-review-human-setup.md](ai-pr-review-human-setup.md); `init` does not
+copy that guide into the target repository.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,6 +39,8 @@ Important `init` behavior:
   the target repository
 - copies `.agents/skills/` recursively so helper scripts, query files, and
   reference docs all arrive together
+- keeps bootstrap guidance in CLI output and the central OpenSymphony docs
+  instead of copying `docs/` files into the target repository
 
 ## 3. Recommended validation commands
 


### PR DESCRIPTION
## Summary
- stop copying repo docs files into target repos during `opensymphony init`
- fix generated `gh` commands and automation calls to use working repository selection syntax
- present the managed local OpenHands server as the normal setup path and point AI review fallback guidance at the central OpenSymphony docs

## Evidence
- `cargo fmt --check`
- `cargo test -p opensymphony-cli --test init`
- `cargo test -p opensymphony-cli init_repo`
- `cargo clippy -p opensymphony-cli --tests -- -D warnings`