### PR TITLE
Add memory init and mapped docs sync

### DIFF
--- a/.agents/skills/opensymphony-memory/SKILL.md
+++ b/.agents/skills/opensymphony-memory/SKILL.md
@@ -36,8 +36,8 @@ is pending docs sync, or has capture warnings. Use `opensymphony memory lint
 
 ## Rules
 
-- Do not create or update issue capsules during ordinary implementation unless the user explicitly asks.
-- Do not archive Linear issues. Archival is a separate operator action guarded by `opensymphony linear archive`.
+- Do not create or update issue capsules during ordinary implementation unless the user explicitly asks; normal capture is run-loop infrastructure when `memory.auto_capture` is enabled.
+- Do not archive Linear issues unless the user explicitly asks. Run-loop auto-archive is disabled by default and still requires successful capture.
 - Do not rewrite public docs from private memory by hand; use `opensymphony memory sync-docs` so the managed sections and indexes stay consistent.
 - Do not copy full agent transcripts into memory or docs.
 - Do not treat retrieved memory as authoritative over current source files, tests, or upstream specs.
@@ -45,7 +45,8 @@ is pending docs sync, or has capture warnings. Use `opensymphony memory lint
 ## Interpretation
 
 Memory output separates source-derived facts from generated synthesis when the
-capture has enough evidence. Prefer source provenance such as PR URLs, commit
-SHAs, and issue identifiers when making claims. If memory is stale, missing, or
-warning-heavy, inspect the linked PRs, current docs, and `opensymphony debug
-ISSUE-ID` before depending on it.
+capture has enough evidence. Prefer source refs such as Linear issue IDs, PR
+URLs, and merge SHAs when making audit claims. Merge SHA is an immutable pointer
+to the merged code state, not an area inference signal. If memory is stale,
+missing, or warning-heavy, inspect the linked PRs, current docs, and
+`opensymphony debug ISSUE-ID` before depending on it.

--- a/.agents/skills/opensymphony-memory/SKILL.md
+++ b/.agents/skills/opensymphony-memory/SKILL.md
@@ -38,7 +38,7 @@ is pending docs sync, or has capture warnings. Use `opensymphony memory lint
 
 - Do not create or update issue capsules during ordinary implementation unless the user explicitly asks.
 - Do not archive Linear issues. Archival is a separate operator action guarded by `opensymphony linear archive`.
-- Do not rewrite public docs from private memory by hand; use `opensymphony memory sync-docs --dry-run` first.
+- Do not rewrite public docs from private memory by hand; use `opensymphony memory sync-docs` so the managed sections and indexes stay consistent.
 - Do not copy full agent transcripts into memory or docs.
 - Do not treat retrieved memory as authoritative over current source files, tests, or upstream specs.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           components: clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
       - name: fmt
         run: cargo fmt --check
       - name: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           components: clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
-        with:
-          cache-targets: false
       - name: fmt
         run: cargo fmt --check
       - name: clippy

--- a/.gitignore
+++ b/.gitignore
@@ -21,13 +21,13 @@ target
 #.idea/
 
 # Local validation artifacts
+.venv/
+var/
+tools/openhands-server/workspace/
+.DS_Store
 .opensymphony*
 !.opensymphony/
 .opensymphony/*
 !.opensymphony/memory/
 .opensymphony/memory/*
 !.opensymphony/memory/memory.yaml
-.venv/
-var/
-tools/openhands-server/workspace/
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ target
 
 # Local validation artifacts
 .opensymphony*
+!.opensymphony/
+.opensymphony/*
+!.opensymphony/memory/
+.opensymphony/memory/*
+!.opensymphony/memory/memory.yaml
 .venv/
 var/
 tools/openhands-server/workspace/

--- a/.opensymphony/memory/memory.yaml
+++ b/.opensymphony/memory/memory.yaml
@@ -45,16 +45,103 @@ areas:
       - docs/architecture.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
       linear_issues:
       - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
       - COE-259
       - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-283
+      - COE-284
+      - COE-286
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
       - '#10'
       - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
       - '#26'
+      - '#27'
       - '#29'
       - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#49'
+      - '#50'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
+  cli:
+    title: Cli
+    docs_target: docs/cli.md
+    visibility: public
+    status: stable
+    confidence: 90
+    aliases:
+    - cli
+    source_refs:
+      linear_labels:
+      - cli
+      linear_issues:
+      - COE-284
+      github_prs:
+      - '#47'
+      - '#83'
   configuration:
     title: Configuration
     docs_target: docs/configuration.md
@@ -68,13 +155,89 @@ areas:
       - docs/configuration.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
       linear_issues:
       - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
       - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-286
+      - COE-287
+      - COE-288
+      - COE-293
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
       - '#10'
       - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
       - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#49'
+      - '#51'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#56'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   deployment-modes:
     title: Deployment Modes
     docs_target: docs/deployment-modes.md
@@ -83,9 +246,52 @@ areas:
     confidence: 85
     aliases:
     - deployment modes
+    - deployment-modes
     source_refs:
       docs:
       - docs/deployment-modes.md
+      linear_milestones:
+      - 'M2: OpenHands runtime adapter'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
+      linear_issues:
+      - COE-253
+      - COE-256
+      - COE-261
+      - COE-262
+      - COE-265
+      - COE-266
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#13'
+      - '#19'
+      - '#20'
+      - '#34'
+      - '#36'
+      - '#40'
+      - '#41'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#83'
   development:
     title: Development Guide
     docs_target: docs/DEVELOPMENT.md
@@ -100,12 +306,113 @@ areas:
       - docs/DEVELOPMENT.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
       linear_issues:
       - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
       - '#10'
       - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
       - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
+  devex:
+    title: Devex
+    docs_target: docs/devex.md
+    visibility: public
+    status: stable
+    confidence: 90
+    aliases:
+    - devex
+    source_refs:
+      linear_labels:
+      - devex
+      linear_issues:
+      - COE-284
+      github_prs:
+      - '#47'
+      - '#83'
+  doctor-live-probe:
+    title: Doctor Live Probe
+    docs_target: docs/doctor-live-probe.md
+    visibility: public
+    status: candidate
+    confidence: 60
+    aliases:
+    - doctor live probe
+    - doctor-live-probe
+    source_refs:
+      linear_issues:
+      - COE-278
+      github_prs:
+      - '#36'
   elixir-hierarchy-changes:
     title: Changes Needed in Upstream Elixir Implementation for Hierarchy-Aware Task Selection
     docs_target: docs/elixir-hierarchy-changes.md
@@ -114,9 +421,31 @@ areas:
     confidence: 85
     aliases:
     - changes needed in upstream elixir implementation for hierarchy-aware task selection
+    - elixir-hierarchy-changes
     source_refs:
       docs:
       - docs/elixir-hierarchy-changes.md
+      linear_milestones:
+      - 'M3: Symphony orchestration core'
+      linear_issues:
+      - COE-254
+      - COE-263
+      - COE-264
+      - COE-267
+      - COE-268
+      - COE-270
+      - COE-277
+      github_prs:
+      - '#14'
+      - '#18'
+      - '#24'
+      - '#33'
+      - '#35'
+      - '#39'
+      - '#42'
+      - '#43'
+      - '#6'
+      - '#83'
   host-client-architecture:
     title: OpenSymphony Host-Client Architecture
     docs_target: docs/host-client-architecture.md
@@ -164,13 +493,85 @@ areas:
       - docs/implementation-plan.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
       linear_issues:
       - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
       - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
       - '#10'
       - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
       - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   linear-and-tools:
     title: Linear and Tools
     docs_target: docs/linear-and-tools.md
@@ -179,9 +580,31 @@ areas:
     confidence: 85
     aliases:
     - linear and tools
+    - linear-and-tools
     source_refs:
       docs:
       - docs/linear-and-tools.md
+      linear_milestones:
+      - 'M3: Symphony orchestration core'
+      linear_issues:
+      - COE-254
+      - COE-263
+      - COE-264
+      - COE-267
+      - COE-268
+      - COE-270
+      - COE-277
+      github_prs:
+      - '#14'
+      - '#18'
+      - '#24'
+      - '#33'
+      - '#35'
+      - '#39'
+      - '#42'
+      - '#43'
+      - '#6'
+      - '#83'
   memory:
     title: Project Memory
     docs_target: docs/memory.md
@@ -189,10 +612,90 @@ areas:
     status: stable
     confidence: 85
     aliases:
+    - memory
     - project memory
     source_refs:
       docs:
       - docs/memory.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
+      linear_issues:
+      - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#10'
+      - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
+      - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   memory-capture-and-doc-sync:
     title: OpenSymphony Memory Capture and Documentation Sync
     docs_target: docs/memory-capture-and-doc-sync.md
@@ -223,9 +726,93 @@ areas:
     confidence: 85
     aliases:
     - openhands agent-server integration
+    - openhands-agent-server
     source_refs:
       docs:
       - docs/openhands-agent-server.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
+      linear_issues:
+      - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-287
+      - COE-293
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#10'
+      - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
+      - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#56'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   openhands-agent-server-subscription-auth-analysis:
     title: Subscription-Based OpenAI ChatGPT/Codex Authentication with `openhands agent-server`
     docs_target: docs/openhands_agent_server_subscription_auth_analysis.md
@@ -248,6 +835,91 @@ areas:
     source_refs:
       docs:
       - docs/operations.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
+      linear_issues:
+      - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-286
+      - COE-287
+      - COE-293
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#10'
+      - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
+      - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#49'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#56'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   prerequisites:
     title: Prerequisites
     docs_target: docs/prerequisites.md
@@ -259,6 +931,52 @@ areas:
     source_refs:
       docs:
       - docs/prerequisites.md
+      linear_milestones:
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
+      linear_issues:
+      - COE-256
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#13'
+      - '#20'
+      - '#41'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#83'
+  refactor-orchestrator-run:
+    title: Refactor Orchestrator Run
+    docs_target: docs/refactor-orchestrator-run.md
+    visibility: public
+    status: candidate
+    confidence: 60
+    aliases:
+    - refactor orchestrator run
+    - refactor-orchestrator-run
+    source_refs:
+      linear_issues:
+      - COE-285
+      github_prs:
+      - '#53'
   repository-layout:
     title: Repository Layout
     docs_target: docs/repository-layout.md
@@ -273,13 +991,83 @@ areas:
       - docs/repository-layout.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
       linear_issues:
       - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
       - COE-258
+      - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
       - '#10'
       - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
       - '#26'
+      - '#27'
+      - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   sources:
     title: Sources and Trust Notes
     docs_target: docs/sources.md
@@ -287,10 +1075,63 @@ areas:
     status: stable
     confidence: 85
     aliases:
+    - sources
     - sources and trust notes
     source_refs:
       docs:
       - docs/sources.md
+      linear_milestones:
+      - 'M2: OpenHands runtime adapter'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
+      linear_issues:
+      - COE-253
+      - COE-255
+      - COE-256
+      - COE-261
+      - COE-262
+      - COE-265
+      - COE-266
+      - COE-269
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#13'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#27'
+      - '#34'
+      - '#36'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#7'
+      - '#83'
   symphony-spec-alignment:
     title: Symphony Spec Alignment
     docs_target: docs/symphony-spec-alignment.md
@@ -305,12 +1146,83 @@ areas:
       - docs/symphony-spec-alignment.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
       linear_issues:
+      - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
       - COE-259
       - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-277
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-284
+      - COE-287
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
+      - '#10'
+      - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
+      - '#26'
+      - '#27'
       - '#29'
       - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   testing-and-operations:
     title: Testing
     docs_target: docs/testing-and-operations.md
@@ -325,14 +1237,90 @@ areas:
       - docs/testing-and-operations.md
       linear_milestones:
       - 'M1: Foundation and contracts'
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
       linear_issues:
       - COE-252
+      - COE-253
+      - COE-254
+      - COE-255
+      - COE-256
+      - COE-258
       - COE-259
+      - COE-260
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-269
+      - COE-270
+      - COE-271
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-277
+      - COE-279
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-283
+      - COE-284
+      - COE-287
+      - COE-288
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
       github_prs:
+      - '#1'
       - '#10'
       - '#11'
+      - '#13'
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#20'
+      - '#23'
+      - '#24'
       - '#26'
+      - '#27'
       - '#29'
+      - '#32'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#4'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#47'
+      - '#48'
+      - '#50'
+      - '#51'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#6'
+      - '#7'
+      - '#83'
   ui-frankentui:
     title: FrankenTUI Operator UI
     docs_target: docs/ui-frankentui.md
@@ -341,9 +1329,27 @@ areas:
     confidence: 85
     aliases:
     - frankentui operator ui
+    - ui-frankentui
     source_refs:
       docs:
       - docs/ui-frankentui.md
+      linear_milestones:
+      - 'M4: Operator UX and repo harness'
+      linear_issues:
+      - COE-255
+      - COE-269
+      - COE-271
+      - COE-287
+      - COE-321
+      github_prs:
+      - '#23'
+      - '#27'
+      - '#4'
+      - '#41'
+      - '#48'
+      - '#59'
+      - '#7'
+      - '#83'
   websocket-runtime:
     title: WebSocket Runtime Contract
     docs_target: docs/websocket-runtime.md
@@ -352,9 +1358,52 @@ areas:
     confidence: 85
     aliases:
     - websocket runtime contract
+    - websocket-runtime
     source_refs:
       docs:
       - docs/websocket-runtime.md
+      linear_milestones:
+      - 'M2: OpenHands runtime adapter'
+      - 'M5: Validation and local packaging'
+      - 'M6: Hosted deployment follow-on'
+      linear_issues:
+      - COE-253
+      - COE-256
+      - COE-261
+      - COE-262
+      - COE-265
+      - COE-266
+      - COE-272
+      - COE-273
+      - COE-274
+      - COE-275
+      - COE-280
+      - COE-281
+      - COE-282
+      - COE-294
+      - COE-382
+      - COE-383
+      - COE-384
+      - COE-385
+      - COE-386
+      - COE-387
+      github_prs:
+      - '#1'
+      - '#13'
+      - '#19'
+      - '#20'
+      - '#34'
+      - '#36'
+      - '#40'
+      - '#41'
+      - '#44'
+      - '#45'
+      - '#46'
+      - '#52'
+      - '#54'
+      - '#55'
+      - '#58'
+      - '#83'
   workspace-and-lifecycle:
     title: Workspace and Lifecycle
     docs_target: docs/workspace-and-lifecycle.md
@@ -363,8 +1412,44 @@ areas:
     confidence: 85
     aliases:
     - workspace and lifecycle
+    - workspace-and-lifecycle
     source_refs:
       docs:
       - docs/workspace-and-lifecycle.md
+      linear_milestones:
+      - 'M2: OpenHands runtime adapter'
+      - 'M3: Symphony orchestration core'
+      - 'M4: Operator UX and repo harness'
+      linear_issues:
+      - COE-253
+      - COE-254
+      - COE-261
+      - COE-262
+      - COE-263
+      - COE-264
+      - COE-265
+      - COE-266
+      - COE-267
+      - COE-268
+      - COE-270
+      - COE-277
+      - COE-287
+      github_prs:
+      - '#14'
+      - '#18'
+      - '#19'
+      - '#24'
+      - '#33'
+      - '#34'
+      - '#35'
+      - '#36'
+      - '#39'
+      - '#40'
+      - '#41'
+      - '#42'
+      - '#43'
+      - '#48'
+      - '#6'
+      - '#83'
 redaction:
   deny_patterns: []

--- a/.opensymphony/memory/memory.yaml
+++ b/.opensymphony/memory/memory.yaml
@@ -1,118 +1,370 @@
+enabled: true
 memory_root: .opensymphony/memory
 visibility: private
 index_path: .opensymphony/memory/memory.duckdb
+confidence_threshold: 75
 source_snapshots: hashes
 markdown_indexes: true
-
 docs:
   public_root: docs
   default_visibility: public
   deny_private_links: true
-
 areas:
-  agent-runtime:
-    title: Agent Runtime
-    docs_target: docs/agent-runtime.md
-    path_hints:
-      - agent
-      - agent-runtime
-      - runtime
-    labels:
-      - agent-runtime
-  domain:
-    title: Domain
-    docs_target: docs/domain.md
-    path_hints:
-      - domain
-    labels:
-      - domain
-  foundation:
-    title: Foundation
-    docs_target: docs/foundation.md
-    path_hints:
-      - foundation
-    labels:
-      - foundation
-  hosted-follow-on:
-    title: Hosted Follow On
-    docs_target: docs/hosted-follow-on.md
-    path_hints:
-      - follow
-      - hosted
-      - hosted-follow-on
-      - on
-    labels:
-      - hosted-follow-on
-  openhands:
-    title: Openhands
-    docs_target: docs/openhands.md
-    path_hints:
-      - openhands
-    labels:
-      - openhands
-  orchestration:
-    title: Orchestration
-    docs_target: docs/orchestration.md
-    path_hints:
-      - orchestration
-    labels:
-      - orchestration
-  quality-ops:
-    title: Quality Ops
-    docs_target: docs/quality-ops.md
-    path_hints:
-      - ops
-      - quality
-      - quality-ops
-    labels:
-      - quality-ops
-  repo-harness:
-    title: Repo Harness
-    docs_target: docs/repo-harness.md
-    path_hints:
-      - harness
-      - repo
-      - repo-harness
-    labels:
-      - repo-harness
-  tracker:
-    title: Tracker
-    docs_target: docs/tracker.md
-    path_hints:
-      - tracker
-    labels:
-      - tracker
-  tracker-tools:
-    title: Tracker Tools
-    docs_target: docs/tracker-tools.md
-    path_hints:
-      - tools
-      - tracker
-      - tracker-tools
-    labels:
-      - tracker-tools
-  ui-observability:
-    title: Ui Observability
-    docs_target: docs/ui-observability.md
-    path_hints:
-      - observability
-      - ui
-      - ui-observability
-    labels:
-      - ui-observability
-  workflow-config:
-    title: Workflow Config
-    docs_target: docs/workflow-config.md
-    path_hints:
-      - config
-      - workflow
-      - workflow-config
-    labels:
-      - workflow-config
-  workspace:
-    title: Workspace
-    docs_target: docs/workspace.md
-    path_hints:
-      - workspace
-    labels:
-      - workspace
+  ai-pr-review-human-setup:
+    title: OpenHands PR Review - Human Setup Guide
+    docs_target: docs/ai-pr-review-human-setup.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - openhands pr review - human setup guide
+    source_refs:
+      docs:
+      - docs/ai-pr-review-human-setup.md
+  ai-pr-review-system-spec:
+    title: Provider-agnostic AI PR review system for GitHub using OpenHands
+    docs_target: docs/ai-pr-review-system-spec.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - provider-agnostic ai pr review system for github using openhands
+    source_refs:
+      docs:
+      - docs/ai-pr-review-system-spec.md
+  architecture:
+    title: Architecture
+    docs_target: docs/architecture.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - architecture
+    source_refs:
+      docs:
+      - docs/architecture.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-252
+      - COE-259
+      - COE-260
+      github_prs:
+      - '#10'
+      - '#11'
+      - '#26'
+      - '#29'
+      - '#32'
+  configuration:
+    title: Configuration
+    docs_target: docs/configuration.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - configuration
+    source_refs:
+      docs:
+      - docs/configuration.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-252
+      - COE-258
+      github_prs:
+      - '#10'
+      - '#11'
+      - '#26'
+  deployment-modes:
+    title: Deployment Modes
+    docs_target: docs/deployment-modes.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - deployment modes
+    source_refs:
+      docs:
+      - docs/deployment-modes.md
+  development:
+    title: Development Guide
+    docs_target: docs/DEVELOPMENT.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - development
+    - development guide
+    source_refs:
+      docs:
+      - docs/DEVELOPMENT.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-252
+      github_prs:
+      - '#10'
+      - '#11'
+      - '#26'
+  elixir-hierarchy-changes:
+    title: Changes Needed in Upstream Elixir Implementation for Hierarchy-Aware Task Selection
+    docs_target: docs/elixir-hierarchy-changes.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - changes needed in upstream elixir implementation for hierarchy-aware task selection
+    source_refs:
+      docs:
+      - docs/elixir-hierarchy-changes.md
+  host-client-architecture:
+    title: OpenSymphony Host-Client Architecture
+    docs_target: docs/host-client-architecture.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - opensymphony host-client architecture
+    source_refs:
+      docs:
+      - docs/host-client-architecture.md
+  host-client-implementation-plan:
+    title: OpenSymphony Rich Client, Hosted Mode, and Planning Implementation Plan
+    docs_target: docs/host-client-implementation_plan.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - opensymphony rich client, hosted mode, and planning implementation plan
+    source_refs:
+      docs:
+      - docs/host-client-implementation_plan.md
+  hosted-client-prd:
+    title: OpenSymphony Rich Client, Hosted Mode, and Collaborative Planning PRD
+    docs_target: docs/hosted-client-PRD.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - opensymphony rich client, hosted mode, and collaborative planning prd
+    source_refs:
+      docs:
+      - docs/hosted-client-PRD.md
+  implementation-plan:
+    title: Implementation Plan
+    docs_target: docs/implementation-plan.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - implementation plan
+    - implementation-plan
+    source_refs:
+      docs:
+      - docs/implementation-plan.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-252
+      - COE-258
+      github_prs:
+      - '#10'
+      - '#11'
+      - '#26'
+  linear-and-tools:
+    title: Linear and Tools
+    docs_target: docs/linear-and-tools.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - linear and tools
+    source_refs:
+      docs:
+      - docs/linear-and-tools.md
+  memory:
+    title: Project Memory
+    docs_target: docs/memory.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - project memory
+    source_refs:
+      docs:
+      - docs/memory.md
+  memory-capture-and-doc-sync:
+    title: OpenSymphony Memory Capture and Documentation Sync
+    docs_target: docs/memory-capture-and-doc-sync.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - opensymphony memory capture and documentation sync
+    source_refs:
+      docs:
+      - docs/memory-capture-and-doc-sync.md
+  migration-1-0-0:
+    title: OpenSymphony 1.0.0 Migration Guide
+    docs_target: docs/migration-1.0.0.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - opensymphony 1.0.0 migration guide
+    source_refs:
+      docs:
+      - docs/migration-1.0.0.md
+  openhands-agent-server:
+    title: OpenHands Agent-Server Integration
+    docs_target: docs/openhands-agent-server.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - openhands agent-server integration
+    source_refs:
+      docs:
+      - docs/openhands-agent-server.md
+  openhands-agent-server-subscription-auth-analysis:
+    title: Subscription-Based OpenAI ChatGPT/Codex Authentication with `openhands agent-server`
+    docs_target: docs/openhands_agent_server_subscription_auth_analysis.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - subscription-based openai chatgpt/codex authentication with `openhands agent-server`
+    source_refs:
+      docs:
+      - docs/openhands_agent_server_subscription_auth_analysis.md
+  operations:
+    title: Operations
+    docs_target: docs/operations.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - operations
+    source_refs:
+      docs:
+      - docs/operations.md
+  prerequisites:
+    title: Prerequisites
+    docs_target: docs/prerequisites.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - prerequisites
+    source_refs:
+      docs:
+      - docs/prerequisites.md
+  repository-layout:
+    title: Repository Layout
+    docs_target: docs/repository-layout.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - repository layout
+    - repository-layout
+    source_refs:
+      docs:
+      - docs/repository-layout.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-252
+      - COE-258
+      github_prs:
+      - '#10'
+      - '#11'
+      - '#26'
+  sources:
+    title: Sources and Trust Notes
+    docs_target: docs/sources.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - sources and trust notes
+    source_refs:
+      docs:
+      - docs/sources.md
+  symphony-spec-alignment:
+    title: Symphony Spec Alignment
+    docs_target: docs/symphony-spec-alignment.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - symphony spec alignment
+    - symphony-spec-alignment
+    source_refs:
+      docs:
+      - docs/symphony-spec-alignment.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-259
+      - COE-260
+      github_prs:
+      - '#29'
+      - '#32'
+  testing-and-operations:
+    title: Testing
+    docs_target: docs/testing-and-operations.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - testing
+    - testing-and-operations
+    source_refs:
+      docs:
+      - docs/testing-and-operations.md
+      linear_milestones:
+      - 'M1: Foundation and contracts'
+      linear_issues:
+      - COE-252
+      - COE-259
+      github_prs:
+      - '#10'
+      - '#11'
+      - '#26'
+      - '#29'
+  ui-frankentui:
+    title: FrankenTUI Operator UI
+    docs_target: docs/ui-frankentui.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - frankentui operator ui
+    source_refs:
+      docs:
+      - docs/ui-frankentui.md
+  websocket-runtime:
+    title: WebSocket Runtime Contract
+    docs_target: docs/websocket-runtime.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - websocket runtime contract
+    source_refs:
+      docs:
+      - docs/websocket-runtime.md
+  workspace-and-lifecycle:
+    title: Workspace and Lifecycle
+    docs_target: docs/workspace-and-lifecycle.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+    - workspace and lifecycle
+    source_refs:
+      docs:
+      - docs/workspace-and-lifecycle.md
+redaction:
+  deny_patterns: []

--- a/.opensymphony/memory/memory.yaml
+++ b/.opensymphony/memory/memory.yaml
@@ -1,0 +1,118 @@
+memory_root: .opensymphony/memory
+visibility: private
+index_path: .opensymphony/memory/memory.duckdb
+source_snapshots: hashes
+markdown_indexes: true
+
+docs:
+  public_root: docs
+  default_visibility: public
+  deny_private_links: true
+
+areas:
+  agent-runtime:
+    title: Agent Runtime
+    docs_target: docs/agent-runtime.md
+    path_hints:
+      - agent
+      - agent-runtime
+      - runtime
+    labels:
+      - agent-runtime
+  domain:
+    title: Domain
+    docs_target: docs/domain.md
+    path_hints:
+      - domain
+    labels:
+      - domain
+  foundation:
+    title: Foundation
+    docs_target: docs/foundation.md
+    path_hints:
+      - foundation
+    labels:
+      - foundation
+  hosted-follow-on:
+    title: Hosted Follow On
+    docs_target: docs/hosted-follow-on.md
+    path_hints:
+      - follow
+      - hosted
+      - hosted-follow-on
+      - on
+    labels:
+      - hosted-follow-on
+  openhands:
+    title: Openhands
+    docs_target: docs/openhands.md
+    path_hints:
+      - openhands
+    labels:
+      - openhands
+  orchestration:
+    title: Orchestration
+    docs_target: docs/orchestration.md
+    path_hints:
+      - orchestration
+    labels:
+      - orchestration
+  quality-ops:
+    title: Quality Ops
+    docs_target: docs/quality-ops.md
+    path_hints:
+      - ops
+      - quality
+      - quality-ops
+    labels:
+      - quality-ops
+  repo-harness:
+    title: Repo Harness
+    docs_target: docs/repo-harness.md
+    path_hints:
+      - harness
+      - repo
+      - repo-harness
+    labels:
+      - repo-harness
+  tracker:
+    title: Tracker
+    docs_target: docs/tracker.md
+    path_hints:
+      - tracker
+    labels:
+      - tracker
+  tracker-tools:
+    title: Tracker Tools
+    docs_target: docs/tracker-tools.md
+    path_hints:
+      - tools
+      - tracker
+      - tracker-tools
+    labels:
+      - tracker-tools
+  ui-observability:
+    title: Ui Observability
+    docs_target: docs/ui-observability.md
+    path_hints:
+      - observability
+      - ui
+      - ui-observability
+    labels:
+      - ui-observability
+  workflow-config:
+    title: Workflow Config
+    docs_target: docs/workflow-config.md
+    path_hints:
+      - config
+      - workflow
+      - workflow-config
+    labels:
+      - workflow-config
+  workspace:
+    title: Workspace
+    docs_target: docs/workspace.md
+    path_hints:
+      - workspace
+    labels:
+      - workspace

--- a/.opensymphony/memory/memory.yaml
+++ b/.opensymphony/memory/memory.yaml
@@ -1,4 +1,3 @@
-enabled: true
 memory_root: .opensymphony/memory
 visibility: private
 index_path: .opensymphony/memory/memory.duckdb
@@ -17,7 +16,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - openhands pr review - human setup guide
+    - OpenHands PR Review - Human Setup Guide
     source_refs:
       docs:
       - docs/ai-pr-review-human-setup.md
@@ -28,7 +27,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - provider-agnostic ai pr review system for github using openhands
+    - Provider-agnostic AI PR review system for GitHub using OpenHands
     source_refs:
       docs:
       - docs/ai-pr-review-system-spec.md
@@ -39,109 +38,21 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - architecture
+    - Architecture
     source_refs:
       docs:
       - docs/architecture.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-283
-      - COE-284
-      - COE-286
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#49'
-      - '#50'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   cli:
     title: Cli
     docs_target: docs/cli.md
     visibility: public
     status: stable
-    confidence: 90
+    confidence: 85
     aliases:
-    - cli
+    - Cli
     source_refs:
-      linear_labels:
-      - cli
-      linear_issues:
-      - COE-284
-      github_prs:
-      - '#47'
-      - '#83'
+      docs:
+      - docs/cli.md
   configuration:
     title: Configuration
     docs_target: docs/configuration.md
@@ -149,95 +60,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - configuration
+    - Configuration
     source_refs:
       docs:
       - docs/configuration.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-286
-      - COE-287
-      - COE-288
-      - COE-293
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#49'
-      - '#51'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#56'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   deployment-modes:
     title: Deployment Modes
     docs_target: docs/deployment-modes.md
@@ -245,53 +71,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - deployment modes
-    - deployment-modes
+    - Deployment Modes
     source_refs:
       docs:
       - docs/deployment-modes.md
-      linear_milestones:
-      - 'M2: OpenHands runtime adapter'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-253
-      - COE-256
-      - COE-261
-      - COE-262
-      - COE-265
-      - COE-266
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#13'
-      - '#19'
-      - '#20'
-      - '#34'
-      - '#36'
-      - '#40'
-      - '#41'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#83'
   development:
     title: Development Guide
     docs_target: docs/DEVELOPMENT.md
@@ -299,120 +82,21 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - development
-    - development guide
+    - Development Guide
     source_refs:
       docs:
       - docs/DEVELOPMENT.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   devex:
     title: Devex
     docs_target: docs/devex.md
     visibility: public
     status: stable
-    confidence: 90
+    confidence: 85
     aliases:
-    - devex
+    - Devex
     source_refs:
-      linear_labels:
-      - devex
-      linear_issues:
-      - COE-284
-      github_prs:
-      - '#47'
-      - '#83'
-  doctor-live-probe:
-    title: Doctor Live Probe
-    docs_target: docs/doctor-live-probe.md
-    visibility: public
-    status: candidate
-    confidence: 60
-    aliases:
-    - doctor live probe
-    - doctor-live-probe
-    source_refs:
-      linear_issues:
-      - COE-278
-      github_prs:
-      - '#36'
+      docs:
+      - docs/devex.md
   elixir-hierarchy-changes:
     title: Changes Needed in Upstream Elixir Implementation for Hierarchy-Aware Task Selection
     docs_target: docs/elixir-hierarchy-changes.md
@@ -420,32 +104,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - changes needed in upstream elixir implementation for hierarchy-aware task selection
-    - elixir-hierarchy-changes
+    - Changes Needed in Upstream Elixir Implementation for Hierarchy-Aware Task Selection
     source_refs:
       docs:
       - docs/elixir-hierarchy-changes.md
-      linear_milestones:
-      - 'M3: Symphony orchestration core'
-      linear_issues:
-      - COE-254
-      - COE-263
-      - COE-264
-      - COE-267
-      - COE-268
-      - COE-270
-      - COE-277
-      github_prs:
-      - '#14'
-      - '#18'
-      - '#24'
-      - '#33'
-      - '#35'
-      - '#39'
-      - '#42'
-      - '#43'
-      - '#6'
-      - '#83'
   host-client-architecture:
     title: OpenSymphony Host-Client Architecture
     docs_target: docs/host-client-architecture.md
@@ -453,7 +115,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - opensymphony host-client architecture
+    - OpenSymphony Host-Client Architecture
     source_refs:
       docs:
       - docs/host-client-architecture.md
@@ -464,7 +126,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - opensymphony rich client, hosted mode, and planning implementation plan
+    - OpenSymphony Rich Client, Hosted Mode, and Planning Implementation Plan
     source_refs:
       docs:
       - docs/host-client-implementation_plan.md
@@ -475,7 +137,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - opensymphony rich client, hosted mode, and collaborative planning prd
+    - OpenSymphony Rich Client, Hosted Mode, and Collaborative Planning PRD
     source_refs:
       docs:
       - docs/hosted-client-PRD.md
@@ -486,92 +148,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - implementation plan
-    - implementation-plan
+    - Implementation Plan
     source_refs:
       docs:
       - docs/implementation-plan.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   linear-and-tools:
     title: Linear and Tools
     docs_target: docs/linear-and-tools.md
@@ -579,32 +159,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - linear and tools
-    - linear-and-tools
+    - Linear and Tools
     source_refs:
       docs:
       - docs/linear-and-tools.md
-      linear_milestones:
-      - 'M3: Symphony orchestration core'
-      linear_issues:
-      - COE-254
-      - COE-263
-      - COE-264
-      - COE-267
-      - COE-268
-      - COE-270
-      - COE-277
-      github_prs:
-      - '#14'
-      - '#18'
-      - '#24'
-      - '#33'
-      - '#35'
-      - '#39'
-      - '#42'
-      - '#43'
-      - '#6'
-      - '#83'
   memory:
     title: Project Memory
     docs_target: docs/memory.md
@@ -612,90 +170,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - memory
-    - project memory
+    - Project Memory
     source_refs:
       docs:
       - docs/memory.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   memory-capture-and-doc-sync:
     title: OpenSymphony Memory Capture and Documentation Sync
     docs_target: docs/memory-capture-and-doc-sync.md
@@ -703,7 +181,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - opensymphony memory capture and documentation sync
+    - OpenSymphony Memory Capture and Documentation Sync
     source_refs:
       docs:
       - docs/memory-capture-and-doc-sync.md
@@ -714,7 +192,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - opensymphony 1.0.0 migration guide
+    - OpenSymphony 1.0.0 Migration Guide
     source_refs:
       docs:
       - docs/migration-1.0.0.md
@@ -725,94 +203,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - openhands agent-server integration
-    - openhands-agent-server
+    - OpenHands Agent-Server Integration
     source_refs:
       docs:
       - docs/openhands-agent-server.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-287
-      - COE-293
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#56'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   openhands-agent-server-subscription-auth-analysis:
     title: Subscription-Based OpenAI ChatGPT/Codex Authentication with `openhands agent-server`
     docs_target: docs/openhands_agent_server_subscription_auth_analysis.md
@@ -820,7 +214,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - subscription-based openai chatgpt/codex authentication with `openhands agent-server`
+    - Subscription-Based OpenAI ChatGPT/Codex Authentication with `openhands agent-server`
     source_refs:
       docs:
       - docs/openhands_agent_server_subscription_auth_analysis.md
@@ -831,95 +225,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - operations
+    - Operations
     source_refs:
       docs:
       - docs/operations.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-286
-      - COE-287
-      - COE-293
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#49'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#56'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   prerequisites:
     title: Prerequisites
     docs_target: docs/prerequisites.md
@@ -927,56 +236,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - prerequisites
+    - Prerequisites
     source_refs:
       docs:
       - docs/prerequisites.md
-      linear_milestones:
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-256
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#13'
-      - '#20'
-      - '#41'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#83'
-  refactor-orchestrator-run:
-    title: Refactor Orchestrator Run
-    docs_target: docs/refactor-orchestrator-run.md
-    visibility: public
-    status: candidate
-    confidence: 60
-    aliases:
-    - refactor orchestrator run
-    - refactor-orchestrator-run
-    source_refs:
-      linear_issues:
-      - COE-285
-      github_prs:
-      - '#53'
   repository-layout:
     title: Repository Layout
     docs_target: docs/repository-layout.md
@@ -984,90 +247,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - repository layout
-    - repository-layout
+    - Repository Layout
     source_refs:
       docs:
       - docs/repository-layout.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   sources:
     title: Sources and Trust Notes
     docs_target: docs/sources.md
@@ -1075,63 +258,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - sources
-    - sources and trust notes
+    - Sources and Trust Notes
     source_refs:
       docs:
       - docs/sources.md
-      linear_milestones:
-      - 'M2: OpenHands runtime adapter'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-253
-      - COE-255
-      - COE-256
-      - COE-261
-      - COE-262
-      - COE-265
-      - COE-266
-      - COE-269
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#13'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#27'
-      - '#34'
-      - '#36'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#7'
-      - '#83'
   symphony-spec-alignment:
     title: Symphony Spec Alignment
     docs_target: docs/symphony-spec-alignment.md
@@ -1139,90 +269,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - symphony spec alignment
-    - symphony-spec-alignment
+    - Symphony Spec Alignment
     source_refs:
       docs:
       - docs/symphony-spec-alignment.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-277
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-284
-      - COE-287
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   testing-and-operations:
     title: Testing
     docs_target: docs/testing-and-operations.md
@@ -1230,97 +280,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - testing
-    - testing-and-operations
+    - Testing
     source_refs:
       docs:
       - docs/testing-and-operations.md
-      linear_milestones:
-      - 'M1: Foundation and contracts'
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-252
-      - COE-253
-      - COE-254
-      - COE-255
-      - COE-256
-      - COE-258
-      - COE-259
-      - COE-260
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-269
-      - COE-270
-      - COE-271
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-277
-      - COE-279
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-283
-      - COE-284
-      - COE-287
-      - COE-288
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#10'
-      - '#11'
-      - '#13'
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#20'
-      - '#23'
-      - '#24'
-      - '#26'
-      - '#27'
-      - '#29'
-      - '#32'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#4'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#47'
-      - '#48'
-      - '#50'
-      - '#51'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#6'
-      - '#7'
-      - '#83'
   ui-frankentui:
     title: FrankenTUI Operator UI
     docs_target: docs/ui-frankentui.md
@@ -1328,28 +291,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - frankentui operator ui
-    - ui-frankentui
+    - FrankenTUI Operator UI
     source_refs:
       docs:
       - docs/ui-frankentui.md
-      linear_milestones:
-      - 'M4: Operator UX and repo harness'
-      linear_issues:
-      - COE-255
-      - COE-269
-      - COE-271
-      - COE-287
-      - COE-321
-      github_prs:
-      - '#23'
-      - '#27'
-      - '#4'
-      - '#41'
-      - '#48'
-      - '#59'
-      - '#7'
-      - '#83'
   websocket-runtime:
     title: WebSocket Runtime Contract
     docs_target: docs/websocket-runtime.md
@@ -1357,53 +302,10 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - websocket runtime contract
-    - websocket-runtime
+    - WebSocket Runtime Contract
     source_refs:
       docs:
       - docs/websocket-runtime.md
-      linear_milestones:
-      - 'M2: OpenHands runtime adapter'
-      - 'M5: Validation and local packaging'
-      - 'M6: Hosted deployment follow-on'
-      linear_issues:
-      - COE-253
-      - COE-256
-      - COE-261
-      - COE-262
-      - COE-265
-      - COE-266
-      - COE-272
-      - COE-273
-      - COE-274
-      - COE-275
-      - COE-280
-      - COE-281
-      - COE-282
-      - COE-294
-      - COE-382
-      - COE-383
-      - COE-384
-      - COE-385
-      - COE-386
-      - COE-387
-      github_prs:
-      - '#1'
-      - '#13'
-      - '#19'
-      - '#20'
-      - '#34'
-      - '#36'
-      - '#40'
-      - '#41'
-      - '#44'
-      - '#45'
-      - '#46'
-      - '#52'
-      - '#54'
-      - '#55'
-      - '#58'
-      - '#83'
   workspace-and-lifecycle:
     title: Workspace and Lifecycle
     docs_target: docs/workspace-and-lifecycle.md
@@ -1411,45 +313,7 @@ areas:
     status: stable
     confidence: 85
     aliases:
-    - workspace and lifecycle
-    - workspace-and-lifecycle
+    - Workspace and Lifecycle
     source_refs:
       docs:
       - docs/workspace-and-lifecycle.md
-      linear_milestones:
-      - 'M2: OpenHands runtime adapter'
-      - 'M3: Symphony orchestration core'
-      - 'M4: Operator UX and repo harness'
-      linear_issues:
-      - COE-253
-      - COE-254
-      - COE-261
-      - COE-262
-      - COE-263
-      - COE-264
-      - COE-265
-      - COE-266
-      - COE-267
-      - COE-268
-      - COE-270
-      - COE-277
-      - COE-287
-      github_prs:
-      - '#14'
-      - '#18'
-      - '#19'
-      - '#24'
-      - '#33'
-      - '#34'
-      - '#35'
-      - '#36'
-      - '#39'
-      - '#40'
-      - '#41'
-      - '#42'
-      - '#43'
-      - '#48'
-      - '#6'
-      - '#83'
-redaction:
-  deny_patterns: []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opensymphony"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/kumanday/OpenSymphony"
 rust-version = "1.93"
-version = "1.4.0"
+version = "1.5.0"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -130,10 +130,12 @@ workflows, see [Operations](docs/operations.md).
 
 ### Project Memory
 
-OpenSymphony can preserve completed-issue knowledge as you build. Live memory
-capture reads Linear evidence and discovers matching GitHub PRs by default,
-writes private issue capsules under `.opensymphony/memory/`, indexes them in
-DuckDB, and can sync selected knowledge into public topic docs:
+OpenSymphony can preserve completed-issue knowledge as you build. When
+`memory.auto_capture` is enabled in `config.yaml` (the default),
+`opensymphony run` captures terminal issue transitions from Linear and matching
+GitHub PR narrative, writes private memory under `.opensymphony/memory/`, and
+syncs stable learned topics into public docs. Manual commands remain available
+for setup, backfill, inspection, and guarded archival:
 
 ```bash
 opensymphony memory init
@@ -145,8 +147,8 @@ opensymphony linear archive --issues COE-123
 ```
 
 See [Project Memory](docs/memory.md) for archive guards, YAML import/backfill,
-source schema, and the distinction between CLI commands and template-managed
-agent skills.
+source schema, automation flags, and the distinction between CLI commands and
+template-managed agent skills.
 
 The memory index uses DuckDB's bundled build so local installs do not need a
 separate DuckDB system package. That choice adds compile time and binary size,

--- a/README.md
+++ b/README.md
@@ -100,11 +100,14 @@ opensymphony init
 
 `opensymphony init` guides the bootstrap flow, customizes `WORKFLOW.md`, and
 can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review), including GitHub setup through `gh` when it is installed and authorized for the target repo. It also ensures `.gitignore` ignores local OpenSymphony runtime state.
+It also initializes `.opensymphony/memory/memory.yaml`, the shared policy and
+learned structure file required for default-on memory auto-capture.
 
 For an existing target repo, `opensymphony update` is the lighter-weight
 maintenance path: it refreshes changed or new template-owned skill files under
 `.agents/skills/` without touching `WORKFLOW.md`, `AGENTS.md`, or the broader
-bootstrap files.
+bootstrap files. When run from an OpenSymphony target repo, `update` also
+initializes or repairs the memory config and `.gitignore` policy if needed.
 
 ### Running the Orchestrator
 
@@ -134,8 +137,9 @@ OpenSymphony can preserve completed-issue knowledge as you build. When
 `memory.auto_capture` is enabled in `config.yaml` (the default),
 `opensymphony run` captures terminal issue transitions from Linear and matching
 GitHub PR narrative, writes private memory under `.opensymphony/memory/`, and
-syncs stable learned topics into public docs. Manual commands remain available
-for setup, backfill, inspection, and guarded archival:
+syncs stable learned topics into public docs. Repos initialized or updated with
+this release get the required memory config automatically. Manual commands
+remain available for setup repair, backfill, inspection, and guarded archival:
 
 ```bash
 opensymphony memory init

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ opensymphony init
 ```
 
 `opensymphony init` guides the bootstrap flow, customizes `WORKFLOW.md`, and
-can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review), including GitHub setup through `gh` when it is installed and authorized for the target repo. It also ensures `.gitignore` contains `.opensymphony*` so local OpenSymphony state stays out of version control.
+can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review), including GitHub setup through `gh` when it is installed and authorized for the target repo. It also ensures `.gitignore` ignores local OpenSymphony runtime state.
 
 For an existing target repo, `opensymphony update` is the lighter-weight
 maintenance path: it refreshes changed or new template-owned skill files under
@@ -136,12 +136,12 @@ writes private issue capsules under `.opensymphony/memory/`, indexes them in
 DuckDB, and can sync selected knowledge into public topic docs:
 
 ```bash
-opensymphony memory capture COE-123 --dry-run
+opensymphony memory init
 opensymphony memory capture COE-123
 opensymphony memory brief COE-123
 opensymphony memory related --area openhands-runtime
-opensymphony memory sync-docs --issues COE-123 --dry-run
-opensymphony linear archive --issues COE-123 --dry-run
+opensymphony memory sync-docs --since-last-sync
+opensymphony linear archive --issues COE-123
 ```
 
 See [Project Memory](docs/memory.md) for archive guards, YAML import/backfill,

--- a/config.yaml
+++ b/config.yaml
@@ -3,3 +3,7 @@ control_plane:
 
 openhands:
   tool_dir: ~/.opensymphony/openhands-server
+
+memory:
+  auto_capture: true
+  auto_archive: false

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -6,9 +6,8 @@ use std::{
     time::Duration,
 };
 
-use crate::opensymphony_memory::{
-    MemoryInitApplyReport, MemoryInitFileChange, ensure_memory_initialized,
-};
+use super::memory_init_summary::record_memory_init_changes;
+use crate::opensymphony_memory::ensure_memory_initialized;
 use clap::Args;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
@@ -840,50 +839,6 @@ fn build_final_contents(
         PlannedAction::Skip | PlannedAction::Unchanged => None,
         PlannedAction::Prompt => None,
     }
-}
-
-fn record_memory_init_changes(
-    report: &MemoryInitApplyReport,
-    target_repo: &Path,
-    created: &mut Vec<String>,
-    updated: &mut Vec<String>,
-    unchanged: &mut Vec<String>,
-) {
-    record_memory_init_change(
-        relative_path_for_summary(target_repo, &report.config_path),
-        report.config,
-        created,
-        updated,
-        unchanged,
-    );
-    record_memory_init_change(
-        relative_path_for_summary(target_repo, &report.gitignore_path),
-        report.gitignore,
-        created,
-        updated,
-        unchanged,
-    );
-}
-
-fn record_memory_init_change(
-    path: String,
-    change: MemoryInitFileChange,
-    created: &mut Vec<String>,
-    updated: &mut Vec<String>,
-    unchanged: &mut Vec<String>,
-) {
-    match change {
-        MemoryInitFileChange::Created => created.push(path),
-        MemoryInitFileChange::Updated => updated.push(path),
-        MemoryInitFileChange::Unchanged => unchanged.push(path),
-    }
-}
-
-fn relative_path_for_summary(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .into_owned()
 }
 
 fn prompt_for_missing_llm_env<R, W, E>(

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -6,6 +6,9 @@ use std::{
     time::Duration,
 };
 
+use crate::opensymphony_memory::{
+    MemoryInitApplyReport, MemoryInitFileChange, ensure_memory_initialized,
+};
 use clap::Args;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
@@ -35,7 +38,6 @@ const AI_REVIEW_LABEL_NAME: &str = "review-this";
 const PRESERVED_AGENTS_MARKER: &str = "## Preserved Existing AGENTS.md";
 const WORKFLOW_PROJECT_SLUG_PLACEHOLDER: &str = "\"YOUR-PROJECT-SLUG\"";
 const WORKFLOW_GIT_REMOTE_PLACEHOLDER: &str = "https://github.com/YOUR-ORG/YOUR-REPO.git";
-const OPENSYMPHONY_GITIGNORE_ENTRY: &str = ".opensymphony*";
 
 #[derive(Debug, Args, Clone)]
 pub struct InitArgs {}
@@ -112,6 +114,8 @@ pub(crate) enum InitCommandError {
     PromptClosed,
     #[error("initialization aborted")]
     AbortedByUser,
+    #[error("failed to initialize project memory: {0}")]
+    MemoryInit(#[from] crate::opensymphony_memory::MemoryError),
 }
 
 #[derive(Clone, Copy)]
@@ -459,14 +463,13 @@ where
         }
     }
 
-    match ensure_opensymphony_gitignore_entry(&target_repo)? {
-        AppliedChange::Created => created.push(".gitignore".to_owned()),
-        AppliedChange::Updated => updated.push(".gitignore".to_owned()),
-        AppliedChange::Unchanged => unchanged.push(".gitignore".to_owned()),
-        AppliedChange::Overwritten | AppliedChange::Merged | AppliedChange::Skipped => {
-            unreachable!("gitignore management is create/update only")
-        }
-    }
+    record_memory_init_changes(
+        &ensure_memory_initialized(&target_repo, None)?,
+        &target_repo,
+        &mut created,
+        &mut updated,
+        &mut unchanged,
+    );
 
     ui.blank_line()?;
     ui.line("Initialization summary:")?;
@@ -839,46 +842,48 @@ fn build_final_contents(
     }
 }
 
-fn ensure_opensymphony_gitignore_entry(
+fn record_memory_init_changes(
+    report: &MemoryInitApplyReport,
     target_repo: &Path,
-) -> Result<AppliedChange, InitCommandError> {
-    let gitignore_path = target_repo.join(".gitignore");
-    match fs::read_to_string(&gitignore_path) {
-        Ok(existing) => {
-            if existing
-                .lines()
-                .any(|line| line.trim() == OPENSYMPHONY_GITIGNORE_ENTRY)
-            {
-                return Ok(AppliedChange::Unchanged);
-            }
+    created: &mut Vec<String>,
+    updated: &mut Vec<String>,
+    unchanged: &mut Vec<String>,
+) {
+    record_memory_init_change(
+        relative_path_for_summary(target_repo, &report.config_path),
+        report.config,
+        created,
+        updated,
+        unchanged,
+    );
+    record_memory_init_change(
+        relative_path_for_summary(target_repo, &report.gitignore_path),
+        report.gitignore,
+        created,
+        updated,
+        unchanged,
+    );
+}
 
-            let mut updated = existing;
-            if !updated.is_empty() && !updated.ends_with('\n') {
-                updated.push('\n');
-            }
-            updated.push_str(OPENSYMPHONY_GITIGNORE_ENTRY);
-            updated.push('\n');
-
-            fs::write(&gitignore_path, updated).map_err(|source| InitCommandError::WriteFile {
-                path: gitignore_path,
-                source,
-            })?;
-            Ok(AppliedChange::Updated)
-        }
-        Err(source) if source.kind() == io::ErrorKind::NotFound => {
-            fs::write(&gitignore_path, format!("{OPENSYMPHONY_GITIGNORE_ENTRY}\n")).map_err(
-                |source| InitCommandError::WriteFile {
-                    path: gitignore_path.clone(),
-                    source,
-                },
-            )?;
-            Ok(AppliedChange::Created)
-        }
-        Err(source) => Err(InitCommandError::ReadFile {
-            path: gitignore_path,
-            source,
-        }),
+fn record_memory_init_change(
+    path: String,
+    change: MemoryInitFileChange,
+    created: &mut Vec<String>,
+    updated: &mut Vec<String>,
+    unchanged: &mut Vec<String>,
+) {
+    match change {
+        MemoryInitFileChange::Created => created.push(path),
+        MemoryInitFileChange::Updated => updated.push(path),
+        MemoryInitFileChange::Unchanged => unchanged.push(path),
     }
+}
+
+fn relative_path_for_summary(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn prompt_for_missing_llm_env<R, W, E>(
@@ -1656,13 +1661,10 @@ mod tests {
     use std::collections::BTreeMap;
     use std::time::Duration;
 
-    use tempfile::TempDir;
-
     use super::{
         DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL, DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS,
-        GitRemoteDetection, OPENSYMPHONY_GITIGNORE_ENTRY, PRESERVED_AGENTS_MARKER, PromptUi,
-        agents_already_initialized, comparable_text, custom_codereview_guide_contents,
-        customize_workflow, ensure_opensymphony_gitignore_entry, git_remote_url,
+        GitRemoteDetection, PRESERVED_AGENTS_MARKER, PromptUi, agents_already_initialized,
+        comparable_text, custom_codereview_guide_contents, customize_workflow, git_remote_url,
         github_repo_slug_from_remote, merge_agents, normalize_github_repo_slug,
         prompt_ai_review_config, prompt_for_missing_llm_env, prompt_yes_no, select_remote_name,
         shell_single_quote, template_fetch_timeout_from_env,
@@ -1743,41 +1745,6 @@ hooks:
     #[test]
     fn comparable_text_ignores_crlf_and_trailing_newlines() {
         assert_eq!(comparable_text("a\r\nb\r\n"), comparable_text("a\nb\n\n"));
-    }
-
-    #[test]
-    fn gitignore_helper_creates_rule_when_missing() {
-        let repo = TempDir::new().expect("temp repo should exist");
-
-        let change =
-            ensure_opensymphony_gitignore_entry(repo.path()).expect("gitignore helper should run");
-
-        assert!(matches!(change, super::AppliedChange::Created));
-        assert_eq!(
-            std::fs::read_to_string(repo.path().join(".gitignore"))
-                .expect(".gitignore should exist"),
-            format!("{OPENSYMPHONY_GITIGNORE_ENTRY}\n")
-        );
-    }
-
-    #[test]
-    fn gitignore_helper_is_idempotent_when_rule_already_exists() {
-        let repo = TempDir::new().expect("temp repo should exist");
-        std::fs::write(
-            repo.path().join(".gitignore"),
-            format!("target/\n{OPENSYMPHONY_GITIGNORE_ENTRY}\n"),
-        )
-        .expect(".gitignore should write");
-
-        let change =
-            ensure_opensymphony_gitignore_entry(repo.path()).expect("gitignore helper should run");
-
-        assert!(matches!(change, super::AppliedChange::Unchanged));
-        assert_eq!(
-            std::fs::read_to_string(repo.path().join(".gitignore"))
-                .expect(".gitignore should exist"),
-            format!("target/\n{OPENSYMPHONY_GITIGNORE_ENTRY}\n")
-        );
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -2,6 +2,7 @@ mod debug_session;
 mod init_repo;
 mod install_tooling;
 mod memory;
+mod memory_init_summary;
 mod orchestrator_run;
 mod update_repo;
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -859,6 +859,7 @@ fn finish_archive_write(
 }
 
 const AUTO_MEMORY_STATUS_LOG_LIMIT: usize = 100;
+const AUTO_MEMORY_STATUS_LOG_MAX_BYTES: usize = 64 * 1024;
 
 fn record_auto_memory_status(
     config: &MemoryConfig,
@@ -890,11 +891,15 @@ fn record_auto_memory_status(
         }
     }
     contents.push('\n');
-    let contents = trim_auto_memory_status_log(&contents, AUTO_MEMORY_STATUS_LOG_LIMIT);
+    let contents = trim_auto_memory_status_log(
+        &contents,
+        AUTO_MEMORY_STATUS_LOG_LIMIT,
+        AUTO_MEMORY_STATUS_LOG_MAX_BYTES,
+    );
     fs::write(&path, contents).map_err(|source| MemoryError::WriteFile { path, source })
 }
 
-fn trim_auto_memory_status_log(contents: &str, max_entries: usize) -> String {
+fn trim_auto_memory_status_log(contents: &str, max_entries: usize, max_bytes: usize) -> String {
     let mut entries = Vec::new();
     let mut current = Vec::new();
     for line in contents.lines() {
@@ -912,8 +917,19 @@ fn trim_auto_memory_status_log(contents: &str, max_entries: usize) -> String {
     }
 
     let start = entries.len().saturating_sub(max_entries);
+    let mut retained = entries.into_iter().skip(start).collect::<Vec<_>>();
+    loop {
+        let rendered = render_auto_memory_status_log(&retained);
+        if rendered.len() <= max_bytes || retained.len() <= 1 {
+            return rendered;
+        }
+        retained.remove(0);
+    }
+}
+
+fn render_auto_memory_status_log(entries: &[String]) -> String {
     let mut output = "# OpenSymphony Memory Automation Log\n\n".to_string();
-    for entry in entries.into_iter().skip(start) {
+    for entry in entries {
         output.push_str(entry.trim_end());
         output.push_str("\n\n");
     }
@@ -976,6 +992,8 @@ fn replace_or_append_managed_section(
     replacement: &str,
 ) -> String {
     if let Some(begin_index) = existing.find(begin) {
+        // A missing end marker means the managed block was truncated; replace
+        // from BEGIN to the end so repeated updates cannot append duplicates.
         let end_index = existing[begin_index..]
             .find(end)
             .map(|relative_end| begin_index + relative_end + end.len())
@@ -1333,11 +1351,37 @@ mod tests {
 - Captured: COE-3
 ";
 
-        let trimmed = trim_auto_memory_status_log(contents, 2);
+        let trimmed = trim_auto_memory_status_log(contents, 2, usize::MAX);
 
         assert!(!trimmed.contains("COE-1"));
         assert!(trimmed.contains("COE-2"));
         assert!(trimmed.contains("COE-3"));
         assert_eq!(trimmed.matches("## ").count(), 2);
+    }
+
+    #[test]
+    fn auto_memory_status_log_respects_size_limit() {
+        let contents = "\
+# OpenSymphony Memory Automation Log
+
+## 2026-05-16T00:00:00Z
+
+- Captured: COE-1
+
+## 2026-05-16T00:01:00Z
+
+- Captured: COE-2 with a longer status line
+
+## 2026-05-16T00:02:00Z
+
+- Captured: COE-3 with a longer status line
+";
+
+        let trimmed = trim_auto_memory_status_log(contents, 100, 120);
+
+        assert!(!trimmed.contains("COE-1"));
+        assert!(!trimmed.contains("COE-2"));
+        assert!(trimmed.contains("COE-3"));
+        assert!(trimmed.len() <= 120);
     }
 }

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -14,8 +14,9 @@ use crate::{
         ArchivePlan, CommentEvidence, DocsSyncPlan, IssueEvidence, IssueSelection, LintSeverity,
         MemoryConfig, MemoryError, SourceFile, brief, context_for_issue, docs_for_area,
         expand_issue_range, lint, load_source_file, mark_archived, plan_archive, plan_capture,
-        plan_docs_sync, related_by_area, related_by_issue, related_by_paths, render_archive_plan,
-        render_capture_dry_run, search, status, write_capture_plan, write_docs_sync_plan,
+        plan_docs_sync, plan_memory_init, related_by_area, related_by_issue, related_by_paths,
+        render_archive_plan, render_capture_dry_run, search, status, write_capture_plan,
+        write_docs_sync_plan, write_memory_init_plan,
     },
     opensymphony_workflow::WorkflowDefinition,
 };
@@ -30,6 +31,8 @@ pub struct MemoryArgs {
 
 #[derive(Debug, Subcommand)]
 enum MemoryCommand {
+    #[command(about = "Create project memory configuration")]
+    Init(InitArgs),
     #[command(about = "Capture completed issue evidence into issue memory")]
     Capture(CaptureArgs),
     #[command(about = "Import deterministic YAML issue evidence into issue memory")]
@@ -52,6 +55,14 @@ enum MemoryCommand {
     Context(ContextArgs),
     #[command(about = "Lint memory and docs for stale or unsafe state")]
     Lint(LintArgs),
+}
+
+#[derive(Debug, Args)]
+struct InitArgs {
+    #[arg(long, help = "Only show the proposed memory configuration")]
+    dry_run: bool,
+    #[arg(long, help = "Overwrite an existing memory configuration")]
+    force: bool,
 }
 
 #[derive(Debug, Args)]
@@ -250,19 +261,56 @@ async fn run_memory(args: MemoryArgs) -> Result<(), MemoryError> {
         path: PathBuf::from("."),
         source,
     })?;
-    let config = MemoryConfig::load(&repo_root, args.config.as_deref())?;
-    match args.command {
-        MemoryCommand::Capture(args) => run_capture(&repo_root, &config, args).await,
-        MemoryCommand::Import(args) => run_import(&config, args),
-        MemoryCommand::SyncDocs(args) => run_sync_docs(&config, args),
-        MemoryCommand::Status(args) => run_status(&config, args),
-        MemoryCommand::Show(args) => run_show(&config, args, ShowMode::Full),
-        MemoryCommand::Brief(args) => run_show(&config, args, ShowMode::Brief),
-        MemoryCommand::Search(args) => run_search(&config, args),
-        MemoryCommand::Related(args) => run_related(&config, args),
-        MemoryCommand::Docs(args) => run_docs(&config, args),
-        MemoryCommand::Context(args) => run_context(&config, args),
-        MemoryCommand::Lint(args) => run_lint(&config, args),
+    let MemoryArgs {
+        config: config_path,
+        command,
+    } = args;
+    match command {
+        MemoryCommand::Init(args) => run_init(&repo_root, config_path.as_deref(), args),
+        MemoryCommand::Capture(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_capture(&repo_root, &config, args).await
+        }
+        MemoryCommand::Import(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_import(&config, args)
+        }
+        MemoryCommand::SyncDocs(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_sync_docs(&config, args)
+        }
+        MemoryCommand::Status(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_status(&config, args)
+        }
+        MemoryCommand::Show(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_show(&config, args, ShowMode::Full)
+        }
+        MemoryCommand::Brief(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_show(&config, args, ShowMode::Brief)
+        }
+        MemoryCommand::Search(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_search(&config, args)
+        }
+        MemoryCommand::Related(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_related(&config, args)
+        }
+        MemoryCommand::Docs(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_docs(&config, args)
+        }
+        MemoryCommand::Context(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_context(&config, args)
+        }
+        MemoryCommand::Lint(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_lint(&config, args)
+        }
     }
 }
 
@@ -270,6 +318,32 @@ async fn run_linear(args: LinearArgs) -> Result<(), MemoryError> {
     match args.command {
         LinearCommand::Archive(args) => run_archive(args).await,
     }
+}
+
+fn run_init(
+    repo_root: &Path,
+    config_path: Option<&Path>,
+    args: InitArgs,
+) -> Result<(), MemoryError> {
+    let plan = plan_memory_init(repo_root, config_path, args.force)?;
+    println!("# Memory Init Plan\n");
+    println!("Config: {}", plan.config_path.display());
+    println!("Git ignore: {}", plan.gitignore_path.display());
+    if args.dry_run {
+        println!("\n## Proposed config\n");
+        println!("{}", plan.config_contents);
+        println!("Dry run only. Re-run without `--dry-run` to create memory configuration.");
+        return Ok(());
+    }
+
+    write_memory_init_plan(&plan)?;
+    println!("Wrote memory configuration: {}", plan.config_path.display());
+    if plan.gitignore_before.as_deref() == Some(plan.gitignore_after.as_str()) {
+        println!("Git ignore already allowed the shared memory config.");
+    } else {
+        println!("Updated git ignore: {}", plan.gitignore_path.display());
+    }
+    Ok(())
 }
 
 async fn run_capture(

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::ExitCode,
+    process::{self, ExitCode},
 };
 
 use chrono::{NaiveDate, Utc};
@@ -259,10 +259,20 @@ pub async fn run_linear_command(args: LinearArgs) -> ExitCode {
 
 #[derive(Debug, Default)]
 pub(crate) struct AutoMemoryReport {
+    pub(crate) completed_issue_keys: Vec<String>,
     pub(crate) captured_issue_keys: Vec<String>,
     pub(crate) archived_issue_keys: Vec<String>,
     pub(crate) docs_written: Vec<PathBuf>,
+    pub(crate) capture_completed: bool,
+    pub(crate) docs_sync_completed: bool,
+    pub(crate) archive_completed: bool,
     pub(crate) warnings: Vec<String>,
+}
+
+impl AutoMemoryReport {
+    pub(crate) fn workflow_completed(&self) -> bool {
+        self.capture_completed && self.docs_sync_completed && self.archive_completed
+    }
 }
 
 pub(crate) async fn auto_capture_terminal(
@@ -289,10 +299,15 @@ pub(crate) async fn auto_capture_terminal(
         ..IssueSelection::default()
     };
     let mut capture_plan = plan_capture(&config, &source, &selection, true, true)?;
+    let issue_keys = capture_plan
+        .selected
+        .iter()
+        .map(|issue| issue.issue.identifier.clone())
+        .collect::<Vec<_>>();
     capture_plan
         .selected
         .retain(|issue| !issue.already_captured || issue.stale);
-    if capture_plan.selected.is_empty() {
+    if issue_keys.is_empty() {
         return Ok(AutoMemoryReport::default());
     }
 
@@ -301,42 +316,58 @@ pub(crate) async fn auto_capture_terminal(
         .iter()
         .map(|issue| issue.issue.identifier.clone())
         .collect::<Vec<_>>();
-    let capture_report = write_capture_plan(&config, &capture_plan, false)?;
-
-    let mut warnings = capture_report.warnings;
-    let evolved_config = match MemoryConfig::load(repo_root, None) {
-        Ok(config) => config,
-        Err(error) => {
-            warnings.push(format!(
-                "failed to reload evolved memory config after capture: {error}"
-            ));
-            let _ = record_auto_memory_status(&config, &captured_issue_keys, &warnings);
-            return Ok(AutoMemoryReport {
-                captured_issue_keys,
-                archived_issue_keys: Vec::new(),
-                docs_written: Vec::new(),
-                warnings,
-            });
+    let mut warnings = Vec::new();
+    let mut capture_completed = true;
+    let evolved_config = if capture_plan.selected.is_empty() {
+        config.clone()
+    } else {
+        let capture_report = write_capture_plan(&config, &capture_plan, false)?;
+        warnings.extend(capture_report.warnings);
+        match MemoryConfig::load(repo_root, None) {
+            Ok(config) => config,
+            Err(error) => {
+                capture_completed = false;
+                warnings.push(format!(
+                    "failed to reload evolved memory config after capture: {error}"
+                ));
+                let _ = record_auto_memory_status(&config, &issue_keys, &warnings);
+                return Ok(AutoMemoryReport {
+                    completed_issue_keys: Vec::new(),
+                    captured_issue_keys,
+                    archived_issue_keys: Vec::new(),
+                    docs_written: Vec::new(),
+                    capture_completed,
+                    docs_sync_completed: false,
+                    archive_completed: !auto_archive,
+                    warnings,
+                });
+            }
         }
     };
     let docs_selection = IssueSelection {
-        identifiers: captured_issue_keys.clone(),
+        identifiers: issue_keys.clone(),
         since_last_sync: true,
         ..IssueSelection::default()
     };
 
     let mut archived_issue_keys = Vec::new();
     let mut docs_written = Vec::new();
+    let mut docs_sync_completed = false;
     match plan_docs_sync(&evolved_config, &docs_selection, true, false) {
         Ok(docs_plan) => {
             warnings.extend(docs_plan.warnings.clone());
             if !docs_plan.targets.is_empty() {
                 match write_docs_sync_plan(&evolved_config, &docs_plan) {
-                    Ok(written) => docs_written = written,
+                    Ok(written) => {
+                        docs_written = written;
+                        docs_sync_completed = true;
+                    }
                     Err(error) => {
                         warnings.push(format!("failed to sync captured memory docs: {error}"));
                     }
                 }
+            } else {
+                docs_sync_completed = true;
             }
         }
         Err(error) => {
@@ -344,48 +375,67 @@ pub(crate) async fn auto_capture_terminal(
         }
     }
 
+    let mut archive_completed = !auto_archive;
     if auto_archive {
-        let archive_plan = archive_plan_after_capture(&evolved_config, &capture_plan, true, false);
-        warnings.extend(archive_plan.warnings.clone());
-        match archive_in_linear(repo_root, Some(workflow_path), &archive_plan).await {
-            Ok(archive_report) => {
-                if !archive_report.archived.is_empty()
-                    && let Err(error) = mark_archived(&evolved_config, &archive_report.archived)
-                {
-                    warnings.push(format!("failed to mark archived memory capsules: {error}"));
+        match plan_archive(&evolved_config, &issue_keys, false, None, true, false) {
+            Ok(archive_plan) => {
+                warnings.extend(archive_plan.warnings.clone());
+                match archive_in_linear(repo_root, Some(workflow_path), &archive_plan).await {
+                    Ok(archive_report) => {
+                        archive_completed =
+                            archive_plan.warnings.is_empty() && archive_report.failures.is_empty();
+                        if !archive_report.archived.is_empty()
+                            && let Err(error) =
+                                mark_archived(&evolved_config, &archive_report.archived)
+                        {
+                            archive_completed = false;
+                            warnings
+                                .push(format!("failed to mark archived memory capsules: {error}"));
+                        }
+                        archived_issue_keys = archive_report.archived;
+                        warnings.extend(archive_report.failures);
+                    }
+                    Err(error) => {
+                        warnings.push(format!("failed to archive captured Linear issues: {error}"));
+                    }
                 }
-                archived_issue_keys = archive_report.archived;
-                warnings.extend(archive_report.failures);
             }
             Err(error) => {
-                warnings.push(format!("failed to archive captured Linear issues: {error}"));
+                warnings.push(format!(
+                    "failed to plan captured Linear issue archive: {error}"
+                ));
             }
         }
     }
 
-    if let Err(error) = record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)
-    {
+    if let Err(error) = record_auto_memory_status(&evolved_config, &issue_keys, &warnings) {
         warnings.push(format!(
             "failed to record local memory automation status: {error}"
         ));
     }
     if !warnings.is_empty()
-        && let Err(error) =
-            update_linear_memory_status(&client, &captured_issue_keys, &warnings).await
+        && let Err(error) = update_linear_memory_status(&client, &issue_keys, &warnings).await
     {
         warnings.push(format!("failed to update Linear memory status: {error}"));
-        if let Err(error) =
-            record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)
-        {
+        if let Err(error) = record_auto_memory_status(&evolved_config, &issue_keys, &warnings) {
             warnings.push(format!(
                 "failed to record local memory automation status after Linear update failure: {error}"
             ));
         }
     }
+    let completed_issue_keys = if capture_completed && docs_sync_completed && archive_completed {
+        issue_keys
+    } else {
+        Vec::new()
+    };
     Ok(AutoMemoryReport {
+        completed_issue_keys,
         captured_issue_keys,
         archived_issue_keys,
         docs_written,
+        capture_completed,
+        docs_sync_completed,
+        archive_completed,
         warnings,
     })
 }
@@ -928,9 +978,14 @@ fn record_auto_memory_status(
     }
     let mut contents = fs::read_to_string(&path)
         .unwrap_or_else(|_| "# OpenSymphony Memory Automation Log\n\n".to_string());
+    contents = trim_auto_memory_status_log(
+        &contents,
+        AUTO_MEMORY_STATUS_LOG_LIMIT,
+        AUTO_MEMORY_STATUS_LOG_MAX_BYTES,
+    );
     contents.push_str(&format!("## {}\n\n", Utc::now().to_rfc3339()));
     if !issue_keys.is_empty() {
-        contents.push_str(&format!("- Captured: {}\n", issue_keys.join(", ")));
+        contents.push_str(&format!("- Issues: {}\n", issue_keys.join(", ")));
     }
     if warnings.is_empty() {
         contents.push_str("- Status: completed without blocking warnings\n");
@@ -946,7 +1001,31 @@ fn record_auto_memory_status(
         AUTO_MEMORY_STATUS_LOG_LIMIT,
         AUTO_MEMORY_STATUS_LOG_MAX_BYTES,
     );
-    fs::write(&path, contents).map_err(|source| MemoryError::WriteFile { path, source })
+    atomic_write_auto_memory_status(&path, &contents)
+}
+
+fn atomic_write_auto_memory_status(path: &Path, contents: &str) -> Result<(), MemoryError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("automation.md");
+    let temp_path = parent.join(format!(
+        ".{file_name}.tmp-{}-{}",
+        process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    fs::write(&temp_path, contents).map_err(|source| MemoryError::WriteFile {
+        path: temp_path.clone(),
+        source,
+    })?;
+    fs::rename(&temp_path, path).map_err(|source| {
+        let _ = fs::remove_file(&temp_path);
+        MemoryError::WriteFile {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
 }
 
 fn trim_auto_memory_status_log(contents: &str, max_entries: usize, max_bytes: usize) -> String {

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -302,41 +302,84 @@ pub(crate) async fn auto_capture_terminal(
         .collect::<Vec<_>>();
     let capture_report = write_capture_plan(&config, &capture_plan, false)?;
 
-    let evolved_config = MemoryConfig::load(repo_root, None)?;
+    let mut warnings = capture_report.warnings;
+    let evolved_config = match MemoryConfig::load(repo_root, None) {
+        Ok(config) => config,
+        Err(error) => {
+            warnings.push(format!(
+                "failed to reload evolved memory config after capture: {error}"
+            ));
+            let _ = record_auto_memory_status(&config, &captured_issue_keys, &warnings);
+            return Ok(AutoMemoryReport {
+                captured_issue_keys,
+                archived_issue_keys: Vec::new(),
+                docs_written: Vec::new(),
+                warnings,
+            });
+        }
+    };
     let docs_selection = IssueSelection {
         identifiers: captured_issue_keys.clone(),
         since_last_sync: true,
         ..IssueSelection::default()
     };
-    let docs_plan = plan_docs_sync(&evolved_config, &docs_selection, true, false)?;
-    let docs_written = if docs_plan.targets.is_empty() {
-        Vec::new()
-    } else {
-        write_docs_sync_plan(&evolved_config, &docs_plan)?
-    };
 
     let mut archived_issue_keys = Vec::new();
-    let mut warnings = capture_report.warnings;
-    warnings.extend(docs_plan.warnings);
+    let mut docs_written = Vec::new();
+    match plan_docs_sync(&evolved_config, &docs_selection, true, false) {
+        Ok(docs_plan) => {
+            warnings.extend(docs_plan.warnings.clone());
+            if !docs_plan.targets.is_empty() {
+                match write_docs_sync_plan(&evolved_config, &docs_plan) {
+                    Ok(written) => docs_written = written,
+                    Err(error) => {
+                        warnings.push(format!("failed to sync captured memory docs: {error}"));
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            warnings.push(format!("failed to plan captured memory docs sync: {error}"));
+        }
+    }
+
     if auto_archive {
         let archive_plan = archive_plan_after_capture(&evolved_config, &capture_plan, true, false);
         warnings.extend(archive_plan.warnings.clone());
-        let archive_report =
-            archive_in_linear(repo_root, Some(workflow_path), &archive_plan).await?;
-        if !archive_report.archived.is_empty() {
-            mark_archived(&evolved_config, &archive_report.archived)?;
+        match archive_in_linear(repo_root, Some(workflow_path), &archive_plan).await {
+            Ok(archive_report) => {
+                if !archive_report.archived.is_empty()
+                    && let Err(error) = mark_archived(&evolved_config, &archive_report.archived)
+                {
+                    warnings.push(format!("failed to mark archived memory capsules: {error}"));
+                }
+                archived_issue_keys = archive_report.archived;
+                warnings.extend(archive_report.failures);
+            }
+            Err(error) => {
+                warnings.push(format!("failed to archive captured Linear issues: {error}"));
+            }
         }
-        archived_issue_keys = archive_report.archived;
-        warnings.extend(archive_report.failures);
     }
 
-    record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)?;
+    if let Err(error) = record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)
+    {
+        warnings.push(format!(
+            "failed to record local memory automation status: {error}"
+        ));
+    }
     if !warnings.is_empty()
         && let Err(error) =
             update_linear_memory_status(&client, &captured_issue_keys, &warnings).await
     {
         warnings.push(format!("failed to update Linear memory status: {error}"));
-        record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)?;
+        if let Err(error) =
+            record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)
+        {
+            warnings.push(format!(
+                "failed to record local memory automation status after Linear update failure: {error}"
+            ));
+        }
     }
     Ok(AutoMemoryReport {
         captured_issue_keys,

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -858,6 +858,8 @@ fn finish_archive_write(
     Ok(())
 }
 
+const AUTO_MEMORY_STATUS_LOG_LIMIT: usize = 100;
+
 fn record_auto_memory_status(
     config: &MemoryConfig,
     issue_keys: &[String],
@@ -888,7 +890,34 @@ fn record_auto_memory_status(
         }
     }
     contents.push('\n');
+    let contents = trim_auto_memory_status_log(&contents, AUTO_MEMORY_STATUS_LOG_LIMIT);
     fs::write(&path, contents).map_err(|source| MemoryError::WriteFile { path, source })
+}
+
+fn trim_auto_memory_status_log(contents: &str, max_entries: usize) -> String {
+    let mut entries = Vec::new();
+    let mut current = Vec::new();
+    for line in contents.lines() {
+        if line.starts_with("## ") {
+            if !current.is_empty() {
+                entries.push(current.join("\n"));
+            }
+            current = vec![line.to_string()];
+        } else if !current.is_empty() {
+            current.push(line.to_string());
+        }
+    }
+    if !current.is_empty() {
+        entries.push(current.join("\n"));
+    }
+
+    let start = entries.len().saturating_sub(max_entries);
+    let mut output = "# OpenSymphony Memory Automation Log\n\n".to_string();
+    for entry in entries.into_iter().skip(start) {
+        output.push_str(entry.trim_end());
+        output.push_str("\n\n");
+    }
+    output
 }
 
 const LINEAR_MEMORY_STATUS_BEGIN: &str = "<!-- BEGIN OPENSYMPHONY MANAGED MEMORY STATUS -->";
@@ -1245,6 +1274,7 @@ fn print_search_results(
 mod tests {
     use super::{
         LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, replace_or_append_managed_section,
+        trim_auto_memory_status_log,
     };
 
     #[test]
@@ -1283,5 +1313,31 @@ mod tests {
         assert!(updated.contains("new"));
         assert_eq!(updated.matches(LINEAR_MEMORY_STATUS_BEGIN).count(), 1);
         assert!(!updated.contains("old without end marker"));
+    }
+
+    #[test]
+    fn auto_memory_status_log_keeps_recent_entries() {
+        let contents = "\
+# OpenSymphony Memory Automation Log
+
+## 2026-05-16T00:00:00Z
+
+- Captured: COE-1
+
+## 2026-05-16T00:01:00Z
+
+- Captured: COE-2
+
+## 2026-05-16T00:02:00Z
+
+- Captured: COE-3
+";
+
+        let trimmed = trim_auto_memory_status_log(contents, 2);
+
+        assert!(!trimmed.contains("COE-1"));
+        assert!(trimmed.contains("COE-2"));
+        assert!(trimmed.contains("COE-3"));
+        assert_eq!(trimmed.matches("## ").count(), 2);
     }
 }

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -4,7 +4,7 @@ use std::{
     process::ExitCode,
 };
 
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Utc};
 use clap::{Args, Subcommand};
 
 use crate::{
@@ -256,6 +256,96 @@ pub async fn run_linear_command(args: LinearArgs) -> ExitCode {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct AutoMemoryReport {
+    pub(crate) captured_issue_keys: Vec<String>,
+    pub(crate) archived_issue_keys: Vec<String>,
+    pub(crate) docs_written: Vec<PathBuf>,
+    pub(crate) warnings: Vec<String>,
+}
+
+pub(crate) async fn auto_capture_terminal(
+    repo_root: &Path,
+    workflow_path: &Path,
+    identifiers: &[String],
+    auto_archive: bool,
+) -> Result<AutoMemoryReport, MemoryError> {
+    let mut identifiers = identifiers
+        .iter()
+        .filter_map(|identifier| non_empty(identifier))
+        .collect::<Vec<_>>();
+    identifiers.sort();
+    identifiers.dedup();
+    if identifiers.is_empty() {
+        return Ok(AutoMemoryReport::default());
+    }
+
+    let config = MemoryConfig::load(repo_root, None)?;
+    let client = linear_client_from_workflow(repo_root, Some(workflow_path))?;
+    let source = load_linear_source_from_client(&client, &identifiers).await?;
+    let selection = IssueSelection {
+        identifiers,
+        ..IssueSelection::default()
+    };
+    let mut capture_plan = plan_capture(&config, &source, &selection, true, true)?;
+    capture_plan
+        .selected
+        .retain(|issue| !issue.already_captured || issue.stale);
+    if capture_plan.selected.is_empty() {
+        return Ok(AutoMemoryReport::default());
+    }
+
+    let captured_issue_keys = capture_plan
+        .selected
+        .iter()
+        .map(|issue| issue.issue.identifier.clone())
+        .collect::<Vec<_>>();
+    let capture_report = write_capture_plan(&config, &capture_plan, false)?;
+
+    let evolved_config = MemoryConfig::load(repo_root, None)?;
+    let docs_selection = IssueSelection {
+        identifiers: captured_issue_keys.clone(),
+        since_last_sync: true,
+        ..IssueSelection::default()
+    };
+    let docs_plan = plan_docs_sync(&evolved_config, &docs_selection, true, false)?;
+    let docs_written = if docs_plan.targets.is_empty() {
+        Vec::new()
+    } else {
+        write_docs_sync_plan(&evolved_config, &docs_plan)?
+    };
+
+    let mut archived_issue_keys = Vec::new();
+    let mut warnings = capture_report.warnings;
+    warnings.extend(docs_plan.warnings);
+    if auto_archive {
+        let archive_plan = archive_plan_after_capture(&evolved_config, &capture_plan, true, false);
+        warnings.extend(archive_plan.warnings.clone());
+        let archive_report =
+            archive_in_linear(repo_root, Some(workflow_path), &archive_plan).await?;
+        if !archive_report.archived.is_empty() {
+            mark_archived(&evolved_config, &archive_report.archived)?;
+        }
+        archived_issue_keys = archive_report.archived;
+        warnings.extend(archive_report.failures);
+    }
+
+    record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)?;
+    if !warnings.is_empty()
+        && let Err(error) =
+            update_linear_memory_status(&client, &captured_issue_keys, &warnings).await
+    {
+        warnings.push(format!("failed to update Linear memory status: {error}"));
+        record_auto_memory_status(&evolved_config, &captured_issue_keys, &warnings)?;
+    }
+    Ok(AutoMemoryReport {
+        captured_issue_keys,
+        archived_issue_keys,
+        docs_written,
+        warnings,
+    })
+}
+
 async fn run_memory(args: MemoryArgs) -> Result<(), MemoryError> {
     let repo_root = std::env::current_dir().map_err(|source| MemoryError::ReadFile {
         path: PathBuf::from("."),
@@ -450,6 +540,9 @@ fn run_sync_docs(config: &MemoryConfig, args: SyncDocsArgs) -> Result<(), Memory
     print_docs_plan(&plan);
     if !write {
         println!("Dry run only. Re-run without `--dry-run` to update topic docs.");
+        return Ok(());
+    }
+    if plan.targets.is_empty() {
         return Ok(());
     }
     let written = write_docs_sync_plan(config, &plan)?;
@@ -765,6 +858,118 @@ fn finish_archive_write(
     Ok(())
 }
 
+fn record_auto_memory_status(
+    config: &MemoryConfig,
+    issue_keys: &[String],
+    warnings: &[String],
+) -> Result<(), MemoryError> {
+    if issue_keys.is_empty() && warnings.is_empty() {
+        return Ok(());
+    }
+    let path = config.memory_root.join("indexes/automation.md");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| MemoryError::CreateDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let mut contents = fs::read_to_string(&path)
+        .unwrap_or_else(|_| "# OpenSymphony Memory Automation Log\n\n".to_string());
+    contents.push_str(&format!("## {}\n\n", Utc::now().to_rfc3339()));
+    if !issue_keys.is_empty() {
+        contents.push_str(&format!("- Captured: {}\n", issue_keys.join(", ")));
+    }
+    if warnings.is_empty() {
+        contents.push_str("- Status: completed without blocking warnings\n");
+    } else {
+        contents.push_str("- Warnings:\n");
+        for warning in warnings {
+            contents.push_str(&format!("  - {warning}\n"));
+        }
+    }
+    contents.push('\n');
+    fs::write(&path, contents).map_err(|source| MemoryError::WriteFile { path, source })
+}
+
+const LINEAR_MEMORY_STATUS_BEGIN: &str = "<!-- BEGIN OPENSYMPHONY MANAGED MEMORY STATUS -->";
+const LINEAR_MEMORY_STATUS_END: &str = "<!-- END OPENSYMPHONY MANAGED MEMORY STATUS -->";
+
+async fn update_linear_memory_status(
+    client: &LinearClient,
+    issue_keys: &[String],
+    warnings: &[String],
+) -> Result<(), MemoryError> {
+    let Some(project) = client
+        .project_overview()
+        .await
+        .map_err(|error| MemoryError::Linear(format!("Linear project lookup failed: {error}")))?
+    else {
+        return Ok(());
+    };
+    let existing = project.content.unwrap_or_default();
+    let section = render_linear_memory_status_section(issue_keys, warnings);
+    let updated = replace_or_append_managed_section(
+        &existing,
+        LINEAR_MEMORY_STATUS_BEGIN,
+        LINEAR_MEMORY_STATUS_END,
+        &section,
+    );
+    client
+        .update_project_content(&project.id, &updated)
+        .await
+        .map_err(|error| MemoryError::Linear(format!("Linear project update failed: {error}")))
+}
+
+fn render_linear_memory_status_section(issue_keys: &[String], warnings: &[String]) -> String {
+    let mut section = String::new();
+    section.push_str(LINEAR_MEMORY_STATUS_BEGIN);
+    section.push_str("\n\n## OpenSymphony Memory Status\n\n");
+    section.push_str(&format!("- Updated: {}\n", Utc::now().to_rfc3339()));
+    if !issue_keys.is_empty() {
+        section.push_str(&format!("- Captured: {}\n", issue_keys.join(", ")));
+    }
+    section.push_str("- Attention needed:\n");
+    for warning in warnings.iter().take(10) {
+        section.push_str(&format!("  - {warning}\n"));
+    }
+    if warnings.len() > 10 {
+        section.push_str(&format!("  - ...and {} more\n", warnings.len() - 10));
+    }
+    section.push('\n');
+    section.push_str(LINEAR_MEMORY_STATUS_END);
+    section
+}
+
+fn replace_or_append_managed_section(
+    existing: &str,
+    begin: &str,
+    end: &str,
+    replacement: &str,
+) -> String {
+    if let (Some(begin_index), Some(end_index)) = (existing.find(begin), existing.find(end)) {
+        let end_index = end_index + end.len();
+        let mut output = String::new();
+        output.push_str(existing[..begin_index].trim_end());
+        if !output.is_empty() {
+            output.push_str("\n\n");
+        }
+        output.push_str(replacement.trim_end());
+        let tail = existing[end_index..].trim_start();
+        if !tail.is_empty() {
+            output.push_str("\n\n");
+            output.push_str(tail);
+        }
+        output
+    } else {
+        let mut output = existing.trim_end().to_string();
+        if !output.is_empty() {
+            output.push_str("\n\n");
+        }
+        output.push_str(replacement.trim_end());
+        output
+    }
+}
+
 #[derive(Debug, Default)]
 struct LinearArchiveReport {
     archived: Vec<String>,
@@ -828,7 +1033,14 @@ async fn load_linear_source(
     identifiers: &[String],
 ) -> Result<SourceFile, MemoryError> {
     let client = linear_client_from_workflow(repo_root, workflow_path)?;
-    let tracker_issues = load_linear_issue_tree(&client, identifiers).await?;
+    load_linear_source_from_client(&client, identifiers).await
+}
+
+async fn load_linear_source_from_client(
+    client: &LinearClient,
+    identifiers: &[String],
+) -> Result<SourceFile, MemoryError> {
+    let tracker_issues = load_linear_issue_tree(client, identifiers).await?;
 
     let mut issues = Vec::new();
     for issue in tracker_issues {
@@ -913,6 +1125,7 @@ fn issue_evidence_from_tracker(
         comments: workpad
             .map(|comment| {
                 vec![CommentEvidence {
+                    id: Some(comment.id),
                     body: comment.body,
                     updated_at: Some(comment.updated_at),
                     source: Some("linear:workpad".to_string()),
@@ -980,11 +1193,14 @@ fn non_empty(value: &str) -> Option<String> {
 }
 
 fn print_docs_plan(plan: &DocsSyncPlan) {
-    println!("# Docs Sync Plan\n");
+    println!("# Docs Sync Summary\n");
     println!("Selected issues: {}", plan.selected_issue_keys.join(", "));
+    if plan.targets.is_empty() {
+        println!("No stable topic docs selected for writing.");
+    }
     for target in &plan.targets {
         println!(
-            "\n## {} ({})\n\n{}",
+            "\n## {} ({})\n{}",
             target.title,
             if target.create { "create" } else { "update" },
             target.diff
@@ -1019,5 +1235,32 @@ fn print_search_results(
             path.display(),
             result.snippet
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, replace_or_append_managed_section,
+    };
+
+    #[test]
+    fn managed_linear_memory_status_replaces_existing_section() {
+        let existing = format!(
+            "Intro\n\n{LINEAR_MEMORY_STATUS_BEGIN}\nold\n{LINEAR_MEMORY_STATUS_END}\n\nTail"
+        );
+        let replacement = format!("{LINEAR_MEMORY_STATUS_BEGIN}\nnew\n{LINEAR_MEMORY_STATUS_END}");
+
+        let updated = replace_or_append_managed_section(
+            &existing,
+            LINEAR_MEMORY_STATUS_BEGIN,
+            LINEAR_MEMORY_STATUS_END,
+            &replacement,
+        );
+
+        assert!(updated.contains("Intro"));
+        assert!(updated.contains("new"));
+        assert!(updated.contains("Tail"));
+        assert!(!updated.contains("old"));
     }
 }

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -12,11 +12,12 @@ use crate::{
     opensymphony_linear::{LinearClient, LinearConfig},
     opensymphony_memory::{
         ArchivePlan, CommentEvidence, DocsSyncPlan, IssueEvidence, IssueSelection, LintSeverity,
-        MemoryConfig, MemoryError, SourceFile, brief, context_for_issue, docs_for_area,
-        expand_issue_range, lint, load_source_file, mark_archived, plan_archive, plan_capture,
-        plan_docs_sync, plan_memory_init, related_by_area, related_by_issue, related_by_paths,
-        render_archive_plan, render_capture_dry_run, search, status, write_capture_plan,
-        write_docs_sync_plan, write_memory_init_plan,
+        MemoryConfig, MemoryError, SourceFile, archive_blocking_warning_count, brief,
+        context_for_issue, docs_for_area, expand_issue_range, lint, load_source_file,
+        mark_archived, plan_archive, plan_capture, plan_docs_sync, plan_memory_init,
+        related_by_area, related_by_issue, related_by_paths, render_archive_plan,
+        render_capture_dry_run, search, status, write_capture_plan, write_docs_sync_plan,
+        write_memory_init_plan,
     },
     opensymphony_workflow::WorkflowDefinition,
 };
@@ -838,7 +839,13 @@ fn archive_plan_after_capture(
     });
     for issue in selected {
         let issue_key = issue.issue.identifier.clone();
-        let warning_count = issue.warnings.len() + capture_plan.warnings.len();
+        let capture_warnings = issue
+            .warnings
+            .iter()
+            .chain(capture_plan.warnings.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        let warning_count = archive_blocking_warning_count(&capture_warnings);
         let (eligible, reason) = if force {
             (
                 true,

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -946,8 +946,11 @@ fn replace_or_append_managed_section(
     end: &str,
     replacement: &str,
 ) -> String {
-    if let (Some(begin_index), Some(end_index)) = (existing.find(begin), existing.find(end)) {
-        let end_index = end_index + end.len();
+    if let Some(begin_index) = existing.find(begin) {
+        let end_index = existing[begin_index..]
+            .find(end)
+            .map(|relative_end| begin_index + relative_end + end.len())
+            .unwrap_or(existing.len());
         let mut output = String::new();
         output.push_str(existing[..begin_index].trim_end());
         if !output.is_empty() {
@@ -1262,5 +1265,23 @@ mod tests {
         assert!(updated.contains("new"));
         assert!(updated.contains("Tail"));
         assert!(!updated.contains("old"));
+    }
+
+    #[test]
+    fn managed_linear_memory_status_replaces_truncated_section() {
+        let existing = format!("Intro\n\n{LINEAR_MEMORY_STATUS_BEGIN}\nold without end marker");
+        let replacement = format!("{LINEAR_MEMORY_STATUS_BEGIN}\nnew\n{LINEAR_MEMORY_STATUS_END}");
+
+        let updated = replace_or_append_managed_section(
+            &existing,
+            LINEAR_MEMORY_STATUS_BEGIN,
+            LINEAR_MEMORY_STATUS_END,
+            &replacement,
+        );
+
+        assert!(updated.contains("Intro"));
+        assert!(updated.contains("new"));
+        assert_eq!(updated.matches(LINEAR_MEMORY_STATUS_BEGIN).count(), 1);
+        assert!(!updated.contains("old without end marker"));
     }
 }

--- a/crates/opensymphony-cli/src/memory_init_summary.rs
+++ b/crates/opensymphony-cli/src/memory_init_summary.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use crate::opensymphony_memory::{MemoryInitApplyReport, MemoryInitFileChange};
+
+pub(crate) fn record_memory_init_changes(
+    report: &MemoryInitApplyReport,
+    target_repo: &Path,
+    created: &mut Vec<String>,
+    updated: &mut Vec<String>,
+    unchanged: &mut Vec<String>,
+) {
+    record_memory_init_change(
+        relative_path_for_summary(target_repo, &report.config_path),
+        report.config,
+        created,
+        updated,
+        unchanged,
+    );
+    record_memory_init_change(
+        relative_path_for_summary(target_repo, &report.gitignore_path),
+        report.gitignore,
+        created,
+        updated,
+        unchanged,
+    );
+}
+
+pub(crate) fn memory_init_change_lists(
+    report: &MemoryInitApplyReport,
+    target_repo: &Path,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut created = Vec::new();
+    let mut updated = Vec::new();
+    let mut unchanged = Vec::new();
+    record_memory_init_changes(
+        report,
+        target_repo,
+        &mut created,
+        &mut updated,
+        &mut unchanged,
+    );
+    (created, updated, unchanged)
+}
+
+fn record_memory_init_change(
+    path: String,
+    change: MemoryInitFileChange,
+    created: &mut Vec<String>,
+    updated: &mut Vec<String>,
+    unchanged: &mut Vec<String>,
+) {
+    match change {
+        MemoryInitFileChange::Created => created.push(path),
+        MemoryInitFileChange::Updated => updated.push(path),
+        MemoryInitFileChange::Unchanged => unchanged.push(path),
+    }
+}
+
+fn relative_path_for_summary(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -944,6 +944,10 @@ Run the scheduler.
             workflow,
             bind: "127.0.0.1:3000".parse().expect("bind should parse"),
             tool_dir: None,
+            memory: super::super::config::RunMemoryConfig {
+                auto_capture: true,
+                auto_archive: false,
+            },
         };
 
         let error = match build_runtime_transport(&runtime).await {

--- a/crates/opensymphony-cli/src/orchestrator_run/config.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/config.rs
@@ -23,6 +23,8 @@ struct RunConfigFile {
     control_plane: ControlPlaneConfigFile,
     #[serde(default)]
     openhands: RunOpenHandsConfigFile,
+    #[serde(default)]
+    memory: RunMemoryConfigFile,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -37,6 +39,19 @@ struct RunOpenHandsConfigFile {
     tool_dir: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct RunMemoryConfigFile {
+    #[serde(default)]
+    auto_capture: Option<bool>,
+    #[serde(default)]
+    auto_archive: Option<bool>,
+}
+
+pub(super) struct RunMemoryConfig {
+    pub(super) auto_capture: bool,
+    pub(super) auto_archive: bool,
+}
+
 pub(super) struct RunRuntimeConfig {
     pub(super) config_path: Option<PathBuf>,
     pub(super) target_repo: PathBuf,
@@ -44,6 +59,7 @@ pub(super) struct RunRuntimeConfig {
     pub(super) workflow: ResolvedWorkflow,
     pub(super) bind: SocketAddr,
     pub(super) tool_dir: Option<PathBuf>,
+    pub(super) memory: RunMemoryConfig,
 }
 
 pub(super) async fn resolve_runtime_config(
@@ -100,6 +116,10 @@ pub(super) async fn resolve_runtime_config(
         .tool_dir
         .as_deref()
         .map(|path| super::super::resolve_path(config_root, path));
+    let memory = RunMemoryConfig {
+        auto_capture: config.memory.auto_capture.unwrap_or(true),
+        auto_archive: config.memory.auto_archive.unwrap_or(false),
+    };
 
     Ok(RunRuntimeConfig {
         config_path,
@@ -108,6 +128,7 @@ pub(super) async fn resolve_runtime_config(
         workflow,
         bind,
         tool_dir,
+        memory,
     })
 }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/config.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/config.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::opensymphony_memory::DEFAULT_PRIVATE_MEMORY_CONFIG_FILE;
 use crate::opensymphony_workflow::{ResolvedWorkflow, WorkflowDefinition};
 use serde::Deserialize;
 use tokio::fs;
@@ -120,6 +121,7 @@ pub(super) async fn resolve_runtime_config(
         auto_capture: config.memory.auto_capture.unwrap_or(true),
         auto_archive: config.memory.auto_archive.unwrap_or(false),
     };
+    validate_memory_bootstrap(&target_repo, &memory)?;
 
     Ok(RunRuntimeConfig {
         config_path,
@@ -130,6 +132,20 @@ pub(super) async fn resolve_runtime_config(
         tool_dir,
         memory,
     })
+}
+
+fn validate_memory_bootstrap(
+    target_repo: &Path,
+    memory: &RunMemoryConfig,
+) -> Result<(), RunCommandError> {
+    if !memory.auto_capture {
+        return Ok(());
+    }
+    let path = target_repo.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE);
+    if path.is_file() {
+        return Ok(());
+    }
+    Err(RunCommandError::MissingMemoryConfig { path })
 }
 
 async fn load_run_config(path: &Path) -> Result<RunConfigFile, RunCommandError> {
@@ -184,5 +200,53 @@ fn resolve_relative_to(base: &Path, path: &Path) -> PathBuf {
         path.to_path_buf()
     } else {
         base.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_bootstrap_is_required_when_auto_capture_is_enabled() {
+        let repo = tempfile::tempdir().expect("temp repo should exist");
+        let memory = RunMemoryConfig {
+            auto_capture: true,
+            auto_archive: false,
+        };
+
+        let result = validate_memory_bootstrap(repo.path(), &memory);
+
+        assert!(matches!(
+            result,
+            Err(RunCommandError::MissingMemoryConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn memory_bootstrap_is_not_required_when_auto_capture_is_disabled() {
+        let repo = tempfile::tempdir().expect("temp repo should exist");
+        let memory = RunMemoryConfig {
+            auto_capture: false,
+            auto_archive: false,
+        };
+
+        validate_memory_bootstrap(repo.path(), &memory).expect("disabled auto-capture should pass");
+    }
+
+    #[test]
+    fn memory_bootstrap_accepts_initialized_repo() {
+        let repo = tempfile::tempdir().expect("temp repo should exist");
+        let path = repo.path().join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE);
+        std::fs::create_dir_all(path.parent().expect("memory config should have parent"))
+            .expect("memory config parent should be created");
+        std::fs::write(&path, "memory_root: .opensymphony/memory\n")
+            .expect("memory config should be written");
+        let memory = RunMemoryConfig {
+            auto_capture: true,
+            auto_archive: false,
+        };
+
+        validate_memory_bootstrap(repo.path(), &memory).expect("memory config should satisfy run");
     }
 }

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -414,10 +414,10 @@ fn mark_auto_capture_completed(
     result: &Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
 ) {
     match result {
-        Ok(report) if !report.captured_issue_keys.is_empty() => {
-            completed_issues.extend(report.captured_issue_keys.iter().cloned());
+        Ok(report) if report.workflow_completed() && !report.completed_issue_keys.is_empty() => {
+            completed_issues.extend(report.completed_issue_keys.iter().cloned());
         }
-        Ok(report) if report.warnings.is_empty() => {
+        Ok(report) if report.workflow_completed() && report.warnings.is_empty() => {
             completed_issues.extend(candidates.iter().cloned());
         }
         Ok(_) | Err(_) => {}
@@ -476,14 +476,38 @@ mod tests {
     }
 
     #[test]
-    fn auto_capture_result_marks_capture_success_even_with_warnings() {
+    fn auto_capture_result_waits_for_post_capture_steps_before_completing() {
         let mut completed = issue_set(&["COE-1"]);
         let candidates = vec!["COE-2".to_string()];
         let result = Ok(super::super::memory::AutoMemoryReport {
+            completed_issue_keys: Vec::new(),
             captured_issue_keys: vec!["COE-2".to_string()],
             archived_issue_keys: Vec::new(),
             docs_written: Vec::new(),
+            capture_completed: true,
+            docs_sync_completed: false,
+            archive_completed: true,
             warnings: vec!["docs sync failed after capture".to_string()],
+        });
+
+        mark_auto_capture_completed(&mut completed, &candidates, &result);
+
+        assert_eq!(completed, issue_set(&["COE-1"]));
+    }
+
+    #[test]
+    fn auto_capture_result_marks_full_workflow_complete() {
+        let mut completed = issue_set(&["COE-1"]);
+        let candidates = vec!["COE-2".to_string()];
+        let result = Ok(super::super::memory::AutoMemoryReport {
+            completed_issue_keys: vec!["COE-2".to_string()],
+            captured_issue_keys: vec!["COE-2".to_string()],
+            archived_issue_keys: Vec::new(),
+            docs_written: vec![PathBuf::from("docs/runtime.md")],
+            capture_completed: true,
+            docs_sync_completed: true,
+            archive_completed: true,
+            warnings: Vec::new(),
         });
 
         mark_auto_capture_completed(&mut completed, &candidates, &result);
@@ -492,13 +516,13 @@ mod tests {
     }
 
     #[test]
-    fn auto_capture_result_marks_fresh_noop_as_complete() {
+    fn auto_capture_result_does_not_mark_default_noop_complete() {
         let mut completed = issue_set(&["COE-1"]);
         let candidates = vec!["COE-2".to_string()];
         let result = Ok(super::super::memory::AutoMemoryReport::default());
 
         mark_auto_capture_completed(&mut completed, &candidates, &result);
 
-        assert_eq!(completed, issue_set(&["COE-1", "COE-2"]));
+        assert_eq!(completed, issue_set(&["COE-1"]));
     }
 }

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -33,7 +33,7 @@ use self::{
         RuntimeWorkerBackend, RuntimeWorkspaceBackend, build_runtime_transport,
         build_tracker_backend, build_workspace_manager_config,
     },
-    config::resolve_runtime_config,
+    config::{RunRuntimeConfig, resolve_runtime_config},
     snapshot::{current_agent_server_status, map_snapshot, push_recent_event, terminal_state_set},
 };
 
@@ -248,8 +248,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             &recent_events,
                         )).await;
                         if runtime.memory.auto_capture && !newly_terminal_issues.is_empty() {
-                            let memory_event_added = record_auto_capture_recent_event(
-                                &mut recent_events,
+                            publish_auto_capture_event(
                                 super::memory::auto_capture_terminal(
                                     &runtime.target_repo,
                                     &runtime.workflow_path,
@@ -257,16 +256,13 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                                     runtime.memory.auto_archive,
                                 )
                                 .await,
-                            );
-                            if memory_event_added {
-                                store.publish(map_snapshot(
-                                    &snapshot,
-                                    runtime.workflow.config.workspace.root.as_path(),
-                                    &terminal_state_set(&runtime.workflow),
-                                    current_agent_server_status(&mut supervisor, client.base_url()),
-                                    &recent_events,
-                                )).await;
-                            }
+                                &snapshot,
+                                &runtime,
+                                &mut supervisor,
+                                client.base_url(),
+                                &mut recent_events,
+                                &store,
+                            ).await;
                         }
                     }
                     Err(error) => {
@@ -299,19 +295,45 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     Ok(())
 }
 
+async fn publish_auto_capture_event(
+    result: Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
+    snapshot: &OrchestratorSnapshot,
+    runtime: &RunRuntimeConfig,
+    supervisor: &mut Option<crate::opensymphony_openhands::LocalServerSupervisor>,
+    agent_server_base_url: &str,
+    recent_events: &mut VecDeque<RecentEvent>,
+    store: &SnapshotStore,
+) {
+    if record_auto_capture_recent_event(recent_events, result) {
+        store
+            .publish(map_snapshot(
+                snapshot,
+                runtime.workflow.config.workspace.root.as_path(),
+                &terminal_state_set(&runtime.workflow),
+                current_agent_server_status(supervisor, agent_server_base_url),
+                recent_events,
+            ))
+            .await;
+    }
+}
+
 fn record_auto_capture_recent_event(
     recent_events: &mut VecDeque<RecentEvent>,
     result: Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
 ) -> bool {
     match result {
         Ok(report) => {
-            if report.captured_issue_keys.is_empty() {
+            if report.captured_issue_keys.is_empty() && report.warnings.is_empty() {
                 return false;
             }
-            let mut summary = format!(
-                "memory captured {} issue(s)",
-                report.captured_issue_keys.len()
-            );
+            let mut summary = if report.captured_issue_keys.is_empty() {
+                "memory capture reported no new capsules".to_string()
+            } else {
+                format!(
+                    "memory captured {} issue(s)",
+                    report.captured_issue_keys.len()
+                )
+            };
             if !report.docs_written.is_empty() {
                 summary.push_str(&format!(", synced {} doc(s)", report.docs_written.len()));
             }

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -9,7 +9,9 @@ use std::{
     sync::Arc,
 };
 
-use crate::opensymphony_control::{ControlPlaneServer, RecentEventKind, SnapshotStore};
+use crate::opensymphony_control::{
+    ControlPlaneServer, RecentEvent, RecentEventKind, SnapshotStore,
+};
 use crate::opensymphony_domain::TimestampMs;
 use crate::opensymphony_linear::LinearError;
 use crate::opensymphony_openhands::OpenHandsError;
@@ -246,75 +248,24 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             &recent_events,
                         )).await;
                         if runtime.memory.auto_capture && !newly_terminal_issues.is_empty() {
-                            match super::memory::auto_capture_terminal(
-                                &runtime.target_repo,
-                                &runtime.workflow_path,
-                                &newly_terminal_issues,
-                                runtime.memory.auto_archive,
-                            )
-                            .await
-                            {
-                                Ok(report) => {
-                                    if !report.captured_issue_keys.is_empty() {
-                                        let mut summary = format!(
-                                            "memory captured {} issue(s)",
-                                            report.captured_issue_keys.len()
-                                        );
-                                        if !report.docs_written.is_empty() {
-                                            summary.push_str(&format!(
-                                                ", synced {} doc(s)",
-                                                report.docs_written.len()
-                                            ));
-                                        }
-                                        if !report.archived_issue_keys.is_empty() {
-                                            summary.push_str(&format!(
-                                                ", archived {} issue(s)",
-                                                report.archived_issue_keys.len()
-                                            ));
-                                        }
-                                        if !report.warnings.is_empty() {
-                                            summary.push_str(&format!(
-                                                ", {} warning(s)",
-                                                report.warnings.len()
-                                            ));
-                                        }
-                                        push_recent_event(
-                                            &mut recent_events,
-                                            if report.warnings.is_empty() {
-                                                RecentEventKind::SnapshotPublished
-                                            } else {
-                                                RecentEventKind::Warning
-                                            },
-                                            None,
-                                            summary,
-                                            Utc::now(),
-                                        );
-                                        store.publish(map_snapshot(
-                                            &snapshot,
-                                            runtime.workflow.config.workspace.root.as_path(),
-                                            &terminal_state_set(&runtime.workflow),
-                                            current_agent_server_status(&mut supervisor, client.base_url()),
-                                            &recent_events,
-                                        )).await;
-                                    }
-                                }
-                                Err(error) => {
-                                    warn!(%error, "automatic memory capture failed");
-                                    push_recent_event(
-                                        &mut recent_events,
-                                        RecentEventKind::Warning,
-                                        None,
-                                        format!("automatic memory capture failed: {error}"),
-                                        Utc::now(),
-                                    );
-                                    store.publish(map_snapshot(
-                                        &snapshot,
-                                        runtime.workflow.config.workspace.root.as_path(),
-                                        &terminal_state_set(&runtime.workflow),
-                                        current_agent_server_status(&mut supervisor, client.base_url()),
-                                        &recent_events,
-                                    )).await;
-                                }
+                            let memory_event_added = record_auto_capture_recent_event(
+                                &mut recent_events,
+                                super::memory::auto_capture_terminal(
+                                    &runtime.target_repo,
+                                    &runtime.workflow_path,
+                                    &newly_terminal_issues,
+                                    runtime.memory.auto_archive,
+                                )
+                                .await,
+                            );
+                            if memory_event_added {
+                                store.publish(map_snapshot(
+                                    &snapshot,
+                                    runtime.workflow.config.workspace.root.as_path(),
+                                    &terminal_state_set(&runtime.workflow),
+                                    current_agent_server_status(&mut supervisor, client.base_url()),
+                                    &recent_events,
+                                )).await;
                             }
                         }
                     }
@@ -346,6 +297,58 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     }
 
     Ok(())
+}
+
+fn record_auto_capture_recent_event(
+    recent_events: &mut VecDeque<RecentEvent>,
+    result: Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
+) -> bool {
+    match result {
+        Ok(report) => {
+            if report.captured_issue_keys.is_empty() {
+                return false;
+            }
+            let mut summary = format!(
+                "memory captured {} issue(s)",
+                report.captured_issue_keys.len()
+            );
+            if !report.docs_written.is_empty() {
+                summary.push_str(&format!(", synced {} doc(s)", report.docs_written.len()));
+            }
+            if !report.archived_issue_keys.is_empty() {
+                summary.push_str(&format!(
+                    ", archived {} issue(s)",
+                    report.archived_issue_keys.len()
+                ));
+            }
+            if !report.warnings.is_empty() {
+                summary.push_str(&format!(", {} warning(s)", report.warnings.len()));
+            }
+            push_recent_event(
+                recent_events,
+                if report.warnings.is_empty() {
+                    RecentEventKind::SnapshotPublished
+                } else {
+                    RecentEventKind::Warning
+                },
+                None,
+                summary,
+                Utc::now(),
+            );
+            true
+        }
+        Err(error) => {
+            warn!(%error, "automatic memory capture failed");
+            push_recent_event(
+                recent_events,
+                RecentEventKind::Warning,
+                None,
+                format!("automatic memory capture failed: {error}"),
+                Utc::now(),
+            );
+            true
+        }
+    }
 }
 
 fn terminal_issue_identifiers(snapshot: &OrchestratorSnapshot) -> BTreeSet<String> {

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -179,7 +179,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     let mut server_task = tokio::spawn(async move { server.serve(listener).await });
 
     let bootstrap_snapshot = scheduler.bootstrap(now_timestamp()).await?;
-    let mut known_terminal_issues = terminal_issue_identifiers(&bootstrap_snapshot);
+    let mut auto_capture_completed_issues = terminal_issue_identifiers(&bootstrap_snapshot);
     push_recent_event(
         &mut recent_events,
         RecentEventKind::SnapshotPublished,
@@ -224,11 +224,11 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                 match scheduler.tick(observed_at).await {
                     Ok(snapshot) => {
                         let current_terminal_issues = terminal_issue_identifiers(&snapshot);
-                        let newly_terminal_issues = current_terminal_issues
-                            .difference(&known_terminal_issues)
-                            .cloned()
-                            .collect::<Vec<_>>();
-                        known_terminal_issues = current_terminal_issues;
+                        let auto_capture_candidates = auto_capture_candidates(
+                            &current_terminal_issues,
+                            &mut auto_capture_completed_issues,
+                            runtime.memory.auto_capture,
+                        );
                         push_recent_event(
                             &mut recent_events,
                             RecentEventKind::SnapshotPublished,
@@ -247,15 +247,21 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             current_agent_server_status(&mut supervisor, client.base_url()),
                             &recent_events,
                         )).await;
-                        if runtime.memory.auto_capture && !newly_terminal_issues.is_empty() {
+                        if !auto_capture_candidates.is_empty() {
+                            let auto_capture_result = super::memory::auto_capture_terminal(
+                                &runtime.target_repo,
+                                &runtime.workflow_path,
+                                &auto_capture_candidates,
+                                runtime.memory.auto_archive,
+                            )
+                            .await;
+                            mark_auto_capture_completed(
+                                &mut auto_capture_completed_issues,
+                                &auto_capture_candidates,
+                                &auto_capture_result,
+                            );
                             publish_auto_capture_event(
-                                super::memory::auto_capture_terminal(
-                                    &runtime.target_repo,
-                                    &runtime.workflow_path,
-                                    &newly_terminal_issues,
-                                    runtime.memory.auto_archive,
-                                )
-                                .await,
+                                auto_capture_result,
                                 &snapshot,
                                 &runtime,
                                 &mut supervisor,
@@ -382,6 +388,38 @@ fn terminal_issue_identifiers(snapshot: &OrchestratorSnapshot) -> BTreeSet<Strin
         .collect()
 }
 
+fn auto_capture_candidates(
+    current_terminal_issues: &BTreeSet<String>,
+    completed_issues: &mut BTreeSet<String>,
+    auto_capture_enabled: bool,
+) -> Vec<String> {
+    completed_issues.retain(|issue| current_terminal_issues.contains(issue));
+    if !auto_capture_enabled {
+        *completed_issues = current_terminal_issues.clone();
+        return Vec::new();
+    }
+    current_terminal_issues
+        .difference(completed_issues)
+        .cloned()
+        .collect()
+}
+
+fn mark_auto_capture_completed(
+    completed_issues: &mut BTreeSet<String>,
+    candidates: &[String],
+    result: &Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
+) {
+    match result {
+        Ok(report) if !report.captured_issue_keys.is_empty() => {
+            completed_issues.extend(report.captured_issue_keys.iter().cloned());
+        }
+        Ok(report) if report.warnings.is_empty() => {
+            completed_issues.extend(candidates.iter().cloned());
+        }
+        Ok(_) | Err(_) => {}
+    }
+}
+
 pub(super) fn timestamp_to_datetime(value: TimestampMs) -> DateTime<Utc> {
     DateTime::from_timestamp_millis(value.as_u64() as i64).unwrap_or_else(Utc::now)
 }
@@ -392,4 +430,71 @@ pub(super) fn datetime_to_timestamp_ms(value: DateTime<Utc>) -> TimestampMs {
 
 pub(super) fn now_timestamp() -> TimestampMs {
     TimestampMs::new(Utc::now().timestamp_millis().max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::opensymphony_memory::MemoryError;
+
+    fn issue_set(keys: &[&str]) -> BTreeSet<String> {
+        keys.iter().map(|key| key.to_string()).collect()
+    }
+
+    #[test]
+    fn auto_capture_candidates_retry_until_capture_completes() {
+        let current = issue_set(&["COE-1", "COE-2"]);
+        let mut completed = issue_set(&["COE-1"]);
+
+        let candidates = auto_capture_candidates(&current, &mut completed, true);
+
+        assert_eq!(candidates, vec!["COE-2".to_string()]);
+        mark_auto_capture_completed(
+            &mut completed,
+            &candidates,
+            &Err(MemoryError::InvalidInput("capture failed".to_string())),
+        );
+        assert_eq!(completed, issue_set(&["COE-1"]));
+
+        let retry_candidates = auto_capture_candidates(&current, &mut completed, true);
+        assert_eq!(retry_candidates, vec!["COE-2".to_string()]);
+    }
+
+    #[test]
+    fn auto_capture_candidates_forget_reopened_issues() {
+        let current = issue_set(&["COE-2"]);
+        let mut completed = issue_set(&["COE-1", "COE-2"]);
+
+        let candidates = auto_capture_candidates(&current, &mut completed, true);
+
+        assert!(candidates.is_empty());
+        assert_eq!(completed, issue_set(&["COE-2"]));
+    }
+
+    #[test]
+    fn auto_capture_result_marks_capture_success_even_with_warnings() {
+        let mut completed = issue_set(&["COE-1"]);
+        let candidates = vec!["COE-2".to_string()];
+        let result = Ok(super::super::memory::AutoMemoryReport {
+            captured_issue_keys: vec!["COE-2".to_string()],
+            archived_issue_keys: Vec::new(),
+            docs_written: Vec::new(),
+            warnings: vec!["docs sync failed after capture".to_string()],
+        });
+
+        mark_auto_capture_completed(&mut completed, &candidates, &result);
+
+        assert_eq!(completed, issue_set(&["COE-1", "COE-2"]));
+    }
+
+    #[test]
+    fn auto_capture_result_marks_fresh_noop_as_complete() {
+        let mut completed = issue_set(&["COE-1"]);
+        let candidates = vec!["COE-2".to_string()];
+        let result = Ok(super::super::memory::AutoMemoryReport::default());
+
+        mark_auto_capture_completed(&mut completed, &candidates, &result);
+
+        assert_eq!(completed, issue_set(&["COE-1", "COE-2"]));
+    }
 }

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -2,13 +2,20 @@ pub(crate) mod backends;
 mod config;
 mod snapshot;
 
-use std::{collections::VecDeque, path::PathBuf, process::ExitCode, sync::Arc};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    path::PathBuf,
+    process::ExitCode,
+    sync::Arc,
+};
 
 use crate::opensymphony_control::{ControlPlaneServer, RecentEventKind, SnapshotStore};
 use crate::opensymphony_domain::TimestampMs;
 use crate::opensymphony_linear::LinearError;
 use crate::opensymphony_openhands::OpenHandsError;
-use crate::opensymphony_orchestrator::{Scheduler, SchedulerConfig, SchedulerError};
+use crate::opensymphony_orchestrator::{
+    IssueStateCategory, OrchestratorSnapshot, Scheduler, SchedulerConfig, SchedulerError,
+};
 use crate::opensymphony_workspace::WorkspaceError;
 use chrono::{DateTime, Utc};
 use clap::Args;
@@ -170,6 +177,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     let mut server_task = tokio::spawn(async move { server.serve(listener).await });
 
     let bootstrap_snapshot = scheduler.bootstrap(now_timestamp()).await?;
+    let mut known_terminal_issues = terminal_issue_identifiers(&bootstrap_snapshot);
     push_recent_event(
         &mut recent_events,
         RecentEventKind::SnapshotPublished,
@@ -213,6 +221,12 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                 let observed_at = now_timestamp();
                 match scheduler.tick(observed_at).await {
                     Ok(snapshot) => {
+                        let current_terminal_issues = terminal_issue_identifiers(&snapshot);
+                        let newly_terminal_issues = current_terminal_issues
+                            .difference(&known_terminal_issues)
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        known_terminal_issues = current_terminal_issues;
                         push_recent_event(
                             &mut recent_events,
                             RecentEventKind::SnapshotPublished,
@@ -231,6 +245,78 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             current_agent_server_status(&mut supervisor, client.base_url()),
                             &recent_events,
                         )).await;
+                        if runtime.memory.auto_capture && !newly_terminal_issues.is_empty() {
+                            match super::memory::auto_capture_terminal(
+                                &runtime.target_repo,
+                                &runtime.workflow_path,
+                                &newly_terminal_issues,
+                                runtime.memory.auto_archive,
+                            )
+                            .await
+                            {
+                                Ok(report) => {
+                                    if !report.captured_issue_keys.is_empty() {
+                                        let mut summary = format!(
+                                            "memory captured {} issue(s)",
+                                            report.captured_issue_keys.len()
+                                        );
+                                        if !report.docs_written.is_empty() {
+                                            summary.push_str(&format!(
+                                                ", synced {} doc(s)",
+                                                report.docs_written.len()
+                                            ));
+                                        }
+                                        if !report.archived_issue_keys.is_empty() {
+                                            summary.push_str(&format!(
+                                                ", archived {} issue(s)",
+                                                report.archived_issue_keys.len()
+                                            ));
+                                        }
+                                        if !report.warnings.is_empty() {
+                                            summary.push_str(&format!(
+                                                ", {} warning(s)",
+                                                report.warnings.len()
+                                            ));
+                                        }
+                                        push_recent_event(
+                                            &mut recent_events,
+                                            if report.warnings.is_empty() {
+                                                RecentEventKind::SnapshotPublished
+                                            } else {
+                                                RecentEventKind::Warning
+                                            },
+                                            None,
+                                            summary,
+                                            Utc::now(),
+                                        );
+                                        store.publish(map_snapshot(
+                                            &snapshot,
+                                            runtime.workflow.config.workspace.root.as_path(),
+                                            &terminal_state_set(&runtime.workflow),
+                                            current_agent_server_status(&mut supervisor, client.base_url()),
+                                            &recent_events,
+                                        )).await;
+                                    }
+                                }
+                                Err(error) => {
+                                    warn!(%error, "automatic memory capture failed");
+                                    push_recent_event(
+                                        &mut recent_events,
+                                        RecentEventKind::Warning,
+                                        None,
+                                        format!("automatic memory capture failed: {error}"),
+                                        Utc::now(),
+                                    );
+                                    store.publish(map_snapshot(
+                                        &snapshot,
+                                        runtime.workflow.config.workspace.root.as_path(),
+                                        &terminal_state_set(&runtime.workflow),
+                                        current_agent_server_status(&mut supervisor, client.base_url()),
+                                        &recent_events,
+                                    )).await;
+                                }
+                            }
+                        }
                     }
                     Err(error) => {
                         warn!(%error, "scheduler tick failed");
@@ -260,6 +346,15 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     }
 
     Ok(())
+}
+
+fn terminal_issue_identifiers(snapshot: &OrchestratorSnapshot) -> BTreeSet<String> {
+    snapshot
+        .issues
+        .iter()
+        .filter(|issue| issue.issue.state.category == IssueStateCategory::Terminal)
+        .map(|issue| issue.issue.identifier.to_string())
+        .collect()
 }
 
 pub(super) fn timestamp_to_datetime(value: TimestampMs) -> DateTime<Utc> {

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -80,6 +80,10 @@ enum RunCommandError {
         #[source]
         source: crate::opensymphony_workflow::WorkflowConfigError,
     },
+    #[error(
+        "memory auto-capture is enabled but {path} is missing; run `opensymphony memory init` or `opensymphony update` from the target repo before `opensymphony run`"
+    )]
+    MissingMemoryConfig { path: PathBuf },
     #[error("failed to build tracker client: {0}")]
     Tracker(#[from] LinearError),
     #[error("failed to create workspace manager: {0}")]

--- a/crates/opensymphony-cli/src/update_repo.rs
+++ b/crates/opensymphony-cli/src/update_repo.rs
@@ -12,6 +12,9 @@ use thiserror::Error;
 use tokio::process::Command;
 
 use crate::opensymphony_cli::init_repo::{self, InitCommandError};
+use crate::opensymphony_memory::{
+    MemoryInitApplyReport, MemoryInitFileChange, ensure_memory_initialized,
+};
 
 const DEFAULT_CRATE_METADATA_URL: &str = "https://crates.io/api/v1/crates/opensymphony";
 
@@ -50,6 +53,8 @@ enum UpdateCommandError {
     CargoInstallFailed { status: String },
     #[error("{0}")]
     Template(#[from] InitCommandError),
+    #[error("failed to initialize project memory: {0}")]
+    MemoryInit(#[from] crate::opensymphony_memory::MemoryError),
     #[error("failed to read {path}: {source}")]
     ReadFile {
         path: PathBuf,
@@ -163,11 +168,13 @@ async fn run_update(args: UpdateArgs) -> Result<(), UpdateCommandError> {
 
     println!("Detected an OpenSymphony target repo; refreshing template-managed skill files.");
     let report = sync_template_skills(&current_dir, &client).await?;
+    let memory_report = ensure_memory_initialized(&current_dir, None)?;
 
     println!("Skill refresh summary:");
     print_paths("Created", &report.created);
     print_paths("Updated", &report.updated);
     println!("Unchanged: {} file(s)", report.unchanged_count);
+    print_memory_init_summary(&current_dir, &memory_report);
     println!("OpenSymphony update complete.");
     Ok(())
 }
@@ -338,6 +345,52 @@ fn print_paths(label: &str, paths: &[String]) {
     for path in paths {
         println!("- {path}");
     }
+}
+
+fn print_memory_init_summary(target_repo: &Path, report: &MemoryInitApplyReport) {
+    let mut created = Vec::new();
+    let mut updated = Vec::new();
+    let mut unchanged = Vec::new();
+    record_memory_init_change(
+        relative_path_for_summary(target_repo, &report.config_path),
+        report.config,
+        &mut created,
+        &mut updated,
+        &mut unchanged,
+    );
+    record_memory_init_change(
+        relative_path_for_summary(target_repo, &report.gitignore_path),
+        report.gitignore,
+        &mut created,
+        &mut updated,
+        &mut unchanged,
+    );
+
+    println!("Memory init summary:");
+    print_paths("Created", &created);
+    print_paths("Updated", &updated);
+    println!("Unchanged: {} file(s)", unchanged.len());
+}
+
+fn record_memory_init_change(
+    path: String,
+    change: MemoryInitFileChange,
+    created: &mut Vec<String>,
+    updated: &mut Vec<String>,
+    unchanged: &mut Vec<String>,
+) {
+    match change {
+        MemoryInitFileChange::Created => created.push(path),
+        MemoryInitFileChange::Updated => updated.push(path),
+        MemoryInitFileChange::Unchanged => unchanged.push(path),
+    }
+}
+
+fn relative_path_for_summary(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn join_for_display(items: &[&str]) -> String {

--- a/crates/opensymphony-cli/src/update_repo.rs
+++ b/crates/opensymphony-cli/src/update_repo.rs
@@ -11,10 +11,9 @@ use serde::Deserialize;
 use thiserror::Error;
 use tokio::process::Command;
 
+use super::memory_init_summary::memory_init_change_lists;
 use crate::opensymphony_cli::init_repo::{self, InitCommandError};
-use crate::opensymphony_memory::{
-    MemoryInitApplyReport, MemoryInitFileChange, ensure_memory_initialized,
-};
+use crate::opensymphony_memory::{MemoryInitApplyReport, ensure_memory_initialized};
 
 const DEFAULT_CRATE_METADATA_URL: &str = "https://crates.io/api/v1/crates/opensymphony";
 
@@ -348,49 +347,12 @@ fn print_paths(label: &str, paths: &[String]) {
 }
 
 fn print_memory_init_summary(target_repo: &Path, report: &MemoryInitApplyReport) {
-    let mut created = Vec::new();
-    let mut updated = Vec::new();
-    let mut unchanged = Vec::new();
-    record_memory_init_change(
-        relative_path_for_summary(target_repo, &report.config_path),
-        report.config,
-        &mut created,
-        &mut updated,
-        &mut unchanged,
-    );
-    record_memory_init_change(
-        relative_path_for_summary(target_repo, &report.gitignore_path),
-        report.gitignore,
-        &mut created,
-        &mut updated,
-        &mut unchanged,
-    );
+    let (created, updated, unchanged) = memory_init_change_lists(report, target_repo);
 
     println!("Memory init summary:");
     print_paths("Created", &created);
     print_paths("Updated", &updated);
     println!("Unchanged: {} file(s)", unchanged.len());
-}
-
-fn record_memory_init_change(
-    path: String,
-    change: MemoryInitFileChange,
-    created: &mut Vec<String>,
-    updated: &mut Vec<String>,
-    unchanged: &mut Vec<String>,
-) {
-    match change {
-        MemoryInitFileChange::Created => created.push(path),
-        MemoryInitFileChange::Updated => updated.push(path),
-        MemoryInitFileChange::Unchanged => unchanged.push(path),
-    }
-}
-
-fn relative_path_for_summary(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .into_owned()
 }
 
 fn join_for_display(items: &[&str]) -> String {

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -50,6 +50,7 @@ fn memory_help_explains_capture_and_query_surface() {
     );
     for snippet in [
         "Capture, query, and sync project memory",
+        "init",
         "capture",
         "sync-docs",
         "related",

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -87,7 +87,13 @@ async fn init_copies_template_files_and_customizes_workflow() {
     );
     let gitignore =
         fs::read_to_string(repo.path().join(".gitignore")).expect(".gitignore should exist");
-    assert_eq!(gitignore, ".opensymphony*\n");
+    assert_eq!(gitignore, memory_gitignore_policy(""));
+    let memory_config = fs::read_to_string(repo.path().join(".opensymphony/memory/memory.yaml"))
+        .expect("memory config should be initialized");
+    assert!(
+        memory_config.contains("memory_root: .opensymphony/memory"),
+        "memory config should contain the default memory root: {memory_config}",
+    );
     assert!(
         !repo
             .path()
@@ -100,8 +106,10 @@ async fn init_copies_template_files_and_customizes_workflow() {
         "stdout should contain a summary: {stdout}",
     );
     assert!(
-        stdout.contains("Created:") && stdout.contains("- .gitignore"),
-        "stdout should report the generated ignore entry: {stdout}",
+        stdout.contains("Created:")
+            && stdout.contains("- .gitignore")
+            && stdout.contains("- .opensymphony/memory/memory.yaml"),
+        "stdout should report the generated memory files: {stdout}",
     );
 }
 
@@ -327,7 +335,7 @@ async fn init_merges_agents_and_skips_conflicting_file_when_requested() {
 }
 
 #[tokio::test]
-async fn init_appends_opensymphony_rule_to_existing_gitignore() {
+async fn init_repairs_gitignore_for_memory_policy() {
     let server = TemplateServer::start().await;
     let repo = TempDir::new().expect("temp repo should exist");
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
@@ -350,7 +358,7 @@ async fn init_appends_opensymphony_rule_to_existing_gitignore() {
 
     let gitignore =
         fs::read_to_string(repo.path().join(".gitignore")).expect(".gitignore should exist");
-    assert_eq!(gitignore, "node_modules/\n.opensymphony*\n");
+    assert_eq!(gitignore, memory_gitignore_policy("node_modules/\n"));
     assert!(
         stdout.contains("Updated:") && stdout.contains("- .gitignore"),
         "stdout should report the updated ignore entry: {stdout}",
@@ -501,6 +509,12 @@ fn run_git(repo_root: &std::path::Path, args: &[&str]) {
         .status()
         .expect("git should run");
     assert!(status.success(), "git {:?} should succeed", args);
+}
+
+fn memory_gitignore_policy(prefix: &str) -> String {
+    format!(
+        "{prefix}.opensymphony*\n!.opensymphony/\n.opensymphony/*\n!.opensymphony/memory/\n.opensymphony/memory/*\n!.opensymphony/memory/memory.yaml\n"
+    )
 }
 
 struct TemplateServer {

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -91,6 +91,127 @@ fn memory_capture_write_query_and_sync_docs_are_reviewable() {
 }
 
 #[test]
+fn memory_init_creates_private_config_and_gitignore_policy() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    fs::create_dir_all(repo.path().join("docs/tasks")).expect("tasks dir should write");
+    fs::write(
+        repo.path().join("docs/tasks/task.md"),
+        "---\narea: agent-runtime\n---\n# Task\n",
+    )
+    .expect("task should write");
+    fs::write(repo.path().join(".gitignore"), ".opensymphony*\n").expect("gitignore should write");
+
+    let output = run(repo.path(), ["memory", "init"]);
+    assert_success(&output, "memory init");
+
+    let config_path = repo.path().join(".opensymphony/memory/memory.yaml");
+    let config = fs::read_to_string(&config_path).expect("memory config should exist");
+    assert!(config.contains("agent-runtime:"));
+    assert!(config.contains("docs_target: docs/agent-runtime.md"));
+    assert!(
+        !repo
+            .path()
+            .join(".opensymphony/memory/memory.duckdb")
+            .exists()
+    );
+
+    let gitignore =
+        fs::read_to_string(repo.path().join(".gitignore")).expect("gitignore should be readable");
+    assert!(gitignore.contains("!.opensymphony/memory/memory.yaml"));
+    assert!(gitignore.contains(".opensymphony/memory/*"));
+
+    let duplicate = run(repo.path(), ["memory", "init"]);
+    assert_failure(&duplicate, "memory init duplicate");
+    assert!(String::from_utf8_lossy(&duplicate.stderr).contains("already exists"));
+
+    let forced = run(repo.path(), ["memory", "init", "--force"]);
+    assert_success(&forced, "memory init force");
+}
+
+#[test]
+fn memory_init_dry_run_does_not_write_files() {
+    let repo = TempDir::new().expect("temp repo should exist");
+
+    let output = run(repo.path(), ["memory", "init", "--dry-run"]);
+    assert_success(&output, "memory init dry-run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Proposed config"));
+    assert!(stdout.contains("general:"));
+    assert!(
+        !repo
+            .path()
+            .join(".opensymphony/memory/memory.yaml")
+            .exists()
+    );
+    assert!(!repo.path().join(".gitignore").exists());
+}
+
+#[test]
+fn sync_docs_requires_configured_area_mapping() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    fs::write(repo.path().join("source.yaml"), sample_source())
+        .expect("source evidence should write");
+    assert_success(
+        &run(
+            repo.path(),
+            [
+                "memory",
+                "import",
+                "COE-123",
+                "--source-file",
+                "source.yaml",
+            ],
+        ),
+        "capture without config",
+    );
+
+    let output = run(repo.path(), ["memory", "sync-docs"]);
+    assert_failure(&output, "sync-docs without mappings");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("No docs area mapping found. Run opensymphony memory init.")
+    );
+}
+
+#[test]
+fn sync_docs_writes_only_configured_areas_and_dry_run_writes_nothing() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_general_memory_config(repo.path());
+    fs::write(repo.path().join("source.yaml"), noisy_file_source())
+        .expect("source evidence should write");
+    assert_success(
+        &run(
+            repo.path(),
+            [
+                "memory",
+                "import",
+                "COE-123",
+                "--source-file",
+                "source.yaml",
+            ],
+        ),
+        "capture noisy file source",
+    );
+
+    let dry_run = run(repo.path(), ["memory", "sync-docs", "--dry-run"]);
+    assert_success(&dry_run, "sync-docs dry-run");
+    assert!(
+        !repo.path().join("docs/general.md").exists(),
+        "dry run should not write docs"
+    );
+
+    let write = run(repo.path(), ["memory", "sync-docs"]);
+    assert_success(&write, "sync-docs write");
+    assert!(repo.path().join("docs/general.md").is_file());
+    for bad_path in ["docs/readme-md.md", "docs/cargo.md", "docs/cargo-lock.md"] {
+        assert!(
+            !repo.path().join(bad_path).exists(),
+            "{bad_path} should not be generated from changed filenames"
+        );
+    }
+}
+
+#[test]
 fn memory_import_reports_missing_source_file() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_memory_config(repo.path());
@@ -523,6 +644,24 @@ areas:
     .expect("memory config should write");
 }
 
+fn write_general_memory_config(repo: &std::path::Path) {
+    fs::create_dir_all(repo.join(".opensymphony/memory")).expect("memory dir should write");
+    fs::write(
+        repo.join(".opensymphony/memory/memory.yaml"),
+        r#"
+areas:
+  general:
+    title: General
+    docs_target: docs/general.md
+    path_hints:
+      - general
+    labels:
+      - general
+"#,
+    )
+    .expect("memory config should write");
+}
+
 fn write_workflow(repo: &std::path::Path, linear_endpoint: &str) {
     fs::write(
         repo.join("WORKFLOW.md"),
@@ -887,6 +1026,32 @@ prs:
       - reviewer: reviewer
         state: APPROVED
         disposition: Reconnect ordering looked correct.
+"#
+}
+
+fn noisy_file_source() -> &'static str {
+    r#"
+issues:
+  - identifier: COE-123
+    title: Repo metadata cleanup
+    url: https://linear.app/example/issue/COE-123
+    description: Update root repository metadata.
+    state: Done
+    linked_prs:
+      - 456
+prs:
+  - number: 456
+    title: COE-123 update repository metadata
+    url: https://github.com/example/repo/pull/456
+    branch: coe-123-metadata
+    merge_sha: abcdef1234567890
+    changed_files:
+      - path: README.md
+        change_kind: modified
+      - path: Cargo.toml
+        change_kind: modified
+      - path: Cargo.lock
+        change_kind: modified
 "#
 }
 

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -70,7 +70,7 @@ fn memory_capture_write_query_and_sync_docs_are_reviewable() {
     );
     assert_success(&docs, "docs dry-run");
     let stdout = String::from_utf8_lossy(&docs.stdout);
-    assert!(stdout.contains("Docs Sync Plan"));
+    assert!(stdout.contains("Docs Sync Summary"));
     assert!(stdout.contains("COE-123"));
     assert!(!stdout.contains(".opensymphony/memory/issues"));
 
@@ -99,6 +99,11 @@ fn memory_init_creates_private_config_and_gitignore_policy() {
         "---\narea: agent-runtime\n---\n# Task\n",
     )
     .expect("task should write");
+    fs::write(
+        repo.path().join("docs/agent-runtime.md"),
+        "# Agent Runtime\n",
+    )
+    .expect("doc should write");
     fs::write(repo.path().join(".gitignore"), ".opensymphony*\n").expect("gitignore should write");
 
     let output = run(repo.path(), ["memory", "init"]);
@@ -108,6 +113,8 @@ fn memory_init_creates_private_config_and_gitignore_policy() {
     let config = fs::read_to_string(&config_path).expect("memory config should exist");
     assert!(config.contains("agent-runtime:"));
     assert!(config.contains("docs_target: docs/agent-runtime.md"));
+    assert!(config.contains("status: stable"));
+    assert!(config.contains("confidence: 85"));
     assert!(
         !repo
             .path()
@@ -136,7 +143,8 @@ fn memory_init_dry_run_does_not_write_files() {
     assert_success(&output, "memory init dry-run");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Proposed config"));
-    assert!(stdout.contains("general:"));
+    assert!(stdout.contains("areas:"));
+    assert!(!stdout.contains("general:"));
     assert!(
         !repo
             .path()
@@ -149,7 +157,7 @@ fn memory_init_dry_run_does_not_write_files() {
 #[test]
 fn sync_docs_requires_configured_area_mapping() {
     let repo = TempDir::new().expect("temp repo should exist");
-    fs::write(repo.path().join("source.yaml"), sample_source())
+    fs::write(repo.path().join("source.yaml"), candidate_only_source())
         .expect("source evidence should write");
     assert_success(
         &run(
@@ -166,11 +174,11 @@ fn sync_docs_requires_configured_area_mapping() {
     );
 
     let output = run(repo.path(), ["memory", "sync-docs"]);
-    assert_failure(&output, "sync-docs without mappings");
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("No docs area mapping found. Run opensymphony memory init.")
-    );
+    assert_success(&output, "sync-docs without stable mappings");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("candidate or unmapped docs areas"));
+    assert!(stdout.contains("confidence improves"));
+    assert!(!repo.path().join("docs/readme-md.md").exists());
 }
 
 #[test]
@@ -635,10 +643,14 @@ areas:
   openhands-runtime:
     title: OpenHands Runtime
     docs_target: docs/openhands-runtime.md
-    path_hints:
-      - openhands
-    labels:
+    status: stable
+    confidence: 90
+    aliases:
       - runtime
+      - OpenHands Runtime
+    source_refs:
+      linear_labels:
+        - runtime
 "#,
     )
     .expect("memory config should write");
@@ -653,10 +665,13 @@ areas:
   general:
     title: General
     docs_target: docs/general.md
-    path_hints:
+    status: stable
+    confidence: 90
+    aliases:
       - general
-    labels:
-      - general
+    source_refs:
+      linear_labels:
+        - general
 "#,
     )
     .expect("memory config should write");
@@ -1037,6 +1052,8 @@ issues:
     url: https://linear.app/example/issue/COE-123
     description: Update root repository metadata.
     state: Done
+    labels:
+      - general
     linked_prs:
       - 456
 prs:
@@ -1051,6 +1068,28 @@ prs:
       - path: Cargo.toml
         change_kind: modified
       - path: Cargo.lock
+        change_kind: modified
+"#
+}
+
+fn candidate_only_source() -> &'static str {
+    r#"
+issues:
+  - identifier: COE-123
+    title: Repo metadata cleanup
+    url: https://linear.app/example/issue/COE-123
+    description: Update root repository metadata.
+    state: Done
+    linked_prs:
+      - 456
+prs:
+  - number: 456
+    title: COE-123 update repository metadata
+    url: https://github.com/example/repo/pull/456
+    branch: coe-123-metadata
+    merge_sha: abcdef1234567890
+    changed_files:
+      - path: README.md
         change_kind: modified
 "#
 }

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -540,6 +540,60 @@ fn linear_archive_with_explicit_issues_captures_before_archiving() {
 }
 
 #[test]
+fn linear_archive_does_not_block_when_no_github_pr_matches() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    let server = TinyGraphqlServer::start([
+        linear_issue_response("COE-123", "WebSocket reconnect recovery"),
+        linear_empty_comments("issue-COE-123"),
+        r#"{"data":{"issueArchive":{"success":true}}}"#.to_string(),
+    ]);
+    write_workflow(repo.path(), &server.base_url);
+
+    let bin_dir = repo.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir should write");
+    write_fake_gh_no_matches(bin_dir.join("gh"));
+
+    let archive = run_with_path(
+        repo.path(),
+        ["linear", "archive", "--issues", "COE-123"],
+        bin_dir.to_str().expect("bin path should be utf-8"),
+    );
+
+    assert_success(&archive, "archive without matched GitHub PR");
+    let stdout = String::from_utf8_lossy(&archive.stdout);
+    assert!(stdout.contains("no GitHub PR source was matched"));
+    assert!(!stdout.contains("Linear Archive Dry Run"));
+    assert!(stdout.contains("Archived 1 Linear issue(s)."));
+    assert_eq!(archive_status(repo.path(), "COE-123"), "archived");
+    let requests = server.requests();
+    assert_eq!(requests.len(), 3);
+    assert!(requests[2].contains("\"id\":\"COE-123\""));
+}
+
+#[test]
+fn archive_from_memory_does_not_block_when_only_warning_is_no_github_pr() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    let server = TinyGraphqlServer::start([
+        linear_issue_response("COE-123", "WebSocket reconnect recovery"),
+        linear_empty_comments("issue-COE-123"),
+        r#"{"data":{"issueArchive":{"success":true}}}"#.to_string(),
+    ]);
+    write_workflow(repo.path(), &server.base_url);
+
+    assert_success(
+        &run(repo.path(), ["memory", "capture", "COE-123", "--no-github"]),
+        "capture without matched GitHub PR",
+    );
+    let archive = run(repo.path(), ["linear", "archive", "--from-memory"]);
+
+    assert_success(&archive, "archive from memory without matched GitHub PR");
+    assert!(String::from_utf8_lossy(&archive.stdout).contains("Archived 1 Linear issue(s)."));
+    assert_eq!(archive_status(repo.path(), "COE-123"), "archived");
+}
+
+#[test]
 fn linear_archive_write_marks_successes_before_reporting_partial_failure() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_memory_config(repo.path());
@@ -893,6 +947,21 @@ fi
 if [ "${1-}" = "pr" ] && [ "${2-}" = "view" ]; then
   printf '%s\n' 'simulated gh view failure' >&2
   exit 2
+fi
+printf 'unexpected gh command: %s\n' "$*" >&2
+exit 1
+"#,
+    );
+}
+
+fn write_fake_gh_no_matches(path: std::path::PathBuf) {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+if [ "${1-}" = "pr" ] && [ "${2-}" = "list" ]; then
+  printf '%s\n' '[]'
+  exit 0
 fi
 printf 'unexpected gh command: %s\n' "$*" >&2
 exit 1

--- a/crates/opensymphony-cli/tests/run.rs
+++ b/crates/opensymphony-cli/tests/run.rs
@@ -26,6 +26,7 @@ async fn run_auto_detects_config_and_workflow_from_project_directory() {
         openhands.base_url(),
         format!("control_plane:\n  bind: {bind_addr}\n"),
     );
+    write_memory_config(project.path());
 
     let mut child = spawn_run_child(project.path(), &[]);
 
@@ -52,6 +53,7 @@ async fn run_config_flag_overrides_auto_detected_config_file() {
         openhands.base_url(),
         format!("control_plane:\n  bind: {default_bind}\n"),
     );
+    write_memory_config(project.path());
     std::fs::write(
         project.path().join("override.yaml"),
         format!("control_plane:\n  bind: {override_bind}\n"),
@@ -88,6 +90,7 @@ async fn run_accepts_existing_repo_config_shape_with_extra_doctor_fields() {
             "target_repo: .\ncontrol_plane:\n  bind: {bind_addr}\nopenhands:\n  probe_model: fake-model\n  probe_api_key_env: FAKE_API_KEY\nlinear:\n  enabled: false\n"
         ),
     );
+    write_memory_config(project.path());
 
     let mut child = spawn_run_child(project.path(), &[]);
 
@@ -133,6 +136,7 @@ Run the scheduler.
         ),
     )
     .expect("config should be written");
+    write_memory_config(project.path());
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_opensymphony"))
         .arg("run")
@@ -183,6 +187,13 @@ fn write_project_files(
     .expect("workflow should be written");
     std::fs::write(project_root.join("config.yaml"), config_contents)
         .expect("config should be written");
+}
+
+fn write_memory_config(project_root: &std::path::Path) {
+    let memory_dir = project_root.join(".opensymphony/memory");
+    std::fs::create_dir_all(&memory_dir).expect("memory dir should be written");
+    std::fs::write(memory_dir.join("memory.yaml"), "areas: {}\n")
+        .expect("memory config should be written");
 }
 
 fn reserve_socket_addr() -> std::net::SocketAddr {

--- a/crates/opensymphony-cli/tests/update.rs
+++ b/crates/opensymphony-cli/tests/update.rs
@@ -85,6 +85,16 @@ async fn update_skips_reinstall_when_current_matches_latest_and_refreshes_skills
             .expect("local-only skill should survive"),
         "# keep me\n",
     );
+    let memory_config = fs::read_to_string(repo.path().join(".opensymphony/memory/memory.yaml"))
+        .expect("update should initialize memory config in target repos");
+    assert!(
+        memory_config.contains("memory_root: .opensymphony/memory"),
+        "memory config should contain the default memory root: {memory_config}",
+    );
+    assert_eq!(
+        fs::read_to_string(repo.path().join(".gitignore")).expect(".gitignore should exist"),
+        memory_gitignore_policy("")
+    );
     assert!(
         !repo.path().join("AGENTS.md").exists(),
         "update should not create other bootstrap assets",
@@ -110,6 +120,12 @@ async fn update_skips_reinstall_when_current_matches_latest_and_refreshes_skills
             && stdout.contains("- .agents/skills/push/SKILL.md")
             && !stdout.contains("- .agents/skills/opensymphony-memory/SKILL.md"),
         "stdout should list created skill files: {stdout}",
+    );
+    assert!(
+        stdout.contains("Memory init summary:")
+            && stdout.contains("- .opensymphony/memory/memory.yaml")
+            && stdout.contains("- .gitignore"),
+        "stdout should list memory initialization files: {stdout}",
     );
 }
 
@@ -292,6 +308,12 @@ fn cargo_invocation_count(log_path: &Path) -> usize {
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => 0,
         Err(source) => panic!("cargo log should be readable: {source}"),
     }
+}
+
+fn memory_gitignore_policy(prefix: &str) -> String {
+    format!(
+        "{prefix}.opensymphony*\n!.opensymphony/\n.opensymphony/*\n!.opensymphony/memory/\n.opensymphony/memory/*\n!.opensymphony/memory/memory.yaml\n"
+    )
 }
 
 fn path_only(path: &Path) -> OsString {

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -18,7 +18,10 @@ use super::graphql::{
     IssueByIdentifierData, IssueByIdentifierVariables, IssueCommentsData, IssueCommentsVariables,
     IssueInverseRelationsData, IssueInverseRelationsVariables, IssueLabelsData,
     IssueLabelsVariables, IssueStatesByIdsData, IssueStatesByIdsVariables, IssuesByStateData,
-    IssuesByStateVariables, LinearIssueNode, LinearLabelConnection, LinearRelationConnection,
+    IssuesByStateVariables, LinearIssueNode, LinearLabelConnection, LinearProjectNode,
+    LinearRelationConnection, PROJECT_BY_SLUG_QUERY, PROJECT_UPDATE_CONTENT_MUTATION,
+    ProjectBySlugData, ProjectBySlugVariables, ProjectUpdateContentData,
+    ProjectUpdateContentVariables,
 };
 use super::normalize::{normalize_issue, normalize_issue_state};
 
@@ -83,6 +86,15 @@ pub struct WorkpadComment {
     pub id: String,
     pub body: String,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinearProjectOverview {
+    pub id: String,
+    pub name: String,
+    pub slug_id: String,
+    pub url: String,
+    pub content: Option<String>,
 }
 
 impl LinearClient {
@@ -355,6 +367,42 @@ impl LinearClient {
         }
     }
 
+    pub async fn project_overview(&self) -> Result<Option<LinearProjectOverview>, LinearError> {
+        let variables = ProjectBySlugVariables {
+            slug: self.config.project_slug.clone(),
+        };
+        let response: ProjectBySlugData = self
+            .execute_graphql(PROJECT_BY_SLUG_QUERY, json!(variables))
+            .await?;
+        Ok(response
+            .projects
+            .nodes
+            .into_iter()
+            .next()
+            .map(LinearProjectOverview::from))
+    }
+
+    pub async fn update_project_content(
+        &self,
+        project_id: &str,
+        content: &str,
+    ) -> Result<(), LinearError> {
+        let variables = ProjectUpdateContentVariables {
+            id: normalize_required_string("project_id", project_id)?,
+            content: content.to_string(),
+        };
+        let response: ProjectUpdateContentData = self
+            .execute_graphql(PROJECT_UPDATE_CONTENT_MUTATION, json!(variables))
+            .await?;
+        if response.project_update.success {
+            Ok(())
+        } else {
+            Err(LinearError::InvalidResponse(
+                "Linear projectUpdate returned success=false".to_string(),
+            ))
+        }
+    }
+
     async fn expand_issue(
         &self,
         mut issue: LinearIssueNode,
@@ -615,6 +663,18 @@ impl LinearClient {
             }
         }
         delay
+    }
+}
+
+impl From<LinearProjectNode> for LinearProjectOverview {
+    fn from(node: LinearProjectNode) -> Self {
+        Self {
+            id: node.id,
+            name: node.name,
+            slug_id: node.slug_id,
+            url: node.url,
+            content: node.content,
+        }
     }
 }
 

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -260,6 +260,35 @@ mutation IssueArchive($id: String!, $trash: Boolean) {
 }
 "#;
 
+pub(super) const PROJECT_BY_SLUG_QUERY: &str = r#"
+query ProjectBySlug($slug: String!) {
+  projects(filter: { slugId: { eq: $slug } }, first: 1) {
+    nodes {
+      id
+      name
+      slugId
+      url
+      content
+    }
+  }
+}
+"#;
+
+pub(super) const PROJECT_UPDATE_CONTENT_MUTATION: &str = r#"
+mutation UpdateProjectContent($id: String!, $content: String!) {
+  projectUpdate(id: $id, input: { content: $content }) {
+    success
+    project {
+      id
+      name
+      slugId
+      content
+      updatedAt
+    }
+  }
+}
+"#;
+
 #[derive(Debug, Deserialize)]
 pub(super) struct GraphqlEnvelope<T> {
     pub data: Option<T>,
@@ -337,6 +366,17 @@ pub(super) struct IssueArchiveVariables {
     pub trash: bool,
 }
 
+#[derive(Debug, Serialize)]
+pub(super) struct ProjectBySlugVariables {
+    pub slug: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ProjectUpdateContentVariables {
+    pub id: String,
+    pub content: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub(super) struct IssuesByStateData {
     pub issues: IssuesConnection<LinearIssueNode>,
@@ -374,8 +414,39 @@ pub(super) struct IssueArchiveData {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct ProjectBySlugData {
+    pub projects: ProjectsConnection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ProjectUpdateContentData {
+    pub project_update: ProjectUpdatePayload,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct IssueArchivePayload {
     pub success: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ProjectUpdatePayload {
+    pub success: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ProjectsConnection {
+    pub nodes: Vec<LinearProjectNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct LinearProjectNode {
+    pub id: String,
+    pub name: String,
+    pub slug_id: String,
+    pub url: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/opensymphony-memory/src/archive.rs
+++ b/crates/opensymphony-memory/src/archive.rs
@@ -93,7 +93,11 @@ fn archive_state_matches(issue: &IndexedIssue, state: &str) -> bool {
 
 pub fn render_archive_plan(config: &MemoryConfig, plan: &ArchivePlan) -> String {
     let mut output = String::new();
-    output.push_str("# Linear Archive Dry Run\n\n");
+    if plan.write {
+        output.push_str("# Linear Archive Eligibility\n\n");
+    } else {
+        output.push_str("# Linear Archive Dry Run\n\n");
+    }
     for issue in &plan.issues {
         output.push_str(&format!(
             "- {}: {} ({})\n",

--- a/crates/opensymphony-memory/src/archive.rs
+++ b/crates/opensymphony-memory/src/archive.rs
@@ -57,7 +57,7 @@ pub fn plan_archive(
             ),
             None => (
                 false,
-                "blocked: no captured memory found; run `opensymphony memory capture --write` first"
+                "blocked: no captured memory found; run `opensymphony memory capture` first"
                     .to_string(),
                 None,
             ),

--- a/crates/opensymphony-memory/src/capture.rs
+++ b/crates/opensymphony-memory/src/capture.rs
@@ -119,10 +119,12 @@ pub fn write_capture_plan(
         written_capsules.push(issue_plan.capsule_path.clone());
     }
 
-    index_capture_plan(config, plan)?;
-    let milestone_nodes = write_milestone_nodes(config, plan)?;
-    let markdown_indexes = if config.markdown_indexes {
-        write_markdown_indexes(config)?
+    let evolved_config = evolve_memory_config(config, plan);
+    write_memory_config(&evolved_config)?;
+    index_capture_plan(&evolved_config, plan)?;
+    let milestone_nodes = write_milestone_nodes(&evolved_config, plan)?;
+    let markdown_indexes = if evolved_config.markdown_indexes {
+        write_markdown_indexes(&evolved_config)?
     } else {
         Vec::new()
     };
@@ -133,7 +135,7 @@ pub fn write_capture_plan(
 
     Ok(CaptureWriteReport {
         written_capsules,
-        index_path: config.index_path.clone(),
+        index_path: evolved_config.index_path.clone(),
         markdown_indexes,
         milestone_nodes,
         warnings,

--- a/crates/opensymphony-memory/src/capture_render.rs
+++ b/crates/opensymphony-memory/src/capture_render.rs
@@ -213,14 +213,29 @@ fn area_matches_evidence(
     issue: &IssueEvidence,
     prs: &[PullRequestEvidence],
 ) -> bool {
-    let evidence = area_evidence_text(issue, prs);
+    let evidence = search_tokens(&area_evidence_text(issue, prs));
     let mut candidates = vec![area.slug.clone(), area.title.to_ascii_lowercase()];
     candidates.extend(area.aliases.clone());
     candidates.extend(area.source_refs.linear_milestones.clone());
     candidates.into_iter().any(|candidate| {
         let candidate = candidate.trim().to_ascii_lowercase();
-        candidate.len() >= 4 && evidence.contains(&candidate)
+        candidate.len() >= 4 && token_sequence_contains(&evidence, &search_tokens(&candidate))
     })
+}
+
+fn token_sequence_contains(haystack: &[String], needle: &[String]) -> bool {
+    !needle.is_empty()
+        && needle.len() <= haystack.len()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+}
+
+fn search_tokens(text: &str) -> Vec<String> {
+    text.split(|character: char| !character.is_ascii_alphanumeric())
+        .filter_map(normalize_optional)
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
 }
 
 fn area_evidence_text(issue: &IssueEvidence, prs: &[PullRequestEvidence]) -> String {

--- a/crates/opensymphony-memory/src/capture_render.rs
+++ b/crates/opensymphony-memory/src/capture_render.rs
@@ -224,6 +224,8 @@ fn area_matches_evidence(
 }
 
 fn token_sequence_contains(haystack: &[String], needle: &[String]) -> bool {
+    // Whole-token equality keeps aliases like "runtime" from matching tokens
+    // such as "gruntime" or "runtimeerror".
     !needle.is_empty()
         && needle.len() <= haystack.len()
         && haystack

--- a/crates/opensymphony-memory/src/capture_render.rs
+++ b/crates/opensymphony-memory/src/capture_render.rs
@@ -161,44 +161,314 @@ fn infer_areas(
     let mut areas = BTreeSet::new();
     let labels = normalize_list(issue.labels.clone());
     for (slug, area) in &config.areas {
-        if labels.iter().any(|label| area.labels.contains(label)) {
+        if labels.iter().any(|label| area_alias_matches(area, label))
+            || area_matches_evidence(area, issue, prs)
+        {
             areas.insert(slug.clone());
         }
     }
-    let changed_files = prs
-        .iter()
-        .flat_map(|pr| pr.changed_files.iter())
-        .map(|file| file.path.to_string_lossy().to_ascii_lowercase())
-        .collect::<Vec<_>>();
-    for (slug, area) in &config.areas {
-        if area.path_hints.iter().any(|hint| {
-            changed_files
-                .iter()
-                .any(|file| file.contains(&hint.to_ascii_lowercase()))
-        }) {
-            areas.insert(slug.clone());
-        }
-    }
-
-    let configured_labels = config
-        .areas
-        .values()
-        .flat_map(|area| area.labels.iter().cloned())
-        .collect::<BTreeSet<_>>();
     for label in labels {
-        if label != "done" && label != "bug" && label != "feature" {
+        if !is_generic_label(&label) {
             let label_slug = slugify(&label);
-            if !configured_labels.contains(&label) && !areas.contains(&label_slug) {
+            if !areas.contains(&label_slug) {
                 areas.insert(label_slug);
             }
         }
     }
 
+    if areas.is_empty()
+        && let Some(milestone) = issue.milestone.as_deref().and_then(normalize_optional)
+        && !is_generic_milestone(&milestone)
+    {
+        areas.insert(slugify(&milestone));
+    }
+    if areas.is_empty()
+        && let Some(candidate) = infer_candidate_area_from_narrative(issue, prs)
+    {
+        areas.insert(candidate);
+    }
     if areas.is_empty() {
         areas.insert("general".to_string());
     }
 
     areas.into_iter().collect()
+}
+
+fn area_alias_matches(area: &AreaConfig, value: &str) -> bool {
+    let value_slug = slugify(value);
+    value_slug == area.slug
+        || area.aliases.iter().any(|alias| {
+            let alias_slug = slugify(alias);
+            value_slug == alias_slug || value == alias
+        })
+        || area
+            .source_refs
+            .linear_labels
+            .iter()
+            .any(|label| value_slug == slugify(label))
+}
+
+fn area_matches_evidence(
+    area: &AreaConfig,
+    issue: &IssueEvidence,
+    prs: &[PullRequestEvidence],
+) -> bool {
+    let evidence = area_evidence_text(issue, prs);
+    let mut candidates = vec![area.slug.clone(), area.title.to_ascii_lowercase()];
+    candidates.extend(area.aliases.clone());
+    candidates.extend(area.source_refs.linear_milestones.clone());
+    candidates.into_iter().any(|candidate| {
+        let candidate = candidate.trim().to_ascii_lowercase();
+        candidate.len() >= 4 && evidence.contains(&candidate)
+    })
+}
+
+fn area_evidence_text(issue: &IssueEvidence, prs: &[PullRequestEvidence]) -> String {
+    let mut parts = vec![issue.title.clone()];
+    if let Some(description) = &issue.description {
+        parts.push(description.clone());
+    }
+    if let Some(milestone) = &issue.milestone {
+        parts.push(milestone.clone());
+    }
+    if let Some(parent) = &issue.parent
+        && let Some(title) = &parent.title
+    {
+        parts.push(title.clone());
+    }
+    for child in &issue.children {
+        if let Some(title) = &child.title {
+            parts.push(title.clone());
+        }
+    }
+    parts.extend(issue.comments.iter().map(|comment| comment.body.clone()));
+    for pr in prs {
+        parts.push(pr.title.clone());
+        if let Some(body) = &pr.body {
+            parts.push(body.clone());
+        }
+        for review in &pr.reviews {
+            if let Some(disposition) = &review.disposition {
+                parts.push(disposition.clone());
+            }
+        }
+        for check in &pr.checks {
+            parts.push(check.name.clone());
+            if let Some(conclusion) = &check.conclusion {
+                parts.push(conclusion.clone());
+            }
+        }
+    }
+    parts.join("\n").to_ascii_lowercase()
+}
+
+fn is_generic_label(label: &str) -> bool {
+    matches!(
+        label,
+        "done"
+            | "bug"
+            | "feature"
+            | "enhancement"
+            | "documentation"
+            | "docs"
+            | "urgent"
+            | "high"
+            | "medium"
+            | "low"
+            | "priority"
+    )
+}
+
+fn is_generic_milestone(milestone: &str) -> bool {
+    let slug = slugify(milestone);
+    slug.is_empty()
+        || slug.chars().all(|character| character.is_ascii_digit())
+        || slug.len() <= 2
+        || matches!(slug.as_str(), "mvp" | "v1" | "v2" | "m1" | "m2" | "m3" | "m4")
+}
+
+fn infer_candidate_area_from_narrative(
+    issue: &IssueEvidence,
+    prs: &[PullRequestEvidence],
+) -> Option<String> {
+    for text in std::iter::once(issue.title.as_str())
+        .chain(issue.description.iter().map(String::as_str))
+        .chain(
+            issue
+                .parent
+                .iter()
+                .filter_map(|parent| parent.title.as_deref()),
+        )
+        .chain(issue.children.iter().filter_map(|child| child.title.as_deref()))
+        .chain(issue.comments.iter().map(|comment| comment.body.as_str()))
+        .chain(prs.iter().map(|pr| pr.title.as_str()))
+        .chain(prs.iter().filter_map(|pr| pr.body.as_deref()))
+        .chain(
+            prs.iter()
+                .flat_map(|pr| pr.reviews.iter())
+                .filter_map(|review| review.disposition.as_deref()),
+        )
+        .chain(
+            prs.iter()
+                .flat_map(|pr| pr.checks.iter())
+                .map(|check| check.name.as_str()),
+        )
+    {
+        if let Some(slug) = candidate_area_slug_from_text(text) {
+            return Some(slug);
+        }
+    }
+    None
+}
+
+fn candidate_area_slug_from_text(text: &str) -> Option<String> {
+    let mut tokens = Vec::new();
+    let raw_tokens = text
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.trim().is_empty())
+        .collect::<Vec<_>>();
+    for (index, raw) in raw_tokens.iter().enumerate() {
+        if raw.len() <= 5
+            && raw.chars().all(|character| character.is_ascii_uppercase())
+            && raw_tokens
+                .get(index + 1)
+                .is_some_and(|next| next.chars().all(|character| character.is_ascii_digit()))
+        {
+            continue;
+        }
+        let token = raw.trim().to_ascii_lowercase();
+        if token.len() < 3
+            || token.chars().all(|character| character.is_ascii_digit())
+            || looks_like_issue_key_token(&token)
+            || is_area_stopword(&token)
+        {
+            continue;
+        }
+        tokens.push(token);
+        if tokens.len() == 3 {
+            break;
+        }
+    }
+    if tokens.is_empty() {
+        return None;
+    }
+    Some(slugify(&tokens.join("-")))
+}
+
+fn looks_like_issue_key_token(token: &str) -> bool {
+    let Some((prefix, suffix)) = token.split_once('-') else {
+        return false;
+    };
+    prefix.chars().all(|character| character.is_ascii_alphabetic())
+        && suffix.chars().all(|character| character.is_ascii_digit())
+}
+
+fn is_area_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "add"
+            | "adds"
+            | "added"
+            | "build"
+            | "create"
+            | "define"
+            | "fix"
+            | "for"
+            | "from"
+            | "implement"
+            | "implements"
+            | "issue"
+            | "make"
+            | "new"
+            | "support"
+            | "the"
+            | "this"
+            | "update"
+            | "updates"
+            | "with"
+    )
+}
+
+fn evolve_memory_config(
+    config: &MemoryConfig,
+    plan: &CapturePlan,
+) -> MemoryConfig {
+    let mut evolved = config.clone();
+    for issue_plan in &plan.selected {
+        for area_slug in &issue_plan.areas {
+            let mut area = evolved.area_or_default(area_slug);
+            merge_area_evidence(&mut area, issue_plan, config.confidence_threshold);
+            evolved.areas.insert(area.slug.clone(), area);
+        }
+    }
+    evolved
+}
+
+fn merge_area_evidence(
+    area: &mut AreaConfig,
+    issue_plan: &CaptureIssuePlan,
+    confidence_threshold: u8,
+) {
+    let issue_key = normalize_issue_key(&issue_plan.issue.identifier);
+    push_unique(&mut area.source_refs.linear_issues, issue_key);
+    if let Some(milestone) = issue_plan.issue.milestone.as_deref().and_then(normalize_optional) {
+        push_unique(&mut area.source_refs.linear_milestones, milestone);
+    }
+    for label in normalize_list(issue_plan.issue.labels.clone()) {
+        if slugify(&label) == area.slug || area_alias_matches(area, &label) {
+            push_unique(&mut area.source_refs.linear_labels, label.clone());
+            push_unique(&mut area.aliases, label);
+        }
+    }
+    for pr in &issue_plan.prs {
+        push_unique(&mut area.source_refs.github_prs, format!("#{}", pr.number));
+    }
+
+    push_unique(&mut area.aliases, area.slug.clone());
+    push_unique(&mut area.aliases, area.title.to_ascii_lowercase());
+    let confidence = inferred_area_confidence(area, issue_plan);
+    area.confidence = area.confidence.max(confidence);
+    if area.confidence >= confidence_threshold {
+        area.status = AreaStatus::Stable;
+    }
+}
+
+fn inferred_area_confidence(area: &AreaConfig, issue_plan: &CaptureIssuePlan) -> u8 {
+    let base: u8 = if normalize_list(issue_plan.issue.labels.clone())
+        .iter()
+        .any(|label| slugify(label) == area.slug && !is_generic_label(label))
+    {
+        90
+    } else if issue_plan
+        .issue
+        .milestone
+        .as_deref()
+        .is_some_and(|milestone| slugify(milestone) == area.slug)
+    {
+        65
+    } else if area.slug == "general" {
+        40
+    } else {
+        60
+    };
+    let reinforcement = area
+        .source_refs
+        .linear_issues
+        .len()
+        .saturating_sub(1)
+        .saturating_mul(10)
+        .min(25) as u8;
+    base.saturating_add(reinforcement).min(95)
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if normalize_optional(&value).is_none() {
+        return;
+    }
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+        values.sort();
+    }
 }
 
 fn source_hash(issue: &IssueEvidence, prs: &[PullRequestEvidence]) -> Result<String, MemoryError> {
@@ -261,10 +531,22 @@ fn render_issue_capsule(
                 .milestone_id
                 .as_ref()
                 .map(|milestone_id| format!("linear:project-milestone:{milestone_id}")),
+            linear_workpad_comment: plan
+                .issue
+                .comments
+                .iter()
+                .find(|comment| comment.source.as_deref() == Some("linear:workpad"))
+                .and_then(|comment| comment.id.as_ref())
+                .map(|id| format!("linear:comment:{id}")),
             github_prs: plan
                 .prs
                 .iter()
                 .map(|pr| format!("github:pr:{}", pr.number))
+                .collect(),
+            github_merge_shas: plan
+                .prs
+                .iter()
+                .filter_map(|pr| pr.merge_sha.clone())
                 .collect(),
         },
         captured_at: Utc::now(),
@@ -311,7 +593,7 @@ fn render_issue_capsule(
             markdown.push_str(&format!("- {warning}\n"));
         }
     }
-    markdown.push_str("\n## Provenance\n\n");
+    markdown.push_str("\n## Source refs\n\n");
     match &plan.issue.url {
         Some(url) => markdown.push_str(&format!("- Linear: {url}\n")),
         None => markdown.push_str(&format!("- Linear: {issue_key}\n")),
@@ -322,6 +604,9 @@ fn render_issue_capsule(
             |url| format!("[#{}]({url})", pr.number),
         );
         markdown.push_str(&format!("- PR: {label}\n"));
+        if let Some(sha) = pr.merge_sha.as_deref() {
+            markdown.push_str(&format!("- Merge SHA: `{sha}`\n"));
+        }
     }
     if let Some(milestone) = plan.issue.milestone.as_deref() {
         markdown.push_str(&format!(
@@ -401,7 +686,11 @@ struct SourceRefs {
     linear_children: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     linear_milestone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    linear_workpad_comment: Option<String>,
     github_prs: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    github_merge_shas: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -475,17 +764,6 @@ fn render_outcome(plan: &CaptureIssuePlan) -> String {
             }
             lines.push(line);
         }
-    }
-    let changed_files = plan
-        .prs
-        .iter()
-        .flat_map(|pr| pr.changed_files.iter())
-        .take(8)
-        .map(|file| format!("  - {}", file.path.display()))
-        .collect::<Vec<_>>();
-    if !changed_files.is_empty() {
-        lines.push("- Notable changed files:".to_string());
-        lines.extend(changed_files);
     }
     lines.join("\n")
 }

--- a/crates/opensymphony-memory/src/capture_render.rs
+++ b/crates/opensymphony-memory/src/capture_render.rs
@@ -1,11 +1,15 @@
 fn default_config_path(repo_root: &Path) -> Option<PathBuf> {
+    let private = repo_root.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE);
+    if private.exists() {
+        return Some(private);
+    }
     let public = repo_root.join(DEFAULT_MEMORY_CONFIG_FILE);
     if public.exists() {
         return Some(public);
     }
-    let private = repo_root.join(FALLBACK_PRIVATE_MEMORY_CONFIG_FILE);
-    if private.exists() {
-        Some(private)
+    let legacy_private = repo_root.join(FALLBACK_PRIVATE_MEMORY_CONFIG_FILE);
+    if legacy_private.exists() {
+        Some(legacy_private)
     } else {
         None
     }
@@ -191,12 +195,7 @@ fn infer_areas(
     }
 
     if areas.is_empty() {
-        let first_path_area = prs
-            .iter()
-            .flat_map(|pr| pr.changed_files.iter())
-            .find_map(|file| file.path.components().next())
-            .map(|component| slugify(&component.as_os_str().to_string_lossy()));
-        areas.insert(first_path_area.unwrap_or_else(|| "general".to_string()));
+        areas.insert("general".to_string());
     }
 
     areas.into_iter().collect()

--- a/crates/opensymphony-memory/src/capture_render.rs
+++ b/crates/opensymphony-memory/src/capture_render.rs
@@ -426,8 +426,6 @@ fn merge_area_evidence(
     issue_plan: &CaptureIssuePlan,
     confidence_threshold: u8,
 ) {
-    let issue_key = normalize_issue_key(&issue_plan.issue.identifier);
-    push_unique(&mut area.source_refs.linear_issues, issue_key);
     if let Some(milestone) = issue_plan.issue.milestone.as_deref().and_then(normalize_optional) {
         push_unique(&mut area.source_refs.linear_milestones, milestone);
     }
@@ -437,10 +435,6 @@ fn merge_area_evidence(
             push_unique(&mut area.aliases, label);
         }
     }
-    for pr in &issue_plan.prs {
-        push_unique(&mut area.source_refs.github_prs, format!("#{}", pr.number));
-    }
-
     push_unique(&mut area.aliases, area.slug.clone());
     push_unique(&mut area.aliases, area.title.to_ascii_lowercase());
     let confidence = inferred_area_confidence(area, issue_plan);
@@ -468,13 +462,8 @@ fn inferred_area_confidence(area: &AreaConfig, issue_plan: &CaptureIssuePlan) ->
     } else {
         60
     };
-    let reinforcement = area
-        .source_refs
-        .linear_issues
-        .len()
-        .saturating_sub(1)
-        .saturating_mul(10)
-        .min(25) as u8;
+    let reinforcement = u8::from(!issue_plan.prs.is_empty()).saturating_mul(10)
+        + u8::from(issue_plan.issue.milestone.is_some()).saturating_mul(5);
     base.saturating_add(reinforcement).min(95)
 }
 

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -8,6 +8,9 @@ impl MemoryConfig {
             Some(path) => Some(resolve_path(&repo_root, path)),
             None => default_config_path(&repo_root),
         };
+        let resolved_config_path = config_file
+            .clone()
+            .unwrap_or_else(|| repo_root.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE));
 
         let parsed = match config_file {
             Some(path) => {
@@ -59,8 +62,10 @@ impl MemoryConfig {
                         .map(|path| resolve_path(&repo_root, path))
                         .unwrap_or_else(|| public_root.join(format!("{slug}.md"))),
                     visibility: area.visibility.unwrap_or(default_doc_visibility),
-                    path_hints: normalize_list(area.path_hints),
-                    labels: normalize_list(area.labels),
+                    status: area.status.unwrap_or(AreaStatus::Candidate),
+                    confidence: area.confidence.unwrap_or_default(),
+                    aliases: normalize_list(area.aliases),
+                    source_refs: normalize_area_source_refs(area.source_refs),
                     slug,
                 },
             );
@@ -68,10 +73,12 @@ impl MemoryConfig {
 
         Ok(Self {
             enabled: parsed.enabled.unwrap_or(true),
+            config_path: resolved_config_path,
             repo_root,
             memory_root,
             visibility,
             index_path,
+            confidence_threshold: parsed.confidence_threshold.unwrap_or(75),
             source_snapshot_policy: parsed.source_snapshots.unwrap_or_default(),
             markdown_indexes: parsed.markdown_indexes.unwrap_or(true),
             docs: DocsConfig {
@@ -103,8 +110,10 @@ impl MemoryConfig {
                 title: titleize_slug(&slug),
                 docs_target: self.docs.public_root.join(format!("{slug}.md")),
                 visibility: self.docs.default_visibility,
-                path_hints: Vec::new(),
-                labels: Vec::new(),
+                status: AreaStatus::Candidate,
+                confidence: 0,
+                aliases: Vec::new(),
+                source_refs: AreaSourceRefs::default(),
                 slug,
             })
     }
@@ -145,99 +154,175 @@ pub fn write_memory_init_plan(plan: &MemoryInitPlan) -> Result<(), MemoryError> 
     Ok(())
 }
 
-fn render_memory_init_config(repo_root: &Path) -> Result<String, MemoryError> {
-    let areas = discover_task_areas(repo_root)?;
-    let areas = if areas.is_empty() {
-        vec!["general".to_string()]
-    } else {
-        areas
-    };
-
-    let mut output = String::from(
-        "memory_root: .opensymphony/memory\n\
-visibility: private\n\
-index_path: .opensymphony/memory/memory.duckdb\n\
-source_snapshots: hashes\n\
-markdown_indexes: true\n\n\
-docs:\n\
-  public_root: docs\n\
-  default_visibility: public\n\
-  deny_private_links: true\n\n\
-areas:\n",
-    );
-    for area in areas {
-        let docs_target = docs_target_for_area(repo_root, &area);
-        output.push_str(&format!("  {area}:\n"));
-        output.push_str(&format!("    title: {}\n", titleize_slug(&area)));
-        output.push_str(&format!(
-            "    docs_target: {}\n",
-            display_path(repo_root, &docs_target)
-        ));
-        output.push_str("    path_hints:\n");
-        for hint in path_hints_for_area(&area) {
-            output.push_str(&format!("      - {hint}\n"));
-        }
-        output.push_str("    labels:\n");
-        output.push_str(&format!("      - {area}\n"));
+fn write_memory_config(config: &MemoryConfig) -> Result<(), MemoryError> {
+    let mut areas = BTreeMap::new();
+    for (slug, area) in &config.areas {
+        areas.insert(
+            slug.clone(),
+            AreaConfigFile {
+                title: Some(area.title.clone()),
+                docs_target: Some(PathBuf::from(path_relative_to(
+                    &config.repo_root,
+                    &area.docs_target,
+                ))),
+                visibility: Some(area.visibility),
+                status: Some(area.status),
+                confidence: Some(area.confidence),
+                aliases: area.aliases.clone(),
+                source_refs: area.source_refs.clone(),
+            },
+        );
     }
-    Ok(output)
+    let file = MemoryConfigFile {
+        enabled: Some(config.enabled),
+        memory_root: Some(PathBuf::from(path_relative_to(
+            &config.repo_root,
+            &config.memory_root,
+        ))),
+        visibility: Some(config.visibility),
+        index_path: Some(PathBuf::from(path_relative_to(
+            &config.repo_root,
+            &config.index_path,
+        ))),
+        confidence_threshold: Some(config.confidence_threshold),
+        source_snapshots: Some(config.source_snapshot_policy),
+        markdown_indexes: Some(config.markdown_indexes),
+        docs: Some(DocsConfigFile {
+            public_root: Some(PathBuf::from(path_relative_to(
+                &config.repo_root,
+                &config.docs.public_root,
+            ))),
+            default_visibility: Some(config.docs.default_visibility),
+            deny_private_links: Some(config.docs.deny_private_links),
+        }),
+        areas,
+        redaction: Some(RedactionConfigFile {
+            deny_patterns: config.redaction.deny_patterns.clone(),
+        }),
+    };
+    let contents = serde_yaml::to_string(&file).map_err(|source| MemoryError::ParseYaml {
+        path: config.config_path.clone(),
+        source,
+    })?;
+    write_file(&config.config_path, &contents)
 }
 
-fn discover_task_areas(repo_root: &Path) -> Result<Vec<String>, MemoryError> {
-    let tasks_root = repo_root.join("docs/tasks");
-    if !tasks_root.is_dir() {
+fn render_memory_init_config(repo_root: &Path) -> Result<String, MemoryError> {
+    let mut areas = BTreeMap::new();
+    for area in discover_doc_areas(repo_root)? {
+        areas.insert(
+            area.slug,
+            AreaConfigFile {
+                title: Some(area.title.clone()),
+                docs_target: Some(PathBuf::from(display_path(repo_root, &area.docs_target))),
+                visibility: Some(MemoryVisibility::Public),
+                status: Some(AreaStatus::Stable),
+                confidence: Some(85),
+                aliases: vec![area.title],
+                source_refs: AreaSourceRefs {
+                    docs: vec![display_path(repo_root, &area.docs_target)],
+                    ..AreaSourceRefs::default()
+                },
+            },
+        );
+    }
+    let config = MemoryConfigFile {
+        memory_root: Some(PathBuf::from(DEFAULT_MEMORY_ROOT)),
+        visibility: Some(MemoryVisibility::Private),
+        index_path: Some(PathBuf::from(format!(
+            "{DEFAULT_MEMORY_ROOT}/{DEFAULT_INDEX_FILE_NAME}"
+        ))),
+        confidence_threshold: Some(75),
+        source_snapshots: Some(SourceSnapshotPolicy::Hashes),
+        markdown_indexes: Some(true),
+        docs: Some(DocsConfigFile {
+            public_root: Some(PathBuf::from(DEFAULT_PUBLIC_DOCS_ROOT)),
+            default_visibility: Some(MemoryVisibility::Public),
+            deny_private_links: Some(true),
+        }),
+        areas,
+        ..MemoryConfigFile::default()
+    };
+    serde_yaml::to_string(&config).map_err(|source| MemoryError::ParseYaml {
+        path: repo_root.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE),
+        source,
+    })
+}
+
+struct DiscoveredDocArea {
+    slug: String,
+    title: String,
+    docs_target: PathBuf,
+}
+
+fn discover_doc_areas(repo_root: &Path) -> Result<Vec<DiscoveredDocArea>, MemoryError> {
+    let docs_root = repo_root.join("docs");
+    if !docs_root.is_dir() {
         return Ok(Vec::new());
     }
 
-    let mut areas = BTreeSet::new();
-    for entry in fs::read_dir(&tasks_root).map_err(|source| MemoryError::ReadFile {
-        path: tasks_root.clone(),
+    let mut areas = BTreeMap::new();
+    for entry in fs::read_dir(&docs_root).map_err(|source| MemoryError::ReadFile {
+        path: docs_root.clone(),
         source,
     })? {
         let entry = entry.map_err(|source| MemoryError::ReadFile {
-            path: tasks_root.clone(),
+            path: docs_root.clone(),
             source,
         })?;
         let path = entry.path();
         if path.extension().and_then(OsStr::to_str) != Some("md") {
             continue;
         }
-        let contents = read_to_string(&path)?;
-        if let Some(area) = parse_task_area(&contents) {
-            areas.insert(area);
-        }
-    }
-    Ok(areas.into_iter().collect())
-}
-
-fn parse_task_area(contents: &str) -> Option<String> {
-    let mut lines = contents.lines();
-    if lines.next()?.trim() != "---" {
-        return None;
-    }
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            return None;
-        }
-        let Some(value) = trimmed.strip_prefix("area:") else {
+        let Some(stem) = path.file_stem().and_then(OsStr::to_str) else {
             continue;
         };
-        return normalize_optional(value).map(|area| slugify(&area));
+        let slug = slugify(stem);
+        if slug.is_empty() {
+            continue;
+        }
+        let contents = read_to_string(&path)?;
+        let title = first_markdown_heading(&contents).unwrap_or_else(|| titleize_slug(&slug));
+        areas.insert(
+            slug.clone(),
+            DiscoveredDocArea {
+                slug,
+                title,
+                docs_target: path,
+            },
+        );
+    }
+    Ok(areas.into_values().collect())
+}
+
+fn first_markdown_heading(contents: &str) -> Option<String> {
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        let Some(value) = trimmed.strip_prefix("# ") else {
+            continue;
+        };
+        return normalize_optional(value);
     }
     None
 }
 
-fn docs_target_for_area(repo_root: &Path, area: &str) -> PathBuf {
-    repo_root.join("docs").join(format!("{area}.md"))
+fn normalize_area_source_refs(mut refs: AreaSourceRefs) -> AreaSourceRefs {
+    refs.docs = normalize_source_ref_list(refs.docs);
+    refs.linear_labels = normalize_source_ref_list(refs.linear_labels);
+    refs.linear_milestones = normalize_source_ref_list(refs.linear_milestones);
+    refs.linear_issues = normalize_source_ref_list(refs.linear_issues);
+    refs.github_prs = normalize_source_ref_list(refs.github_prs);
+    refs
 }
 
-fn path_hints_for_area(area: &str) -> Vec<String> {
-    let mut hints = BTreeSet::from([area.to_string()]);
-    for token in area.split('-').filter(|token| !token.is_empty()) {
-        hints.insert(token.to_string());
-    }
-    hints.into_iter().collect()
+fn normalize_source_ref_list(values: Vec<String>) -> Vec<String> {
+    let mut normalized = values
+        .into_iter()
+        .filter_map(|value| normalize_optional(&value))
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized.dedup();
+    normalized
 }
 
 fn render_memory_gitignore(before: Option<&str>) -> String {

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -229,12 +229,7 @@ fn parse_task_area(contents: &str) -> Option<String> {
 }
 
 fn docs_target_for_area(repo_root: &Path, area: &str) -> PathBuf {
-    let target = repo_root.join("docs").join(format!("{area}.md"));
-    if target.exists() {
-        target
-    } else {
-        repo_root.join("docs").join(format!("{area}.md"))
-    }
+    repo_root.join("docs").join(format!("{area}.md"))
 }
 
 fn path_hints_for_area(area: &str) -> Vec<String> {

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -216,7 +216,7 @@ fn write_memory_config(config: &MemoryConfig) -> Result<(), MemoryError> {
                 status: Some(area.status),
                 confidence: Some(area.confidence),
                 aliases: area.aliases.clone(),
-                source_refs: area.source_refs.clone(),
+                source_refs: tracked_area_source_refs(&area.source_refs),
             },
         );
     }
@@ -360,6 +360,16 @@ fn normalize_area_source_refs(mut refs: AreaSourceRefs) -> AreaSourceRefs {
     refs.linear_issues = normalize_source_ref_list(refs.linear_issues);
     refs.github_prs = normalize_source_ref_list(refs.github_prs);
     refs
+}
+
+fn tracked_area_source_refs(refs: &AreaSourceRefs) -> AreaSourceRefs {
+    AreaSourceRefs {
+        docs: refs.docs.clone(),
+        linear_labels: refs.linear_labels.clone(),
+        linear_milestones: refs.linear_milestones.clone(),
+        linear_issues: Vec::new(),
+        github_prs: Vec::new(),
+    }
 }
 
 fn normalize_source_ref_list(values: Vec<String>) -> Vec<String> {

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -154,6 +154,53 @@ pub fn write_memory_init_plan(plan: &MemoryInitPlan) -> Result<(), MemoryError> 
     Ok(())
 }
 
+pub fn ensure_memory_initialized(
+    repo_root: impl AsRef<Path>,
+    config_path: Option<&Path>,
+) -> Result<MemoryInitApplyReport, MemoryError> {
+    let repo_root = normalize_path(repo_root.as_ref());
+    let config_path = config_path
+        .map(|path| resolve_path(&repo_root, path))
+        .unwrap_or_else(|| repo_root.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE));
+    let config = if config_path.exists() {
+        MemoryInitFileChange::Unchanged
+    } else {
+        write_file(&config_path, &render_memory_init_config(&repo_root)?)?;
+        MemoryInitFileChange::Created
+    };
+
+    let gitignore_path = repo_root.join(".gitignore");
+    let gitignore_before = match fs::read_to_string(&gitignore_path) {
+        Ok(contents) => Some(contents),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => None,
+        Err(source) => {
+            return Err(MemoryError::ReadFile {
+                path: gitignore_path,
+                source,
+            });
+        }
+    };
+    let gitignore_after = render_memory_gitignore(gitignore_before.as_deref());
+    let gitignore = match gitignore_before {
+        Some(before) if before == gitignore_after => MemoryInitFileChange::Unchanged,
+        Some(_) => {
+            write_file(&gitignore_path, &gitignore_after)?;
+            MemoryInitFileChange::Updated
+        }
+        None => {
+            write_file(&gitignore_path, &gitignore_after)?;
+            MemoryInitFileChange::Created
+        }
+    };
+
+    Ok(MemoryInitApplyReport {
+        config_path,
+        config,
+        gitignore_path,
+        gitignore,
+    })
+}
+
 fn write_memory_config(config: &MemoryConfig) -> Result<(), MemoryError> {
     let mut areas = BTreeMap::new();
     for (slug, area) in &config.areas {

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -109,3 +109,169 @@ impl MemoryConfig {
             })
     }
 }
+
+pub fn plan_memory_init(
+    repo_root: impl AsRef<Path>,
+    config_path: Option<&Path>,
+    force: bool,
+) -> Result<MemoryInitPlan, MemoryError> {
+    let repo_root = normalize_path(repo_root.as_ref());
+    let config_path = config_path
+        .map(|path| resolve_path(&repo_root, path))
+        .unwrap_or_else(|| repo_root.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE));
+    if config_path.exists() && !force {
+        return Err(MemoryError::InvalidInput(format!(
+            "{} already exists; use --force to overwrite it",
+            display_path(&repo_root, &config_path)
+        )));
+    }
+
+    let gitignore_path = repo_root.join(".gitignore");
+    let gitignore_before = fs::read_to_string(&gitignore_path).ok();
+    let gitignore_after = render_memory_gitignore(gitignore_before.as_deref());
+
+    Ok(MemoryInitPlan {
+        config_path,
+        config_contents: render_memory_init_config(&repo_root)?,
+        gitignore_path,
+        gitignore_before,
+        gitignore_after,
+    })
+}
+
+pub fn write_memory_init_plan(plan: &MemoryInitPlan) -> Result<(), MemoryError> {
+    write_file(&plan.config_path, &plan.config_contents)?;
+    write_file(&plan.gitignore_path, &plan.gitignore_after)?;
+    Ok(())
+}
+
+fn render_memory_init_config(repo_root: &Path) -> Result<String, MemoryError> {
+    let areas = discover_task_areas(repo_root)?;
+    let areas = if areas.is_empty() {
+        vec!["general".to_string()]
+    } else {
+        areas
+    };
+
+    let mut output = String::from(
+        "memory_root: .opensymphony/memory\n\
+visibility: private\n\
+index_path: .opensymphony/memory/memory.duckdb\n\
+source_snapshots: hashes\n\
+markdown_indexes: true\n\n\
+docs:\n\
+  public_root: docs\n\
+  default_visibility: public\n\
+  deny_private_links: true\n\n\
+areas:\n",
+    );
+    for area in areas {
+        let docs_target = docs_target_for_area(repo_root, &area);
+        output.push_str(&format!("  {area}:\n"));
+        output.push_str(&format!("    title: {}\n", titleize_slug(&area)));
+        output.push_str(&format!(
+            "    docs_target: {}\n",
+            display_path(repo_root, &docs_target)
+        ));
+        output.push_str("    path_hints:\n");
+        for hint in path_hints_for_area(&area) {
+            output.push_str(&format!("      - {hint}\n"));
+        }
+        output.push_str("    labels:\n");
+        output.push_str(&format!("      - {area}\n"));
+    }
+    Ok(output)
+}
+
+fn discover_task_areas(repo_root: &Path) -> Result<Vec<String>, MemoryError> {
+    let tasks_root = repo_root.join("docs/tasks");
+    if !tasks_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut areas = BTreeSet::new();
+    for entry in fs::read_dir(&tasks_root).map_err(|source| MemoryError::ReadFile {
+        path: tasks_root.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| MemoryError::ReadFile {
+            path: tasks_root.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("md") {
+            continue;
+        }
+        let contents = read_to_string(&path)?;
+        if let Some(area) = parse_task_area(&contents) {
+            areas.insert(area);
+        }
+    }
+    Ok(areas.into_iter().collect())
+}
+
+fn parse_task_area(contents: &str) -> Option<String> {
+    let mut lines = contents.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            return None;
+        }
+        let Some(value) = trimmed.strip_prefix("area:") else {
+            continue;
+        };
+        return normalize_optional(value).map(|area| slugify(&area));
+    }
+    None
+}
+
+fn docs_target_for_area(repo_root: &Path, area: &str) -> PathBuf {
+    let target = repo_root.join("docs").join(format!("{area}.md"));
+    if target.exists() {
+        target
+    } else {
+        repo_root.join("docs").join(format!("{area}.md"))
+    }
+}
+
+fn path_hints_for_area(area: &str) -> Vec<String> {
+    let mut hints = BTreeSet::from([area.to_string()]);
+    for token in area.split('-').filter(|token| !token.is_empty()) {
+        hints.insert(token.to_string());
+    }
+    hints.into_iter().collect()
+}
+
+fn render_memory_gitignore(before: Option<&str>) -> String {
+    const MEMORY_IGNORE_LINES: [&str; 6] = [
+        ".opensymphony*",
+        "!.opensymphony/",
+        ".opensymphony/*",
+        "!.opensymphony/memory/",
+        ".opensymphony/memory/*",
+        "!.opensymphony/memory/memory.yaml",
+    ];
+
+    let mut lines = before
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !MEMORY_IGNORE_LINES.contains(&line.trim()))
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+
+    let mut output = lines.join("\n");
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    for line in MEMORY_IGNORE_LINES {
+        output.push_str(line);
+        output.push('\n');
+    }
+    output
+}

--- a/crates/opensymphony-memory/src/docs_sync.rs
+++ b/crates/opensymphony-memory/src/docs_sync.rs
@@ -94,11 +94,14 @@ fn missing_docs_area_mapping_error(
         );
     }
 
-    let areas = if unmapped_areas.is_empty() {
-        "none".to_string()
-    } else {
-        unmapped_areas.into_iter().collect::<Vec<_>>().join(", ")
-    };
+    if unmapped_areas.is_empty() {
+        return MemoryError::InvalidInput(
+            "Selected issues have no docs areas. Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
+                .to_string(),
+        );
+    }
+
+    let areas = unmapped_areas.into_iter().collect::<Vec<_>>().join(", ");
     MemoryError::InvalidInput(format!(
         "selected issues only reference unmapped docs areas ({areas}). Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
     ))

--- a/crates/opensymphony-memory/src/docs_sync.rs
+++ b/crates/opensymphony-memory/src/docs_sync.rs
@@ -4,12 +4,6 @@ pub fn plan_docs_sync(
     write: bool,
     with_diagrams: bool,
 ) -> Result<DocsSyncPlan, MemoryError> {
-    if config.areas.is_empty() {
-        return Err(MemoryError::InvalidInput(
-            "No docs area mapping found. Run opensymphony memory init.".to_string(),
-        ));
-    }
-
     let selected = select_indexed_issues_for_docs(config, selection)?;
     if selected.is_empty() {
         return Err(MemoryError::InvalidInput(
@@ -17,7 +11,7 @@ pub fn plan_docs_sync(
         ));
     }
 
-    let mut by_area: BTreeMap<String, Vec<IndexedIssue>> = BTreeMap::new();
+    let mut by_area: BTreeMap<String, (AreaConfig, Vec<IndexedIssue>)> = BTreeMap::new();
     let mut unmapped_areas = BTreeSet::new();
     for issue in selected {
         for area in issue.areas() {
@@ -28,32 +22,24 @@ pub fn plan_docs_sync(
             {
                 continue;
             }
-            if !config.areas.contains_key(&area) {
+            if let Some(area_config) = config.areas.get(&area) {
+                by_area
+                    .entry(area)
+                    .or_insert_with(|| (area_config.clone(), Vec::new()))
+                    .1
+                    .push(issue.clone());
+            } else {
                 unmapped_areas.insert(area);
-                continue;
             }
-            by_area.entry(area).or_default().push(issue.clone());
         }
     }
     if by_area.is_empty() {
-        let areas = if unmapped_areas.is_empty() {
-            "none".to_string()
-        } else {
-            unmapped_areas.into_iter().collect::<Vec<_>>().join(", ")
-        };
-        return Err(MemoryError::InvalidInput(format!(
-            "selected issues only reference unmapped docs areas ({areas}). Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
-        )));
+        return Err(missing_docs_area_mapping_error(config, unmapped_areas));
     }
 
     let mut targets = Vec::new();
     let mut warnings = Vec::new();
-    for (area_slug, issues) in by_area {
-        let area = config
-            .areas
-            .get(&area_slug)
-            .cloned()
-            .ok_or_else(|| MemoryError::InvalidInput(format!("area `{area_slug}` is not mapped")))?;
+    for (_area_slug, (area, issues)) in by_area {
         let before = if area.docs_target.exists() {
             Some(read_to_string(&area.docs_target)?)
         } else {
@@ -96,6 +82,26 @@ pub fn plan_docs_sync(
         targets,
         warnings,
     })
+}
+
+fn missing_docs_area_mapping_error(
+    config: &MemoryConfig,
+    unmapped_areas: BTreeSet<String>,
+) -> MemoryError {
+    if config.areas.is_empty() {
+        return MemoryError::InvalidInput(
+            "No docs area mapping found. Run opensymphony memory init.".to_string(),
+        );
+    }
+
+    let areas = if unmapped_areas.is_empty() {
+        "none".to_string()
+    } else {
+        unmapped_areas.into_iter().collect::<Vec<_>>().join(", ")
+    };
+    MemoryError::InvalidInput(format!(
+        "selected issues only reference unmapped docs areas ({areas}). Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
+    ))
 }
 
 pub fn write_docs_sync_plan(

--- a/crates/opensymphony-memory/src/docs_sync.rs
+++ b/crates/opensymphony-memory/src/docs_sync.rs
@@ -10,6 +10,10 @@ pub fn plan_docs_sync(
             "no captured issues selected for docs sync".to_string(),
         ));
     }
+    let all_selected_issue_keys = selected
+        .iter()
+        .map(|issue| issue.issue_key.clone())
+        .collect::<BTreeSet<_>>();
 
     let mut by_area: BTreeMap<String, (AreaConfig, Vec<IndexedIssue>)> = BTreeMap::new();
     let mut unmapped_areas = BTreeSet::new();
@@ -23,6 +27,12 @@ pub fn plan_docs_sync(
                 continue;
             }
             if let Some(area_config) = config.areas.get(&area) {
+                if area_config.status != AreaStatus::Stable
+                    || area_config.confidence < config.confidence_threshold
+                {
+                    unmapped_areas.insert(area);
+                    continue;
+                }
                 by_area
                     .entry(area)
                     .or_insert_with(|| (area_config.clone(), Vec::new()))
@@ -33,12 +43,11 @@ pub fn plan_docs_sync(
             }
         }
     }
-    if by_area.is_empty() {
-        return Err(missing_docs_area_mapping_error(config, unmapped_areas));
-    }
-
     let mut targets = Vec::new();
     let mut warnings = Vec::new();
+    if by_area.is_empty() {
+        warnings.push(missing_docs_area_mapping_message(config, unmapped_areas));
+    }
     for (_area_slug, (area, issues)) in by_area {
         let before = if area.docs_target.exists() {
             Some(read_to_string(&area.docs_target)?)
@@ -55,7 +64,7 @@ pub fn plan_docs_sync(
                 display_path(&config.repo_root, &area.docs_target)
             ));
         }
-        let diff = render_diff(before.as_deref().unwrap_or(""), &after, &area.docs_target);
+        let diff = render_diff_stat(before.as_deref().unwrap_or(""), &after, &area.docs_target);
         targets.push(DocsTargetPlan {
             area: area.slug,
             title: area.title,
@@ -69,12 +78,15 @@ pub fn plan_docs_sync(
         });
     }
 
-    let selected_issue_keys = targets
+    let mut selected_issue_keys = targets
         .iter()
         .flat_map(|target| target.issue_keys.clone())
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
+    if selected_issue_keys.is_empty() {
+        selected_issue_keys = all_selected_issue_keys.into_iter().collect();
+    }
 
     Ok(DocsSyncPlan {
         write,
@@ -84,27 +96,22 @@ pub fn plan_docs_sync(
     })
 }
 
-fn missing_docs_area_mapping_error(
+fn missing_docs_area_mapping_message(
     config: &MemoryConfig,
     unmapped_areas: BTreeSet<String>,
-) -> MemoryError {
+) -> String {
     if config.areas.is_empty() {
-        return MemoryError::InvalidInput(
-            "No docs area mapping found. Run opensymphony memory init.".to_string(),
-        );
+        return "No stable learned docs area found. Run opensymphony memory init or capture issues with stronger Linear/PR evidence.".to_string();
     }
 
     if unmapped_areas.is_empty() {
-        return MemoryError::InvalidInput(
-            "Selected issues have no docs areas. Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
-                .to_string(),
-        );
+        return "Selected issues have no stable docs areas yet; capture kept their memory private until confidence improves.".to_string();
     }
 
     let areas = unmapped_areas.into_iter().collect::<Vec<_>>().join(", ");
-    MemoryError::InvalidInput(format!(
-        "selected issues only reference unmapped docs areas ({areas}). Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
-    ))
+    format!(
+        "selected issues only reference candidate or unmapped docs areas ({areas}); capture kept them private until confidence improves."
+    )
 }
 
 pub fn write_docs_sync_plan(

--- a/crates/opensymphony-memory/src/docs_sync.rs
+++ b/crates/opensymphony-memory/src/docs_sync.rs
@@ -4,6 +4,12 @@ pub fn plan_docs_sync(
     write: bool,
     with_diagrams: bool,
 ) -> Result<DocsSyncPlan, MemoryError> {
+    if config.areas.is_empty() {
+        return Err(MemoryError::InvalidInput(
+            "No docs area mapping found. Run opensymphony memory init.".to_string(),
+        ));
+    }
+
     let selected = select_indexed_issues_for_docs(config, selection)?;
     if selected.is_empty() {
         return Err(MemoryError::InvalidInput(
@@ -12,6 +18,7 @@ pub fn plan_docs_sync(
     }
 
     let mut by_area: BTreeMap<String, Vec<IndexedIssue>> = BTreeMap::new();
+    let mut unmapped_areas = BTreeSet::new();
     for issue in selected {
         for area in issue.areas() {
             if selection
@@ -21,14 +28,32 @@ pub fn plan_docs_sync(
             {
                 continue;
             }
+            if !config.areas.contains_key(&area) {
+                unmapped_areas.insert(area);
+                continue;
+            }
             by_area.entry(area).or_default().push(issue.clone());
         }
+    }
+    if by_area.is_empty() {
+        let areas = if unmapped_areas.is_empty() {
+            "none".to_string()
+        } else {
+            unmapped_areas.into_iter().collect::<Vec<_>>().join(", ")
+        };
+        return Err(MemoryError::InvalidInput(format!(
+            "selected issues only reference unmapped docs areas ({areas}). Run opensymphony memory init or update .opensymphony/memory/memory.yaml."
+        )));
     }
 
     let mut targets = Vec::new();
     let mut warnings = Vec::new();
     for (area_slug, issues) in by_area {
-        let area = config.area_or_default(&area_slug);
+        let area = config
+            .areas
+            .get(&area_slug)
+            .cloned()
+            .ok_or_else(|| MemoryError::InvalidInput(format!("area `{area_slug}` is not mapped")))?;
         let before = if area.docs_target.exists() {
             Some(read_to_string(&area.docs_target)?)
         } else {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -527,7 +527,7 @@ fn render_topic_doc(
     for issue in issues {
         managed.push_str(&format!("- {}: {}\n", issue.issue_key, issue.title));
     }
-    managed.push_str("\n## Provenance\n\n");
+    managed.push_str("\n## Source refs\n\n");
     for issue in issues {
         managed.push_str(&format!("- {}\n", issue.issue_key));
     }
@@ -584,7 +584,7 @@ fn invariants_from_issues(issues: &[IndexedIssue]) -> String {
         }
     }
     if lines.is_empty() {
-        "- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.\n- Use capsule provenance to inspect the original PR or Linear issue when context is ambiguous.".to_string()
+        "- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.\n- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.".to_string()
     } else {
         lines.join("\n")
     }
@@ -686,27 +686,27 @@ fn mark_docs_synced(config: &MemoryConfig, plan: &DocsSyncPlan) -> Result<(), Me
     Ok(())
 }
 
-fn render_diff(before: &str, after: &str, path: &Path) -> String {
+fn render_diff_stat(before: &str, after: &str, path: &Path) -> String {
     if before == after {
-        return format!("diff -- {}\n(no changes)\n", path.display());
+        return format!("{} | no changes\n", path.display());
     }
     let operations = line_diff(before, after);
-    let mut diff = String::new();
-    diff.push_str(&format!("diff -- {}\n", path.display()));
-    diff.push_str(&format!("--- {}\n+++ {}\n", path.display(), path.display()));
-    diff.push_str("@@\n");
-    const MAX_DIFF_LINES: usize = 240;
-    for operation in operations.iter().take(MAX_DIFF_LINES) {
-        match operation {
-            DiffOperation::Unchanged(line) => diff.push_str(&format!(" {line}\n")),
-            DiffOperation::Removed(line) => diff.push_str(&format!("-{line}\n")),
-            DiffOperation::Added(line) => diff.push_str(&format!("+{line}\n")),
-        }
-    }
-    if operations.len() > MAX_DIFF_LINES {
-        diff.push_str("... diff truncated ...\n");
-    }
-    diff
+    let added = operations
+        .iter()
+        .filter(|operation| matches!(operation, DiffOperation::Added(_)))
+        .count();
+    let removed = operations
+        .iter()
+        .filter(|operation| matches!(operation, DiffOperation::Removed(_)))
+        .count();
+    format!(
+        "{} | {} -> {} lines, +{} -{}\n",
+        path.display(),
+        before.lines().count(),
+        after.lines().count(),
+        added,
+        removed
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -38,7 +38,7 @@ fn index_capture_plan(config: &MemoryConfig, plan: &CapturePlan) -> Result<(), M
                     issue_plan.capsule_path.to_string_lossy().to_string(),
                     config.visibility.as_str(),
                     issue_plan.source_hash.clone(),
-                    issue_plan.warnings.len() as i64,
+                    archive_blocking_warning_count(&issue_plan.warnings) as i64,
                     "pending",
                     body,
                     Utc::now().to_rfc3339(),

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -813,6 +813,37 @@ Reviews are triggered when you open a pull request for review.
     }
 
     #[test]
+    fn area_evidence_matching_requires_whole_tokens() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = config_for(repo.path());
+        let mut source = sample_source();
+        source.issues[0].title = "OpenHands gruntimeerror handling".to_string();
+        source.issues[0].description =
+            Some("Fix gruntimeerror handling without ownership changes.".to_string());
+        source.issues[0].labels.clear();
+        source.prs[0].title = "COE-123 harden gruntimeerror handling".to_string();
+        source.prs[0].body = Some("No ownership area changed.".to_string());
+
+        let plan = plan_capture(
+            &config,
+            &source,
+            &IssueSelection {
+                identifiers: vec!["COE-123".to_string()],
+                ..IssueSelection::default()
+            },
+            true,
+            false,
+        )
+        .expect("plan");
+
+        assert!(
+            !plan.selected[0]
+                .areas
+                .contains(&"openhands-runtime".to_string())
+        );
+    }
+
+    #[test]
     fn capture_index_rolls_back_when_a_later_issue_fails() {
         let repo = TempDir::new().expect("temp repo");
         let config = config_for(repo.path());

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -107,10 +107,12 @@ pub enum SourceSnapshotPolicy {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryConfig {
     pub enabled: bool,
+    pub config_path: PathBuf,
     pub repo_root: PathBuf,
     pub memory_root: PathBuf,
     pub visibility: MemoryVisibility,
     pub index_path: PathBuf,
+    pub confidence_threshold: u8,
     pub source_snapshot_policy: SourceSnapshotPolicy,
     pub markdown_indexes: bool,
     pub docs: DocsConfig,
@@ -131,8 +133,51 @@ pub struct AreaConfig {
     pub title: String,
     pub docs_target: PathBuf,
     pub visibility: MemoryVisibility,
-    pub path_hints: Vec<String>,
-    pub labels: Vec<String>,
+    pub status: AreaStatus,
+    pub confidence: u8,
+    pub aliases: Vec<String>,
+    pub source_refs: AreaSourceRefs,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AreaStatus {
+    #[default]
+    Candidate,
+    Stable,
+}
+
+impl AreaStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Candidate => "candidate",
+            Self::Stable => "stable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AreaSourceRefs {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub docs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub linear_labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub linear_milestones: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub linear_issues: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub github_prs: Vec<String>,
+}
+
+impl AreaSourceRefs {
+    fn is_empty(&self) -> bool {
+        self.docs.is_empty()
+            && self.linear_labels.is_empty()
+            && self.linear_milestones.is_empty()
+            && self.linear_issues.is_empty()
+            && self.github_prs.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -149,53 +194,59 @@ pub struct MemoryInitPlan {
     pub gitignore_after: String,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 struct MemoryConfigFile {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     memory_root: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     visibility: Option<MemoryVisibility>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     index_path: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    confidence_threshold: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     source_snapshots: Option<SourceSnapshotPolicy>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     markdown_indexes: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     docs: Option<DocsConfigFile>,
     #[serde(default)]
     areas: BTreeMap<String, AreaConfigFile>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     redaction: Option<RedactionConfigFile>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 struct DocsConfigFile {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     public_root: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     default_visibility: Option<MemoryVisibility>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     deny_private_links: Option<bool>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 struct AreaConfigFile {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     title: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     docs_target: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     visibility: Option<MemoryVisibility>,
-    #[serde(default)]
-    path_hints: Vec<String>,
-    #[serde(default)]
-    labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    status: Option<AreaStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    confidence: Option<u8>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    aliases: Vec<String>,
+    #[serde(default, skip_serializing_if = "AreaSourceRefs::is_empty")]
+    source_refs: AreaSourceRefs,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 struct RedactionConfigFile {
     #[serde(default)]
     deny_patterns: Vec<String>,
@@ -259,6 +310,8 @@ pub struct IssueLinkEvidence {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommentEvidence {
+    #[serde(default)]
+    pub id: Option<String>,
     #[serde(default)]
     pub author: Option<String>,
     #[serde(default)]
@@ -667,6 +720,99 @@ Reviews are triggered when you open a pull request for review.
     }
 
     #[test]
+    fn capture_evolves_memory_config_and_keeps_changed_files_index_only() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("default config");
+        let source = sample_source();
+        let plan = plan_capture(
+            &config,
+            &source,
+            &IssueSelection {
+                identifiers: vec!["COE-123".to_string()],
+                ..IssueSelection::default()
+            },
+            true,
+            false,
+        )
+        .expect("plan");
+
+        write_capture_plan(&config, &plan, false).expect("write");
+
+        let evolved = MemoryConfig::load(repo.path(), None).expect("evolved config");
+        let area = evolved.areas.get("runtime").expect("runtime area");
+        assert_eq!(area.status, AreaStatus::Stable);
+        assert!(area.confidence >= evolved.confidence_threshold);
+        assert!(
+            area.source_refs
+                .linear_labels
+                .contains(&"runtime".to_string())
+        );
+        assert!(
+            area.source_refs
+                .linear_issues
+                .contains(&"COE-123".to_string())
+        );
+        assert!(area.source_refs.github_prs.contains(&"#456".to_string()));
+
+        let capsule =
+            fs::read_to_string(evolved.issue_capsule_path("COE-123")).expect("capsule should read");
+        assert!(capsule.contains("github_merge_shas"));
+        assert!(capsule.contains("abcdef1234567890"));
+        assert!(
+            !capsule.contains("crates/opensymphony-openhands/src/client.rs"),
+            "changed files should stay out of capsule prose and frontmatter"
+        );
+
+        let connection = Connection::open(&evolved.index_path).expect("index should open");
+        let changed_file: String = connection
+            .query_row(
+                "SELECT file_path FROM changed_files WHERE issue_key = 'COE-123'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("changed file should be indexed");
+        assert_eq!(changed_file, "crates/opensymphony-openhands/src/client.rs");
+    }
+
+    #[test]
+    fn capture_creates_candidate_area_from_linear_and_pr_narrative() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("default config");
+        let mut source = sample_source();
+        source.issues[0].title = "OpenHands runtime adapter".to_string();
+        source.issues[0].milestone = None;
+        source.issues[0].labels.clear();
+        source.prs[0].title = "COE-123 support OpenHands runtime adapter".to_string();
+        let plan = plan_capture(
+            &config,
+            &source,
+            &IssueSelection {
+                identifiers: vec!["COE-123".to_string()],
+                ..IssueSelection::default()
+            },
+            true,
+            false,
+        )
+        .expect("plan");
+
+        assert_eq!(plan.selected[0].areas, vec!["openhands-runtime-adapter"]);
+        write_capture_plan(&config, &plan, false).expect("write");
+
+        let evolved = MemoryConfig::load(repo.path(), None).expect("evolved config");
+        let area = evolved
+            .areas
+            .get("openhands-runtime-adapter")
+            .expect("candidate area");
+        assert_eq!(area.status, AreaStatus::Candidate);
+        assert!(area.confidence < evolved.confidence_threshold);
+        assert!(
+            area.source_refs
+                .linear_issues
+                .contains(&"COE-123".to_string())
+        );
+    }
+
+    #[test]
     fn capture_index_rolls_back_when_a_later_issue_fails() {
         let repo = TempDir::new().expect("temp repo");
         let config = config_for(repo.path());
@@ -752,33 +898,37 @@ Reviews are triggered when you open a pull request for review.
     }
 
     #[test]
-    fn docs_sync_diff_is_line_level_not_full_replacement() {
-        let diff = render_diff(
+    fn private_link_guard_allows_tracked_memory_config_path() {
+        assert!(!contains_private_memory_link(
+            "Commit .opensymphony/memory/memory.yaml"
+        ));
+        assert!(contains_private_memory_link(
+            "See .opensymphony/memory/issues/COE-123.md"
+        ));
+        assert!(!contains_private_memory_link(
+            "Do not publish .opensymphony/memory/memory.duckdb"
+        ));
+    }
+
+    #[test]
+    fn docs_sync_summary_reports_changed_line_counts() {
+        let diff = render_diff_stat(
             "alpha\nshared\nold\nomega\n",
             "alpha\nshared\nnew\nomega\n",
             Path::new("docs/topic.md"),
         );
 
-        assert!(diff.contains("\n alpha\n"));
-        assert!(diff.contains("\n shared\n"));
-        assert!(diff.contains("\n-old\n"));
-        assert!(diff.contains("\n+new\n"));
-        assert!(!diff.contains("\n-alpha\n"));
-        assert!(!diff.contains("\n-omega\n"));
+        assert!(diff.contains("docs/topic.md"));
+        assert!(diff.contains("4 -> 4 lines"));
+        assert!(diff.contains("+1 -1"));
     }
 
     #[test]
-    fn docs_sync_diff_for_new_docs_does_not_emit_fake_deletes() {
-        let diff = render_diff("", "alpha\nbeta\n", Path::new("docs/topic.md"));
+    fn docs_sync_summary_for_new_docs_reports_only_adds() {
+        let diff = render_diff_stat("", "alpha\nbeta\n", Path::new("docs/topic.md"));
 
-        assert!(diff.contains("\n+alpha\n"));
-        assert!(diff.contains("\n+beta\n"));
-        assert!(
-            !diff
-                .lines()
-                .any(|line| line.starts_with('-') && !line.starts_with("--- ")),
-            "new doc diff should not include deleted lines: {diff}",
-        );
+        assert!(diff.contains("0 -> 2 lines"));
+        assert!(diff.contains("+2 -0"));
     }
 
     #[test]
@@ -836,10 +986,14 @@ areas:
   openhands-runtime:
     title: OpenHands Runtime
     docs_target: docs/openhands-runtime.md
-    path_hints:
-      - openhands
-    labels:
+    status: stable
+    confidence: 90
+    aliases:
       - runtime
+      - OpenHands Runtime
+    source_refs:
+      linear_labels:
+        - runtime
 "#,
         )
         .expect("config");

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -787,11 +787,13 @@ Reviews are triggered when you open a pull request for review.
                 .contains(&"runtime".to_string())
         );
         assert!(
-            area.source_refs
-                .linear_issues
-                .contains(&"COE-123".to_string())
+            area.source_refs.linear_issues.is_empty(),
+            "per-issue inventory belongs in capsules and DuckDB, not tracked memory.yaml"
         );
-        assert!(area.source_refs.github_prs.contains(&"#456".to_string()));
+        assert!(
+            area.source_refs.github_prs.is_empty(),
+            "per-PR inventory belongs in capsules and DuckDB, not tracked memory.yaml"
+        );
 
         let capsule =
             fs::read_to_string(evolved.issue_capsule_path("COE-123")).expect("capsule should read");
@@ -845,9 +847,8 @@ Reviews are triggered when you open a pull request for review.
         assert_eq!(area.status, AreaStatus::Candidate);
         assert!(area.confidence < evolved.confidence_threshold);
         assert!(
-            area.source_refs
-                .linear_issues
-                .contains(&"COE-123".to_string())
+            area.source_refs.linear_issues.is_empty(),
+            "candidate areas should not accumulate issue inventory in tracked config"
         );
     }
 

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+pub const DEFAULT_PRIVATE_MEMORY_CONFIG_FILE: &str = ".opensymphony/memory/memory.yaml";
 pub const DEFAULT_MEMORY_CONFIG_FILE: &str = "opensymphony-memory.yaml";
 pub const FALLBACK_PRIVATE_MEMORY_CONFIG_FILE: &str = ".opensymphony/memory/config.yaml";
 pub const DEFAULT_MEMORY_ROOT: &str = ".opensymphony/memory";
@@ -137,6 +138,15 @@ pub struct AreaConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RedactionConfig {
     pub deny_patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryInitPlan {
+    pub config_path: PathBuf,
+    pub config_contents: String,
+    pub gitignore_path: PathBuf,
+    pub gitignore_before: Option<String>,
+    pub gitignore_after: String,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -194,6 +194,21 @@ pub struct MemoryInitPlan {
     pub gitignore_after: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryInitFileChange {
+    Created,
+    Updated,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryInitApplyReport {
+    pub config_path: PathBuf,
+    pub config: MemoryInitFileChange,
+    pub gitignore_path: PathBuf,
+    pub gitignore: MemoryInitFileChange,
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct MemoryConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -551,6 +566,30 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn ensure_memory_initialized_creates_config_and_gitignore_policy_once() {
+        let repo = TempDir::new().expect("temp repo");
+
+        let first = ensure_memory_initialized(repo.path(), None).expect("memory init");
+
+        assert_eq!(first.config, MemoryInitFileChange::Created);
+        assert_eq!(first.gitignore, MemoryInitFileChange::Created);
+        assert!(
+            repo.path()
+                .join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE)
+                .is_file()
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join(".gitignore")).expect(".gitignore"),
+            ".opensymphony*\n!.opensymphony/\n.opensymphony/*\n!.opensymphony/memory/\n.opensymphony/memory/*\n!.opensymphony/memory/memory.yaml\n"
+        );
+
+        let second = ensure_memory_initialized(repo.path(), None).expect("memory init idempotent");
+
+        assert_eq!(second.config, MemoryInitFileChange::Unchanged);
+        assert_eq!(second.gitignore, MemoryInitFileChange::Unchanged);
+    }
 
     #[test]
     fn capture_plan_matches_prs_and_infers_areas() {

--- a/crates/opensymphony-memory/src/query.rs
+++ b/crates/opensymphony-memory/src/query.rs
@@ -310,7 +310,7 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
                     severity: LintSeverity::Error,
                     path: Some(path),
                     message: "public docs contain a private memory path".to_string(),
-                    next_command: Some("opensymphony memory sync-docs --dry-run".to_string()),
+                    next_command: Some("opensymphony memory sync-docs".to_string()),
                 });
             }
         }

--- a/crates/opensymphony-memory/src/query.rs
+++ b/crates/opensymphony-memory/src/query.rs
@@ -289,9 +289,9 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
             findings.push(LintFinding {
                 severity: LintSeverity::Error,
                 path: Some(issue.capsule_path.clone()),
-                message: format!("{} has no area mapping", issue.issue_key),
+                message: format!("{} has no learned memory area", issue.issue_key),
                 next_command: Some(format!(
-                    "opensymphony memory capture {} --write --force",
+                    "opensymphony memory capture {} --force",
                     issue.issue_key
                 )),
             });

--- a/crates/opensymphony-memory/src/util.rs
+++ b/crates/opensymphony-memory/src/util.rs
@@ -328,9 +328,14 @@ fn snippet_for_terms(body: &str, terms: &[String]) -> String {
 }
 
 fn contains_private_memory_link(contents: &str) -> bool {
-    contents.contains(".opensymphony/memory")
-        || contents.contains(".opensymphony\\memory")
-        || contents.contains("../.opensymphony")
+    let contents = contents.to_ascii_lowercase();
+    [
+        ".opensymphony/memory/issues",
+        ".opensymphony\\memory\\issues",
+        "../.opensymphony/memory/issues",
+    ]
+    .iter()
+    .any(|private_path| contents.contains(private_path))
 }
 
 fn display_path(repo_root: &Path, path: &Path) -> String {

--- a/crates/opensymphony-memory/src/util.rs
+++ b/crates/opensymphony-memory/src/util.rs
@@ -118,6 +118,19 @@ fn normalize_issue_key(value: &str) -> String {
     value.trim().to_ascii_uppercase()
 }
 
+pub fn archive_blocking_warning_count(warnings: &[String]) -> usize {
+    warnings
+        .iter()
+        .filter(|warning| is_archive_blocking_capture_warning(warning))
+        .count()
+}
+
+pub fn is_archive_blocking_capture_warning(warning: &str) -> bool {
+    !warning
+        .trim()
+        .eq_ignore_ascii_case("no GitHub PR source was matched")
+}
+
 fn sanitize_issue_key(value: &str) -> String {
     let normalized = normalize_issue_key(value);
     let sanitized = normalized

--- a/crates/opensymphony-openhands/tests/supervisor.rs
+++ b/crates/opensymphony-openhands/tests/supervisor.rs
@@ -108,7 +108,7 @@ fn status_preserves_exited_state_after_supervised_child_crashes() {
         .insert("FAKE_SERVER_MODE".to_string(), "crash".to_string());
     config
         .extra_env
-        .insert("FAKE_CRASH_DELAY_SECS".to_string(), "0.1".to_string());
+        .insert("FAKE_CRASH_DELAY_SECS".to_string(), "0.5".to_string());
     config
         .extra_env
         .insert("FAKE_EXIT_CODE".to_string(), "42".to_string());

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -152,3 +152,48 @@ Breaking changes in this line include:
 - `docs/testing-and-operations.md`
 - `docs/repository-layout.md`
 - `docs/migration-1.0.0.md`
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-280 contributed: PR #54: Support workflow-owned OpenHands runtime overrides (merge `5663898`)
+- COE-281 contributed: PR #55: COE-281: support path-prefixed OpenHands URLs and MCP config (merge `a50e435`)
+- COE-282 contributed: PR #52: Support workflow-owned OpenHands conversation reuse policy at runtime (merge `ad111a3`)
+- COE-287 contributed: PR #48: Add opensymphony debug command for issue conversations (merge `021f5ad`)
+- COE-294 contributed: PR #58: COE-294: detect LLM config drift and rehydrate conversations (merge `5ab7015`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Development Guide"]
+  area --> docs["docs/DEVELOPMENT.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-280: Support workflow-owned OpenHands auth, provider, and launcher overrides at runtime
+- COE-281: Support path-bearing OpenHands base URLs and MCP config at runtime
+- COE-282: Support workflow-owned OpenHands conversation reuse policy at runtime
+- COE-287: Add opensymphony debug command for conversational session debugging
+- COE-294: Detect LLM config changes and rehydrate conversations with updated env vars
+
+## Source refs
+
+- COE-280
+- COE-281
+- COE-282
+- COE-287
+- COE-294
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,3 +193,39 @@ Notable removals:
 - workflow-owned `openhands.mcp`
 - the old bridge CLI command
 - provider-specific AI review secret naming
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-283 contributed: PR #50: Cache per-state running counts in the orchestrator scheduler (merge `0378518`)
+- COE-286 contributed: PR #49: Abort active CLI worker tasks on graceful shutdown (merge `2c839fd`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Architecture"]
+  area --> docs["docs/architecture.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-283: Cache per-state running counts in the orchestrator scheduler
+- COE-286: Abort active CLI worker tasks on graceful orchestrator shutdown
+
+## Source refs
+
+- COE-283
+- COE-286
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,41 @@
+---
+type: topic-doc
+area: cli
+visibility: public
+last_memory_sync: 2026-05-16T07:06:20.437326+00:00
+---
+
+# Cli
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-284 contributed: PR #47: Add installable opensymphony run command (merge `51821f0`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Cli"]
+  area --> docs["docs/cli.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-284: Add orchestrator run command to CLI and make it installable
+
+## Source refs
+
+- COE-284
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,10 @@ control_plane:
 
 openhands:
   tool_dir: ~/.opensymphony/openhands-server
+
+memory:
+  auto_capture: true
+  auto_archive: false
 ```
 
 Provision that app-managed directory with:
@@ -177,17 +181,29 @@ config that `opensymphony run` looks for in a target repo.
 
 ## Memory Configuration
 
-Project memory is optional and stores runtime state under `.opensymphony/memory`.
-Initialize shared docs area mappings with:
+Project memory stores runtime state under `.opensymphony/memory` and can be
+captured automatically by `opensymphony run`. Runtime automation is controlled
+by `config.yaml`:
+
+```yaml
+memory:
+  auto_capture: true
+  auto_archive: false
+```
+
+`auto_capture` defaults to `true`. It captures terminal issue transitions
+observed by the run loop. `auto_archive` defaults to `false`; when enabled, it
+archives only after successful capture with no blocking warnings.
+
+Initialize the shared memory policy and learned ontology file with:
 
 ```bash
 opensymphony memory init
 ```
 
 This creates `.opensymphony/memory/memory.yaml` and updates `.gitignore` so only
-that shared config is tracked. If no memory config file exists, memory capture
-can still write local capsules, but docs sync refuses broad topic-doc generation
-until mappings exist:
+that shared config is tracked. Capsules, markdown indexes, DuckDB, source
+snapshots, and runtime logs remain local:
 
 ```text
 .opensymphony/memory/
@@ -197,12 +213,16 @@ until mappings exist:
   memory.duckdb
 ```
 
-To customize areas and docs targets, edit `.opensymphony/memory/memory.yaml`:
+`memory.yaml` contains policy plus learned structure. `memory init` seeds stable
+areas from existing top-level `docs/*.md` files when present; otherwise it
+starts with an empty `areas` map and capture evolves it from Linear and PR
+narrative evidence:
 
 ```yaml
 memory_root: .opensymphony/memory
 visibility: private
 index_path: .opensymphony/memory/memory.duckdb
+confidence_threshold: 75
 markdown_indexes: true
 docs:
   public_root: docs
@@ -212,17 +232,22 @@ areas:
   openhands-runtime:
     title: OpenHands Runtime
     docs_target: docs/openhands-runtime.md
-    path_hints:
-      - openhands
-      - runtime
-    labels:
-      - runtime
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+      - OpenHands Runtime
+    source_refs:
+      docs:
+        - docs/openhands-runtime.md
+      linear_labels:
+        - runtime
 ```
 
-Private memory should stay out of source control. Generated topic docs are
-ordinary repository files that users can review, commit, and publish when they
-choose. Commit `.opensymphony/memory/memory.yaml`; do not commit issue
-capsules, markdown indexes, DuckDB, source snapshots, or runtime state.
+Private memory should stay out of source control. Commit
+`.opensymphony/memory/memory.yaml` and generated public docs when appropriate;
+do not commit issue capsules, markdown indexes, DuckDB, source snapshots, or
+runtime state.
 
 ## OpenHands PR Review
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ opensymphony init
 - prompts before overwriting other conflicting files
 - fills the `WORKFLOW.md` clone hook from `git remote` when possible
 - offers to fill the Linear project slug/key in `WORKFLOW.md`
-- creates or updates `.gitignore` to ensure `.opensymphony*` stays untracked
+- creates or updates `.gitignore` so local OpenSymphony runtime state stays untracked
 - can optionally scaffold OpenHands AI PR review
 - can configure the GitHub Actions variables, label, and optional review secret
   automatically when `gh` is installed and can access the repository
@@ -53,7 +53,7 @@ Core bootstrap payload:
 - `WORKFLOW.md`
 - `AGENTS.md`
 - `config.yaml`
-- `.gitignore` created or updated to include `.opensymphony*`
+- `.gitignore` created or updated to ignore OpenSymphony runtime state
 - `.agents/skills/` copied recursively, including skill-local `references/`, `scripts/`, and similar helper files
 - `.agents/skills/linear/references/`
 - `.github/CODEOWNERS`
@@ -177,18 +177,27 @@ config that `opensymphony run` looks for in a target repo.
 
 ## Memory Configuration
 
-Project memory is optional and defaults to private local state. If no memory
-config file exists, `opensymphony memory` uses:
+Project memory is optional and stores runtime state under `.opensymphony/memory`.
+Initialize shared docs area mappings with:
+
+```bash
+opensymphony memory init
+```
+
+This creates `.opensymphony/memory/memory.yaml` and updates `.gitignore` so only
+that shared config is tracked. If no memory config file exists, memory capture
+can still write local capsules, but docs sync refuses broad topic-doc generation
+until mappings exist:
 
 ```text
 .opensymphony/memory/
+  memory.yaml
   issues/
   indexes/
   memory.duckdb
 ```
 
-To customize areas and docs targets, add `opensymphony-memory.yaml` at the
-target repo root:
+To customize areas and docs targets, edit `.opensymphony/memory/memory.yaml`:
 
 ```yaml
 memory_root: .opensymphony/memory
@@ -212,7 +221,8 @@ areas:
 
 Private memory should stay out of source control. Generated topic docs are
 ordinary repository files that users can review, commit, and publish when they
-choose.
+choose. Commit `.opensymphony/memory/memory.yaml`; do not commit issue
+capsules, markdown indexes, DuckDB, source snapshots, or runtime state.
 
 ## OpenHands PR Review
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,3 +264,42 @@ manual `gh` commands. The full verification and branch-protection guidance
 lives in the OpenSymphony docs at
 [ai-pr-review-human-setup.md](ai-pr-review-human-setup.md); `init` does not
 copy that guide into the target repository.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-286 contributed: PR #49: Abort active CLI worker tasks on graceful shutdown (merge `2c839fd`)
+- COE-288 contributed: PR #51: Add configurable OpenHands context condenser support (merge `102a93c`)
+- COE-293 contributed: PR #56: fix: add OpenHands filesystem tools to coding agents (merge `2f34058`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Configuration"]
+  area --> docs["docs/configuration.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-286: Abort active CLI worker tasks on graceful orchestrator shutdown
+- COE-288: Add context condenser support to prevent LLM context window overflow
+- COE-293: OpenHands agent has no filesystem tools - only FinishTool and ThinkTool
+
+## Source refs
+
+- COE-286
+- COE-288
+- COE-293
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -233,3 +233,36 @@ Support external local server mode for debugging and CI.
 Harden hosted remote mode beyond the current transport/auth support, including stronger workspace isolation and broader hosted-operations concerns.
 
 This sequencing gives the project the fastest path to a working developer-focused MVP while preserving the right long-term boundaries.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-275 contributed: PR #1: COE-257: tighten hosted deployment guidance
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Deployment Modes"]
+  area --> docs["docs/deployment-modes.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-275: Remote agent-server mode and auth hardening
+
+## Source refs
+
+- COE-275
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/devex.md
+++ b/docs/devex.md
@@ -1,0 +1,41 @@
+---
+type: topic-doc
+area: devex
+visibility: public
+last_memory_sync: 2026-05-16T07:06:20.461048+00:00
+---
+
+# Devex
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-284 contributed: PR #47: Add installable opensymphony run command (merge `51821f0`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Devex"]
+  area --> docs["docs/devex.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-284: Add orchestrator run command to CLI and make it installable
+
+## Source refs
+
+- COE-284
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/elixir-hierarchy-changes.md
+++ b/docs/elixir-hierarchy-changes.md
@@ -301,3 +301,53 @@ end
 - Sub-issues are fetched inline with the main issue query (no N+1)
 - The hierarchy check is O(n) where n = number of sub-issues (typically small)
 - Sorting now includes an additional field but complexity remains O(n log n)
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-254 contributed: PR #6: COE-254: bootstrap tracker, workspace, and orchestration core
+- COE-263 contributed: PR #35: COE-263: Implement workspace manager and lifecycle hooks (merge `2693eea`)
+- COE-264 contributed: PR #33: COE-264: Linear read adapter and issue normalization (merge `45cca3c`)
+- COE-267 contributed: PR #83: Add memory init and mapped docs sync
+- COE-268 contributed: PR #43: Implement orchestrator scheduler retries and reconciliation (merge `2ad73ad`)
+- COE-270 contributed: PR #39: COE-270: add deterministic workspace context artifacts (merge `3a90eea`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Changes Needed in Upstream Elixir Implementation for Hierarchy-Aware Task Selection"]
+  area --> docs["docs/elixir-hierarchy-changes.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-254: Tracker, Workspaces, and Orchestration
+- COE-263: Workspace manager and lifecycle hooks
+- COE-264: Linear read adapter and issue normalization
+- COE-267: Linear MCP write surface
+- COE-268: Orchestrator scheduler, retries, and reconciliation
+- COE-270: Repository harness and generated context artifacts
+- COE-277: Implement hierarchy-aware task selection
+
+## Source refs
+
+- COE-254
+- COE-263
+- COE-264
+- COE-267
+- COE-268
+- COE-270
+- COE-277
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -179,3 +179,36 @@ Required evidence:
 - one end-to-end run in a temp repo
 
 If M2 is solid, M3 onward is mostly orchestration work rather than protocol risk.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-275 contributed: PR #1: COE-257: tighten hosted deployment guidance
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Implementation Plan"]
+  area --> docs["docs/implementation-plan.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-275: Remote agent-server mode and auth hardening
+
+## Source refs
+
+- COE-275
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -150,3 +150,53 @@ OpenSymphony 1.0.0 removed workflow-owned Linear bridge configuration.
 
 If an older repository still contains `openhands.mcp`, remove that block and
 use the repo-local Linear GraphQL helper assets with `LINEAR_API_KEY` instead.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-254 contributed: PR #6: COE-254: bootstrap tracker, workspace, and orchestration core
+- COE-263 contributed: PR #35: COE-263: Implement workspace manager and lifecycle hooks (merge `2693eea`)
+- COE-264 contributed: PR #33: COE-264: Linear read adapter and issue normalization (merge `45cca3c`)
+- COE-267 contributed: PR #83: Add memory init and mapped docs sync
+- COE-268 contributed: PR #43: Implement orchestrator scheduler retries and reconciliation (merge `2ad73ad`)
+- COE-270 contributed: PR #39: COE-270: add deterministic workspace context artifacts (merge `3a90eea`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Linear and Tools"]
+  area --> docs["docs/linear-and-tools.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-254: Tracker, Workspaces, and Orchestration
+- COE-263: Workspace manager and lifecycle hooks
+- COE-264: Linear read adapter and issue normalization
+- COE-267: Linear MCP write surface
+- COE-268: Orchestrator scheduler, retries, and reconciliation
+- COE-270: Repository harness and generated context artifacts
+- COE-277: Implement hierarchy-aware task selection
+
+## Source refs
+
+- COE-254
+- COE-263
+- COE-264
+- COE-267
+- COE-268
+- COE-270
+- COE-277
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/memory-capture-and-doc-sync.md
+++ b/docs/memory-capture-and-doc-sync.md
@@ -388,14 +388,13 @@ source facts, issue capsules, areas, and docs sync results.
 
 ## Manual capture workflow
 
-Capture is manual and review-first.
+Capture is manual and writes by default unless `--dry-run` is supplied.
 
 Example command shape:
 
 ```bash
-opensymphony memory capture COE-123 --dry-run
 opensymphony memory capture COE-123
-opensymphony memory capture --issues COE-123,COE-124 --dry-run
+opensymphony memory capture --issues COE-123,COE-124
 opensymphony memory capture --issues-file completed-issues.csv
 opensymphony memory capture --issue-range COE-100..COE-199
 opensymphony memory capture --before-issue COE-300
@@ -433,11 +432,11 @@ Archival is a separate explicit action.
 Example command shape:
 
 ```bash
-opensymphony linear archive --issues COE-123,COE-124 --dry-run
-opensymphony linear archive --issues-file completed-issues.csv --dry-run
-opensymphony linear archive --milestone "M4: Collaborative Planning Alpha" --dry-run
-opensymphony linear archive --captured-before 2026-05-01 --dry-run
-opensymphony linear archive --from-memory --state captured --dry-run
+opensymphony linear archive --issues COE-123,COE-124
+opensymphony linear archive --issues-file completed-issues.csv
+opensymphony linear archive --milestone "M4: Collaborative Planning Alpha"
+opensymphony linear archive --captured-before 2026-05-01
+opensymphony linear archive --from-memory --state captured
 ```
 
 Archive should default to requiring a fresh issue capsule before it archives an
@@ -460,10 +459,11 @@ Documentation sync transforms captured issue memory into topic docs.
 Example command shape:
 
 ```bash
-opensymphony memory sync-docs --since-last-sync --dry-run
-opensymphony memory sync-docs --issues COE-123,COE-124 --dry-run
-opensymphony memory sync-docs --milestone "M4: Collaborative Planning Alpha" --dry-run
-opensymphony memory sync-docs --area authentication --dry-run
+opensymphony memory init
+opensymphony memory sync-docs --since-last-sync
+opensymphony memory sync-docs --issues COE-123,COE-124
+opensymphony memory sync-docs --milestone "M4: Collaborative Planning Alpha"
+opensymphony memory sync-docs --area authentication
 opensymphony memory sync-docs --issues-file completed-issues.csv
 ```
 
@@ -545,7 +545,7 @@ cross-issue knowledge.
 Diagram generation should be optional and reviewable:
 
 ```bash
-opensymphony memory sync-docs --area openhands-runtime --with-diagrams --dry-run
+opensymphony memory sync-docs --area openhands-runtime --with-diagrams
 ```
 
 Docs sync should avoid diagrams that expose private issue-capsule paths in

--- a/docs/memory-capture-and-doc-sync.md
+++ b/docs/memory-capture-and-doc-sync.md
@@ -65,27 +65,29 @@ The memory system should support two different outputs:
 - Issue-centric memory captures what happened for one completed issue.
 - Component-oriented docs describe what is now true about the codebase.
 
-Those are different artifacts. The first is provenance. The second is
-documentation.
+Those are different artifacts. The first is issue-level source refs and
+distillation. The second is documentation.
 
 ## Goals
 
 - Preserve important completed-issue knowledge before Linear archival.
 - Avoid making feature branches responsible for memory merges.
-- Support manual capture and manual archive commands with dry-run review.
+- Support run-loop auto-capture for completed work, plus manual capture and
+  archive commands for backfill and recovery.
 - Keep private memory private by default.
 - Allow users who build in public to publish memory if they choose.
 - Support public repository documentation generated or updated from private or
   public memory.
 - Provide agent discoverability through a real `.agents/skills` skill, not just
   ad hoc CLI commands.
-- Use a queryable embedded index for structured search and provenance queries.
+- Use a queryable embedded index for structured search and source-ref queries.
 - Keep Obsidian and similar markdown tools optional.
 - Avoid storing full agent transcripts or duplicated run logs.
 
 ## Non-goals
 
-- No automatic Linear archival after merge.
+- No automatic Linear archival by default. Auto-archive is an explicit
+  configuration opt-in after successful capture.
 - No requirement to commit private memory into the source repository.
 - No full run transcript storage.
 - No new top-level `decisions` or `components` memory hierarchy as the canonical
@@ -103,7 +105,7 @@ An issue capsule is the primary memory artifact.
 
 It is a markdown page centered on one completed Linear issue. It contains the
 distilled record of intent, outcome, decisions, actions, validation, review,
-follow-ups, and provenance.
+follow-ups, and source refs.
 
 The issue capsule is not a play-by-play transcript. It is a compact closeout
 document with enough links and source references to reconstruct the full record
@@ -186,7 +188,7 @@ Implications:
 
 - Private issue capsules may link to public docs.
 - Public docs should not contain direct links to private issue capsule paths.
-- Public docs may include public provenance such as issue identifiers, PR
+- Public docs may include public source refs such as issue identifiers, PR
   numbers, commit SHAs, and public URLs.
 - A private DuckDB index can preserve the full mapping from public docs back to
   private issue capsules.
@@ -346,10 +348,11 @@ What shipped after review and merge.
 
 - Topic docs that should be created or updated.
 
-## Provenance
+## Source refs
 
 - Linear: link
 - PR: link
+- Merge SHA: immutable audit pointer to merged code state
 - Debug: `opensymphony debug COE-123`
 ```
 
@@ -515,7 +518,7 @@ Failure modes, integration quirks, and constraints.
 
 Short bullets derived from issue capsules.
 
-## Provenance
+## Source refs
 
 Public PRs, commits, and issue identifiers. Private capsule links only when the
 docs visibility allows them.
@@ -636,7 +639,7 @@ The output should be optimized for agent use:
 
 - concise markdown by default
 - optional JSON for tools
-- explicit provenance links
+- explicit source refs
 - warnings when memory is stale
 - separation between "facts from source evidence" and "LLM-generated synthesis"
 - suggested docs or tests to inspect
@@ -653,7 +656,7 @@ Important CLI affordances:
 - explicit `--dry-run` previews before writes
 - clear source discovery output
 - confidence and warning summaries
-- reviewable diffs for docs sync
+- stat-style write output for docs sync
 - separate capture and archive actions
 - commands that open or print generated capsules
 - status commands that show what has been captured, stale, synced, or archived
@@ -718,49 +721,53 @@ Areas are the bridge between issue memory and topic docs.
 
 Area inference can use:
 
-- Linear labels
-- task frontmatter
-- changed file paths
-- PR title and description
-- issue capsule content
-- user overrides
-- existing docs target configuration
+- Linear title, description, labels, milestone, parent, children, and active
+  Workpad comment
+- PR title, description, checks, and review discussions
+- existing learned areas and aliases in the memory config
 
-Area inference should be editable. The capture dry run should show proposed
-areas and let users override them.
+Area inference should not inspect code or diffs. GitHub changed files are useful
+structured metadata for later path-to-issue lookup, but they should not create
+areas or appear in capsule/doc prose. Merge SHA is source-ref metadata, not
+inference input.
 
-Example area configuration:
+Example learned area configuration:
 
 ```yaml
 areas:
   openhands-runtime:
     title: OpenHands Runtime
     docs_target: docs/openhands-runtime.md
-    path_hints:
-      - openhands
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+      - OpenHands Runtime
       - runtime
-  workspace-lifecycle:
-    title: Workspace Lifecycle
-    docs_target: docs/workspace-lifecycle.md
-    path_hints:
-      - workspace
-      - lifecycle
+    source_refs:
+      docs:
+        - docs/openhands-runtime.md
+      linear_labels:
+        - runtime
+      linear_issues:
+        - COE-123
 ```
 
-The initial implementation can keep this configuration in the memory settings
-file. Hosted mode can later move it to project settings.
+`opensymphony memory init` seeds stable areas from existing top-level
+`docs/*.md` files only. Capture then evolves this file from Linear and GitHub
+narrative evidence.
 
 ## Linting and health checks
 
 Memory lint should check:
 
-- issue capsules with missing provenance
+- issue capsules with missing source refs
 - stale capsules where source evidence changed
 - public docs that link to private memory paths
 - docs sync runs that failed or were never reviewed
 - issues marked archive-eligible without fresh capture
-- issue capsules with no area mapping
-- area mappings with no docs target
+- issue capsules with no learned area
+- stable areas with no docs target
 - unresolved follow-ups that were never converted into issues or explicitly
   dismissed
 
@@ -777,7 +784,7 @@ Required behaviors:
 - The default memory root is not committed to the source repository.
 - Public memory mode requires explicit configuration.
 - Public docs sync must detect and warn about private links.
-- Public docs sync should prefer public provenance: PR URLs, commit SHAs, and
+- Public docs sync should prefer public source refs: PR URLs, commit SHAs, and
   issue identifiers.
 - Redaction hooks should exist before writing public memory or public docs.
 - Source snapshots should be optional and private by default.
@@ -850,7 +857,7 @@ Add memory configuration for:
 - DuckDB index path
 - source snapshot policy
 - docs sync targets
-- area mappings
+- learned areas
 - public/private link policy
 - redaction hooks or deny patterns
 
@@ -904,9 +911,9 @@ The first version should:
 
 - select capsules by issue, milestone, area, date, or since-last-sync
 - propose target docs
-- update current model, invariants, gotchas, recent changes, and provenance
+- update current model, invariants, gotchas, recent changes, and source refs
 - optionally generate Mermaid diagrams
-- produce reviewable diffs
+- produce stat-style write output
 - enforce public/private link policy
 
 ### 9. Agent skill installation

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -16,13 +16,14 @@ Project memory has two separate surfaces:
 ## Normal live capture
 
 Live capture requires Linear access from `WORKFLOW.md` and uses GitHub PR
-discovery by default through `gh`:
+discovery by default through `gh`. Initialize shared area mappings once, then
+capture and sync normally:
 
 ```bash
-opensymphony memory capture COE-123 --dry-run
+opensymphony memory init
 opensymphony memory capture COE-123
 opensymphony memory capture --issues COE-123,COE-124
-opensymphony memory capture --issue-range COE-120..COE-130 --dry-run
+opensymphony memory capture --issue-range COE-120..COE-130
 ```
 
 For each selected issue, OpenSymphony:
@@ -40,7 +41,7 @@ GitHub is also part of the default live flow. A missing or failing `gh` command
 is a command failure unless `--no-github` is supplied:
 
 ```bash
-opensymphony memory capture COE-123 --no-github --dry-run
+opensymphony memory capture COE-123 --no-github
 ```
 
 `--no-github` is intended for unusual non-PR work. If GitHub is available but no
@@ -54,10 +55,9 @@ exports. Failed Linear or GitHub access should be fixed before live capture is
 retried.
 
 ```bash
-opensymphony memory import --source-file completed.yaml --dry-run
 opensymphony memory import --source-file completed.yaml
 opensymphony memory import COE-123 --source-file completed.yaml
-opensymphony memory import --issue-range COE-120..COE-130 --source-file completed.yaml --dry-run
+opensymphony memory import --issue-range COE-120..COE-130 --source-file completed.yaml
 ```
 
 The source file is produced by a user or external export tool. OpenSymphony does
@@ -166,17 +166,21 @@ opensymphony memory search "reconnect recovery"
 opensymphony memory docs --area openhands-runtime
 ```
 
-Docs sync is review-first. It shows the managed-section diff before writing:
+Docs sync writes mapped topic docs by default and prints the managed-section
+diff it applied. Use `--dry-run` when you want to preview without writing:
 
 ```bash
-opensymphony memory sync-docs --issues COE-123 --dry-run
+opensymphony memory sync-docs --since-last-sync
 opensymphony memory sync-docs --issues COE-123
+opensymphony memory sync-docs --issues COE-123 --dry-run
 opensymphony memory lint --public-docs
 ```
 
-`opensymphony-memory.yaml` configures memory roots, visibility, area detection,
-docs targets, and redaction. See [Configuration](configuration.md#project-memory)
-for the config shape.
+`.opensymphony/memory/memory.yaml` configures memory roots, visibility, area
+detection, docs targets, and redaction. This shared config is commit-worthy;
+issue capsules, markdown indexes, source snapshots, and DuckDB remain local
+runtime artifacts. See [Configuration](configuration.md#project-memory) for the
+config shape.
 
 ## Archive guard
 
@@ -185,9 +189,8 @@ Archival is guarded by memory capture. For explicit issues,
 archives only eligible issues:
 
 ```bash
-opensymphony linear archive --issues COE-123 --dry-run
 opensymphony linear archive --issues COE-123
-opensymphony linear archive --issue-range COE-120..COE-130 --dry-run
+opensymphony linear archive --issue-range COE-120..COE-130
 ```
 
 An issue is eligible when fresh captured memory exists and has no unresolved
@@ -202,7 +205,7 @@ To archive from already captured memory without recapturing, use
 `--from-memory`:
 
 ```bash
-opensymphony linear archive --from-memory --state captured --dry-run
+opensymphony linear archive --from-memory --state captured
 opensymphony linear archive --from-memory --state pending
 ```
 
@@ -211,7 +214,8 @@ the normal live capture path.
 
 ## Troubleshooting
 
-- Use `opensymphony memory capture ... --dry-run` before running the writing command.
+- Use `--dry-run` on capture, import, sync, or archive commands when you need a
+  non-writing preview.
 - Use `opensymphony memory capture --help`,
   `opensymphony memory import --help`, and
   `opensymphony linear archive --help` for the current command surface.
@@ -219,5 +223,5 @@ the normal live capture path.
   Live capture does not fall back to placeholder records.
 - If GitHub discovery fails, install/authenticate `gh` or intentionally rerun
   with `--no-github`.
-- If archive is blocked by warnings, inspect the capture dry-run or capsule,
-  refresh capture, or use `--force` only after review.
+- If archive is blocked by warnings, inspect the capsule, preview capture with
+  `--dry-run` if useful, refresh capture, or use `--force` only after review.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,58 +1,116 @@
 # Project Memory
 
-OpenSymphony project memory preserves completed-issue knowledge before Linear
-issues are archived. The normal workflow captures evidence from Linear and
-GitHub, writes private issue capsules under `.opensymphony/memory/`, indexes
-them in DuckDB, and can sync selected knowledge into public topic docs.
+OpenSymphony project memory turns completed Linear work into durable development
+context. During `opensymphony run`, terminal issue transitions are captured
+automatically when memory auto-capture is enabled. The capture uses Linear issue
+narrative, active Workpad content, issue hierarchy, milestones, GitHub PR
+descriptions, reviews, checks, and source refs. It writes private issue capsules
+under `.opensymphony/memory/`, updates a DuckDB index, evolves
+`.opensymphony/memory/memory.yaml`, and syncs stable topics into public docs.
 
-Project memory has two separate surfaces:
-
-- **CLI commands** such as `opensymphony memory capture` and
-  `opensymphony linear archive` create, query, sync, and guard memory.
-- **Agent skills** under `.agents/skills/` tell implementation agents when to
-  consult memory. Those skills are target-repo template assets, not files
-  embedded or injected by the OpenSymphony binary.
-
-## Normal live capture
-
-Live capture requires Linear access from `WORKFLOW.md` and uses GitHub PR
-discovery by default through `gh`. Initialize shared area mappings once, then
-capture and sync normally:
+The CLI remains useful for setup, historical backfill, inspection, and manual
+operator actions:
 
 ```bash
 opensymphony memory init
 opensymphony memory capture COE-123
-opensymphony memory capture --issues COE-123,COE-124
-opensymphony memory capture --issue-range COE-120..COE-130
+opensymphony memory brief COE-123
+opensymphony memory related --area openhands-runtime
+opensymphony memory sync-docs --since-last-sync
+opensymphony linear archive --issues COE-123
 ```
 
-For each selected issue, OpenSymphony:
+Use `--dry-run` on write commands when you want a non-writing preview.
 
-1. reads the Linear issue, state, labels, URL, description, and active workpad
-   comment;
-2. discovers matching GitHub PRs with `gh pr list --search ISSUE-KEY`;
-3. enriches matched PRs with changed files, commits, reviews, checks, and merge
-   SHA using `gh pr view`;
-4. renders a capture plan or writes the issue capsule and index entry.
+## Configuration
 
-Linear is always attempted for live capture. A missing `WORKFLOW.md`, invalid
-Linear configuration, missing issue, or Linear API failure is a command failure.
-GitHub is also part of the default live flow. A missing or failing `gh` command
-is a command failure unless `--no-github` is supplied:
+`config.yaml` controls run-loop automation:
+
+```yaml
+memory:
+  auto_capture: true
+  auto_archive: false
+```
+
+`auto_capture` defaults to `true`. `auto_archive` defaults to `false`; when it
+is enabled, OpenSymphony archives only after fresh capture succeeds with no
+blocking warnings.
+
+Initialize the shared memory policy and learned ontology file once:
 
 ```bash
-opensymphony memory capture COE-123 --no-github
+opensymphony memory init
 ```
 
-`--no-github` is intended for unusual non-PR work. If GitHub is available but no
-matching PR is found, capture records a warning. Warnings keep the issue visible
-for review and block archival unless `--force` is used.
+This creates `.opensymphony/memory/memory.yaml` and updates `.gitignore` so only
+that config is tracked. Capsules, indexes, DuckDB, source snapshots, and
+automation logs remain local runtime artifacts.
 
-## Import and backfill
+The config is not a hand-maintained docs map. It is a policy plus learned
+structure file that capture can evolve as more work lands:
+
+```yaml
+memory_root: .opensymphony/memory
+visibility: private
+index_path: .opensymphony/memory/memory.duckdb
+confidence_threshold: 75
+source_snapshots: hashes
+markdown_indexes: true
+docs:
+  public_root: docs
+  default_visibility: public
+  deny_private_links: true
+areas:
+  openhands-runtime:
+    title: OpenHands Runtime
+    docs_target: docs/openhands-agent-server.md
+    visibility: public
+    status: stable
+    confidence: 85
+    aliases:
+      - OpenHands Runtime
+    source_refs:
+      docs:
+        - docs/openhands-agent-server.md
+      linear_labels:
+        - runtime
+      linear_issues:
+        - COE-123
+```
+
+`memory init` seeds stable areas from existing top-level `docs/*.md` files when
+they exist. It does not scan `docs/tasks`, `README.md`, Cargo files, source
+files, or GitHub changed-file lists to create docs topics. When no docs exist,
+the config is still valid and starts with an empty `areas` map.
+
+## Capture Evidence
+
+Live capture requires Linear access from `WORKFLOW.md` and uses GitHub PR
+discovery by default through `gh`. For each issue, OpenSymphony reads:
+
+- Linear title, description, labels, state, URL, milestone, parent, children,
+  and active Workpad comment
+- GitHub PR title, body, branch, checks, review discussion summaries, commits,
+  merge SHA, and changed files
+
+Area inference uses narrative evidence from Linear and GitHub. Merge SHA is not
+used for inference or search; it is stored only under `source_refs` as the
+immutable audit pointer to the exact merged code state. GitHub changed files are
+indexed for later lookup such as "which issues touched this file?", but they are
+not rendered into capsules or docs and do not infer areas.
+
+Selecting a parent issue also captures its child issue closure. Capsules link
+parents, children, and milestones so the Obsidian graph shows the work
+structure.
+
+Linear and GitHub are part of the normal live flow. A missing `WORKFLOW.md`,
+invalid Linear config, missing issue, Linear API failure, or failing `gh`
+command fails capture. Use `--no-github` only for unusual non-PR work.
+
+## Import and Backfill
 
 `memory import` is for deterministic backfills, migrations, tests, or external
-exports. Failed Linear or GitHub access should be fixed before live capture is
-retried.
+exports. It is not the normal path.
 
 ```bash
 opensymphony memory import --source-file completed.yaml
@@ -60,21 +118,7 @@ opensymphony memory import COE-123 --source-file completed.yaml
 opensymphony memory import --issue-range COE-120..COE-130 --source-file completed.yaml
 ```
 
-The source file is produced by a user or external export tool. OpenSymphony does
-not currently generate this file during the normal live capture flow.
-
-Import selection flags filter records already present in the YAML:
-
-- issue selectors: positional issue, `--issues`, `--issues-file`,
-  `--issue-range`
-- source filters: `--milestone`, `--state`, `--before-date`, `--before-issue`
-
-If selected records are not present, import fails instead of inventing
-placeholder issue evidence.
-
-### Source YAML schema
-
-Top-level fields:
+Top-level source YAML fields:
 
 ```yaml
 issues: []
@@ -82,7 +126,7 @@ prs: []
 overrides: {}
 ```
 
-Issue fields:
+Important issue fields:
 
 ```yaml
 issues:
@@ -93,22 +137,26 @@ issues:
     description: Optional issue description
     state: Done
     milestone: M3
+    milestone_id: milestone-id
+    parent:
+      identifier: COE-100
+      title: Parent title
+    children:
+      - identifier: COE-124
+        title: Child title
     labels:
       - runtime
     comments:
-      - author: username
+      - id: comment-id
+        author: username
         body: "Decision or summary text"
         updated_at: 2026-03-25T22:05:00Z
         source: linear:workpad
     linked_prs:
       - 456
-    task_files:
-      - docs/tasks/COE-123.md
-    updated_at: 2026-03-25T22:05:00Z
-    completed_at: 2026-03-26T10:00:00Z
 ```
 
-PR fields:
+Important PR fields:
 
 ```yaml
 prs:
@@ -118,42 +166,21 @@ prs:
     branch: coe-123-reconnect
     body: Pull request summary
     merge_sha: abcdef1234567890
-    merged_at: 2026-03-26T10:30:00Z
-    commits:
-      - sha: abcdef1234567890
-        author: username
-        timestamp: 2026-03-26T10:00:00Z
-        summary: Implement reconnect recovery
     changed_files:
       - path: crates/opensymphony-openhands/src/client.rs
         change_kind: modified
     checks:
       - name: cargo test
         conclusion: success
-        completed_at: 2026-03-26T10:20:00Z
     reviews:
       - reviewer: reviewer
         state: APPROVED
-        submitted_at: 2026-03-26T10:25:00Z
         disposition: Looks correct.
 ```
 
-Overrides are keyed by issue identifier:
-
-```yaml
-overrides:
-  COE-123:
-    prs:
-      - 456
-    areas:
-      - openhands-runtime
-```
-
 All fields except `issues[].identifier` and `prs[].number` are optional.
-`linked_prs` and `overrides.*.prs` associate issue records with PR records in
-the same source file.
 
-## Query and docs sync
+## Query and Docs Sync
 
 Useful read commands:
 
@@ -166,23 +193,21 @@ opensymphony memory search "reconnect recovery"
 opensymphony memory docs --area openhands-runtime
 ```
 
-Docs sync writes mapped topic docs by default and prints the managed-section
-diff it applied. Use `--dry-run` when you want to preview without writing:
+Docs sync writes stable topic docs by default and prints stat-style output with
+file paths, line counts, and changed-line totals:
 
 ```bash
 opensymphony memory sync-docs --since-last-sync
 opensymphony memory sync-docs --issues COE-123
-opensymphony memory sync-docs --issues COE-123 --dry-run
-opensymphony memory lint --public-docs
 ```
 
-`.opensymphony/memory/memory.yaml` configures memory roots, visibility, area
-detection, docs targets, and redaction. This shared config is commit-worthy;
-issue capsules, markdown indexes, source snapshots, and DuckDB remain local
-runtime artifacts. See [Configuration](configuration.md#project-memory) for the
-config shape.
+Candidate or low-confidence areas remain private until later captures raise
+their confidence. Automation records warnings in `.opensymphony/memory/indexes`
+so operators can inspect unresolved capture or docs-sync blockers. When the
+Linear project overview content is available, OpenSymphony also maintains a
+managed memory-status section there for capture warnings that need attention.
 
-## Archive guard
+## Archive Guard
 
 Archival is guarded by memory capture. For explicit issues,
 `opensymphony linear archive` first performs live Linear and GitHub capture, then
@@ -194,34 +219,18 @@ opensymphony linear archive --issue-range COE-120..COE-130
 ```
 
 An issue is eligible when fresh captured memory exists and has no unresolved
-capture warnings. `--force` bypasses the guard when an operator has reviewed the
-risk:
-
-```bash
-opensymphony linear archive --issues COE-123 --force
-```
-
-To archive from already captured memory without recapturing, use
-`--from-memory`:
-
-```bash
-opensymphony linear archive --from-memory --state captured
-opensymphony linear archive --from-memory --state pending
-```
-
-`--state` only applies to `--from-memory`. Explicit issue archive selectors use
-the normal live capture path.
+capture warnings. `--force` bypasses the guard for a deliberate operator
+recovery. To archive from already captured memory without recapturing, use
+`--from-memory`.
 
 ## Troubleshooting
 
-- Use `--dry-run` on capture, import, sync, or archive commands when you need a
-  non-writing preview.
-- Use `opensymphony memory capture --help`,
-  `opensymphony memory import --help`, and
-  `opensymphony linear archive --help` for the current command surface.
 - If Linear fails, fix `WORKFLOW.md`, tracker credentials, or issue selection.
   Live capture does not fall back to placeholder records.
 - If GitHub discovery fails, install/authenticate `gh` or intentionally rerun
   with `--no-github`.
-- If archive is blocked by warnings, inspect the capsule, preview capture with
-  `--dry-run` if useful, refresh capture, or use `--force` only after review.
+- If docs sync writes no topic docs, inspect `.opensymphony/memory/memory.yaml`
+  for candidate areas below the confidence threshold.
+- Use `opensymphony memory capture --help`,
+  `opensymphony memory import --help`, and
+  `opensymphony linear archive --help` for the current command surface.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -234,3 +234,48 @@ recovery. To archive from already captured memory without recapturing, use
 - Use `opensymphony memory capture --help`,
   `opensymphony memory import --help`, and
   `opensymphony linear archive --help` for the current command surface.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-280 contributed: PR #54: Support workflow-owned OpenHands runtime overrides (merge `5663898`)
+- COE-281 contributed: PR #55: COE-281: support path-prefixed OpenHands URLs and MCP config (merge `a50e435`)
+- COE-282 contributed: PR #52: Support workflow-owned OpenHands conversation reuse policy at runtime (merge `ad111a3`)
+- COE-287 contributed: PR #48: Add opensymphony debug command for issue conversations (merge `021f5ad`)
+- COE-294 contributed: PR #58: COE-294: detect LLM config drift and rehydrate conversations (merge `5ab7015`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Project Memory"]
+  area --> docs["docs/memory.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-280: Support workflow-owned OpenHands auth, provider, and launcher overrides at runtime
+- COE-281: Support path-bearing OpenHands base URLs and MCP config at runtime
+- COE-282: Support workflow-owned OpenHands conversation reuse policy at runtime
+- COE-287: Add opensymphony debug command for conversational session debugging
+- COE-294: Detect LLM config changes and rehydrate conversations with updated env vars
+
+## Source refs
+
+- COE-280
+- COE-281
+- COE-282
+- COE-287
+- COE-294
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -152,3 +152,36 @@ When validating a local setup, confirm that:
 OpenSymphony 1.0.0 removed workflow-owned `openhands.mcp`. Older repos should
 remove that block and rely on the repo-local Linear GraphQL helper assets
 copied by `opensymphony init`.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-293 contributed: PR #56: fix: add OpenHands filesystem tools to coding agents (merge `2f34058`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["OpenHands Agent-Server Integration"]
+  area --> docs["docs/openhands-agent-server.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-293: OpenHands agent has no filesystem tools - only FinishTool and ThinkTool
+
+## Source refs
+
+- COE-293
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -216,3 +216,39 @@ opensymphony doctor --config ./config.yaml --rehydrate
 If an older target repo still contains `openhands.mcp`, remove that block.
 OpenSymphony 1.0.0 expects Linear access through `LINEAR_API_KEY` and the
 repo-local GraphQL helper assets copied by `opensymphony init`.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-286 contributed: PR #49: Abort active CLI worker tasks on graceful shutdown (merge `2c839fd`)
+- COE-293 contributed: PR #56: fix: add OpenHands filesystem tools to coding agents (merge `2f34058`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Operations"]
+  area --> docs["docs/operations.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-286: Abort active CLI worker tasks on graceful orchestrator shutdown
+- COE-293: OpenHands agent has no filesystem tools - only FinishTool and ThinkTool
+
+## Source refs
+
+- COE-286
+- COE-293
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,18 +133,22 @@ python3 .agents/skills/linear/scripts/linear_graphql.py \
 
 ## 6. Project memory
 
-Memory capture is review-first. Live capture reads Linear and discovers GitHub
-PRs by default, so use dry runs before writing local memory or docs:
+Project memory stores shared area mapping in `.opensymphony/memory/memory.yaml`
+and private runtime artifacts under `.opensymphony/memory/`. Live capture reads
+Linear and discovers GitHub PRs by default:
 
 ```bash
-opensymphony memory capture COE-123 --dry-run
+opensymphony memory init
 opensymphony memory capture COE-123
 opensymphony memory status
 opensymphony memory brief COE-123
 opensymphony memory related --paths crates/opensymphony-openhands
-opensymphony memory sync-docs --issues COE-123 --dry-run
+opensymphony memory sync-docs --since-last-sync
 opensymphony memory lint --public-docs
 ```
+
+Add `--dry-run` to capture, import, sync, or archive commands when an operator
+wants a non-writing preview.
 
 Use `opensymphony memory import --source-file completed.yaml` only for
 deterministic imports, migrations, tests, or external exports. Failed Linear or
@@ -161,7 +165,6 @@ does not archive Linear issues.
 Linear archival is a separate command and is guarded by captured memory:
 
 ```bash
-opensymphony linear archive --issues COE-123 --dry-run
 opensymphony linear archive --issues COE-123
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,9 +133,19 @@ python3 .agents/skills/linear/scripts/linear_graphql.py \
 
 ## 6. Project memory
 
-Project memory stores shared area mapping in `.opensymphony/memory/memory.yaml`
-and private runtime artifacts under `.opensymphony/memory/`. Live capture reads
-Linear and discovers GitHub PRs by default:
+Project memory stores policy and learned structure in
+`.opensymphony/memory/memory.yaml` and private runtime artifacts under
+`.opensymphony/memory/`. `opensymphony run` captures terminal issue transitions
+automatically when `memory.auto_capture` is enabled in `config.yaml`:
+
+```yaml
+memory:
+  auto_capture: true
+  auto_archive: false
+```
+
+Manual commands remain available for setup, backfill, inspection, and guarded
+archive operations:
 
 ```bash
 opensymphony memory init
@@ -147,8 +157,7 @@ opensymphony memory sync-docs --since-last-sync
 opensymphony memory lint --public-docs
 ```
 
-Add `--dry-run` to capture, import, sync, or archive commands when an operator
-wants a non-writing preview.
+Add `--dry-run` to write commands when an operator wants a non-writing preview.
 
 Use `opensymphony memory import --source-file completed.yaml` only for
 deterministic imports, migrations, tests, or external exports. Failed Linear or

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -31,3 +31,36 @@ Rust installed via `rustup` uses the stable toolchain by default, which is what 
 
 **Alternative**
 If you already have Python 3.12 or newer installed, you can keep it and just install `uv`. If you need a manual Python installer, use the official [Python downloads page](https://www.python.org/downloads/).
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-275 contributed: PR #1: COE-257: tighten hosted deployment guidance
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Prerequisites"]
+  area --> docs["docs/prerequisites.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-275: Remote agent-server mode and auth hardening
+
+## Source refs
+
+- COE-275
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -144,3 +144,48 @@ That rule is now part of the supported public behavior.
 OpenSymphony `1.0.0` removed the old agent-side Linear bridge layer. The
 internal module layout above is the post-removal structure and should stay free
 of dead bridge code.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-280 contributed: PR #54: Support workflow-owned OpenHands runtime overrides (merge `5663898`)
+- COE-281 contributed: PR #55: COE-281: support path-prefixed OpenHands URLs and MCP config (merge `a50e435`)
+- COE-282 contributed: PR #52: Support workflow-owned OpenHands conversation reuse policy at runtime (merge `ad111a3`)
+- COE-287 contributed: PR #48: Add opensymphony debug command for issue conversations (merge `021f5ad`)
+- COE-294 contributed: PR #58: COE-294: detect LLM config drift and rehydrate conversations (merge `5ab7015`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Repository Layout"]
+  area --> docs["docs/repository-layout.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-280: Support workflow-owned OpenHands auth, provider, and launcher overrides at runtime
+- COE-281: Support path-bearing OpenHands base URLs and MCP config at runtime
+- COE-282: Support workflow-owned OpenHands conversation reuse policy at runtime
+- COE-287: Add opensymphony debug command for conversational session debugging
+- COE-294: Detect LLM config changes and rehydrate conversations with updated env vars
+
+## Source refs
+
+- COE-280
+- COE-281
+- COE-282
+- COE-287
+- COE-294
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -214,3 +214,36 @@ Key takeaways carried forward:
 - Workspace, retry, reconciliation, and tracker semantics stay Symphony-owned.
 - Session-oriented harness integration is the right abstraction.
 - Real-time runtime streaming is important enough to build in early rather than retrofit later.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-275 contributed: PR #1: COE-257: tighten hosted deployment guidance
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Sources and Trust Notes"]
+  area --> docs["docs/sources.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-275: Remote agent-server mode and auth hardening
+
+## Source refs
+
+- COE-275
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/symphony-spec-alignment.md
+++ b/docs/symphony-spec-alignment.md
@@ -232,3 +232,48 @@ Do not make these mistakes:
 4. `docs/websocket-runtime.md`
 5. `docs/workspace-and-lifecycle.md`
 6. relevant task file in `docs/tasks/`
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-280 contributed: PR #54: Support workflow-owned OpenHands runtime overrides (merge `5663898`)
+- COE-281 contributed: PR #55: COE-281: support path-prefixed OpenHands URLs and MCP config (merge `a50e435`)
+- COE-282 contributed: PR #52: Support workflow-owned OpenHands conversation reuse policy at runtime (merge `ad111a3`)
+- COE-287 contributed: PR #48: Add opensymphony debug command for issue conversations (merge `021f5ad`)
+- COE-294 contributed: PR #58: COE-294: detect LLM config drift and rehydrate conversations (merge `5ab7015`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Symphony Spec Alignment"]
+  area --> docs["docs/symphony-spec-alignment.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-280: Support workflow-owned OpenHands auth, provider, and launcher overrides at runtime
+- COE-281: Support path-bearing OpenHands base URLs and MCP config at runtime
+- COE-282: Support workflow-owned OpenHands conversation reuse policy at runtime
+- COE-287: Add opensymphony debug command for conversational session debugging
+- COE-294: Detect LLM config changes and rehydrate conversations with updated env vars
+
+## Source refs
+
+- COE-280
+- COE-281
+- COE-282
+- COE-287
+- COE-294
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -357,3 +357,36 @@ That document covers:
 - doctor scope and live probe behavior
 - logging, manifests, and recovery inspection
 - version pinning, CI, and local safety posture
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-279 contributed: No merged PR source was matched during capture.
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Testing"]
+  area --> docs["docs/testing-and-operations.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-279: Reject or propagate unsupported OpenHands agent option passthrough
+
+## Source refs
+
+- COE-279
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/ui-frankentui.md
+++ b/docs/ui-frankentui.md
@@ -295,3 +295,36 @@ Possible later additions:
 - hosted dashboard mode using the same snapshot model
 
 Keep the MVP read-only and reliable first.
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-321 contributed: PR #59: Show more issues in the TUI issue list (merge `d9bd68c`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["FrankenTUI Operator UI"]
+  area --> docs["docs/ui-frankentui.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-321: Add more lines to TUI issue list for better visibility
+
+## Source refs
+
+- COE-321
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/websocket-runtime.md
+++ b/docs/websocket-runtime.md
@@ -456,3 +456,36 @@ Live test scenarios:
 - send prompt, trigger run, receive progress
 - clean completion
 - forced server restart and reconnect behavior
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-275 contributed: PR #1: COE-257: tighten hosted deployment guidance
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["WebSocket Runtime Contract"]
+  area --> docs["docs/websocket-runtime.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-275: Remote agent-server mode and auth hardening
+
+## Source refs
+
+- COE-275
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -480,3 +480,36 @@ trait WorkspaceManager {
 - terminal cleanup
 - issue and run metadata file write and reload
 - conversation reset path preserves workspace safety
+
+<!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Current model
+
+- COE-287 contributed: PR #48: Add opensymphony debug command for issue conversations (merge `021f5ad`)
+
+## Important invariants
+
+- Preserve the behavior described in the recent captured changes unless current code and tests show it has changed.
+- Use capsule source refs to inspect the original PR or Linear issue when context is ambiguous.
+
+## Operational flow
+
+```mermaid
+flowchart TD
+  memory["Captured issue memory"] --> area["Workspace and Lifecycle"]
+  area --> docs["docs/workspace-and-lifecycle.md"]
+```
+
+## Known gotchas
+
+- No area-specific gotchas were inferred from the selected memory.
+
+## Recent changes
+
+- COE-287: Add opensymphony debug command for conversational session debugging
+
+## Source refs
+
+- COE-287
+
+<!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->

--- a/examples/target-repo/config.yaml
+++ b/examples/target-repo/config.yaml
@@ -3,3 +3,7 @@ control_plane:
 
 openhands:
   tool_dir: ~/.opensymphony/openhands-server
+
+memory:
+  auto_capture: true
+  auto_archive: false


### PR DESCRIPTION
## Summary

Repositions OpenSymphony memory as autonomous, self-evolving post-merge infrastructure rather than a manually curated docs mapping. `.opensymphony/memory/memory.yaml` is now the tracked policy and learned ontology file; private capsules, indexes, DuckDB, source snapshots, and runtime state remain ignored.

## Changes

- `opensymphony memory init` creates `.opensymphony/memory/memory.yaml`, updates `.gitignore`, and seeds stable areas from existing top-level `docs/*.md` files only. It still works in repos with no docs.
- `opensymphony init` now runs memory initialization automatically, and target-repo `opensymphony update` initializes or repairs memory config and `.gitignore` policy when needed.
- Capture evolves `memory.yaml` from Linear and PR narrative evidence: issue title/body, labels, milestone, parent/children, active Workpad, PR title/body, review text, and check summaries.
- GitHub changed files are fetched and indexed for later lookup, but do not infer areas and are not rendered into capsules or public docs.
- `source_refs` replaces ambiguous provenance language and records Linear issue/parent/children/milestone/Workpad ids, GitHub PRs, changed-file metadata, and merge SHA metadata in capsules/indexes.
- The tracked `memory.yaml` intentionally keeps only compact policy and area structure; per-issue and per-PR inventories stay in capsules and DuckDB.
- `memory sync-docs` writes stable configured topics by default and prints stat-style summaries instead of raw diffs; `--dry-run` prints the same summary without writing.
- `opensymphony run` now supports repo-level memory automation via `config.yaml`: `memory.auto_capture` defaults on and `memory.auto_archive` defaults off. It fails fast if auto-capture is enabled but `.opensymphony/memory/memory.yaml` is missing.
- Auto-capture reuses the same live capture/write paths as the CLI, updates indexes, evolves config, syncs stable docs, and records blocked or low-confidence captures in local status logs plus a managed Linear overview section when project-content updates are available.
- Auto-capture now tracks capture, docs sync, and optional archive completion separately, so the run loop retries terminal issues until every enabled memory step finishes.
- Archive eligibility now treats a missing matched GitHub PR as non-blocking evidence, so Linear-only issues can still be captured and archived without `--force`.
- Generated stable topic docs and the tracked memory ontology are committed, and the crate version is bumped to `1.5.0` for release.

## Evidence

### Linear recovery

Verified Linear supports `issueUnarchive`, then unarchived the requested issues and the full parent/child closure. Final verification reported no remaining archived issues in the closure.

```text
COE-252, COE-253, COE-254, COE-255, COE-256, COE-258, COE-259,
COE-260, COE-261, COE-262, COE-263, COE-264, COE-265, COE-266,
COE-267, COE-268, COE-269, COE-270, COE-271, COE-272, COE-273,
COE-274, COE-277, COE-280, COE-281, COE-282, COE-284, COE-287,
COE-294, COE-382, COE-383, COE-384, COE-385, COE-386, COE-387
```

### Real COE-252 capture

```text
$ cargo run -- memory capture COE-252
Wrote 4 capsule(s).
- /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/issues/COE-252.md
- /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/issues/COE-258.md
- /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/issues/COE-259.md
- /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/issues/COE-260.md
Updated DuckDB index: /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/memory.duckdb
Updated markdown index: /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/indexes/index.md
Updated markdown index: /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/indexes/log.md
Updated milestone node: /Users/magos/dev/kumanday/OpenSymphony/.opensymphony/memory/milestones/m1-foundation-and-contracts.md

Warnings:
- no GitHub PR source was matched
```

### Generated tracked `memory.yaml` excerpt

```yaml
memory_root: .opensymphony/memory
visibility: private
index_path: .opensymphony/memory/memory.duckdb
confidence_threshold: 75
source_snapshots: hashes
markdown_indexes: true
docs:
  public_root: docs
  default_visibility: public
  deny_private_links: true
areas:
  architecture:
    title: Architecture
    docs_target: docs/architecture.md
    visibility: public
    status: stable
    confidence: 85
    aliases:
    - Architecture
    source_refs:
      docs:
      - docs/architecture.md
  cli:
    title: Cli
    docs_target: docs/cli.md
    visibility: public
    status: stable
    confidence: 85
    aliases:
    - Cli
    source_refs:
      docs:
      - docs/cli.md
```

The committed config is 319 lines and contains no `linear_issues`, `github_prs`, `COE-*`, or `#83` entries. Captured issue/PR inventory remains in capsules and DuckDB.

### Sanitized child capsule excerpt

```yaml
issue: COE-258
title: Bootstrap workspace and crate boundaries
state: Done
milestone: 'M1: Foundation and contracts'
parent:
  issue: COE-252
  title: Foundation and Contracts
areas:
- configuration
- implementation-plan
- repository-layout
source_refs:
  linear_issue: linear:COE-258
  linear_parent: linear:COE-252
  linear_milestone: linear:project-milestone:1dfca048-68bf-4aac-8721-3def8a52d8db
```

Rendered relationship/body excerpt:

```text
# COE-258: Bootstrap workspace and crate boundaries

## Relationships

- Parent: [[COE-252|COE-252: Foundation and Contracts]]
- Milestone: [[milestones/m1-foundation-and-contracts|M1: Foundation and contracts]]

## Documentation impact

- docs/configuration.md
- docs/implementation-plan.md
- docs/repository-layout.md
```

### `sync-docs` stat output

```text
$ cargo run -- memory sync-docs --since-last-sync --dry-run
# Docs Sync Summary

Selected issues: COE-252, COE-258, COE-259, COE-260

## Architecture (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/architecture.md | 195 -> 230 lines, +35 -0

## Configuration (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/configuration.md | 266 -> 298 lines, +32 -0

## Development Guide (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/DEVELOPMENT.md | 154 -> 183 lines, +29 -0

## Implementation Plan (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/implementation-plan.md | 181 -> 213 lines, +32 -0

## Repository Layout (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/repository-layout.md | 146 -> 178 lines, +32 -0

## Symphony Spec Alignment (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/symphony-spec-alignment.md | 234 -> 266 lines, +32 -0

## Testing (update)
/Users/magos/dev/kumanday/OpenSymphony/docs/testing-and-operations.md | 359 -> 391 lines, +32 -0
```

### Latest review-hardening checks

```text
cargo fmt && cargo clippy --all-targets -- -D warnings
cargo test --workspace --no-fail-fast
cargo metadata --no-deps --format-version 1  # 1.5.0
git diff --check
wc -l .opensymphony/memory/memory.yaml        # 319
rg -n "linear_issues|github_prs|#83|COE-" .opensymphony/memory/memory.yaml
```

All commands above passed; the `rg` check returned no matches.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

This replaces the same-day manual docs-mapping workflow from the earlier PR revision. It is not expected to break production users because the memory system has not been released in production yet.

## Related issues

Follow-up to the project memory capture/docs sync rollout and testing feedback.
