### PR TITLE
docs: gateway inventory, domain vocabulary, and DTO boundary checklist (COE-389)

### DIFF
--- a/docs/domain-vocabulary-and-id-mapping.md
+++ b/docs/domain-vocabulary-and-id-mapping.md
@@ -162,7 +162,8 @@ Events that flow through the system use these entity references:
 
 ```text
 ControlPlaneRecentEvent
-├── issue_identifier: String (e.g. "COE-389")
+├── happened_at: DateTime<Utc>
+├── issue_identifier: Option<String> (e.g. "COE-389")
 ├── kind: enum
 └── summary: String
 

--- a/docs/domain-vocabulary-and-id-mapping.md
+++ b/docs/domain-vocabulary-and-id-mapping.md
@@ -1,0 +1,188 @@
+# Domain Vocabulary and ID Mapping
+
+> Defines the public vocabulary (`Project`, `Milestone`, `Issue`, `SubIssue`, `Run`, `Workspace`, `HarnessSession`, `TerminalSession`, `PlanningSession`, `Artifact`) and the Linear-to-OpenSymphony ID mapping rules for local and hosted modes. Consistent with `docs/hosted-client-PRD.md` and `PRODUCT.md`.
+
+## 1. Vocabulary
+
+### 1.1 `Project`
+
+A Linear project combined with a repository execution scope managed by OpenSymphony.
+
+- **Linear mapping**: `Linear Project` (via `project_slug` in workflow config).
+- **OpenSymphony representation**: Not yet a first-class tracked entity; currently implied by workflow `project_slug` + repository root.
+- **Future gateway entity**: `Project { id, slug, name, repo_root, milestones[], issues[], created_at, updated_at }`.
+- **ID rule**: In local mode, the project is identified by `project_slug` (e.g. `e7b957855cb7`). In hosted mode, a stable `ProjectId` (UUID) will be minted by the gateway and mapped to the Linear project.
+
+### 1.2 `Milestone`
+
+A Linear project milestone representing a major delivery stage or checkpoint.
+
+- **Linear mapping**: `Linear ProjectMilestone`.
+- **GSD-2 mapping**: GSD-2 milestone / phase-level planning.
+- **OpenSymphony representation**: Currently surfaced through `TrackerProjectMilestone { id, name }` on `TrackerIssue`.
+- **Future gateway entity**: `Milestone { id, project_id, linear_id, name, target_date, issues[], state }`.
+- **ID rule**: Linear milestone UUID is the canonical ID. Gateway may wrap with a local stable ID in hosted mode.
+
+### 1.3 `Issue`
+
+A Linear issue under a milestone. An issue is a demoable vertical capability or deliverable unit.
+
+- **Linear mapping**: `Linear Issue` with `parent_id: null` (top-level under milestone).
+- **GSD-2 mapping**: GSD-2 slice.
+- **OpenSymphony representation**: `NormalizedIssue` in the domain model.
+- **Key fields**: `id` (Linear UUID), `identifier` (e.g. `COE-389`), `title`, `description`, `priority`, `state { id, name, category }`, `branch_name`, `url`, `labels`, `parent_id`, `blocked_by[]`, `sub_issues[]`, `created_at`, `updated_at`.
+- **ID rule**: `IssueId` = Linear issue UUID string (e.g. `lin_389`). `IssueIdentifier` = human-readable ticket key (e.g. `COE-389`). Both are non-empty string wrappers.
+
+### 1.4 `SubIssue`
+
+A Linear sub-issue under an issue. A bounded unit of implementation, validation, documentation, or cleanup that can be assigned to a human or executed by an agent run.
+
+- **Linear mapping**: `Linear Issue` with `parent_id` pointing to the parent issue.
+- **GSD-2 mapping**: GSD-2 task.
+- **OpenSymphony representation**: Same `NormalizedIssue` type; distinguished by `parent_id` being non-null.
+- **In scheduling**: Sub-issues are leaf nodes that can be dispatched directly. Parent issues are blocked until all children reach terminal states.
+- **ID rule**: Same as `Issue` — `IssueId` = Linear UUID, `IssueIdentifier` = ticket key.
+
+### 1.5 `Run`
+
+A specific OpenSymphony attempt to execute a Linear issue or sub-issue through a harness. Includes workspace, conversation/session, events, logs, terminal streams, diffs, validation, outcome, and retry metadata.
+
+- **OpenSymphony representation**: `RunAttempt` in the domain model + `IssueExecution` state machine.
+- **Lifecycle**: `Unclaimed → Claimed → Running → (RetryQueued | Released)`.
+- **Key fields**: `worker_id`, `issue_id`, `issue_identifier`, `workspace_path`, `claimed_at`, `started_at`, `attempt` (`RetryAttempt`), `normal_retry_count`, `turn_count`, `max_turns`.
+- **Outcome**: `WorkerOutcomeRecord` with `outcome` (`succeeded`, `failed`, `timed_out`, `stalled`, `cancelled`), `turn_count`, `summary`, `error`.
+- **ID rule**: A run is identified by the tuple `(worker_id, issue_id, attempt)`. No standalone run UUID exists yet; runs are nested under `IssueExecution`.
+- **Future gateway entity**: `Run { id, issue_id, attempt, worker_id, workspace_id, harness_session_id, state, started_at, finished_at, outcome, events[], diffs[], files[], validation_results[] }`.
+
+### 1.6 `Workspace`
+
+A deterministic per-issue filesystem workspace with lifecycle hooks (create, update, cleanup).
+
+- **OpenSymphony representation**: `WorkspaceRecord`.
+- **Key fields**: `path` (absolute filesystem path), `workspace_key` (sanitized issue identifier), `created_now`, `created_at`, `updated_at`, `last_seen_tracker_refresh_at`.
+- **Sanitization**: `sanitize_workspace_key` replaces non-alphanumeric/`.`/`_`/` -` chars with `_`.
+- **Local mode**: Physical directory under `workspace_root` (e.g. `/tmp/opensymphony/COE-389`).
+- **Hosted mode**: Abstract workspace reference; actual path resolved by server-side isolation layer (container, VM, or managed sandbox).
+- **ID rule**: `WorkspaceKey` = sanitized issue identifier. In hosted mode, a gateway-assigned `WorkspaceId` (UUID) will wrap the key.
+
+### 1.7 `HarnessSession`
+
+A live coding-agent conversation/session managed by an external harness (initially OpenHands agent-server).
+
+- **OpenSymphony representation**: `ConversationMetadata` in the domain model.
+- **Initial harness**: OpenHands agent-server.
+- **Future harnesses**: Codex app-server, Rust-native SDK, in-process harnesses.
+- **Key fields**: `conversation_id`, `server_base_url`, `transport_target`, `http_auth_mode`, `websocket_auth_mode`, `websocket_query_param_name`, `fresh_conversation`, `runtime_contract_version`, `stream_state`, `last_event_id`, `last_event_kind`, `last_event_at`, `last_event_summary`, `recent_activity[]`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `total_tokens`, `runtime_seconds`.
+- **Stream states**: `Detached → Attaching → Ready → Reconnecting → Closed | Failed`.
+- **ID rule**: `ConversationId` = harness-assigned string (e.g. OpenHands conversation UUID). In hosted mode, gateway mints a `HarnessSessionId` that maps to the harness conversation.
+
+### 1.8 `TerminalSession`
+
+A bounded stream of terminal/log output produced by the harness during a run.
+
+- **Current representation**: Not a standalone entity. Terminal output is part of `EventEnvelope` payloads (e.g. `ObservationEvent` with `tool_name: "terminal"`).
+- **Future gateway entity**: `TerminalSession { id, run_id, harness_session_id, frames[], scrollback, state }`.
+- **Stream behavior**: High-throughput, bounded, replayable with cursor. Separated from control events in the gateway stream design.
+- **ID rule**: Derived from `Run.id + "terminal"` or gateway-assigned `TerminalSessionId`.
+
+### 1.9 `PlanningSession`
+
+A collaborative human-AI workspace for project intake, analysis, and task decomposition that produces Linear milestones, issues, and sub-issues.
+
+- **Scope**: Out of scope for COE-389 implementation; vocabulary definition only.
+- **Future gateway entity**: `PlanningSession { id, project_id, state, artifacts[], milestones_draft[], issues_draft[], human_approval_status, created_at, updated_at }`.
+- **ID rule**: Gateway-assigned `PlanningSessionId` (UUID).
+
+### 1.10 `Artifact`
+
+A persistent output produced during a run or planning session: file changes, diffs, logs, validation results, screenshots, or planning documents.
+
+- **Current representation**: `ControlPlaneFileChange { path, change_kind, lines_added, lines_removed }` in the control-plane snapshot.
+- **Future gateway entity**: `Artifact { id, run_id, kind, path, url, size, created_at }`.
+- **Kinds**: `file_change`, `diff`, `log`, `validation_result`, `screenshot`, `plan_document`.
+- **ID rule**: Gateway-assigned `ArtifactId` (UUID). In local mode, physical path serves as implicit ID.
+
+## 2. Linear-to-OpenSymphony ID Mapping
+
+### 2.1 Local mode
+
+| Linear Entity | OpenSymphony Domain Type | Mapping Rule |
+|:--------------|:-------------------------|:-------------|
+| `Project` (slugId) | implied by workflow | `project_slug` string in workflow config |
+| `ProjectMilestone` (id, name) | `TrackerProjectMilestone` | Linear UUID → `id`, name passthrough |
+| `Issue` (id, identifier) | `NormalizedIssue` | Linear UUID → `IssueId`, ticket key → `IssueIdentifier` |
+| `Issue` parent_id | `NormalizedIssue.parent_id` | Linear parent UUID → `Option<IssueId>` |
+| `Issue` state | `IssueState` | Linear state id → `TrackerStateId` (optional), name passthrough, category derived from workflow `active_states` / `terminal_states` |
+| `Issue` sub_issues | `NormalizedIssue.sub_issues: Vec<IssueRef>` | Each child mapped to `IssueRef { id, identifier, state }` |
+| `Issue` blocked_by | `NormalizedIssue.blocked_by: Vec<BlockerRef>` | Blocker id, identifier, state name |
+| `Issue` branch_name | `NormalizedIssue.branch_name` | Linear branch_name (if set) or derived from identifier |
+
+### 2.2 Hosted mode (future)
+
+| OpenSymphony Entity | Mapping Rule |
+|:--------------------|:-------------|
+| `Project` | Gateway mints `ProjectId` (UUID). Maps to Linear `project_slug` via project configuration table. |
+| `Milestone` | Gateway mints `MilestoneId` (UUID). Maps to Linear `ProjectMilestone.id`. |
+| `Issue` / `SubIssue` | Reuses Linear `IssueId` (UUID) as primary key. `IssueIdentifier` remains human-readable. Gateway adds `ProjectId` and `MilestoneId` foreign keys for fast graph queries. |
+| `Run` | Gateway mints `RunId` (UUID). Foreign keys: `issue_id`, `workspace_id`, `harness_session_id`. |
+| `Workspace` | Gateway mints `WorkspaceId` (UUID). Maps to `WorkspaceKey` (sanitized issue identifier). Physical path is server-side private. |
+| `HarnessSession` | Gateway mints `HarnessSessionId` (UUID). Maps to harness-specific `ConversationId`. |
+| `TerminalSession` | Derived from `RunId` or gateway-minted `TerminalSessionId`. |
+| `PlanningSession` | Gateway mints `PlanningSessionId` (UUID). Foreign key: `project_id`. |
+| `Artifact` | Gateway mints `ArtifactId` (UUID). Foreign key: `run_id` or `planning_session_id`. URL is gateway-served. |
+
+### 2.3 ID stability rules
+
+1. **Linear IDs are immutable**: Once an issue is created in Linear, its UUID (`IssueId`) never changes. OpenSymphony treats this as the stable primary key.
+2. **Issue identifiers are mutable in display**: Linear allows identifier reuse/reassignment. OpenSymphony uses `IssueId` for all internal references and `IssueIdentifier` only for human display and workspace key derivation.
+3. **Workspace keys are derived from issue identifiers**: `WorkspaceKey::new(issue.identifier.as_str())`. If the identifier changes, the workspace key must be migrated or remapped.
+4. **Runs are not globally unique yet**: In the current model, runs are scoped to `IssueExecution`. A future gateway will mint `RunId` UUIDs.
+5. **Sequences, not IDs, for ordering**: `SnapshotEnvelope.sequence` and `EventEnvelope` timestamps provide ordering. Do not assume ID ordering.
+
+## 3. Taxonomy consistency with PRD
+
+The PRD (`docs/hosted-client-PRD.md`) defines the user-facing taxonomy. The mapping to current code is:
+
+| PRD Concept | Current Code Type | Location |
+|:------------|:------------------|:---------|
+| `Project` | Implied by workflow `project_slug` | `opensymphony_workflow::ResolvedWorkflow` |
+| `Milestone` | `TrackerProjectMilestone` | `opensymphony-domain::tracker::TrackerProjectMilestone` |
+| `Issue` | `NormalizedIssue` | `opensymphony-domain::issue::NormalizedIssue` |
+| `SubIssue` | `NormalizedIssue` with `parent_id` set | `opensymphony-domain::issue::NormalizedIssue` |
+| `Run` | `RunAttempt` + `IssueExecution` | `opensymphony-domain::runtime::RunAttempt`, `opensymphony-domain::state_machine::IssueExecution` |
+| `Workspace` | `WorkspaceRecord` | `opensymphony-domain::runtime::WorkspaceRecord` |
+| `HarnessSession` | `ConversationMetadata` | `opensymphony-domain::runtime::ConversationMetadata` |
+| `TerminalSession` | Part of `EventEnvelope` payload | `opensymphony-openhands::models::EventEnvelope` |
+| `PlanningSession` | Not yet implemented | Future gateway entity |
+| `Artifact` | `ControlPlaneFileChange` | `opensymphony-domain::control_plane::ControlPlaneFileChange` |
+
+## 4. Event reference schema
+
+Events that flow through the system use these entity references:
+
+```text
+ControlPlaneRecentEvent
+├── issue_identifier: String (e.g. "COE-389")
+├── kind: enum
+└── summary: String
+
+ConversationActivityEvent
+├── event_id: String
+├── happened_at: TimestampMs
+├── kind: String (harness event kind)
+└── summary: String
+
+EventEnvelope (OpenHands runtime)
+├── id: String
+├── timestamp: DateTime<Utc>
+├── source: String
+├── kind: String
+├── payload: serde_json::Value
+├── key: Option<String>
+└── value: Option<serde_json::Value>
+```
+
+Future gateway event journal will add:
+- `sequence: u64` (global monotonic sequence)
+- `correlation_id: String` (links action request to resulting events)
+- `entity_ref: EntityRef { kind, id }`

--- a/docs/gateway-api-inventory.md
+++ b/docs/gateway-api-inventory.md
@@ -85,8 +85,8 @@
   "http_auth_mode": "none",
   "websocket_auth_mode": "none",
   "websocket_query_param_name": null,
-  "recent_events": [],
-  "modified_files": [],
+  // "recent_events"   — omitted when empty (#[serde(skip_serializing_if = "Vec::is_empty")])
+  // "modified_files"  — omitted when empty (#[serde(skip_serializing_if = "Vec::is_empty")])
   "input_tokens": 1024,
   "output_tokens": 512,
   "cache_read_tokens": 256

--- a/docs/gateway-api-inventory.md
+++ b/docs/gateway-api-inventory.md
@@ -1,0 +1,419 @@
+# Current Gateway API Inventory
+
+> Inventory of the existing OpenSymphony control plane, orchestrator surfaces, and runtime contracts. This document captures repo paths and representative payload shapes as of the current codebase. It is the deliverable for `P0.1` in `docs/host-client-implementation_plan.md`.
+
+## 1. Control Plane Server (`crates/opensymphony-control`)
+
+### 1.1 Endpoints
+
+| Method | Path | Handler | Response Type | File |
+|:------:|:-----|:--------|:--------------|:-----|
+| `GET`  | `/healthz` | `health` | `HealthResponse` | `crates/opensymphony-control/src/lib.rs:121` |
+| `GET`  | `/api/v1/snapshot` | `snapshot` | `SnapshotEnvelope` | `crates/opensymphony-control/src/lib.rs:131` |
+| `GET`  | `/api/v1/events` | `events` | SSE stream (`Event`) | `crates/opensymphony-control/src/lib.rs:135` |
+
+### 1.2 `HealthResponse` shape
+
+```json
+{
+  "status": "ok",
+  "current_sequence": 42,
+  "published_at": "2026-03-21T20:00:00Z",
+  "issue_count": 3
+}
+```
+
+### 1.3 `SnapshotEnvelope` shape
+
+```json
+{
+  "sequence": 42,
+  "published_at": "2026-03-21T20:00:00Z",
+  "snapshot": { /* ControlPlaneDaemonSnapshot */ }
+}
+```
+
+### 1.4 `ControlPlaneDaemonSnapshot` shape
+
+```json
+{
+  "generated_at": "2026-03-21T20:00:00Z",
+  "daemon": {
+    "state": "ready",
+    "last_poll_at": "2026-03-21T20:00:00Z",
+    "workspace_root": "/tmp/opensymphony",
+    "status_line": "poll=1000ms, running=1, retry_queue=0"
+  },
+  "agent_server": {
+    "reachable": true,
+    "base_url": "http://127.0.0.1:3000",
+    "conversation_count": 2,
+    "status_line": "healthy"
+  },
+  "metrics": {
+    "running_issues": 1,
+    "retry_queue_depth": 0,
+    "input_tokens": 2048,
+    "output_tokens": 2048,
+    "cache_read_tokens": 512,
+    "total_tokens": 4096,
+    "total_cost_micros": 120000
+  },
+  "issues": [ /* ControlPlaneIssueSnapshot[] */ ],
+  "recent_events": [ /* ControlPlaneRecentEvent[] */ ]
+}
+```
+
+### 1.5 `ControlPlaneIssueSnapshot` shape
+
+```json
+{
+  "identifier": "COE-255",
+  "title": "Observability and FrankenTUI",
+  "tracker_state": "In Progress",
+  "runtime_state": "running",
+  "last_outcome": "running",
+  "last_event_at": "2026-03-21T20:00:00Z",
+  "conversation_id_suffix": "c0e255",
+  "workspace_path_suffix": "COE-255",
+  "retry_count": 0,
+  "blocked": false,
+  "server_base_url": "http://127.0.0.1:3000",
+  "transport_target": "loopback",
+  "http_auth_mode": "none",
+  "websocket_auth_mode": "none",
+  "websocket_query_param_name": null,
+  "recent_events": [],
+  "modified_files": [],
+  "input_tokens": 1024,
+  "output_tokens": 512,
+  "cache_read_tokens": 256
+}
+```
+
+### 1.6 `ControlPlaneRecentEvent` shape
+
+```json
+{
+  "happened_at": "2026-03-21T20:00:00Z",
+  "issue_identifier": "COE-255",
+  "kind": "snapshot_published",
+  "summary": "published step 1"
+}
+```
+
+### 1.7 SSE Stream behavior
+
+- Server-sent events via `async_stream::stream!` + `axum::response::sse::Sse`.
+- Event type: `snapshot`.
+- Event `id`: sequence number as string.
+- Keepalive interval: 15 seconds (`: keepalive\n\n`).
+- Stream attach timeout: 5 seconds.
+- Stream read timeout: 35 seconds.
+- Lagged receivers fast-forward to latest snapshot instead of draining backlog.
+- Deduplication by sequence number on the client.
+
+### 1.8 Control Plane Client
+
+- `ControlPlaneClient::new(base_url)` — `fetch_snapshot()` + `stream_updates()`.
+- Path-prefixed base URLs supported (e.g. `http://host/opensymphony`).
+- Configurable timeouts via `with_timeouts()`.
+
+## 2. Domain DTOs (`crates/opensymphony-domain`)
+
+### 2.1 Public control-plane types (`src/control_plane.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `SnapshotEnvelope` | Versioned snapshot wrapper with sequence + timestamp | `src/control_plane.rs:5` |
+| `ControlPlaneDaemonSnapshot` | Top-level daemon + metrics + issues + events | `src/control_plane.rs:12` |
+| `ControlPlaneDaemonStatus` | Daemon state, last poll, workspace root, status line | `src/control_plane.rs:28` |
+| `ControlPlaneDaemonState` | Enum: `starting`, `ready`, `degraded`, `stopped` | `src/control_plane.rs:37` |
+| `ControlPlaneAgentServerStatus` | Reachability, base URL, conversation count | `src/control_plane.rs:45` |
+| `ControlPlaneMetricsSnapshot` | Token counts, cost micros, queue depth | `src/control_plane.rs:53` |
+| `ControlPlaneIssueSnapshot` | Per-issue public runtime view | `src/control_plane.rs:64` |
+| `ControlPlaneIssueRuntimeState` | Enum: `idle`, `running`, `retry_queued`, `releasing`, `completed`, `failed` | `src/control_plane.rs:123` |
+| `ControlPlaneWorkerOutcome` | Enum: `unknown`, `running`, `continued`, `completed`, `failed`, `canceled` | `src/control_plane.rs:134` |
+| `ControlPlaneRecentEvent` | Timestamped event with issue ref and kind | `src/control_plane.rs:143` |
+| `ControlPlaneRecentEventKind` | Enum: `worker_started`, `workspace_prepared`, `stream_attached`, `snapshot_published`, `worker_completed`, `retry_scheduled`, `client_attached`, `client_detached`, `warning` | `src/control_plane.rs:153` |
+| `ControlPlaneConversationEvent` | Per-conversation activity event | `src/control_plane.rs:98` |
+| `ControlPlaneFileChange` | Path, kind, lines added/removed | `src/control_plane.rs:106` |
+| `ControlPlaneFileChangeKind` | Enum: `created`, `modified`, `removed` | `src/control_plane.rs:115` |
+
+### 2.2 Identifiers (`src/identifiers.rs`)
+
+| Type | Kind | File |
+|:-----|:-----|:-----|
+| `ConversationId` | String wrapper | `src/identifiers.rs:59` |
+| `IssueId` | String wrapper | `src/identifiers.rs:60` |
+| `IssueIdentifier` | String wrapper | `src/identifiers.rs:61` |
+| `TrackerStateId` | String wrapper | `src/identifiers.rs:62` |
+| `WorkerId` | String wrapper | `src/identifiers.rs:63` |
+| `WorkspaceKey` | Sanitized string (`sanitize_workspace_key`) | `src/identifiers.rs:67` |
+
+### 2.3 Runtime types (`src/runtime.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `WorkspaceRecord` | Path, key, created/updated timestamps | `src/runtime.rs:11` |
+| `RetryAttempt` | Non-zero u32 attempt ordinal | `src/runtime.rs:22` |
+| `RuntimeStreamState` | Enum: `detached`, `attaching`, `ready`, `reconnecting`, `closed`, `failed` | `src/runtime.rs:74` |
+| `ConversationMetadata` | Full harness session metadata + token counts + recent_activity | `src/runtime.rs:83` |
+| `ConversationActivityEvent` | Per-activity event (id, timestamp, kind, summary) | `src/runtime.rs:118` |
+| `RetryPolicy` | Continuation / failure delays + max backoff | `src/runtime.rs:170` |
+| `RetryReason` | Enum: `continuation`, `failure`, `stalled`, `cancelled`, `reconciliation` | `src/runtime.rs:201` |
+| `RetryEntry` | Scheduled retry with issue ref, attempt, due time | `src/runtime.rs:210` |
+| `RunAttempt` | Worker claim: id, issue, path, claimed/started timestamps, turns | `src/runtime.rs:269` |
+| `StallMetadata` | Last activity + stall timeout + stalled_at | `src/runtime.rs:322` |
+| `WorkerOutcomeKind` | Enum: `succeeded`, `failed`, `timed_out`, `stalled`, `cancelled` | `src/runtime.rs:348` |
+| `WorkerOutcomeRecord` | Outcome with worker, attempt, timestamps, turns, summary, error | `src/runtime.rs:358` |
+| `ReleaseReason` | Enum: `completed`, `tracker_inactive`, `tracker_terminal`, `cancelled`, `retry_exhausted` | `src/runtime.rs:392` |
+
+### 2.4 Snapshot types (`src/snapshot.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `ComponentHealthSnapshot` | Status, detail, updated_at | `src/snapshot.rs:20` |
+| `RuntimeUsageTotals` | Aggregated token/cost/runtime metrics | `src/snapshot.rs:27` |
+| `DaemonSnapshot` | Internal daemon health + counts + usage | `src/snapshot.rs:37` |
+| `WorkerAttemptSnapshot` | Worker id, attempt, retry count, turns, max turns | `src/snapshot.rs:71` |
+| `RetrySnapshot` | Retry attempt, count, schedule/due times, reason, error | `src/snapshot.rs:92` |
+| `RuntimeStateSnapshot` | Scheduler state + claim/start/release times + worker + event/stall | `src/snapshot.rs:115` |
+| `IssueSnapshot` | NormalizedIssue + runtime + workspace + conversation + retry + outcomes | `src/snapshot.rs:188` |
+| `OrchestratorSnapshot` | generated_at + daemon + issues (internal orchestrator output) | `src/snapshot.rs:214` |
+
+### 2.5 Issue types (`src/issue.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `IssueStateCategory` | Enum: `active`, `non_active`, `terminal` | `src/issue.rs:7` |
+| `IssueState` | Optional id, name, category | `src/issue.rs:14` |
+| `BlockerRef` | Blocker id, identifier, state, timestamps | `src/issue.rs:21` |
+| `IssueRef` | Child issue id, identifier, state | `src/issue.rs:30` |
+| `NormalizedIssue` | The canonical issue representation used by the orchestrator | `src/issue.rs:37` |
+
+### 2.6 State machine (`src/state_machine.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `SchedulerStatus` | Enum: `unclaimed`, `claimed`, `running`, `retry_queued`, `released` | `src/state_machine.rs:19` |
+| `TransitionAction` | Enum: `claim`, `start_running`, `record_turn_started`, `observe_runtime_event`, `queue_retry`, `release`, `reopen` | `src/state_machine.rs:47` |
+| `StateTransitionError` | InvalidTransition, AttemptMismatch, IssueMismatch, WorkspaceNotAttached, WorkspaceIssueMismatch, WorkspaceIdentityMismatch, WorkspacePathMismatch, ConversationNotAttached, WorkerMismatch | `src/state_machine.rs:77` |
+| `SchedulerState` | Tagged enum of all scheduler states with details | `src/state_machine.rs:123` |
+| `IssueExecution` | Core orchestrator state machine struct; owns issue, workspace, conversation, state, outcomes | `src/state_machine.rs:156` |
+
+### 2.7 Tracker types (`src/tracker.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `TrackerIssue` | Raw Linear issue with project_milestone, parent, blocked_by, sub_issues | `src/tracker.rs:7` |
+| `TrackerIssueStateSnapshot` | Issue id, identifier, state, updated_at | `src/tracker.rs:30` |
+| `TrackerIssueState` | id, name, tracker_type, kind | `src/tracker.rs:38` |
+| `TrackerIssueBlocker` | Blocker id, identifier, title, state | `src/tracker.rs:53` |
+| `TrackerIssueRef` | Issue id, identifier, optional title/url, state | `src/tracker.rs:67` |
+| `TrackerProjectMilestone` | Milestone id, name | `src/tracker.rs:87` |
+| `TrackerIssueStateKind` | Enum: `backlog`, `unstarted`, `started`, `completed`, `canceled`, `triage`, `unknown(String)` | `src/tracker.rs:93` |
+| `TrackerErrorCategory` | Enum: `auth`, `rate_limited`, `transport`, `timeout`, `invalid_response`, `not_found`, `invalid_state_transition`, `permission_denied` | `src/tracker.rs:124` |
+
+## 3. Orchestrator (`crates/opensymphony-orchestrator`)
+
+### 3.1 Public API surface (`src/scheduler.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `SchedulerConfig` | Poll interval, concurrency, turns, state limits, retry policy, stall timeout, active/terminal states | `src/scheduler.rs:28` |
+| `RecoveryRecord` | Issue + workspace + had_in_flight_run flag | `src/scheduler.rs:93` |
+| `WorkerStartRequest` | Issue + workspace + run | `src/scheduler.rs:100` |
+| `WorkerLaunch` | Conversation metadata returned by harness start | `src/scheduler.rs:107` |
+| `WorkerUpdate` | RuntimeEvent / ConversationMetadataUpdate / Finished | `src/scheduler.rs:113` |
+| `WorkerAbortReason` | TrackerInactive / TrackerTerminal / Stalled | `src/scheduler.rs:132` |
+| `TrackerBackend` | Trait: candidate_issues, terminal_issues, issue_states_by_ids | `src/scheduler.rs:139` |
+| `WorkspaceBackend` | Trait: ensure_workspace, recover_workspaces, cleanup_workspace | `src/scheduler.rs:151` |
+| `WorkerBackend` | Trait: start_worker, start_workers (default), poll_updates, abort_worker | `src/scheduler.rs:170` |
+| `SchedulerError` | InvalidConfiguration, Tracker, Workspace, Worker, StateTransition, RetryCalculation, Identifier | `src/scheduler.rs:198` |
+| `Scheduler<T, W, M>` | Core struct with tracker, workspace, worker, config, executions, running_counts_by_state, worker_index, pending_recovery, recovered, next_worker_ordinal, last_poll_at, health | `src/scheduler.rs:216` |
+
+### 3.2 Scheduler methods
+
+| Method | Visibility | Purpose | File |
+|:-------|:-----------|:--------|:-----|
+| `new` | `pub` | Constructor | `src/scheduler.rs:237` |
+| `config` | `pub` | Immutable config ref | `src/scheduler.rs:254` |
+| `tracker` | `pub` | Immutable tracker ref | `src/scheduler.rs:258` |
+| `tracker_mut` | `pub` | Mutable tracker ref | `src/scheduler.rs:262` |
+| `workspace` | `pub` | Immutable workspace ref | `src/scheduler.rs:266` |
+| `workspace_mut` | `pub` | Mutable workspace ref | `src/scheduler.rs:270` |
+| `worker` | `pub` | Immutable worker ref | `src/scheduler.rs:274` |
+| `worker_mut` | `pub` | Mutable worker ref | `src/scheduler.rs:278` |
+| `executions` | `pub` | Immutable executions map ref | `src/scheduler.rs:282` |
+| `execution` | `pub` | Single execution lookup by IssueId | `src/scheduler.rs:286` |
+| `snapshot` | `pub` | Derives `OrchestratorSnapshot` from current state | `src/scheduler.rs:290` |
+| `bootstrap` | `pub async` | Recovery pass: loads workspaces, reconciles in-flight runs | `src/scheduler.rs:334` |
+| `tick` | `pub async` | Single poll-and-dispatch cycle | `src/scheduler.rs:357` |
+| `run_until_shutdown` | `pub async` | Main loop with interval + shutdown signal | `src/scheduler.rs:393` |
+
+### 3.3 Selection logic (`src/selection.rs`)
+
+| Function | Purpose | File |
+|:---------|:--------|:-----|
+| `issue_blocked_by_non_terminal_blockers` | Checks if any blocker is non-terminal | `src/selection.rs:5` |
+| `parent_issue_blocked_by_incomplete_children` | Checks if any child is non-terminal | `src/selection.rs:12` |
+| `should_dispatch_issue` | Combines blocker + hierarchy checks | `src/selection.rs:23` |
+| `filter_issues_for_dispatch` | Filters + sorts eligible issues | `src/selection.rs:28` |
+| `sort_issues_for_dispatch` | Sorts by priority, then child count, then created_at, then identifier | `src/selection.rs:43` |
+
+## 4. Linear Integration (`crates/opensymphony-linear`)
+
+### 4.1 Public API surface (`src/lib.rs`)
+
+| Type | Purpose | File |
+|:-----|:--------|:-----|
+| `LinearClient` | GraphQL client with retry + auth | `src/lib.rs:6` |
+| `LinearConfig` | API key, base URL, project slug, retry policy | `src/lib.rs:6` |
+| `RetryPolicy` | Backoff parameters for GraphQL requests | `src/lib.rs:6` |
+| `WorkpadComment` | Comment body + optional workpad marker | `src/lib.rs:6` |
+| `GraphqlError` | GraphQL error wrapper | `src/lib.rs:7` |
+| `LinearError` | Unified error enum | `src/lib.rs:7` |
+
+### 4.2 Internal modules
+
+- `client.rs` — HTTP/GraphQL client implementation, pagination, retry.
+- `graphql.rs` — Query/mutation strings and variable builders.
+- `normalize.rs` — Normalization from `TrackerIssue` to `NormalizedIssue`.
+- `error.rs` — Error types and categorization.
+
+## 5. OpenHands Runtime (`crates/opensymphony-openhands`)
+
+### 5.1 Client surface (`src/client.rs` → `src/lib.rs` re-exports)
+
+| Type | Purpose |
+|:-----|:--------|
+| `OpenHandsClient` | REST client for conversation create, send, run, search events |
+| `OpenHandsError` | Client error enum |
+| `OpenHandsProbeResult` | Server readiness probe result |
+| `RuntimeEventStream` | WebSocket event stream wrapper |
+| `RuntimeStreamConfig` | Stream configuration |
+| `TransportConfig` / `TransportAuthKind` / `TransportTargetKind` | Connection routing and auth |
+| `TransportDiagnostics` | Debug/diagnostic info |
+| `ApiKeyAuth` / `HttpAuth` / `WebSocketAuth` / `AuthConfig` | Auth configurations |
+
+### 5.2 Models (`src/models.rs`)
+
+| Type | Purpose |
+|:-----|:--------|
+| `ConversationCreateRequest` | POST /conversation payload (workspace, agent, LLM, max_iterations, etc.) |
+| `ConversationRunRequest` | POST /conversation/{id}/run payload (empty object) |
+| `SendMessageRequest` | POST /conversation/{id}/message payload (role, content[], run flag) |
+| `Conversation` | Response shape with id, workspace, agent, stats, execution_status |
+| `EventEnvelope` | Runtime event with id, timestamp, source, kind, payload, key, value. Custom Serialize/Deserialize for flattened payload. |
+| `SearchConversationEventsResponse` | Paginated event list with next_page_id |
+| `AgentConfig` / `LlmConfig` / `CondenserConfig` / `ToolConfig` / `ConfirmationPolicy` / `WorkspaceConfig` | Agent and model configuration |
+| `DoctorProbeConfig` | Lightweight config for health-check conversations |
+| `TextContent` / `AcceptedResponse` | Message content and generic acceptance |
+| `ConversationStateUpdatePayload` | Execution status + state delta |
+
+### 5.3 Events (`src/events.rs`)
+
+| Type | Purpose |
+|:-----|:--------|
+| `KnownEvent` | Discriminated union: ConversationStateUpdate, LLMCompletionLog, ConversationError, Message, Action, Observation, Unknown |
+| `LlmCompletionLogEvent` | Token usage extraction + model name extraction |
+| `ConversationErrorEvent` | Error payload wrapper |
+| `MessageEventPayload` | Role, content, text preview |
+| `ActionEventPayload` | Action id, tool name, message, arguments |
+| `ObservationEventPayload` | Observation id, tool name, content, text preview, exit code |
+| `UnknownEvent` | Fallback for unrecognized kinds |
+| `EventCache` / `ConversationStateMirror` / `ActivityKind` / `ActivitySummary` / `TerminalExecutionStatus` | Event caching and activity summarization |
+
+### 5.4 Session (`src/session.rs`)
+
+| Type | Purpose |
+|:-----|:--------|
+| `IssueSessionRunner` | Orchestrates a full agent run for an issue: create conversation, send prompt, attach stream, consume events, track state, validate, produce result |
+| `IssueSessionContext` / `IssueConversationManifest` / `ConversationLaunchProfile` | Context and manifest types |
+| `IssueSessionResult` / `IssueSessionError` | Outcome and error enums |
+| `IssueSessionObserver` / `IssueSessionPromptKind` / `IssueSessionReusePolicy` | Observer pattern, prompt kinds, reuse policies |
+| `IssueSessionRunnerConfig` / `LlmConfigFingerprint` / `RUNTIME_CONTRACT_VERSION` | Configuration and versioning |
+| `RehydrationOptions` / `RehydrationResult` | Conversation reset/rehydration |
+| `WorkpadComment` / `WorkpadCommentSource` | Workpad comment types |
+
+### 5.5 Supervisor (`src/supervisor.rs`)
+
+| Type | Purpose |
+|:-----|:--------|
+| `LocalServerSupervisor` | Manages local OpenHands agent-server process lifecycle |
+| `ServerMode` / `ServerState` / `ServerStatus` | Server mode enum, runtime state, status |
+| `SupervisorConfig` / `SupervisedServerConfig` / `ExternalServerConfig` / `ProbeConfig` | Configuration structs |
+| `SupervisorError` / `LaunchOwnership` | Error enum and ownership tracking |
+
+### 5.6 Tooling (`src/tooling.rs`)
+
+| Type | Purpose |
+|:-----|:--------|
+| `LocalServerTooling` | Resolves Python environment, openhands-server package, launch command |
+| `LocalToolingLayout` / `LocalToolingError` / `PinStatus` / `ResolvedLaunch` / `ToolingMetadata` | Path layout, errors, pin status, resolved launch, metadata |
+
+### 5.7 Conversation Store (`src/conversation_store.rs`)
+
+| Type | Purpose |
+|:-----|:--------|
+| `OpenHandsConversationStorePaths` | Path resolution for conversation storage |
+| `ConversationStoreKind` | Store kind enum |
+| `ConversationMoveOutcome` / `ConversationStoreError` / `LocatedConversation` | Move outcomes, errors, located conversations |
+
+## 6. CLI (`crates/opensymphony-cli`)
+
+### 6.1 Commands
+
+| Command | Module | Purpose |
+|:--------|:-------|:--------|
+| `init` | `init_repo.rs` | Initialize repo with workflow, AGENTS.md, .agents/skills |
+| `update` | `update_repo.rs` | Update workflow, skills, AGENTS.md from upstream |
+| `install` | `install_tooling.rs` | Install OpenHands server tooling locally |
+| `run` | `orchestrator_run/` | Start the orchestrator daemon with scheduler, backends, control plane |
+| `tui` | `orchestrator_run/` | Start the FrankenTUI operator interface |
+| `debug` | `debug_session.rs` | Launch a debug conversation for an issue |
+| `memory` | `memory.rs` / `memory_init_summary.rs` | Initialize or update AGENTS.md memory |
+
+### 6.2 Snapshot mapping (`orchestrator_run/snapshot.rs`)
+
+- `map_snapshot()` converts `OrchestratorSnapshot` → `ControlPlaneDaemonSnapshot`.
+- `map_issue()` converts `Domain IssueSnapshot` → `ControlPlaneIssueSnapshot`.
+- `map_worker_outcome()` maps `WorkerOutcomeKind` → `ControlPlaneWorkerOutcome`.
+- `push_recent_event()` maintains a bounded `VecDeque<RecentEvent>` (limit = 24).
+- `terminal_state_set()` derives terminal states from workflow config.
+
+## 7. Event flow summary
+
+```text
+Linear API  ──►  LinearClient  ──►  TrackerBackend
+                                              │
+                                              ▼
+                           NormalizedIssue  ──►  IssueExecution (state machine)
+                                              │
+                                              ▼
+                           OrchestratorSnapshot  ──►  map_snapshot()  ──►  ControlPlaneDaemonSnapshot
+                                              │                                          │
+                                              ▼                                          ▼
+                           SnapshotEnvelope  ──►  SnapshotStore.publish()  ──►  SSE /api/v1/events
+                                              │                                          │
+                                              ▼                                          ▼
+                           ControlPlaneClient.fetch_snapshot() / stream_updates()  ──►  TUI / CLI / future Gateway
+```
+
+## 8. Test coverage summary
+
+| Crate | Test file | What it tests |
+|:------|:----------|:--------------|
+| `opensymphony-control` | `tests/control_plane.rs` | Snapshot fetch, SSE stream, path-prefix routing, timeouts, keepalive behavior |
+| `opensymphony-domain` | `src/lib.rs` (inline) | State transitions, workspace attachment, retry binding, stall detection, snapshot derivation |
+| `opensymphony-orchestrator` | `tests/scheduler.rs` | Scheduler tick, bootstrap, dispatch, retry, cancellation |
+| `opensymphony-orchestrator` | `tests/hierarchy_selection.rs` | Parent/child blocking, terminal state filtering, sort order |
+| `opensymphony-openhands` | `tests/client_resilience.rs` | Client retry, timeout, error handling |
+| `opensymphony-openhands` | `tests/fake_server_contract.rs` | Fake server fixture for create/send/run/search |
+| `opensymphony-openhands` | `tests/issue_session_runner.rs` | Full issue session lifecycle |
+| `opensymphony-openhands` | `tests/live_local_suite.rs` | Live local server integration |
+| `opensymphony-openhands` | `tests/live_pinned_server.rs` | Pinned version contract validation |
+| `opensymphony-openhands` | `tests/supervisor.rs` | Server lifecycle supervision |
+| `opensymphony-openhands` | `tests/transport_config.rs` | Transport routing and auth |
+| `opensymphony-cli` | `tests/debug.rs`, `tests/doctor.rs`, `tests/help.rs`, `tests/init.rs`, `tests/install.rs`, `tests/memory.rs`, `tests/run.rs`, `tests/tui.rs`, `tests/update.rs` | CLI command integration tests |

--- a/docs/gateway-api-inventory.md
+++ b/docs/gateway-api-inventory.md
@@ -1,6 +1,8 @@
 # Current Gateway API Inventory
 
 > Inventory of the existing OpenSymphony control plane, orchestrator surfaces, and runtime contracts. This document captures repo paths and representative payload shapes as of the current codebase. It is the deliverable for `P0.1` in `docs/host-client-implementation_plan.md`.
+>
+> **Note:** File paths and line numbers cited below are approximate and refer to the state of the repository as of this commit. They will drift over time; use the paths as module-level navigation hints rather than exact references.
 
 ## 1. Control Plane Server (`crates/opensymphony-control`)
 

--- a/docs/gateway-dto-boundary-checklist.md
+++ b/docs/gateway-dto-boundary-checklist.md
@@ -1,0 +1,128 @@
+# Gateway DTO Boundary Checklist
+
+> Identifies private orchestrator structs and fields that must not leak into public client contracts, plus the DTO boundaries needed for gateway work. Supports `P0.1` → `P1.1` migration in `docs/host-client-implementation_plan.md`.
+
+## Risk levels
+
+- 🔴 **High**: Private struct/field currently exposed or at high risk of exposure. Must have DTO boundary before any client work.
+- 🟡 **Medium**: Private struct/field used internally but could be derived for gateway. Needs clear mapping decision.
+- 🟢 **Low**: Already a public DTO or clearly internal with no leakage path.
+
+## 1. Orchestrator Scheduler (`crates/opensymphony-orchestrator`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `Scheduler<T, W, M>` | 🔴 | Never expose directly. Gateway uses `OrchestratorSnapshot` only. | `COE-390` (gateway schemas) | Contains generic tracker/workspace/worker backends, mutable state, and `BTreeMap<IssueId, IssueExecution>`. |
+| `Scheduler::executions()` | 🔴 | Remove from public API or return read-only DTOs. | `COE-390` | Currently returns `&BTreeMap<IssueId, IssueExecution>`, giving direct access to mutable orchestrator state machine. |
+| `Scheduler::execution()` | 🔴 | Return gateway `ExecutionSummary` DTO instead of `&IssueExecution`. | `COE-390` | Same risk — exposes internal state machine reference. |
+| `Scheduler::tracker()` / `tracker_mut()` / `workspace()` / `workspace_mut()` / `worker()` / `worker_mut()` | 🔴 | These are backend access methods. Gateway should never expose backend internals. Keep private or move to internal-only trait. | `COE-390` | Needed by CLI/bootstrap code today. Consider `pub(crate)` visibility. |
+| `Scheduler::config()` | 🟡 | `SchedulerConfig` is mostly safe, but `max_concurrent_agents_by_state` is scheduling detail. Gateway can expose a capability subset. | `COE-390` | Map to gateway capability DTO. |
+| `Scheduler::bootstrap()` | 🟢 | Internal only. No gateway exposure. | — | |
+| `Scheduler::tick()` | 🟢 | Internal only. No gateway exposure. | — | |
+| `Scheduler::run_until_shutdown()` | 🟢 | Internal only. No gateway exposure. | — | |
+| `Scheduler::snapshot()` | 🟢 | Already safe — returns `OrchestratorSnapshot` DTO. | — | |
+
+## 2. IssueExecution State Machine (`crates/opensymphony-domain::state_machine`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `IssueExecution` | 🔴 | Never expose directly. Gateway uses `IssueSnapshot` or future `RunSummary` DTOs. | `COE-390` | Mutable state machine with transitions (`claim`, `start_running`, `queue_retry`, `release`, `reopen`). Exposing this to clients breaks orchestrator-owned scheduling invariant. |
+| `IssueExecution::state()` | 🟡 | Currently needed by CLI/snapshot mapping. Return `SchedulerStatus` enum only, not the full tagged enum. | `COE-390` | `SchedulerState` has internal details (`run`, `stall`, `retry`, `released_at`) that belong in `IssueSnapshot`, not in a live ref. |
+| `IssueExecution::conversation()` | 🟡 | Returns `&ConversationMetadata`. Safe as read-only DTO, but mutable `update_conversation()` must remain private. | `COE-390` | Gateway should clone, not reference. |
+| `IssueExecution::workspace()` | 🟡 | Returns `&WorkspaceRecord`. Safe read-only, but `attach_workspace()` must stay private. | `COE-390` | Gateway clones for DTO. |
+| `IssueExecution::retry()` | 🟡 | Returns `&RetryEntry`. Safe read-only. | `COE-390` | |
+| `IssueExecution::current_run()` | 🟡 | Returns `&RunAttempt`. Safe read-only. | `COE-390` | |
+| `IssueExecution::last_worker_outcome()` / `recent_worker_outcomes()` | 🟢 | Read-only accessors. Already safe. | — | |
+| `IssueExecution::snapshot()` | 🟢 | Already safe — returns `IssueSnapshot` DTO. | — | |
+| `SchedulerState` (tagged enum) | 🔴 | Internal state representation. Gateway DTO should use `RuntimeStateSnapshot` instead. | `COE-390` | `SchedulerState::Running { run, stall }` contains live `RunAttempt` and `StallMetadata` that must not escape. |
+| `TransitionAction` | 🟢 | Internal only. Audit logging may expose action names, but the enum itself stays private. | — | |
+| `StateTransitionError` | 🟡 | Error type used by internal transitions. Gateway may need a sanitized error DTO for action rejections. | `COE-390` | Do not expose internal path mismatch details to clients. |
+
+## 3. Runtime types (`crates/opensymphony-domain::runtime`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `RunAttempt` | 🟡 | Struct is mostly data, but `record_turn_started()` is a mutable operation. Gateway DTO should be a clone without methods. | `COE-390` | `RunAttempt` has `mark_started()` and `record_turn_started()`. Gateway should not receive mutable references. |
+| `RetryEntry` | 🟢 | Data-only struct. Safe to expose as DTO. | — | Factory methods (`continuation()`, `failure()`) stay internal. |
+| `ConversationMetadata` | 🟡 | Data-only struct. `observe_event()` and `add_tokens()` are mutable. Gateway should clone and not expose methods. | `COE-390` | This is the primary `HarnessSession` DTO. Will be a key gateway type. |
+| `WorkspaceRecord` | 🟢 | Data-only struct. Safe as DTO. | — | |
+| `StallMetadata` | 🟢 | Data-only struct. Safe as DTO. | — | |
+| `WorkerOutcomeRecord` | 🟢 | Data-only struct. Safe as DTO. | — | |
+| `RetryPolicy` | 🟢 | Data-only struct. Safe as DTO. | — | |
+
+## 4. Snapshot types (`crates/opensymphony-domain::snapshot`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `OrchestratorSnapshot` | 🟢 | Already a clean DTO. Safe for gateway. | — | Gateway should add `api_version` field. |
+| `IssueSnapshot` | 🟢 | Already a clean DTO. Safe for gateway. | — | Contains `NormalizedIssue` + `RuntimeStateSnapshot` + `WorkspaceRecord` + `ConversationMetadata` + `RetrySnapshot` + outcomes. All sub-types are safe. |
+| `DaemonSnapshot` (internal) | 🟡 | Used by `OrchestratorSnapshot`. Safe within the snapshot, but the separate `ControlPlaneDaemonSnapshot` (control-plane version) is what clients see. | `COE-390` | Consider merging or aliasing these two `DaemonSnapshot` types to avoid confusion. |
+| `RuntimeStateSnapshot` | 🟢 | Clean read-only DTO. Safe for gateway. | — | |
+| `WorkerAttemptSnapshot` | 🟢 | Clean read-only DTO. Safe for gateway. | — | |
+| `RetrySnapshot` | 🟢 | Clean read-only DTO. Safe for gateway. | — | |
+| `ComponentHealthSnapshot` | 🟢 | Clean read-only DTO. Safe for gateway. | — | |
+| `RuntimeUsageTotals` | 🟢 | Clean read-only DTO. Safe for gateway. | — | |
+
+## 5. Control Plane types (`crates/opensymphony-domain::control_plane`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `ControlPlaneDaemonSnapshot` | 🟢 | This is the current client-facing DTO. Safe for gateway v1. | — | Will evolve into `DashboardSnapshot` in gateway v1.1. |
+| `SnapshotEnvelope` | 🟢 | Already a clean wrapper with sequence + timestamp. Safe for gateway. | — | Gateway should preserve this envelope pattern for all snapshot types. |
+| `ControlPlaneIssueSnapshot` | 🟢 | Client-facing DTO. Safe for gateway. | — | Note: `conversation_id_suffix` and `workspace_path_suffix` are display fields. Gateway v1.2 may replace with full `ConversationMetadata` and `WorkspaceRecord`. |
+| `ControlPlaneMetricsSnapshot` | 🟢 | Client-facing DTO. Safe for gateway. | — | |
+| `ControlPlaneAgentServerStatus` | 🟢 | Client-facing DTO. Safe for gateway. | — | |
+| `ControlPlaneDaemonStatus` | 🟢 | Client-facing DTO. Safe for gateway. | — | |
+| `ControlPlaneRecentEvent` | 🟢 | Client-facing DTO. Safe for gateway. | — | |
+| `ControlPlaneConversationEvent` | 🟢 | Client-facing DTO. Safe for gateway. | — | |
+| `ControlPlaneFileChange` | 🟢 | Client-facing DTO. Safe for gateway. | — | |
+
+## 6. OpenHands Runtime (`crates/opensymphony-openhands`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `OpenHandsClient` | 🔴 | Never expose to gateway clients. Gateway should abstract harness interactions behind a `HarnessAdapter` trait. | `COE-390` + future harness work | Client has auth credentials, HTTP internals, and stream sockets. |
+| `LocalServerSupervisor` | 🔴 | Never expose to gateway clients. Server lifecycle is orchestrator-private. | `COE-390` + `COE-392` | |
+| `ConversationStore` | 🔴 | Never expose. File system paths and conversation storage are orchestrator-private. | `COE-390` + `COE-392` | |
+| `EventEnvelope` | 🟡 | Raw harness event payload (`serde_json::Value`). Gateway should normalize to a stable event DTO while preserving raw payload references. | `COE-390` | Current `KnownEvent` enum is a good start but is harness-specific. Future gateway needs a harness-agnostic event envelope. |
+| `KnownEvent` | 🟡 | Harness-specific event parsing. Gateway should use a generic event DTO with `kind`, `payload`, and optional `harness_kind` field. | `COE-390` | |
+| `IssueSessionRunner` | 🔴 | Never expose. This is the orchestrator's worker backend implementation. | `COE-390` | |
+| `IssueSessionContext` / `Manifest` / `LaunchProfile` | 🔴 | Orchestrator-private context for launching runs. | `COE-390` | |
+| `RehydrationOptions` / `RehydrationResult` | 🟡 | May become a gateway action input (`RehydrateRun` action), but the internal machinery stays private. | `COE-390` | |
+| `AgentConfig` / `LlmConfig` | 🟡 | Contains `api_key`. Must be redacted in any gateway DTO. | `COE-390` + auth work | Gateway should expose model name, base URL (sanitized), and credential reference — never the raw key. |
+| `TransportConfig` / `AuthConfig` | 🔴 | Contains auth secrets. Never expose. | `COE-390` + auth work | |
+
+## 7. Linear Integration (`crates/opensymphony-linear`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `LinearClient` | 🔴 | Never expose to gateway clients. Linear API key is inside. | `COE-390` + `COE-391` | Gateway may expose `TrackerAdapter` trait with capability discovery, but never the concrete client. |
+| `LinearConfig` | 🟡 | Contains `api_key`. Must be redacted in gateway DTOs. | `COE-390` + auth work | |
+| `GraphqlError` / `LinearError` | 🟡 | Error details may contain sensitive query text. Gateway should sanitize to `TrackerErrorCategory` + message. | `COE-390` | |
+
+## 8. CLI (`crates/opensymphony-cli`)
+
+| Item | Risk | Boundary Required | Owner | Notes |
+|:-----|:----:|:------------------|:------|:------|
+| `ResolvedWorkflow` | 🔴 | Contains `LINEAR_API_KEY` and other secrets. Never expose. | `COE-390` + auth work | |
+| `orchestrator_run::backends` | 🔴 | Backend instantiation is CLI-private. Gateway uses pre-configured adapters. | `COE-390` | |
+| `map_snapshot()` / `map_issue()` | 🟢 | Safe mapping functions. These are the DTO boundary *implementation*. | — | These functions model what the gateway should do: transform `OrchestratorSnapshot` → `ControlPlaneDaemonSnapshot`. |
+
+## 9. Summary: boundary rules for gateway v1
+
+1. **No mutable orchestrator state escapes**: `IssueExecution`, `SchedulerState`, `Scheduler` must never be referenced by the gateway. Only `IssueSnapshot`, `OrchestratorSnapshot`, and derived DTOs may cross the boundary.
+2. **No backend internals escape**: `OpenHandsClient`, `LinearClient`, `LocalServerSupervisor`, backend traits, and transport configs stay orchestrator-private.
+3. **No secrets escape**: `api_key`, `LINEAR_API_KEY`, auth tokens, and credential configs must be redacted or replaced with capability/credential-reference DTOs.
+4. **All client-facing types get `api_version`**: Every snapshot, detail, and event envelope must carry a version field for forward compatibility.
+5. **Raw harness payloads get normalized**: `EventEnvelope` (raw JSON) should be converted to a stable gateway event DTO, with raw payload stored server-side and referenced by ID.
+6. **Action inputs are DTOs, not internal structs**: Gateway actions (retry, cancel, rehydrate, comment) must define their own request DTOs and translate to orchestrator operations internally.
+
+## 10. Follow-up task mapping
+
+| Follow-up | Blocked by | Scope | Acceptance |
+|:----------|:-----------|:------|:-----------|
+| `COE-390` Gateway schemas and stream feasibility | `COE-389` | JSON schemas / Rust DTOs for gateway v1; capability discovery; action receipt framework | Draft schemas + benchmark evidence |
+| `COE-391` Gateway module capabilities and dashboard snapshot | `COE-389`, `COE-390` | Implement `/api/v1/capabilities`, `/api/v1/dashboard/snapshot`, module boundary | Tests + fixture validation |
+| `COE-392` Task graph run detail file and diff read APIs | `COE-389`, `COE-390` | Run detail, event history with cursor, changed files, per-file diffs | API tests + file safety tests |
+| Future: harness abstraction v2 | `COE-390` | Generic `HarnessAdapter` trait; `CodexHarnessAdapter` spike | Interface review + fixture tests |
+| Future: hosted auth and identity | `COE-390`, `COE-391` | Credential storage, redaction, refresh tokens, tenant isolation | Threat model + integration tests |

--- a/docs/gateway-dto-boundary-checklist.md
+++ b/docs/gateway-dto-boundary-checklist.md
@@ -82,8 +82,8 @@
 | Item | Risk | Boundary Required | Owner | Notes |
 |:-----|:----:|:------------------|:------|:------|
 | `OpenHandsClient` | 🔴 | Never expose to gateway clients. Gateway should abstract harness interactions behind a `HarnessAdapter` trait. | `COE-390` + future harness work | Client has auth credentials, HTTP internals, and stream sockets. |
-| `LocalServerSupervisor` | 🔴 | Never expose to gateway clients. Server lifecycle is orchestrator-private. | `COE-390` + `COE-392` | |
-| `ConversationStore` | 🔴 | Never expose. File system paths and conversation storage are orchestrator-private. | `COE-390` + `COE-392` | |
+| `LocalServerSupervisor` | 🔴 | Never expose to gateway clients. Server lifecycle is orchestrator-private. | `COE-390` (gateway schemas / harness abstraction) | |
+| `ConversationStore` | 🔴 | Never expose. File system paths and conversation storage are orchestrator-private. | `COE-390` (gateway schemas / harness abstraction) | |
 | `EventEnvelope` | 🟡 | Raw harness event payload (`serde_json::Value`). Gateway should normalize to a stable event DTO while preserving raw payload references. | `COE-390` | Current `KnownEvent` enum is a good start but is harness-specific. Future gateway needs a harness-agnostic event envelope. |
 | `KnownEvent` | 🟡 | Harness-specific event parsing. Gateway should use a generic event DTO with `kind`, `payload`, and optional `harness_kind` field. | `COE-390` | |
 | `IssueSessionRunner` | 🔴 | Never expose. This is the orchestrator's worker backend implementation. | `COE-390` | |


### PR DESCRIPTION
## Summary\n\nInventory the current OpenSymphony control plane and define the public vocabulary that rich clients, hosted mode, task graph, and planning workflow will share. This is the P0.1 and P0.2 deliverable for the gateway foundation work.\n\n## Changes\n\n- Add docs/gateway-api-inventory.md cataloging current control-plane endpoints, payloads, and runtime surfaces.\n- Add docs/domain-vocabulary-and-id-mapping.md defining Project, Milestone, Issue, SubIssue, Run, Workspace, HarnessSession, TerminalSession, PlanningSession, and Artifact.\n- Add docs/gateway-dto-boundary-checklist.md identifying private orchestrator structs and fields that need DTO boundaries.\n\n## Evidence\n\n### Test output\n\n```\n$ cargo test --lib\n\n... (262 passed; 0 failed; 0 ignored)\n\ntest result: ok. 262 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.40s\n```\n\n### Verification\n\n- All documents are pure additions (no code changes).\n- cargo test --lib passes cleanly with no behavior changes.\n- Documents reviewed against docs/host-client-implementation_plan.md P0.1 and P0.2.\n- Documents reviewed against docs/hosted-client-PRD.md taxonomy definitions.\n- AGENTS.md invariants preserved: orchestrator-owned scheduling state, server-owned harness attachment, UI separation.\n\n## Checklist\n\n- [x] Tests pass (cargo test)\n- [x] Code is formatted (cargo fmt)\n- [x] Clippy is clean (cargo clippy)\n- [x] Documentation updated (if behavior changed)\n- [x] AGENTS.md updated (if repo knowledge changed)\n- [x] Evidence section filled out (for substantive changes)\n\n## Type of change\n\n- [x] Documentation\n\n## Breaking changes\n\nNone\n\n## Related issues\n\n- [COE-390](https://linear.app/trilogy-ai-coe/issue/COE-390/gateway-schemas-and-stream-feasibility)\n- [COE-391](https://linear.app/trilogy-ai-coe/issue/COE-391/gateway-module-capabilities-and-dashboard-snapshot)\n- [COE-392](https://linear.app/trilogy-ai-coe/issue/COE-392/task-graph-run-detail-file-and-diff-read-apis)\n\n## Additional notes\n\nThese documents set the language used by every later task in the rich-client-hosted-mode planning wave. Use Linear-native names for user-facing task graph concepts as specified in the ticket notes.\n