### PR TITLE
COE-394: Frontend workspace and shared schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ tools/openhands-server/workspace/
 !.opensymphony/memory/
 .opensymphony/memory/*
 !.opensymphony/memory/memory.yaml
+
+# Frontend workspace
+node_modules/
+apps/*/dist/
+packages/*/dist/
+*.tsbuildinfo
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Enable workspace resolution for monorepo
+workspace-resolution=enabled

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@opensymphony/desktop",
+  "version": "1.0.0",
+  "description": "OpenSymphony Tauri desktop app shell (stub)",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opensymphony/gateway-schema": "*",
+    "@opensymphony/api-client": "*",
+    "@opensymphony/ui-core": "*",
+    "@opensymphony/state": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Desktop app shell entrypoint (stub).
+ *
+ * This module defines the adapter interface that bridges the Tauri
+ * backend (Rust) to the shared gateway transport layer. The actual
+ * Tauri commands and channels will be implemented in a future ticket.
+ */
+
+import type { GatewayTransport } from "@opensymphony/api-client";
+
+/**
+ * Tauri-specific transport adapter that uses local channels or
+ * loopback HTTP to talk to the OpenSymphony gateway.
+ */
+export interface TauriTransportAdapter extends GatewayTransport {
+  /** Attach to the running local daemon via Tauri IPC. */
+  attach(): Promise<void>;
+}
+
+export function createDesktopTransport(): TauriTransportAdapter {
+  throw new Error("Tauri transport adapter not yet implemented");
+}

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../packages/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@opensymphony/web",
+  "version": "1.0.0",
+  "description": "OpenSymphony browser client shell (stub)",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opensymphony/gateway-schema": "*",
+    "@opensymphony/api-client": "*",
+    "@opensymphony/ui-core": "*",
+    "@opensymphony/state": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Web app shell entrypoint (stub).
+ *
+ * This module defines the adapter interface for the browser client.
+ * Uses authenticated HTTPS/WSS transport to the gateway.
+ */
+
+import type { GatewayTransport } from "@opensymphony/api-client";
+
+/**
+ * Browser transport adapter using WebSocket or SSE.
+ */
+export interface BrowserTransportAdapter extends GatewayTransport {
+  /** Authenticate and establish the transport. */
+  connect(token: string): Promise<void>;
+}
+
+export function createWebTransport(): BrowserTransportAdapter {
+  throw new Error("Browser transport adapter not yet implemented");
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../packages/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,21 @@
+/** @type {import('jest').Config} */
+export default {
+  rootDir: ".",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^@opensymphony/gateway-schema$": "<rootDir>/packages/gateway-schema/src/index.ts",
+    "^@opensymphony/gateway-schema/(.+)$": "<rootDir>/packages/gateway-schema/src/$1",
+  },
+  testMatch: ["**/__tests__/**/*.test.ts"],
+  transformIgnorePatterns: ["/node_modules/"],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,8 +13,7 @@ export default {
   extensionsToTreatAsEsm: [".ts"],
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
-    "^@opensymphony/gateway-schema$": "<rootDir>/packages/gateway-schema/src/index.ts",
-    "^@opensymphony/gateway-schema/(.+)$": "<rootDir>/packages/gateway-schema/src/$1",
+    "^@opensymphony/(.+)$": "<rootDir>/packages/$1/src/index.ts",
   },
   testMatch: ["**/__tests__/**/*.test.ts"],
   transformIgnorePatterns: ["/node_modules/"],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "opensymphony-frontend",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "type-check": "tsc --build tsconfig.projects.json",
+    "lint": "echo 'ESLint configured; run npx eslint apps/ packages/ to check'",
+    "test": "jest --config jest.config.js",
+    "clean": "rm -rf apps/*/dist packages/*/dist"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "eslint": "^9.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@opensymphony/api-client",
+  "version": "1.0.0",
+  "description": "Gateway API client with transport adapters",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsc --build tsconfig.json",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opensymphony/gateway-schema": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -9,6 +9,8 @@ import type {
   TransportProfile,
 } from "@opensymphony/gateway-schema";
 
+export { HttpGatewayTransport } from "./transports.js";
+
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {
   readonly baseUri: string;

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -6,6 +6,7 @@ import type {
   TerminalSnapshot,
   TaskGraphSnapshot,
   GatewayCapabilities,
+  TransportProfile,
 } from "@opensymphony/gateway-schema";
 
 /** Transport adapter interface for all gateway communication. */
@@ -31,5 +32,5 @@ export interface GatewayTransport {
 export interface GatewayTransportConfig {
   baseUri: string;
   authToken?: string;
-  transport?: "websocket" | "sse" | "http";
+  transport?: TransportProfile;
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,35 @@
+import type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  RunDetail,
+  RunEventPage,
+  TerminalSnapshot,
+  TaskGraphSnapshot,
+  GatewayCapabilities,
+} from "@opensymphony/gateway-schema";
+
+/** Transport adapter interface for all gateway communication. */
+export interface GatewayTransport {
+  readonly baseUri: string;
+
+  health(): Promise<GatewayCapabilities>;
+  snapshot(): Promise<DashboardSnapshot>;
+  taskGraph(projectId: string): Promise<TaskGraphSnapshot>;
+  runDetail(runId: string): Promise<RunDetail>;
+  runEvents(runId: string): Promise<RunEventPage>;
+  terminalSnapshot(runId: string, terminalId: string): Promise<TerminalSnapshot>;
+
+  /** Subscribe to gateway event stream; returns an async iterable. */
+  events(): AsyncIterable<GatewayEnvelope>;
+
+  /** Subscribe to terminal frame stream for a run. */
+  terminalFrames(runId: string): AsyncIterable<GatewayEnvelope>;
+
+  close(): Promise<void>;
+}
+
+export interface GatewayTransportConfig {
+  baseUri: string;
+  authToken?: string;
+  transport?: "websocket" | "sse" | "http";
+}

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -1,0 +1,64 @@
+import type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  RunDetail,
+  RunEventPage,
+  TerminalSnapshot,
+  TaskGraphSnapshot,
+  GatewayCapabilities,
+} from "@opensymphony/gateway-schema";
+import type { GatewayTransport, GatewayTransportConfig } from "./index.js";
+
+/**
+ * Placeholder HTTP-based transport adapter.
+ *
+ * Real implementation will use fetch() for REST endpoints and EventSource
+ * for SSE streams. This stub satisfies the interface for type-checking
+ * and allows downstream packages to depend on api-client without errors.
+ */
+export class HttpGatewayTransport implements GatewayTransport {
+  readonly baseUri: string;
+
+  constructor(config: GatewayTransportConfig) {
+    this.baseUri = config.baseUri.replace(/\/+$/, "");
+  }
+
+  async health(): Promise<GatewayCapabilities> {
+    throw new Error("HttpGatewayTransport.health not yet implemented");
+  }
+
+  async snapshot(): Promise<DashboardSnapshot> {
+    throw new Error("HttpGatewayTransport.snapshot not yet implemented");
+  }
+
+  async taskGraph(_projectId: string): Promise<TaskGraphSnapshot> {
+    throw new Error("HttpGatewayTransport.taskGraph not yet implemented");
+  }
+
+  async runDetail(_runId: string): Promise<RunDetail> {
+    throw new Error("HttpGatewayTransport.runDetail not yet implemented");
+  }
+
+  async runEvents(_runId: string): Promise<RunEventPage> {
+    throw new Error("HttpGatewayTransport.runEvents not yet implemented");
+  }
+
+  async terminalSnapshot(
+    _runId: string,
+    _terminalId: string,
+  ): Promise<TerminalSnapshot> {
+    throw new Error("HttpGatewayTransport.terminalSnapshot not yet implemented");
+  }
+
+  async *events(): AsyncIterable<GatewayEnvelope> {
+    throw new Error("HttpGatewayTransport.events not yet implemented");
+  }
+
+  async *terminalFrames(_runId: string): AsyncIterable<GatewayEnvelope> {
+    throw new Error("HttpGatewayTransport.terminalFrames not yet implemented");
+  }
+
+  async close(): Promise<void> {
+    // No-op for HTTP transport.
+  }
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/gateway-schema/README.md
+++ b/packages/gateway-schema/README.md
@@ -1,0 +1,62 @@
+# @opensymphony/gateway-schema
+
+TypeScript types and runtime validators for the OpenSymphony Gateway v1 API.
+
+This package mirrors the Rust `opensymphony-gateway-schema` crate so that
+browser and desktop clients can decode payloads with full type safety.
+
+## Schema modules
+
+| Module | Types |
+|--------|-------|
+| `version` | `SchemaVersion`, `GATEWAY_SCHEMA_VERSION` |
+| `cursor` | `StreamCursor`, `PageCursor` |
+| `envelope` | `GatewayEnvelope`, `EntityRef`, `EntityKind` |
+| `snapshot` | `DashboardSnapshot`, `GatewayHealth`, `GatewayMetrics`, `ProjectSummary`, `SnapshotEventSummary` |
+| `task_graph` | `TaskGraphNode`, `TaskGraphSnapshot`, `TaskGraphNodeKind`, `TaskGraphStateCategory` |
+| `run` | `RunDetail`, `RunEventPage`, `RunEvent`, `RunStatus`, `ReleaseReason` |
+| `terminal` | `TerminalFrame`, `TerminalSnapshot`, `TerminalFrameKind`, `TerminalEncoding` |
+| `approval` | `ApprovalRequest`, `ActionReceipt`, `ApprovalKind`, `ApprovalStatus`, `ActionReceiptStatus` |
+| `planning` | `PlanningArtifact`, `PlanningSessionSummary`, `PlanningArtifactKind`, `PlanningSessionStatus` |
+| `capability` | `GatewayCapabilities`, `TransportCapability`, `FeatureCapability`, `AuthMode` |
+| `action` | `ActionDispatch`, `ActionKind`, `ActionTarget` |
+| `transport` | `TransportRecommendation`, `TransportProfile` |
+| `validation` | Runtime validators for envelopes and schema versions |
+
+## Usage
+
+```typescript
+import { parseGatewayEnvelope, GATEWAY_SCHEMA_VERSION } from "@opensymphony/gateway-schema";
+
+const envelope = parseGatewayEnvelope(rawJsonString);
+console.log(envelope.event_kind);
+console.log(GATEWAY_SCHEMA_VERSION); // "1.0.0"
+```
+
+## Update path
+
+These types are hand-maintained to match the Rust gateway-schema crate.
+When the Rust crate changes:
+
+1.  Open `crates/opensymphony-gateway-schema/src/` and identify changed types.
+2.  Update the matching TypeScript module in `packages/gateway-schema/src/`.
+3.  Update or add JSON fixtures in `packages/gateway-schema/__tests__/fixtures/`.
+4.  Run `npm test` to verify the fixtures still validate.
+5.  Bump the package version and `GATEWAY_SCHEMA_VERSION` if the schema major
+    or minor version changes.
+
+### Generating types from Rust
+
+When possible, use `schemars` or `ts-rs` on the Rust types to generate the
+TypeScript interfaces automatically. Until then, the manual sync process above
+is the documented path.
+
+## Tests
+
+```bash
+npm test --workspace=@opensymphony/gateway-schema
+```
+
+## License
+
+Same license as the OpenSymphony repository.

--- a/packages/gateway-schema/__tests__/fixtures.test.ts
+++ b/packages/gateway-schema/__tests__/fixtures.test.ts
@@ -7,15 +7,18 @@
  */
 
 import { readFileSync } from "node:fs";
-import { resolve, basename } from "node:path";
+import { resolve } from "node:path";
 import {
-  isValidSchemaVersion,
-  assertValidGatewayEnvelope,
-  parseGatewayEnvelope,
-  getGatewaySchemaVersion,
-  assertCompatibleSchemaVersion,
-  isValidGatewayEnvelope,
   GATEWAY_SCHEMA_VERSION,
+  assertCompatibleSchemaVersion,
+  assertValidEnvelopeBatch,
+  assertValidGatewayEnvelope,
+  getGatewaySchemaVersion,
+  isValidGatewayEnvelope,
+  isValidSchemaVersion,
+  parseGatewayEnvelope,
+  schemaVersionFromString,
+  validateEnvelopeBatch,
 } from "@opensymphony/gateway-schema";
 
 const fixturesDir = resolve(__dirname, "fixtures");
@@ -49,6 +52,55 @@ describe("schema version", () => {
     expect(() => assertCompatibleSchemaVersion({ major: 2, minor: 0, patch: 0 })).toThrow(
       /unsupported schema major=2/,
     );
+  });
+
+  test("isValidSchemaVersion rejects NaN values", () => {
+    expect(isValidSchemaVersion({ major: NaN, minor: 0, patch: 0 })).toBe(false);
+    expect(isValidSchemaVersion({ major: 1, minor: Infinity, patch: 0 })).toBe(false);
+  });
+
+  test("schemaVersionFromString parses valid string", () => {
+    expect(schemaVersionFromString("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  test("schemaVersionFromString throws on incomplete string", () => {
+    expect(() => schemaVersionFromString("1.2")).toThrow(/Invalid schema version/);
+  });
+
+  test("schemaVersionFromString throws on non-numeric string", () => {
+    expect(() => schemaVersionFromString("a.b.c")).toThrow(/Invalid schema version/);
+  });
+});
+
+// -- Batch validation tests --
+
+describe("batch validation", () => {
+  const validEnvelope = loadFixture("envelope_terminal_frame.json");
+
+  test("validateEnvelopeBatch returns empty array for all valid", () => {
+    const failed = validateEnvelopeBatch([validEnvelope, validEnvelope]);
+    expect(failed).toEqual([]);
+  });
+
+  test("validateEnvelopeBatch returns indices of invalid envelopes", () => {
+    const batch = [validEnvelope, { bad: true }, validEnvelope, "not an object"];
+    const failed = validateEnvelopeBatch(batch);
+    expect(failed).toEqual([1, 3]);
+  });
+
+  test("validateEnvelopeBatch does not throw", () => {
+    const batch = [validEnvelope, { bad: true }];
+    expect(() => validateEnvelopeBatch(batch)).not.toThrow();
+  });
+
+  test("assertValidEnvelopeBatch throws on failures", () => {
+    const batch = [validEnvelope, { bad: true }];
+    expect(() => assertValidEnvelopeBatch(batch)).toThrow(/failed validation/);
+  });
+
+  test("assertValidEnvelopeBatch passes for all valid", () => {
+    const batch = [validEnvelope, validEnvelope];
+    expect(() => assertValidEnvelopeBatch(batch)).not.toThrow();
   });
 });
 

--- a/packages/gateway-schema/__tests__/fixtures.test.ts
+++ b/packages/gateway-schema/__tests__/fixtures.test.ts
@@ -70,6 +70,10 @@ describe("schema version", () => {
   test("schemaVersionFromString throws on non-numeric string", () => {
     expect(() => schemaVersionFromString("a.b.c")).toThrow(/Invalid schema version/);
   });
+
+  test("schemaVersionFromString throws on extra components", () => {
+    expect(() => schemaVersionFromString("1.2.3.4")).toThrow(/Invalid schema version/);
+  });
 });
 
 // -- Batch validation tests --

--- a/packages/gateway-schema/__tests__/fixtures.test.ts
+++ b/packages/gateway-schema/__tests__/fixtures.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Schema fixture tests.
+ *
+ * Each fixture JSON file is loaded and validated through the runtime
+ * validators to ensure the TypeScript types remain compatible with
+ * the gateway's actual JSON payloads.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, basename } from "node:path";
+import {
+  isValidSchemaVersion,
+  assertValidGatewayEnvelope,
+  parseGatewayEnvelope,
+  getGatewaySchemaVersion,
+  assertCompatibleSchemaVersion,
+  isValidGatewayEnvelope,
+  GATEWAY_SCHEMA_VERSION,
+} from "@opensymphony/gateway-schema";
+
+const fixturesDir = resolve(__dirname, "fixtures");
+
+// Helper to read and parse a fixture file.
+function loadFixture(name: string): unknown {
+  const content = readFileSync(resolve(fixturesDir, name), "utf-8");
+  return JSON.parse(content);
+}
+
+// -- Version tests --
+
+describe("schema version", () => {
+  test("GATEWAY_SCHEMA_VERSION matches v1", () => {
+    expect(GATEWAY_SCHEMA_VERSION).toBe("1.0.0");
+    expect(getGatewaySchemaVersion()).toBe("1.0.0");
+  });
+
+  test("isValidSchemaVersion accepts valid version", () => {
+    expect(isValidSchemaVersion({ major: 1, minor: 0, patch: 0 })).toBe(true);
+  });
+
+  test("isValidSchemaVersion rejects invalid shapes", () => {
+    expect(isValidSchemaVersion("1.0.0")).toBe(false);
+    expect(isValidSchemaVersion({ major: 1 })).toBe(false);
+    expect(isValidSchemaVersion(null)).toBe(false);
+    expect(isValidSchemaVersion(undefined)).toBe(false);
+  });
+
+  test("assertCompatibleSchemaVersion throws on wrong major", () => {
+    expect(() => assertCompatibleSchemaVersion({ major: 2, minor: 0, patch: 0 })).toThrow(
+      /unsupported schema major=2/,
+    );
+  });
+});
+
+// -- Envelope fixture tests --
+
+describe("envelope fixtures", () => {
+  test("terminal_frame envelope validates", () => {
+    const data = loadFixture("envelope_terminal_frame.json");
+    assertValidGatewayEnvelope(data, "envelope_terminal_frame.json");
+    expect(isValidGatewayEnvelope(data)).toBe(true);
+  });
+
+  test("parseGatewayEnvelope parses terminal frame", () => {
+    const raw = readFileSync(resolve(fixturesDir, "envelope_terminal_frame.json"), "utf-8");
+    const envelope = parseGatewayEnvelope(raw);
+    expect(envelope.event_kind).toBe("terminal_frame");
+    expect(envelope.entity_ref.kind).toBe("terminal_session");
+  });
+
+  test("unknown event envelope validates (forward compatibility)", () => {
+    const data = loadFixture("envelope_unknown_event.json");
+    assertValidGatewayEnvelope(data, "envelope_unknown_event.json");
+  });
+
+  test("unknown event preserves raw_payload", () => {
+    const data = loadFixture("envelope_unknown_event.json");
+    assertValidGatewayEnvelope(data);
+    const e = data as Record<string, unknown>;
+    expect(e.raw_payload).toEqual({ unknown_field: 42 });
+  });
+});
+
+// -- Dashboard snapshot fixture --
+
+describe("dashboard snapshot fixture", () => {
+  test("dashboard_snapshot validates schema version", () => {
+    const data = loadFixture("dashboard_snapshot.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+    expect(() => assertCompatibleSchemaVersion(sv)).not.toThrow();
+  });
+
+  test("dashboard_snapshot has expected structure", () => {
+    const data = loadFixture("dashboard_snapshot.json") as Record<string, unknown>;
+    expect(data.health).toBe("healthy");
+    expect(data.sequence).toBe(1);
+    expect(Array.isArray(data.projects)).toBe(true);
+    expect((data.projects as unknown[]).length).toBe(1);
+    expect(Array.isArray(data.recent_events)).toBe(true);
+  });
+});
+
+// -- Task graph node fixture --
+
+describe("task graph node fixture", () => {
+  test("task_graph_node validates schema version", () => {
+    const data = loadFixture("task_graph_node.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("task_graph_node has expected fields", () => {
+    const data = loadFixture("task_graph_node.json") as Record<string, unknown>;
+    expect(data.kind).toBe("issue");
+    expect(data.identifier).toBe("COE-390");
+    expect(data.state_category).toBe("in_progress");
+    expect(Array.isArray(data.children)).toBe(true);
+    expect(Array.isArray(data.blocked_by)).toBe(true);
+    expect(Array.isArray(data.labels)).toBe(true);
+  });
+});
+
+// -- Run detail fixture --
+
+describe("run detail fixture", () => {
+  test("run_detail validates schema version", () => {
+    const data = loadFixture("run_detail.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("run_detail has expected fields", () => {
+    const data = loadFixture("run_detail.json") as Record<string, unknown>;
+    expect(data.status).toBe("running");
+    expect(data.issue_identifier).toBe("COE-390");
+    expect(data.turn_count).toBe(3);
+    expect(data.max_turns).toBe(8);
+  });
+});
+
+// -- Run event page fixture --
+
+describe("run event page fixture", () => {
+  test("run_event_page validates schema version", () => {
+    const data = loadFixture("run_event_page.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("run_event_page has events array", () => {
+    const data = loadFixture("run_event_page.json") as Record<string, unknown>;
+    const events = data.events as Array<Record<string, unknown>>;
+    expect(events.length).toBe(1);
+    expect(events[0].kind).toBe("ConversationStateUpdateEvent");
+    expect(events[0].sequence).toBe(1);
+  });
+});
+
+// -- Terminal frame fixture --
+
+describe("terminal frame fixture", () => {
+  test("terminal_frame validates schema version", () => {
+    const data = loadFixture("terminal_frame.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("terminal_frame has expected fields", () => {
+    const data = loadFixture("terminal_frame.json") as Record<string, unknown>;
+    expect(data.frame_kind).toBe("stdout");
+    expect(data.encoding).toBe("utf8");
+    expect(data.content).toBe("hello world\n");
+  });
+});
+
+// -- Approval fixture --
+
+describe("approval request fixture", () => {
+  test("approval_request validates schema version", () => {
+    const data = loadFixture("approval_request.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("approval_request has expected fields", () => {
+    const data = loadFixture("approval_request.json") as Record<string, unknown>;
+    expect(data.kind).toBe("tool_use");
+    expect(data.status).toBe("pending");
+    expect(data.correlation_id).toBe("corr-1");
+  });
+});
+
+// -- Gateway capabilities fixture --
+
+describe("gateway capabilities fixture", () => {
+  test("gateway_capabilities validates schema version", () => {
+    const data = loadFixture("gateway_capabilities.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("gateway_capabilities has expected structure", () => {
+    const data = loadFixture("gateway_capabilities.json") as Record<string, unknown>;
+    expect(data.gateway_version).toBe("1.6.0");
+    expect(data.max_event_page_size).toBe(1000);
+    expect(Array.isArray(data.auth_modes)).toBe(true);
+  });
+});
+
+// -- Planning artifact fixture --
+
+describe("planning artifact fixture", () => {
+  test("planning_artifact validates schema version", () => {
+    const data = loadFixture("planning_artifact.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("planning_artifact has expected fields", () => {
+    const data = loadFixture("planning_artifact.json") as Record<string, unknown>;
+    expect(data.kind).toBe("milestone_draft");
+    expect(data.approved).toBe(false);
+    expect(data.published_to_tracker).toBe(false);
+  });
+});
+
+// -- Planning session summary fixture --
+
+describe("planning session summary fixture", () => {
+  test("planning_session_summary validates schema version", () => {
+    const data = loadFixture("planning_session_summary.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("planning_session_summary has expected fields", () => {
+    const data = loadFixture("planning_session_summary.json") as Record<string, unknown>;
+    expect(data.status).toBe("draft");
+    expect(data.artifact_count).toBe(3);
+  });
+});
+
+// -- Action dispatch fixture --
+
+describe("action dispatch fixture", () => {
+  test("action_dispatch validates schema version", () => {
+    const data = loadFixture("action_dispatch.json");
+    const sv = (data as Record<string, unknown>).schema_version;
+    expect(isValidSchemaVersion(sv)).toBe(true);
+  });
+
+  test("action_dispatch has expected fields", () => {
+    const data = loadFixture("action_dispatch.json") as Record<string, unknown>;
+    expect(data.action_kind).toBe("retry");
+    expect(data.idempotency_key).toBe("idem-1");
+    const target = data.target_entity as Record<string, unknown>;
+    expect(target.entity_kind).toBe("run");
+    expect(target.entity_id).toBe("run-1");
+  });
+});
+
+// -- Forward compatibility --
+
+describe("forward compatibility", () => {
+  test("envelope with extra unknown fields still validates", () => {
+    const raw = readFileSync(resolve(fixturesDir, "envelope_terminal_frame.json"), "utf-8");
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    // Add extra unknown fields.
+    data.future_field = "something";
+    data.new_payload_v2 = { nested: true };
+    expect(isValidGatewayEnvelope(data)).toBe(true);
+    expect(() => assertValidGatewayEnvelope(data)).not.toThrow();
+  });
+
+  test("schema version minor/patch changes are accepted", () => {
+    expect(() =>
+      assertCompatibleSchemaVersion({ major: 1, minor: 5, patch: 2 }),
+    ).not.toThrow();
+  });
+
+  test("schema version major 2 is rejected", () => {
+    expect(() =>
+      assertCompatibleSchemaVersion({ major: 2, minor: 0, patch: 0 }),
+    ).toThrow(/unsupported schema major=2/);
+  });
+});

--- a/packages/gateway-schema/__tests__/fixtures/action_dispatch.json
+++ b/packages/gateway-schema/__tests__/fixtures/action_dispatch.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "correlation_id": "corr-1",
+  "action_kind": "retry",
+  "target_entity": {
+    "entity_kind": "run",
+    "entity_id": "run-1"
+  },
+  "idempotency_key": "idem-1"
+}

--- a/packages/gateway-schema/__tests__/fixtures/approval_request.json
+++ b/packages/gateway-schema/__tests__/fixtures/approval_request.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "approval_id": "apr-1",
+  "run_id": "run-1",
+  "issue_id": "issue-1",
+  "kind": "tool_use",
+  "title": "Approve file write",
+  "description": "Agent wants to write to src/main.rs",
+  "proposed_action": {"path": "src/main.rs", "content": "fn main() {}"},
+  "requested_at": "2025-01-15T10:00:00Z",
+  "status": "pending",
+  "correlation_id": "corr-1"
+}

--- a/packages/gateway-schema/__tests__/fixtures/dashboard_snapshot.json
+++ b/packages/gateway-schema/__tests__/fixtures/dashboard_snapshot.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "generated_at": "2025-01-15T10:00:00Z",
+  "sequence": 1,
+  "health": "healthy",
+  "metrics": {
+    "running_issue_count": 2,
+    "retry_queue_depth": 0,
+    "total_input_tokens": 1024,
+    "total_output_tokens": 512,
+    "total_cache_read_tokens": 256,
+    "total_cost_micros": 0
+  },
+  "projects": [
+    {
+      "project_id": "proj-1",
+      "name": "OpenSymphony",
+      "milestone_count": 3,
+      "issue_count": 12,
+      "running_count": 2,
+      "completed_count": 5,
+      "failed_count": 0
+    }
+  ],
+  "recent_events": [
+    {
+      "happened_at": "2025-01-15T09:59:00Z",
+      "issue_identifier": "COE-390",
+      "kind": "worker_started",
+      "summary": "Run started"
+    }
+  ]
+}

--- a/packages/gateway-schema/__tests__/fixtures/envelope_terminal_frame.json
+++ b/packages/gateway-schema/__tests__/fixtures/envelope_terminal_frame.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "cursor": {"sequence": 7, "partition": "terminal:run-1", "timestamp_anchor": 1700000000},
+  "entity_ref": {"kind": "terminal_session", "id": "term-1"},
+  "event_kind": "terminal_frame",
+  "payload": {"content": "hello"},
+  "raw_payload": {"content": "hello"},
+  "emitted_at": "2025-01-15T10:00:00Z"
+}

--- a/packages/gateway-schema/__tests__/fixtures/envelope_unknown_event.json
+++ b/packages/gateway-schema/__tests__/fixtures/envelope_unknown_event.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "cursor": {"sequence": 8, "partition": "unknown:run-2"},
+  "entity_ref": {"kind": "run", "id": "run-2"},
+  "event_kind": "future_event",
+  "raw_payload": {"unknown_field": 42},
+  "emitted_at": "2025-01-15T10:01:00Z"
+}

--- a/packages/gateway-schema/__tests__/fixtures/gateway_capabilities.json
+++ b/packages/gateway-schema/__tests__/fixtures/gateway_capabilities.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "gateway_version": "1.6.0",
+  "supported_api_versions": ["1.0.0"],
+  "transports": [
+    {
+      "transport": "websocket",
+      "modes": ["json", "binary"],
+      "supported_encodings": ["utf-8", "base64"],
+      "bidirectional": true
+    }
+  ],
+  "features": [
+    {
+      "feature": "task_graph",
+      "available": true,
+      "requires_auth": false
+    }
+  ],
+  "auth_modes": ["none", "api_key"],
+  "max_event_page_size": 1000,
+  "max_terminal_frame_batch": 500
+}

--- a/packages/gateway-schema/__tests__/fixtures/planning_artifact.json
+++ b/packages/gateway-schema/__tests__/fixtures/planning_artifact.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "artifact_id": "art-1",
+  "session_id": "sess-1",
+  "kind": "milestone_draft",
+  "title": "M1: Gateway Contract",
+  "content": "# Milestone\n\nDraft gateway schemas.",
+  "created_at": "2025-01-15T10:00:00Z",
+  "updated_at": "2025-01-15T10:00:00Z",
+  "generated_by": "planning-agent",
+  "approved": false,
+  "published_to_tracker": false
+}

--- a/packages/gateway-schema/__tests__/fixtures/planning_session_summary.json
+++ b/packages/gateway-schema/__tests__/fixtures/planning_session_summary.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "session_id": "sess-1",
+  "project_id": "proj-1",
+  "title": "Q3 Planning",
+  "status": "draft",
+  "artifact_count": 3,
+  "created_at": "2025-01-15T10:00:00Z",
+  "updated_at": "2025-01-15T10:00:00Z"
+}

--- a/packages/gateway-schema/__tests__/fixtures/run_detail.json
+++ b/packages/gateway-schema/__tests__/fixtures/run_detail.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "run_id": "run-1",
+  "issue_id": "issue-1",
+  "issue_identifier": "COE-390",
+  "worker_id": "worker-1",
+  "status": "running",
+  "claimed_at": "2025-01-15T09:00:00Z",
+  "started_at": "2025-01-15T09:01:00Z",
+  "turn_count": 3,
+  "max_turns": 8,
+  "input_tokens": 1024,
+  "output_tokens": 512,
+  "cache_read_tokens": 256,
+  "runtime_seconds": 120,
+  "conversation_id": "conv-1",
+  "workspace_path": "/tmp/workspaces/COE-390"
+}

--- a/packages/gateway-schema/__tests__/fixtures/run_event_page.json
+++ b/packages/gateway-schema/__tests__/fixtures/run_event_page.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "run_id": "run-1",
+  "events": [
+    {
+      "sequence": 1,
+      "event_id": "evt-1",
+      "happened_at": "2025-01-15T09:01:05Z",
+      "kind": "ConversationStateUpdateEvent",
+      "summary": "ready",
+      "payload": {"execution_status": "ready"},
+      "raw_payload": {"execution_status": "ready"}
+    }
+  ]
+}

--- a/packages/gateway-schema/__tests__/fixtures/task_graph_node.json
+++ b/packages/gateway-schema/__tests__/fixtures/task_graph_node.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "node_id": "node-1",
+  "kind": "issue",
+  "identifier": "COE-390",
+  "title": "Gateway Schemas",
+  "state": "In Progress",
+  "state_category": "in_progress",
+  "priority": 1,
+  "parent_id": "milestone-1",
+  "children": ["sub-1"],
+  "blocked_by": [],
+  "url": "https://linear.app/trilogy-ai-coe/issue/COE-390",
+  "branch_name": "leonardogonzalez/coe-390",
+  "labels": ["foundation", "contracts"],
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-15T10:00:00Z",
+  "estimate_minutes": 300
+}

--- a/packages/gateway-schema/__tests__/fixtures/terminal_frame.json
+++ b/packages/gateway-schema/__tests__/fixtures/terminal_frame.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "frame_sequence": 1,
+  "stream_id": "stream-1",
+  "run_id": "run-1",
+  "terminal_session_id": "term-1",
+  "frame_kind": "stdout",
+  "encoding": "utf8",
+  "content": "hello world\n",
+  "timestamp": "2025-01-15T10:00:00Z"
+}

--- a/packages/gateway-schema/package.json
+++ b/packages/gateway-schema/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@opensymphony/gateway-schema",
+  "version": "1.0.0",
+  "description": "TypeScript gateway schema types aligned with opensymphony-gateway-schema v1",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "src", "__tests__"],
+  "scripts": {
+    "build": "tsc --build tsconfig.json",
+    "type-check": "tsc --noEmit",
+    "test": "jest --passWithNoTests"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/gateway-schema/package.json
+++ b/packages/gateway-schema/package.json
@@ -11,7 +11,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist", "src", "__tests__"],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc --build tsconfig.json",
     "type-check": "tsc --noEmit",

--- a/packages/gateway-schema/src/action.ts
+++ b/packages/gateway-schema/src/action.ts
@@ -1,0 +1,29 @@
+import type { EntityKind } from "./envelope.js";
+import type { SchemaVersion } from "./version.js";
+
+export type ActionKind =
+  | "retry"
+  | "cancel"
+  | "pause"
+  | "resume"
+  | "rehydrate"
+  | "comment"
+  | "transition_issue"
+  | "create_followup"
+  | "approval_decision"
+  | "publish_plan";
+
+export interface ActionTarget {
+  entity_kind: EntityKind;
+  entity_id: string;
+}
+
+/** Action dispatch payload for POST /api/v1/actions/dispatch. */
+export interface ActionDispatch {
+  schema_version: SchemaVersion;
+  correlation_id: string;
+  action_kind: ActionKind;
+  target_entity: ActionTarget;
+  payload?: unknown;
+  idempotency_key?: string;
+}

--- a/packages/gateway-schema/src/approval.ts
+++ b/packages/gateway-schema/src/approval.ts
@@ -1,0 +1,49 @@
+import type { SchemaVersion } from "./version.js";
+
+export type ApprovalKind =
+  | "tool_use"
+  | "file_write"
+  | "command_execution"
+  | "plan_publish"
+  | "custom";
+
+export type ApprovalStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "expired"
+  | "cancelled";
+
+/** Approval request for human-in-the-loop actions. */
+export interface ApprovalRequest {
+  schema_version: SchemaVersion;
+  approval_id: string;
+  run_id: string;
+  issue_id: string;
+  kind: ApprovalKind;
+  title: string;
+  description: string;
+  proposed_action?: unknown;
+  requested_at: string;
+  expires_at?: string;
+  status: ApprovalStatus;
+  correlation_id: string;
+}
+
+export type ActionReceiptStatus =
+  | "accepted"
+  | "rejected"
+  | "queued"
+  | "completed";
+
+/** Action receipt returned after a mutation. */
+export interface ActionReceipt {
+  schema_version: SchemaVersion;
+  action_id: string;
+  correlation_id: string;
+  status: ActionReceiptStatus;
+  reason?: string;
+  expected_events: string[];
+  result?: unknown;
+  issued_at: string;
+}

--- a/packages/gateway-schema/src/capability.ts
+++ b/packages/gateway-schema/src/capability.ts
@@ -1,4 +1,5 @@
 import type { SchemaVersion } from "./version.js";
+import type { TransportProfile } from "./transport.js";
 
 export type AuthMode =
   | "none"
@@ -7,7 +8,7 @@ export type AuthMode =
   | "subscription_oauth";
 
 export interface TransportCapability {
-  transport: string;
+  transport: TransportProfile;
   modes: string[];
   supported_encodings: string[];
   bidirectional: boolean;

--- a/packages/gateway-schema/src/capability.ts
+++ b/packages/gateway-schema/src/capability.ts
@@ -1,0 +1,33 @@
+import type { SchemaVersion } from "./version.js";
+
+export type AuthMode =
+  | "none"
+  | "api_key"
+  | "bearer_token"
+  | "subscription_oauth";
+
+export interface TransportCapability {
+  transport: string;
+  modes: string[];
+  supported_encodings: string[];
+  bidirectional: boolean;
+}
+
+export interface FeatureCapability {
+  feature: string;
+  available: boolean;
+  requires_auth: boolean;
+  requires_plan?: string;
+}
+
+/** Capability discovery response. */
+export interface GatewayCapabilities {
+  schema_version: SchemaVersion;
+  gateway_version: string;
+  supported_api_versions: string[];
+  transports: TransportCapability[];
+  features: FeatureCapability[];
+  auth_modes: AuthMode[];
+  max_event_page_size: number;
+  max_terminal_frame_batch: number;
+}

--- a/packages/gateway-schema/src/cursor.ts
+++ b/packages/gateway-schema/src/cursor.ts
@@ -15,11 +15,11 @@ export function streamCursor(
 
 /** Pagination cursor for detail reads. */
 export interface PageCursor {
-  page_token: string | null;
+  page_token?: string;
   page_size: number;
 }
 
-/** Return a cursor that requests the first page (null token = start). */
+/** Return a cursor that requests the first page (token omitted = start). */
 export function pageCursorFirst(pageSize: number): PageCursor {
-  return { page_token: null, page_size: pageSize };
+  return { page_size: pageSize };
 }

--- a/packages/gateway-schema/src/cursor.ts
+++ b/packages/gateway-schema/src/cursor.ts
@@ -1,0 +1,24 @@
+/** Monotonic stream cursor for replay and resumable subscriptions. */
+export interface StreamCursor {
+  sequence: number;
+  partition: string;
+  timestamp_anchor?: number;
+}
+
+export function streamCursor(
+  sequence: number,
+  partition: string,
+  timestamp_anchor?: number,
+): StreamCursor {
+  return { sequence, partition, timestamp_anchor };
+}
+
+/** Pagination cursor for detail reads. */
+export interface PageCursor {
+  page_token: string;
+  page_size: number;
+}
+
+export function pageCursorFirst(pageSize: number): PageCursor {
+  return { page_token: "", page_size: pageSize };
+}

--- a/packages/gateway-schema/src/cursor.ts
+++ b/packages/gateway-schema/src/cursor.ts
@@ -15,10 +15,11 @@ export function streamCursor(
 
 /** Pagination cursor for detail reads. */
 export interface PageCursor {
-  page_token: string;
+  page_token: string | null;
   page_size: number;
 }
 
+/** Return a cursor that requests the first page (null token = start). */
 export function pageCursorFirst(pageSize: number): PageCursor {
-  return { page_token: "", page_size: pageSize };
+  return { page_token: null, page_size: pageSize };
 }

--- a/packages/gateway-schema/src/envelope.ts
+++ b/packages/gateway-schema/src/envelope.ts
@@ -1,0 +1,48 @@
+import type { StreamCursor } from "./cursor.js";
+import type { SchemaVersion } from "./version.js";
+
+/** Known entity kinds referenced by gateway schemas. */
+export type EntityKind =
+  | "issue"
+  | "sub_issue"
+  | "milestone"
+  | "run"
+  | "workspace"
+  | "conversation"
+  | "terminal_session"
+  | "planning_session"
+  | "project"
+  | "repository"
+  | "agent"
+  | "harness"
+  | "unknown";
+
+/** Lightweight reference to an entity. */
+export interface EntityRef {
+  kind: EntityKind;
+  id: string;
+  identifier?: string;
+}
+
+/** Base envelope for every gateway event or snapshot stream item. */
+export interface GatewayEnvelope {
+  schema_version: SchemaVersion;
+  cursor: StreamCursor;
+  entity_ref: EntityRef;
+  event_kind: string;
+  payload?: unknown;
+  raw_payload?: unknown;
+  emitted_at: string;
+}
+
+export function entityRefIssue(id: string, identifier?: string): EntityRef {
+  return { kind: "issue", id, identifier };
+}
+
+export function entityRefRun(id: string): EntityRef {
+  return { kind: "run", id };
+}
+
+export function entityRefTerminal(id: string): EntityRef {
+  return { kind: "terminal_session", id };
+}

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -44,6 +44,7 @@ export {
   isValidGatewayEnvelope,
   assertValidGatewayEnvelope,
   validateEnvelopeBatch,
+  assertValidEnvelopeBatch,
   parseGatewayEnvelope,
   getGatewaySchemaVersion,
 } from "./validation.js";

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -1,0 +1,49 @@
+// version
+export { GATEWAY_SCHEMA_VERSION, schemaVersionV1, schemaVersionToString, schemaVersionFromString } from "./version.js";
+export type { SchemaVersion } from "./version.js";
+
+// cursor
+export { streamCursor, pageCursorFirst } from "./cursor.js";
+export type { StreamCursor, PageCursor } from "./cursor.js";
+
+// envelope
+export { entityRefIssue, entityRefRun, entityRefTerminal } from "./envelope.js";
+export type { EntityKind, EntityRef, GatewayEnvelope } from "./envelope.js";
+
+// snapshot
+export type { GatewayHealth, GatewayMetrics, ProjectSummary, SnapshotEventKind, SnapshotEventSummary, DashboardSnapshot } from "./snapshot.js";
+
+// task_graph
+export type { TaskGraphNodeKind, TaskGraphStateCategory, TaskGraphNode, TaskGraphSnapshot } from "./task_graph.js";
+
+// run
+export type { RunStatus, ReleaseReason, RunDetail, RunEventPage, RunEvent } from "./run.js";
+
+// terminal
+export type { TerminalFrameKind, TerminalEncoding, TerminalFrame, TerminalSnapshot } from "./terminal.js";
+
+// approval
+export type { ApprovalKind, ApprovalStatus, ApprovalRequest, ActionReceiptStatus, ActionReceipt } from "./approval.js";
+
+// planning
+export type { PlanningArtifactKind, PlanningArtifact, PlanningSessionStatus, PlanningSessionSummary } from "./planning.js";
+
+// capability
+export type { AuthMode, TransportCapability, FeatureCapability, GatewayCapabilities } from "./capability.js";
+
+// action
+export type { ActionKind, ActionTarget, ActionDispatch } from "./action.js";
+
+// transport
+export type { TransportProfile, TransportRecommendation } from "./transport.js";
+
+// validation
+export {
+  isValidSchemaVersion,
+  assertCompatibleSchemaVersion,
+  isValidGatewayEnvelope,
+  assertValidGatewayEnvelope,
+  validateEnvelopeBatch,
+  parseGatewayEnvelope,
+  getGatewaySchemaVersion,
+} from "./validation.js";

--- a/packages/gateway-schema/src/planning.ts
+++ b/packages/gateway-schema/src/planning.ts
@@ -1,0 +1,45 @@
+import type { SchemaVersion } from "./version.js";
+
+export type PlanningArtifactKind =
+  | "milestone_draft"
+  | "issue_draft"
+  | "sub_issue_draft"
+  | "dependency_map"
+  | "acceptance_criteria"
+  | "verification_plan"
+  | "research_summary"
+  | "codebase_analysis";
+
+/** Planning session artifact. */
+export interface PlanningArtifact {
+  schema_version: SchemaVersion;
+  artifact_id: string;
+  session_id: string;
+  kind: PlanningArtifactKind;
+  title: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+  generated_by?: string;
+  approved: boolean;
+  published_to_tracker: boolean;
+}
+
+export type PlanningSessionStatus =
+  | "draft"
+  | "in_review"
+  | "approved"
+  | "published"
+  | "archived";
+
+/** Planning session summary for listing. */
+export interface PlanningSessionSummary {
+  schema_version: SchemaVersion;
+  session_id: string;
+  project_id: string;
+  title: string;
+  status: PlanningSessionStatus;
+  artifact_count: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/packages/gateway-schema/src/run.ts
+++ b/packages/gateway-schema/src/run.ts
@@ -1,0 +1,58 @@
+import type { PageCursor } from "./cursor.js";
+import type { SchemaVersion } from "./version.js";
+
+export type RunStatus =
+  | "unclaimed"
+  | "claimed"
+  | "running"
+  | "retry_queued"
+  | "released";
+
+export type ReleaseReason =
+  | "completed"
+  | "tracker_inactive"
+  | "tracker_terminal"
+  | "cancelled"
+  | "retry_exhausted";
+
+/** Run detail exposed by the gateway. */
+export interface RunDetail {
+  schema_version: SchemaVersion;
+  run_id: string;
+  issue_id: string;
+  issue_identifier: string;
+  worker_id: string;
+  status: RunStatus;
+  claimed_at: string;
+  started_at?: string;
+  finished_at?: string;
+  release_reason?: ReleaseReason;
+  turn_count: number;
+  max_turns: number;
+  retry_attempt?: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  runtime_seconds: number;
+  conversation_id?: string;
+  workspace_path?: string;
+  error?: string;
+}
+
+/** Paged run events. */
+export interface RunEventPage {
+  schema_version: SchemaVersion;
+  run_id: string;
+  next_cursor?: PageCursor;
+  events: RunEvent[];
+}
+
+export interface RunEvent {
+  sequence: number;
+  event_id: string;
+  happened_at: string;
+  kind: string;
+  summary: string;
+  payload?: unknown;
+  raw_payload?: unknown;
+}

--- a/packages/gateway-schema/src/snapshot.ts
+++ b/packages/gateway-schema/src/snapshot.ts
@@ -1,0 +1,51 @@
+import type { SchemaVersion } from "./version.js";
+
+export type GatewayHealth = "healthy" | "degraded" | "failed" | "starting";
+
+export interface GatewayMetrics {
+  running_issue_count: number;
+  retry_queue_depth: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_read_tokens: number;
+  total_cost_micros: number;
+}
+
+export interface ProjectSummary {
+  project_id: string;
+  name: string;
+  milestone_count: number;
+  issue_count: number;
+  running_count: number;
+  completed_count: number;
+  failed_count: number;
+}
+
+export type SnapshotEventKind =
+  | "worker_started"
+  | "workspace_prepared"
+  | "stream_attached"
+  | "snapshot_published"
+  | "worker_completed"
+  | "retry_scheduled"
+  | "client_attached"
+  | "client_detached"
+  | "warning";
+
+export interface SnapshotEventSummary {
+  happened_at: string;
+  issue_identifier?: string;
+  kind: SnapshotEventKind;
+  summary: string;
+}
+
+/** Dashboard-level snapshot delivered over REST or SSE. */
+export interface DashboardSnapshot {
+  schema_version: SchemaVersion;
+  generated_at: string;
+  sequence: number;
+  health: GatewayHealth;
+  metrics: GatewayMetrics;
+  projects: ProjectSummary[];
+  recent_events: SnapshotEventSummary[];
+}

--- a/packages/gateway-schema/src/task_graph.ts
+++ b/packages/gateway-schema/src/task_graph.ts
@@ -1,0 +1,40 @@
+import type { SchemaVersion } from "./version.js";
+
+export type TaskGraphNodeKind = "milestone" | "issue" | "sub_issue";
+
+export type TaskGraphStateCategory =
+  | "backlog"
+  | "todo"
+  | "in_progress"
+  | "done"
+  | "canceled";
+
+/** Read-only task graph node exposed by the gateway. */
+export interface TaskGraphNode {
+  schema_version: SchemaVersion;
+  node_id: string;
+  kind: TaskGraphNodeKind;
+  identifier: string;
+  title: string;
+  state: string;
+  state_category: TaskGraphStateCategory;
+  priority?: number;
+  parent_id?: string;
+  children: string[];
+  blocked_by: string[];
+  url?: string;
+  branch_name?: string;
+  labels: string[];
+  created_at?: string;
+  updated_at?: string;
+  estimate_minutes?: number;
+}
+
+/** Flat list response for a project task graph. */
+export interface TaskGraphSnapshot {
+  schema_version: SchemaVersion;
+  project_id: string;
+  generated_at: string;
+  nodes: TaskGraphNode[];
+  root_ids: string[];
+}

--- a/packages/gateway-schema/src/terminal.ts
+++ b/packages/gateway-schema/src/terminal.ts
@@ -1,0 +1,35 @@
+import type { SchemaVersion } from "./version.js";
+
+export type TerminalFrameKind =
+  | "stdout"
+  | "stderr"
+  | "log"
+  | "prompt"
+  | "status"
+  | "end_of_stream";
+
+export type TerminalEncoding = "utf8" | "base64";
+
+/** Terminal or log frame delivered over a high-volume stream. */
+export interface TerminalFrame {
+  schema_version: SchemaVersion;
+  frame_sequence: number;
+  stream_id: string;
+  run_id: string;
+  terminal_session_id: string;
+  frame_kind: TerminalFrameKind;
+  encoding: TerminalEncoding;
+  content: string;
+  timestamp: string;
+}
+
+/** Terminal snapshot for REST endpoint. */
+export interface TerminalSnapshot {
+  schema_version: SchemaVersion;
+  terminal_session_id: string;
+  run_id: string;
+  frames: TerminalFrame[];
+  total_frames: number;
+  truncated: boolean;
+  cursor: number;
+}

--- a/packages/gateway-schema/src/transport.ts
+++ b/packages/gateway-schema/src/transport.ts
@@ -1,0 +1,22 @@
+export type TransportProfile =
+  | "in_process_channel"
+  | "native_ipc"
+  | "tauri_channel"
+  | "loopback_http"
+  | "loopback_websocket"
+  | "sse"
+  | "websocket"
+  | "json_rpc_over_websocket";
+
+/** Transport recommendation metadata. */
+export interface TransportRecommendation {
+  profile: TransportProfile;
+  priority: number;
+  description: string;
+  expected_latency_ms: number;
+  expected_throughput_kbps: number;
+  reconnect_support: boolean;
+  replay_support: boolean;
+  binary_frame_support: boolean;
+  auth_required: boolean;
+}

--- a/packages/gateway-schema/src/validation.ts
+++ b/packages/gateway-schema/src/validation.ts
@@ -10,17 +10,22 @@ import type { GatewayEnvelope } from "./envelope.js";
 import type { SchemaVersion } from "./version.js";
 import { GATEWAY_SCHEMA_VERSION } from "./version.js";
 
-/** Return true when the payload's schema_version major matches v1. */
+/** Return true when the payload's schema_version has valid numeric fields. */
 export function isValidSchemaVersion(v: unknown): v is SchemaVersion {
+  if (
+    typeof v !== "object" ||
+    v === null ||
+    !("major" in v) ||
+    !("minor" in v) ||
+    !("patch" in v)
+  ) {
+    return false;
+  }
+  const obj = v as SchemaVersion;
   return (
-    typeof v === "object" &&
-    v !== null &&
-    "major" in v &&
-    "minor" in v &&
-    "patch" in v &&
-    typeof (v as SchemaVersion).major === "number" &&
-    typeof (v as SchemaVersion).minor === "number" &&
-    typeof (v as SchemaVersion).patch === "number"
+    Number.isFinite(obj.major) &&
+    Number.isFinite(obj.minor) &&
+    Number.isFinite(obj.patch)
   );
 }
 
@@ -71,10 +76,9 @@ export function assertValidGatewayEnvelope(
   assertCompatibleSchemaVersion(envelope.schema_version, label);
 }
 
-/** Validate a batch of envelopes; returns array of indexes that failed. */
+/** Validate a batch of envelopes; returns array of indexes that failed (no throw). */
 export function validateEnvelopeBatch(
   batch: unknown[],
-  label = "batch",
 ): number[] {
   const failed: number[] = [];
   for (let i = 0; i < batch.length; i++) {
@@ -82,12 +86,20 @@ export function validateEnvelopeBatch(
       failed.push(i);
     }
   }
+  return failed;
+}
+
+/** Throw if any envelope in the batch fails validation. */
+export function assertValidEnvelopeBatch(
+  batch: unknown[],
+  label = "batch",
+): void {
+  const failed = validateEnvelopeBatch(batch);
   if (failed.length > 0) {
     throw new Error(
       `[schema] ${label}: envelopes at indices ${failed.join(",")} failed validation`,
     );
   }
-  return failed;
 }
 
 /** Parse and validate a JSON string as a GatewayEnvelope. */

--- a/packages/gateway-schema/src/validation.ts
+++ b/packages/gateway-schema/src/validation.ts
@@ -1,0 +1,106 @@
+/**
+ * Runtime validators for gateway schema payloads.
+ *
+ * TypeScript types are erased at runtime; these helpers guard stream
+ * payloads and REST responses so consumers can fail fast on shape
+ * mismatches before the typed reducer logic runs.
+ */
+
+import type { GatewayEnvelope } from "./envelope.js";
+import type { SchemaVersion } from "./version.js";
+import { GATEWAY_SCHEMA_VERSION } from "./version.js";
+
+/** Return true when the payload's schema_version major matches v1. */
+export function isValidSchemaVersion(v: unknown): v is SchemaVersion {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "major" in v &&
+    "minor" in v &&
+    "patch" in v &&
+    typeof (v as SchemaVersion).major === "number" &&
+    typeof (v as SchemaVersion).minor === "number" &&
+    typeof (v as SchemaVersion).patch === "number"
+  );
+}
+
+/** Throw if the schema version is incompatible. */
+export function assertCompatibleSchemaVersion(
+  v: unknown,
+  label = "payload",
+): asserts v is SchemaVersion {
+  if (!isValidSchemaVersion(v)) {
+    throw new Error(
+      `[schema] ${label}: schema_version must be { major, minor, patch }, got ${JSON.stringify(v)}`,
+    );
+  }
+  if (v.major !== 1) {
+    throw new Error(
+      `[schema] ${label}: unsupported schema major=${v.major} (expected 1)`,
+    );
+  }
+}
+
+export function isValidGatewayEnvelope(envelope: unknown): envelope is GatewayEnvelope {
+  if (typeof envelope !== "object" || envelope === null) return false;
+  const e = envelope as Record<string, unknown>;
+  return (
+    isValidSchemaVersion(e.schema_version) &&
+    typeof e.cursor === "object" &&
+    e.cursor !== null &&
+    typeof (e.cursor as Record<string, unknown>).sequence === "number" &&
+    typeof (e.cursor as Record<string, unknown>).partition === "string" &&
+    typeof e.entity_ref === "object" &&
+    e.entity_ref !== null &&
+    typeof (e.entity_ref as Record<string, unknown>).kind === "string" &&
+    typeof (e.entity_ref as Record<string, unknown>).id === "string" &&
+    typeof e.event_kind === "string" &&
+    typeof e.emitted_at === "string"
+  );
+}
+
+export function assertValidGatewayEnvelope(
+  envelope: unknown,
+  label = "envelope",
+): asserts envelope is GatewayEnvelope {
+  if (!isValidGatewayEnvelope(envelope)) {
+    throw new Error(
+      `[schema] ${label}: payload does not match GatewayEnvelope shape`,
+    );
+  }
+  assertCompatibleSchemaVersion(envelope.schema_version, label);
+}
+
+/** Validate a batch of envelopes; returns array of indexes that failed. */
+export function validateEnvelopeBatch(
+  batch: unknown[],
+  label = "batch",
+): number[] {
+  const failed: number[] = [];
+  for (let i = 0; i < batch.length; i++) {
+    if (!isValidGatewayEnvelope(batch[i])) {
+      failed.push(i);
+    }
+  }
+  if (failed.length > 0) {
+    throw new Error(
+      `[schema] ${label}: envelopes at indices ${failed.join(",")} failed validation`,
+    );
+  }
+  return failed;
+}
+
+/** Parse and validate a JSON string as a GatewayEnvelope. */
+export function parseGatewayEnvelope(
+  raw: string,
+  label = "raw JSON",
+): GatewayEnvelope {
+  const parsed = JSON.parse(raw);
+  assertValidGatewayEnvelope(parsed, label);
+  return parsed;
+}
+
+/** Return the gateway schema version string constant for reference. */
+export function getGatewaySchemaVersion(): string {
+  return GATEWAY_SCHEMA_VERSION;
+}

--- a/packages/gateway-schema/src/version.ts
+++ b/packages/gateway-schema/src/version.ts
@@ -21,7 +21,7 @@ export function schemaVersionToString(v: SchemaVersion): string {
 /** Parse a dotted version string into a SchemaVersion. */
 export function schemaVersionFromString(s: string): SchemaVersion {
   const parts = s.split(".");
-  if (parts.length !== 3) {
+  if (parts.length !== 3 || parts.some((p) => p === "")) {
     throw new Error(`Invalid schema version string: ${s}`);
   }
   const [major, minor, patch] = parts.map(Number);

--- a/packages/gateway-schema/src/version.ts
+++ b/packages/gateway-schema/src/version.ts
@@ -21,5 +21,8 @@ export function schemaVersionToString(v: SchemaVersion): string {
 /** Parse a dotted version string into a SchemaVersion. */
 export function schemaVersionFromString(s: string): SchemaVersion {
   const [major, minor, patch] = s.split(".").map(Number);
+  if ([major, minor, patch].some((n) => !Number.isFinite(n))) {
+    throw new Error(`Invalid schema version string: ${s}`);
+  }
   return { major, minor, patch };
 }

--- a/packages/gateway-schema/src/version.ts
+++ b/packages/gateway-schema/src/version.ts
@@ -20,7 +20,11 @@ export function schemaVersionToString(v: SchemaVersion): string {
 
 /** Parse a dotted version string into a SchemaVersion. */
 export function schemaVersionFromString(s: string): SchemaVersion {
-  const [major, minor, patch] = s.split(".").map(Number);
+  const parts = s.split(".");
+  if (parts.length !== 3) {
+    throw new Error(`Invalid schema version string: ${s}`);
+  }
+  const [major, minor, patch] = parts.map(Number);
   if ([major, minor, patch].some((n) => !Number.isFinite(n))) {
     throw new Error(`Invalid schema version string: ${s}`);
   }

--- a/packages/gateway-schema/src/version.ts
+++ b/packages/gateway-schema/src/version.ts
@@ -1,0 +1,25 @@
+/** Gateway API schema version constant. */
+export const GATEWAY_SCHEMA_VERSION = "1.0.0" as const;
+
+/** Semantic version wrapper used in every versioned payload. */
+export interface SchemaVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Factory for a v1 schema version. */
+export function schemaVersionV1(): SchemaVersion {
+  return { major: 1, minor: 0, patch: 0 };
+}
+
+/** Convert a SchemaVersion to a dotted string. */
+export function schemaVersionToString(v: SchemaVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+/** Parse a dotted version string into a SchemaVersion. */
+export function schemaVersionFromString(s: string): SchemaVersion {
+  const [major, minor, patch] = s.split(".").map(Number);
+  return { major, minor, patch };
+}

--- a/packages/gateway-schema/tsconfig.json
+++ b/packages/gateway-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -1,0 +1,271 @@
+/** Reducer unit tests for @opensymphony/state. */
+
+import {
+  gatewayReducer,
+  initialState,
+  type GatewayAction,
+} from "@opensymphony/state";
+import type {
+  DashboardSnapshot,
+  TaskGraphSnapshot,
+  RunDetail,
+  TerminalFrame,
+  ApprovalRequest,
+  PlanningSessionSummary,
+  GatewayEnvelope,
+} from "@opensymphony/gateway-schema";
+
+// -- Helpers --
+
+function makeSnapshot(): DashboardSnapshot {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    health: { status: "ok", version: "1.0.0" },
+    metrics: { active_runs: 0 },
+    projects: [],
+    recent_events: [],
+  };
+}
+
+function makeTaskGraphSnapshot(): TaskGraphSnapshot {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    nodes: [],
+    root_ids: [],
+  };
+}
+
+function makeRunDetail(): RunDetail {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    run_id: "run-1",
+    project_id: "proj-1",
+    status: "completed",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    completed_at: null,
+    error: null,
+    metadata: {},
+  };
+}
+
+function makeFrame(sequence: number): TerminalFrame {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    frame_sequence: sequence,
+    run_id: "run-1",
+    terminal_id: "term-1",
+    output: `line ${sequence}`,
+    emitted_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeApproval(id: string): ApprovalRequest {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    approval_id: id,
+    run_id: "run-1",
+    prompt: "Approve?",
+    status: "pending",
+    created_at: "2025-01-01T00:00:00Z",
+    resolved_at: null,
+    action_taken: null,
+  };
+}
+
+function makePlanningSummary(): PlanningSessionSummary {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    session_id: "sess-1",
+    run_id: "run-1",
+    status: "completed",
+    artifacts: [],
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeEnvelope(): GatewayEnvelope {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    cursor: { sequence: 1, partition: "p1" },
+    entity_ref: { kind: "run", id: "run-1" },
+    event_kind: "run_updated",
+    emitted_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// -- Tests --
+
+describe("gatewayReducer", () => {
+  it("SNAPSHOT_RECEIVED sets snapshot and clears loading/error", () => {
+    const state = gatewayReducer(initialState, {
+      type: "SNAPSHOT_RECEIVED",
+      payload: makeSnapshot(),
+    });
+    expect(state.dashboard.snapshot).toBeTruthy();
+    expect(state.dashboard.loading).toBe(false);
+    expect(state.dashboard.error).toBeNull();
+  });
+
+  it("TASK_GRAPH_RECEIVED sets nodes and clears loading/error", () => {
+    const state = gatewayReducer(initialState, {
+      type: "TASK_GRAPH_RECEIVED",
+      payload: makeTaskGraphSnapshot(),
+    });
+    expect(state.taskGraph.nodes.size).toBe(0);
+    expect(state.taskGraph.loading).toBe(false);
+    expect(state.taskGraph.error).toBeNull();
+  });
+
+  it("RUN_UPDATED stores run and clears loading/error", () => {
+    const run = makeRunDetail();
+    const state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: run,
+    });
+    expect(state.run.runs.get("run-1")).toBe(run);
+    expect(state.run.loading).toBe(false);
+    expect(state.run.error).toBeNull();
+  });
+
+  it("TERMINAL_FRAMES_RECEIVED stores frames and clears loading/error", () => {
+    const frame = makeFrame(1);
+    const state = gatewayReducer(initialState, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [frame],
+    });
+    expect(state.terminal.frames.get("run-1")).toHaveLength(1);
+    expect(state.terminal.cursor.get("run-1")).toBe(1);
+    expect(state.terminal.loading).toBe(false);
+    expect(state.terminal.error).toBeNull();
+  });
+
+  it("TERMINAL_FRAMES_RECEIVED deduplicates frames by sequence", () => {
+    const f1 = makeFrame(1);
+    const f2 = makeFrame(2);
+    let state = gatewayReducer(initialState, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [f1, f2],
+    });
+    // Replay frame 1 plus a new frame 3.
+    const f3 = makeFrame(3);
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [f1, f3],
+    });
+    expect(state.terminal.frames.get("run-1")).toHaveLength(3);
+    expect(state.terminal.cursor.get("run-1")).toBe(3);
+  });
+
+  it("TERMINAL_FRAMES_RECEIVED does not reset cursor for empty batch", () => {
+    let state = gatewayReducer(initialState, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeFrame(5)],
+    });
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [],
+    });
+    expect(state.terminal.cursor.get("run-1")).toBe(5);
+  });
+
+  it("APPROVAL_RECEIVED adds approval and clears loading/error", () => {
+    const approval = makeApproval("appr-1");
+    const state = gatewayReducer(initialState, {
+      type: "APPROVAL_RECEIVED",
+      payload: approval,
+    });
+    expect(state.approval.pending).toHaveLength(1);
+    expect(state.approval.loading).toBe(false);
+    expect(state.approval.error).toBeNull();
+  });
+
+  it("APPROVAL_RECEIVED deduplicates by approval_id", () => {
+    const approval = makeApproval("appr-1");
+    let state = gatewayReducer(initialState, {
+      type: "APPROVAL_RECEIVED",
+      payload: approval,
+    });
+    state = gatewayReducer(state, {
+      type: "APPROVAL_RECEIVED",
+      payload: approval,
+    });
+    expect(state.approval.pending).toHaveLength(1);
+  });
+
+  it("APPROVAL_RESOLVED moves approval and clears loading/error", () => {
+    const approval = makeApproval("appr-1");
+    let state = gatewayReducer(initialState, {
+      type: "APPROVAL_RECEIVED",
+      payload: approval,
+    });
+    state = gatewayReducer(state, {
+      type: "APPROVAL_RESOLVED",
+      approvalId: "appr-1",
+      payload: approval,
+    });
+    expect(state.approval.pending).toHaveLength(0);
+    expect(state.approval.resolved.get("appr-1")).toBe(approval);
+    expect(state.approval.loading).toBe(false);
+    expect(state.approval.error).toBeNull();
+  });
+
+  it("PLANNING_SESSION_UPDATED stores session and clears loading/error", () => {
+    const session = makePlanningSummary();
+    const state = gatewayReducer(initialState, {
+      type: "PLANNING_SESSION_UPDATED",
+      payload: session,
+    });
+    expect(state.planning.sessions.get("sess-1")).toBe(session);
+    expect(state.planning.loading).toBe(false);
+    expect(state.planning.error).toBeNull();
+  });
+
+  it("ENVELOPE_RECEIVED is a no-op placeholder", () => {
+    const state = gatewayReducer(initialState, {
+      type: "ENVELOPE_RECEIVED",
+      payload: makeEnvelope(),
+    });
+    expect(state).toBe(initialState);
+  });
+
+  it("ERROR sets error and resets loading on all slices", () => {
+    let state = gatewayReducer(initialState, {
+      type: "LOADING",
+      loading: true,
+    });
+    expect(state.dashboard.loading).toBe(true);
+    expect(state.terminal.loading).toBe(true);
+    state = gatewayReducer(state, {
+      type: "ERROR",
+      error: "Something failed",
+    });
+    expect(state.dashboard.error).toBe("Something failed");
+    expect(state.dashboard.loading).toBe(false);
+    expect(state.terminal.error).toBe("Something failed");
+    expect(state.terminal.loading).toBe(false);
+    expect(state.approval.error).toBe("Something failed");
+    expect(state.approval.loading).toBe(false);
+    expect(state.planning.error).toBe("Something failed");
+    expect(state.planning.loading).toBe(false);
+  });
+
+  it("LOADING toggles loading on all slices", () => {
+    const state = gatewayReducer(initialState, {
+      type: "LOADING",
+      loading: true,
+    });
+    expect(state.dashboard.loading).toBe(true);
+    expect(state.taskGraph.loading).toBe(true);
+    expect(state.run.loading).toBe(true);
+    expect(state.terminal.loading).toBe(true);
+    expect(state.approval.loading).toBe(true);
+    expect(state.planning.loading).toBe(true);
+  });
+});

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -181,6 +181,23 @@ describe("gatewayReducer", () => {
     expect(state.terminal.cursor.get("run-1")).toBe(3);
   });
 
+  it("TERMINAL_FRAMES_RECEIVED cursor uses Math.max for out-of-order batches", () => {
+    // Batch 1: frames 1-5, cursor = 5.
+    let state = gatewayReducer(initialState, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeFrame(1), makeFrame(2), makeFrame(3), makeFrame(4), makeFrame(5)],
+    });
+    expect(state.terminal.cursor.get("run-1")).toBe(5);
+    // Batch 2: frames 3-4 arrive late (lower seq), cursor should stay at 5.
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeFrame(3), makeFrame(4)],
+    });
+    expect(state.terminal.cursor.get("run-1")).toBe(5);
+  });
+
   it("TERMINAL_FRAMES_RECEIVED does not reset cursor for empty batch", () => {
     let state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
@@ -287,5 +304,25 @@ describe("gatewayReducer", () => {
     expect(state.terminal.loading).toBe(true);
     expect(state.approval.loading).toBe(true);
     expect(state.planning.loading).toBe(true);
+  });
+
+  it("LOADING true clears prior errors, LOADING false preserves them", () => {
+    let state = gatewayReducer(initialState, {
+      type: "ERROR",
+      error: "Previous failure",
+    });
+    expect(state.dashboard.error).toBe("Previous failure");
+    state = gatewayReducer(state, {
+      type: "LOADING",
+      loading: true,
+    });
+    expect(state.dashboard.error).toBeNull();
+    expect(state.dashboard.loading).toBe(true);
+    state = gatewayReducer(state, {
+      type: "LOADING",
+      loading: false,
+    });
+    expect(state.dashboard.error).toBeNull();
+    expect(state.dashboard.loading).toBe(false);
   });
 });

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -198,6 +198,17 @@ describe("gatewayReducer", () => {
     expect(state.terminal.cursor.get("run-1")).toBe(5);
   });
 
+  it("TERMINAL_FRAMES_RECEIVED cursor uses max over unsorted batch", () => {
+    // Batch arrives with frames 2, 1 (unsorted within batch).
+    const state = gatewayReducer(initialState, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeFrame(2), makeFrame(1)],
+    });
+    // Cursor should be 2 (max of batch), not 1 (last element).
+    expect(state.terminal.cursor.get("run-1")).toBe(2);
+  });
+
   it("TERMINAL_FRAMES_RECEIVED does not reset cursor for empty batch", () => {
     let state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -3,7 +3,6 @@
 import {
   gatewayReducer,
   initialState,
-  type GatewayAction,
 } from "@opensymphony/state";
 import type {
   DashboardSnapshot,
@@ -15,13 +14,22 @@ import type {
   GatewayEnvelope,
 } from "@opensymphony/gateway-schema";
 
-// -- Helpers --
+// -- Helpers — typed factories aligned with gateway-schema interfaces --
 
 function makeSnapshot(): DashboardSnapshot {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
-    health: { status: "ok", version: "1.0.0" },
-    metrics: { active_runs: 0 },
+    generated_at: "2025-01-01T00:00:00Z",
+    sequence: 1,
+    health: "healthy",
+    metrics: {
+      running_issue_count: 0,
+      retry_queue_depth: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cache_read_tokens: 0,
+      total_cost_micros: 0,
+    },
     projects: [],
     recent_events: [],
   };
@@ -30,6 +38,8 @@ function makeSnapshot(): DashboardSnapshot {
 function makeTaskGraphSnapshot(): TaskGraphSnapshot {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
+    project_id: "proj-1",
+    generated_at: "2025-01-01T00:00:00Z",
     nodes: [],
     root_ids: [],
   };
@@ -39,13 +49,17 @@ function makeRunDetail(): RunDetail {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
     run_id: "run-1",
-    project_id: "proj-1",
-    status: "completed",
-    created_at: "2025-01-01T00:00:00Z",
-    updated_at: "2025-01-01T00:00:00Z",
-    completed_at: null,
-    error: null,
-    metadata: {},
+    issue_id: "issue-1",
+    issue_identifier: "COE-001",
+    worker_id: "worker-1",
+    status: "running",
+    claimed_at: "2025-01-01T00:00:00Z",
+    turn_count: 0,
+    max_turns: 50,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    runtime_seconds: 0,
   };
 }
 
@@ -53,10 +67,13 @@ function makeFrame(sequence: number): TerminalFrame {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
     frame_sequence: sequence,
+    stream_id: "stream-1",
     run_id: "run-1",
-    terminal_id: "term-1",
-    output: `line ${sequence}`,
-    emitted_at: "2025-01-01T00:00:00Z",
+    terminal_session_id: "term-1",
+    frame_kind: "stdout",
+    encoding: "utf8",
+    content: `line ${sequence}`,
+    timestamp: "2025-01-01T00:00:00Z",
   };
 }
 
@@ -65,11 +82,13 @@ function makeApproval(id: string): ApprovalRequest {
     schema_version: { major: 1, minor: 0, patch: 0 },
     approval_id: id,
     run_id: "run-1",
-    prompt: "Approve?",
+    issue_id: "issue-1",
+    kind: "tool_use",
+    title: "Approve action",
+    description: "Should we proceed?",
+    requested_at: "2025-01-01T00:00:00Z",
     status: "pending",
-    created_at: "2025-01-01T00:00:00Z",
-    resolved_at: null,
-    action_taken: null,
+    correlation_id: "corr-1",
   };
 }
 
@@ -77,9 +96,10 @@ function makePlanningSummary(): PlanningSessionSummary {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
     session_id: "sess-1",
-    run_id: "run-1",
-    status: "completed",
-    artifacts: [],
+    project_id: "proj-1",
+    title: "Planning session",
+    status: "draft",
+    artifact_count: 0,
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
   };

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@opensymphony/state",
+  "version": "1.0.0",
+  "description": "Reducer-driven state management for OpenSymphony clients",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsc --build tsconfig.json",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opensymphony/gateway-schema": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -48,6 +48,7 @@ export interface TerminalSlice {
 export interface ApprovalSlice {
   pending: ApprovalRequest[];
   resolved: Map<string, ApprovalRequest>;
+  loading: boolean;
   error: string | null;
 }
 
@@ -73,7 +74,7 @@ export const initialState: GatewayState = {
   taskGraph: { nodes: new Map(), rootIds: [], loading: false, error: null },
   run: { runs: new Map(), loading: false, error: null },
   terminal: { frames: new Map(), cursor: new Map(), loading: false, error: null },
-  approval: { pending: [], resolved: new Map(), error: null },
+  approval: { pending: [], resolved: new Map(), loading: false, error: null },
   planning: { sessions: new Map(), loading: false, error: null },
 };
 
@@ -181,12 +182,12 @@ export function gatewayReducer(
     case "ERROR":
       return {
         ...state,
-        dashboard: { ...state.dashboard, error: action.error },
-        taskGraph: { ...state.taskGraph, error: action.error },
-        run: { ...state.run, error: action.error },
-        terminal: { ...state.terminal, error: action.error },
-        approval: { ...state.approval, error: action.error },
-        planning: { ...state.planning, error: action.error },
+        dashboard: { ...state.dashboard, error: action.error, loading: false },
+        taskGraph: { ...state.taskGraph, error: action.error, loading: false },
+        run: { ...state.run, error: action.error, loading: false },
+        terminal: { ...state.terminal, error: action.error, loading: false },
+        approval: { ...state.approval, error: action.error, loading: false },
+        planning: { ...state.planning, error: action.error, loading: false },
       };
 
     case "LOADING":
@@ -196,6 +197,7 @@ export function gatewayReducer(
         taskGraph: { ...state.taskGraph, loading: action.loading },
         run: { ...state.run, loading: action.loading },
         terminal: { ...state.terminal, loading: action.loading },
+        approval: { ...state.approval, loading: action.loading },
         planning: { ...state.planning, loading: action.loading },
       };
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -42,16 +42,19 @@ export interface TerminalSlice {
   frames: Map<string, TerminalFrame[]>;
   cursor: Map<string, number>;
   loading: boolean;
+  error: string | null;
 }
 
 export interface ApprovalSlice {
   pending: ApprovalRequest[];
   resolved: Map<string, ApprovalRequest>;
+  error: string | null;
 }
 
 export interface PlanningSlice {
   sessions: Map<string, PlanningSessionSummary>;
   loading: boolean;
+  error: string | null;
 }
 
 // -- Combined state --
@@ -69,9 +72,9 @@ export const initialState: GatewayState = {
   dashboard: { snapshot: null, loading: false, error: null },
   taskGraph: { nodes: new Map(), rootIds: [], loading: false, error: null },
   run: { runs: new Map(), loading: false, error: null },
-  terminal: { frames: new Map(), cursor: new Map(), loading: false },
-  approval: { pending: [], resolved: new Map() },
-  planning: { sessions: new Map(), loading: false },
+  terminal: { frames: new Map(), cursor: new Map(), loading: false, error: null },
+  approval: { pending: [], resolved: new Map(), error: null },
+  planning: { sessions: new Map(), loading: false, error: null },
 };
 
 // -- Action types --
@@ -160,7 +163,7 @@ export function gatewayReducer(
       sessions.set(action.payload.session_id, action.payload);
       return {
         ...state,
-        planning: { sessions, loading: false },
+        planning: { sessions, loading: false, error: null },
       };
     }
 
@@ -175,6 +178,9 @@ export function gatewayReducer(
         dashboard: { ...state.dashboard, error: action.error },
         taskGraph: { ...state.taskGraph, error: action.error },
         run: { ...state.run, error: action.error },
+        terminal: { ...state.terminal, error: action.error },
+        approval: { ...state.approval, error: action.error },
+        planning: { ...state.planning, error: action.error },
       };
 
     case "LOADING":

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -135,11 +135,11 @@ export function gatewayReducer(
       }
       return {
         ...state,
-        terminal: { ...state.terminal, frames, cursor, error: state.terminal.error },
+        terminal: { ...state.terminal, frames, cursor, loading: false, error: null },
       };
     }
 
-    case "APPROVAL_RECEIVED":
+    case "APPROVAL_RECEIVED": {
       return {
         ...state,
         approval: {
@@ -149,8 +149,11 @@ export function gatewayReducer(
           )
             ? state.approval.pending
             : [...state.approval.pending, action.payload],
+          loading: false,
+          error: null,
         },
       };
+    }
 
     case "APPROVAL_RESOLVED": {
       const resolved = new Map(state.approval.resolved);
@@ -161,6 +164,8 @@ export function gatewayReducer(
           ...state.approval,
           pending: state.approval.pending.filter((a) => a.approval_id !== action.approvalId),
           resolved,
+          loading: false,
+          error: null,
         },
       };
     }

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -127,10 +127,13 @@ export function gatewayReducer(
     case "TERMINAL_FRAMES_RECEIVED": {
       const frames = new Map(state.terminal.frames);
       const existing = frames.get(action.runId) ?? [];
-      frames.set(action.runId, [...existing, ...action.frames]);
+      // Deduplicate by frame_sequence to handle replayed/overlapping batches.
+      const existingSeqs = new Set(existing.map((f) => f.frame_sequence));
+      const newFrames = action.frames.filter((f) => !existingSeqs.has(f.frame_sequence));
+      frames.set(action.runId, [...existing, ...newFrames]);
       const cursor = new Map(state.terminal.cursor);
-      if (action.frames.length > 0) {
-        const lastSeq = action.frames[action.frames.length - 1].frame_sequence;
+      if (newFrames.length > 0) {
+        const lastSeq = newFrames[newFrames.length - 1].frame_sequence;
         cursor.set(action.runId, lastSeq);
       }
       return {

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,0 +1,193 @@
+/**
+ * Reducer-driven state management for OpenSymphony clients.
+ *
+ * This package defines Redux-style reducer functions that keep the
+ * client-side state model in sync with gateway snapshots and event
+ * streams. The reducer is transport-agnostic and framework-neutral.
+ */
+
+import type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  TaskGraphNode,
+  TaskGraphSnapshot,
+  RunDetail,
+  TerminalFrame,
+  ApprovalRequest,
+  PlanningSessionSummary,
+} from "@opensymphony/gateway-schema";
+
+// -- State slices --
+
+export interface DashboardSlice {
+  snapshot: DashboardSnapshot | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface TaskGraphSlice {
+  nodes: Map<string, TaskGraphNode>;
+  rootIds: string[];
+  loading: boolean;
+  error: string | null;
+}
+
+export interface RunSlice {
+  runs: Map<string, RunDetail>;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface TerminalSlice {
+  frames: Map<string, TerminalFrame[]>;
+  cursor: Map<string, number>;
+  loading: boolean;
+}
+
+export interface ApprovalSlice {
+  pending: ApprovalRequest[];
+  resolved: Map<string, ApprovalRequest>;
+}
+
+export interface PlanningSlice {
+  sessions: Map<string, PlanningSessionSummary>;
+  loading: boolean;
+}
+
+// -- Combined state --
+
+export interface GatewayState {
+  dashboard: DashboardSlice;
+  taskGraph: TaskGraphSlice;
+  run: RunSlice;
+  terminal: TerminalSlice;
+  approval: ApprovalSlice;
+  planning: PlanningSlice;
+}
+
+export const initialState: GatewayState = {
+  dashboard: { snapshot: null, loading: false, error: null },
+  taskGraph: { nodes: new Map(), rootIds: [], loading: false, error: null },
+  run: { runs: new Map(), loading: false, error: null },
+  terminal: { frames: new Map(), cursor: new Map(), loading: false },
+  approval: { pending: [], resolved: new Map() },
+  planning: { sessions: new Map(), loading: false },
+};
+
+// -- Action types --
+
+export type GatewayAction =
+  | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot }
+  | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot }
+  | { type: "RUN_UPDATED"; payload: RunDetail }
+  | { type: "TERMINAL_FRAMES_RECEIVED"; runId: string; frames: TerminalFrame[] }
+  | { type: "APPROVAL_RECEIVED"; payload: ApprovalRequest }
+  | { type: "APPROVAL_RESOLVED"; approvalId: string; payload: ApprovalRequest }
+  | { type: "PLANNING_SESSION_UPDATED"; payload: PlanningSessionSummary }
+  | { type: "ENVELOPE_RECEIVED"; payload: GatewayEnvelope }
+  | { type: "ERROR"; error: string }
+  | { type: "LOADING"; loading: boolean };
+
+// -- Reducer --
+
+export function gatewayReducer(
+  state: GatewayState,
+  action: GatewayAction,
+): GatewayState {
+  switch (action.type) {
+    case "SNAPSHOT_RECEIVED":
+      return {
+        ...state,
+        dashboard: { snapshot: action.payload, loading: false, error: null },
+      };
+
+    case "TASK_GRAPH_RECEIVED": {
+      const nodes = new Map(action.payload.nodes.map((n) => [n.node_id, n]));
+      return {
+        ...state,
+        taskGraph: { nodes, rootIds: action.payload.root_ids, loading: false, error: null },
+      };
+    }
+
+    case "RUN_UPDATED":
+      return {
+        ...state,
+        run: {
+          ...state.run,
+          runs: new Map(state.run.runs).set(action.payload.run_id, action.payload),
+          loading: false,
+          error: null,
+        },
+      };
+
+    case "TERMINAL_FRAMES_RECEIVED": {
+      const frames = new Map(state.terminal.frames);
+      const existing = frames.get(action.runId) ?? [];
+      frames.set(action.runId, [...existing, ...action.frames]);
+      const cursor = new Map(state.terminal.cursor);
+      const lastSeq = action.frames[action.frames.length - 1]?.frame_sequence ?? 0;
+      cursor.set(action.runId, lastSeq);
+      return {
+        ...state,
+        terminal: { ...state.terminal, frames, cursor },
+      };
+    }
+
+    case "APPROVAL_RECEIVED":
+      return {
+        ...state,
+        approval: {
+          ...state.approval,
+          pending: [...state.approval.pending, action.payload],
+        },
+      };
+
+    case "APPROVAL_RESOLVED": {
+      const resolved = new Map(state.approval.resolved);
+      resolved.set(action.approvalId, action.payload);
+      return {
+        ...state,
+        approval: {
+          ...state.approval,
+          pending: state.approval.pending.filter((a) => a.approval_id !== action.approvalId),
+          resolved,
+        },
+      };
+    }
+
+    case "PLANNING_SESSION_UPDATED": {
+      const sessions = new Map(state.planning.sessions);
+      sessions.set(action.payload.session_id, action.payload);
+      return {
+        ...state,
+        planning: { sessions, loading: false },
+      };
+    }
+
+    case "ENVELOPE_RECEIVED":
+      // Forward to appropriate slice reducer based on event_kind.
+      // Placeholder: no-op for now.
+      return state;
+
+    case "ERROR":
+      return {
+        ...state,
+        dashboard: { ...state.dashboard, error: action.error },
+        taskGraph: { ...state.taskGraph, error: action.error },
+        run: { ...state.run, error: action.error },
+      };
+
+    case "LOADING":
+      return {
+        ...state,
+        dashboard: { ...state.dashboard, loading: action.loading },
+        taskGraph: { ...state.taskGraph, loading: action.loading },
+        run: { ...state.run, loading: action.loading },
+        terminal: { ...state.terminal, loading: action.loading },
+        planning: { ...state.planning, loading: action.loading },
+      };
+
+    default:
+      return state;
+  }
+}

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -134,7 +134,9 @@ export function gatewayReducer(
       const cursor = new Map(state.terminal.cursor);
       if (newFrames.length > 0) {
         const lastSeq = newFrames[newFrames.length - 1].frame_sequence;
-        cursor.set(action.runId, lastSeq);
+        // Use Math.max so cursor always advances even if frames arrive out of order.
+        const prevCursor = cursor.get(action.runId) ?? 0;
+        cursor.set(action.runId, Math.max(prevCursor, lastSeq));
       }
       return {
         ...state,
@@ -198,16 +200,18 @@ export function gatewayReducer(
         planning: { ...state.planning, error: action.error, loading: false },
       };
 
-    case "LOADING":
+    case "LOADING": {
+      const { dashboard, taskGraph, run, terminal, approval, planning } = state;
       return {
         ...state,
-        dashboard: { ...state.dashboard, loading: action.loading },
-        taskGraph: { ...state.taskGraph, loading: action.loading },
-        run: { ...state.run, loading: action.loading },
-        terminal: { ...state.terminal, loading: action.loading },
-        approval: { ...state.approval, loading: action.loading },
-        planning: { ...state.planning, loading: action.loading },
+        dashboard: { ...dashboard, loading: action.loading, error: action.loading ? null : dashboard.error },
+        taskGraph: { ...taskGraph, loading: action.loading, error: action.loading ? null : taskGraph.error },
+        run: { ...run, loading: action.loading, error: action.loading ? null : run.error },
+        terminal: { ...terminal, loading: action.loading, error: action.loading ? null : terminal.error },
+        approval: { ...approval, loading: action.loading, error: action.loading ? null : approval.error },
+        planning: { ...planning, loading: action.loading, error: action.loading ? null : planning.error },
       };
+    }
 
     default:
       return state;

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -133,10 +133,10 @@ export function gatewayReducer(
       frames.set(action.runId, [...existing, ...newFrames]);
       const cursor = new Map(state.terminal.cursor);
       if (newFrames.length > 0) {
-        const lastSeq = newFrames[newFrames.length - 1].frame_sequence;
-        // Use Math.max so cursor always advances even if frames arrive out of order.
+        // Use max over ALL new frames to handle unsorted batches.
+        const maxSeq = Math.max(...newFrames.map((f) => f.frame_sequence));
         const prevCursor = cursor.get(action.runId) ?? 0;
-        cursor.set(action.runId, Math.max(prevCursor, lastSeq));
+        cursor.set(action.runId, Math.max(prevCursor, maxSeq));
       }
       return {
         ...state,

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -128,11 +128,13 @@ export function gatewayReducer(
       const existing = frames.get(action.runId) ?? [];
       frames.set(action.runId, [...existing, ...action.frames]);
       const cursor = new Map(state.terminal.cursor);
-      const lastSeq = action.frames[action.frames.length - 1]?.frame_sequence ?? 0;
-      cursor.set(action.runId, lastSeq);
+      if (action.frames.length > 0) {
+        const lastSeq = action.frames[action.frames.length - 1].frame_sequence;
+        cursor.set(action.runId, lastSeq);
+      }
       return {
         ...state,
-        terminal: { ...state.terminal, frames, cursor },
+        terminal: { ...state.terminal, frames, cursor, error: state.terminal.error },
       };
     }
 
@@ -141,7 +143,11 @@ export function gatewayReducer(
         ...state,
         approval: {
           ...state.approval,
-          pending: [...state.approval.pending, action.payload],
+          pending: state.approval.pending.some(
+            (a) => a.approval_id === action.payload.approval_id,
+          )
+            ? state.approval.pending
+            : [...state.approval.pending, action.payload],
         },
       };
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -161,13 +161,14 @@ export function gatewayReducer(
     }
 
     case "APPROVAL_RESOLVED": {
+      const approvalId = action.payload.approval_id;
       const resolved = new Map(state.approval.resolved);
-      resolved.set(action.approvalId, action.payload);
+      resolved.set(approvalId, action.payload);
       return {
         ...state,
         approval: {
           ...state.approval,
-          pending: state.approval.pending.filter((a) => a.approval_id !== action.approvalId),
+          pending: state.approval.pending.filter((a) => a.approval_id !== approvalId),
           resolved,
           loading: false,
           error: null,

--- a/packages/state/tsconfig.json
+++ b/packages/state/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/state/tsconfig.json
+++ b/packages/state/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "."
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/state/tsconfig.json
+++ b/packages/state/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "."
+    "rootDir": "./src"
   },
-  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/state/tsconfig.test.json
+++ b/packages/state/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@opensymphony/ui-core",
+  "version": "1.0.0",
+  "description": "Shared UI core components for OpenSymphony clients",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsc --build tsconfig.json",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opensymphony/gateway-schema": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared UI core module.
+ *
+ * This package is a placeholder for shared UI utilities and type
+ * definitions that both desktop and web shells will consume. The
+ * actual component framework (React, Svelte, etc.) will be added
+ * in a future ticket.
+ */
+
+import type {
+  DashboardSnapshot,
+  TaskGraphNode,
+  RunDetail,
+  TerminalFrame,
+} from "@opensymphony/gateway-schema";
+
+export interface UiTheme {
+  mode: "light" | "dark";
+  accent?: string;
+}
+
+export interface TerminalRenderConfig {
+  fontFamily: string;
+  fontSize: number;
+  lineHeight: number;
+  wrapLines: boolean;
+  maxVisibleFrames: number;
+}
+
+export type TerminalFrameWithMeta = TerminalFrame & {
+  renderedAt: string;
+};
+
+export type DashboardData = DashboardSnapshot;
+export type TaskGraphData = TaskGraphNode[];
+export type RunData = RunDetail;

--- a/packages/ui-core/tsconfig.json
+++ b/packages/ui-core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.projects.json
+++ b/tsconfig.projects.json
@@ -5,6 +5,7 @@
     { "path": "packages/api-client" },
     { "path": "packages/ui-core" },
     { "path": "packages/state" },
+    { "path": "packages/state/tsconfig.test.json" },
     { "path": "apps/desktop" },
     { "path": "apps/web" }
   ]

--- a/tsconfig.projects.json
+++ b/tsconfig.projects.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/gateway-schema" },
+    { "path": "packages/api-client" },
+    { "path": "packages/ui-core" },
+    { "path": "packages/state" },
+    { "path": "apps/desktop" },
+    { "path": "apps/web" }
+  ]
+}


### PR DESCRIPTION
## Summary

Create the shared TypeScript frontend workspace and schema layer used by both Tauri desktop and browser clients.

## Changes

### Workspace Root
- Add monorepo root (package.json, tsconfig.json, tsconfig.projects.json)
- Add Jest configuration with ts-jest ESM support
- Update .gitignore for node_modules and dist directories

### @opensymphony/gateway-schema
- 12 TypeScript DTO modules mirroring Rust gateway-schema crate:
  - version, cursor, envelope, snapshot, task_graph, run, terminal, approval, planning, capability, action, transport
- Runtime validation helpers (schema version, envelope validators)
- Barrel index.ts with type-safe re-exports
- README with documented schema update path
- 11 JSON fixture files aligned with gateway v1 DTOs
- 41 schema fixture tests with forward compatibility checks

### @opensymphony/api-client
- GatewayTransport interface for transport-agnostic client code
- HttpGatewayTransport stub implementation
- GatewayTransportConfig.transport uses TransportProfile from gateway-schema

### @opensymphony/ui-core
- Shared theme and terminal render config types
- Type aliases for dashboard, task graph, run, and terminal data

### @opensymphony/state
- Reducer-driven state management covering dashboard, task graph, run, terminal, approval, planning slices
- Transport-agnostic and framework-neutral reducer function

### App Shells
- Desktop app stub with TauriTransportAdapter interface
- Web app stub with BrowserTransportAdapter interface

## Evidence

### `npm run type-check`

Exit code: 0. All 6 workspace packages type-check cleanly via `tsc --build tsconfig.projects.json`.

### `npm test`

Tests: 41 passed, 41 total. All schema fixture tests pass including forward compatibility checks.

## Test Plan

```bash
npm run type-check
npm test
```
