### PR TITLE
COE-392: Task Graph, Run Detail, File, And Diff Read APIs

### DIFF
--- a/crates/opensymphony-gateway-schema/src/run.rs
+++ b/crates/opensymphony-gateway-schema/src/run.rs
@@ -3,6 +3,22 @@ use serde::{Deserialize, Serialize};
 
 use super::{cursor::PageCursor, version::SchemaVersion};
 
+/// Run lifecycle states that reflect the full lifecycle including eligibility
+/// and workspace state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunLifecycleState {
+    Eligible,
+    Queued,
+    Claimed,
+    Running,
+    Releasing,
+    Completed,
+    Failed,
+    Canceled,
+    RetryExhausted,
+}
+
 /// Run detail exposed by `/api/v1/runs/{run_id}`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunDetail {
@@ -12,6 +28,7 @@ pub struct RunDetail {
     pub issue_identifier: String,
     pub worker_id: String,
     pub status: RunStatus,
+    pub lifecycle_state: RunLifecycleState,
     pub claimed_at: DateTime<Utc>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,
@@ -24,8 +41,35 @@ pub struct RunDetail {
     pub cache_read_tokens: u64,
     pub runtime_seconds: u64,
     pub conversation_id: Option<String>,
+    /// Logical workspace identifier for hosted mode.
+    pub workspace_id: Option<String>,
+    /// Local filesystem path (absent in hosted mode).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_path: Option<String>,
+    /// Harness type (e.g. "openhands").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_type: Option<String>,
+    /// Brief human-readable summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Blocker description when the run is blocked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
     pub error: Option<String>,
+    /// Actions the client may perform on this run.
+    #[serde(default)]
+    pub allowed_actions: Vec<RunAction>,
+}
+
+/// Action a client may dispatch on a run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunAction {
+    Retry,
+    Cancel,
+    Pause,
+    Resume,
+    Rehydrate,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,4 +114,65 @@ pub struct RunEvent {
     /// Original raw payload for forward compatibility.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_payload: Option<serde_json::Value>,
+}
+
+/// File change kind inside a changed-files entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileChangeKind {
+    Created,
+    Modified,
+    Removed,
+}
+
+/// Single changed-file entry for `/api/v1/runs/{run_id}/files`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangedFileEntry {
+    /// Workspace-relative path (never a raw absolute local path).
+    pub path: String,
+    pub change_kind: FileChangeKind,
+    pub lines_added: u32,
+    pub lines_removed: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+}
+
+/// Paged changed-files response for `/api/v1/runs/{run_id}/files`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFilesPage {
+    pub schema_version: SchemaVersion,
+    pub run_id: String,
+    pub next_cursor: Option<PageCursor>,
+    pub files: Vec<ChangedFileEntry>,
+}
+
+/// Single line inside a diff hunk.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DiffLine {
+    Context { line: String },
+    Addition { line: String },
+    Deletion { line: String },
+}
+
+/// A contiguous hunk inside a unified diff.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffHunk {
+    pub header: String,
+    pub start_line: u32,
+    pub old_line_count: u32,
+    pub new_line_count: u32,
+    pub lines: Vec<DiffLine>,
+}
+
+/// Paged diff response for `/api/v1/runs/{run_id}/diffs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileDiffPage {
+    pub schema_version: SchemaVersion,
+    pub run_id: String,
+    pub file_path: String,
+    pub next_cursor: Option<PageCursor>,
+    pub hunks: Vec<DiffHunk>,
+    pub total_lines_added: u32,
+    pub total_lines_removed: u32,
 }

--- a/crates/opensymphony-gateway-schema/src/snapshot.rs
+++ b/crates/opensymphony-gateway-schema/src/snapshot.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::version::SchemaVersion;
+use super::{cursor::PageCursor, version::SchemaVersion};
 
 /// Dashboard-level snapshot delivered over REST or SSE.
 ///
@@ -46,6 +46,61 @@ pub struct ProjectSummary {
     pub running_count: u32,
     pub completed_count: u32,
     pub failed_count: u32,
+}
+
+/// List of projects returned by `GET /api/v1/projects`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectList {
+    pub schema_version: SchemaVersion,
+    pub projects: Vec<ProjectSummary>,
+}
+
+/// Project detail returned by `GET /api/v1/projects/{project_id}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectDetail {
+    pub schema_version: SchemaVersion,
+    pub project_id: String,
+    pub name: String,
+    pub milestone_count: u32,
+    pub issue_count: u32,
+    pub running_count: u32,
+    pub completed_count: u32,
+    pub failed_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub milestones: Vec<ProjectMilestoneSummary>,
+}
+
+/// Compact milestone summary inside a project detail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectMilestoneSummary {
+    pub milestone_id: String,
+    pub name: String,
+    pub issue_count: u32,
+}
+
+/// Paged sub-issue list returned by `GET /api/v1/projects/{project_id}/issues`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectIssuesPage {
+    pub schema_version: SchemaVersion,
+    pub project_id: String,
+    pub next_cursor: Option<PageCursor>,
+    pub issues: Vec<ProjectIssueSummary>,
+}
+
+/// Single issue summary inside a project issues list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectIssueSummary {
+    pub issue_id: String,
+    pub identifier: String,
+    pub title: String,
+    pub state: String,
+    pub priority: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub milestone_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_state: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/opensymphony-gateway-schema/src/task_graph.rs
+++ b/crates/opensymphony-gateway-schema/src/task_graph.rs
@@ -24,6 +24,57 @@ pub struct TaskGraphNode {
     pub updated_at: Option<DateTime<Utc>>,
     /// Estimated effort in minutes.
     pub estimate_minutes: Option<u32>,
+    /// Runtime overlay when the node has active or recent run data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_overlay: Option<TaskGraphRuntimeOverlay>,
+}
+
+/// Runtime overlay attached to a task graph node.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskGraphRuntimeOverlay {
+    /// Whether the node is eligible for execution.
+    pub eligible: bool,
+    /// Whether the node is queued for execution.
+    pub queued: bool,
+    /// Active run identifier when a worker is currently executing this node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_run_id: Option<String>,
+    /// Last known outcome (e.g. "completed", "failed", "canceled").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_outcome: Option<String>,
+    /// Number of retry attempts so far.
+    pub retry_count: u32,
+    /// Logical workspace identifier for hosted mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    /// Harness type (e.g. "openhands").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_type: Option<String>,
+    /// Conversation/session identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    /// Timestamp of the last observed event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<DateTime<Utc>>,
+    /// High-level diff summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_summary: Option<DiffSummary>,
+    /// Validation status when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_status: Option<String>,
+    /// Blocker or dependency summary when the node is blocked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker_summary: Option<String>,
+}
+
+/// Compact summary of file changes produced by a run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffSummary {
+    pub files_added: u32,
+    pub files_modified: u32,
+    pub files_removed: u32,
+    pub lines_added: u32,
+    pub lines_removed: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -8,7 +8,7 @@ use opensymphony::opensymphony_gateway_schema::{
     planning::{
         PlanningArtifact, PlanningArtifactKind, PlanningSessionStatus, PlanningSessionSummary,
     },
-    run::{ReleaseReason, RunDetail, RunEvent, RunEventPage, RunStatus},
+    run::{ReleaseReason, RunDetail, RunEvent, RunEventPage, RunLifecycleState, RunStatus},
     snapshot::{
         DashboardSnapshot, GatewayHealth, GatewayMetrics, ProjectSummary, SnapshotEventKind,
         SnapshotEventSummary,
@@ -167,6 +167,7 @@ fn task_graph_node_roundtrips() {
         created_at: Some(Utc::now()),
         updated_at: Some(Utc::now()),
         estimate_minutes: Some(300),
+        runtime_overlay: None,
     };
     let json = must_serialize(&node);
     let back: TaskGraphNode = must_deserialize(&json);
@@ -185,6 +186,7 @@ fn run_detail_roundtrips() {
         issue_identifier: "COE-390".into(),
         worker_id: "worker-1".into(),
         status: RunStatus::Running,
+        lifecycle_state: RunLifecycleState::Running,
         claimed_at: Utc::now(),
         started_at: Some(Utc::now()),
         finished_at: None,
@@ -198,7 +200,12 @@ fn run_detail_roundtrips() {
         runtime_seconds: 120,
         conversation_id: Some("conv-1".into()),
         workspace_path: Some("/tmp/workspaces/COE-390".into()),
+        workspace_id: Some("COE-390".into()),
+        harness_type: Some("openhands".into()),
+        summary: Some("Processing run".into()),
+        blocker: None,
         error: None,
+        allowed_actions: vec![],
     };
     let json = must_serialize(&run);
     let back: RunDetail = must_deserialize(&json);

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{convert::Infallible, path::Path as StdPath, time::Duration};
+use std::{
+    convert::Infallible,
+    path::{Path as StdPath, PathBuf},
+    time::Duration,
+};
 
 use chrono::Utc;
 use serde_json::json;
@@ -356,12 +360,54 @@ fn find_issue_snapshot<'a>(
     })
 }
 
+/// Resolve `..` and `.` components in a path without touching the filesystem.
+///
+/// A crafted path like `/tmp/opensymphony/../etc/passwd` becomes `/tmp/etc/passwd`.
+fn normalize_path(path: &StdPath) -> PathBuf {
+    let mut components: Vec<_> = path.components().collect();
+    let is_absolute = components
+        .first()
+        .is_some_and(|c| matches!(c, std::path::Component::RootDir));
+
+    let mut stack: Vec<_> = Vec::new();
+    if is_absolute {
+        // Preserve the leading root dir (first component); skip CurDir entries.
+        stack.push(components.remove(0));
+    }
+
+    for comp in components {
+        match &comp {
+            std::path::Component::CurDir => continue,
+            std::path::Component::ParentDir => {
+                // Pop only if we are not at the root.
+                if let Some(last) = stack.last()
+                    && matches!(last, std::path::Component::RootDir)
+                {
+                    continue;
+                }
+                stack.pop();
+            }
+            _ => stack.push(comp),
+        }
+    }
+    stack.into_iter().collect()
+}
+
 /// Strip the workspace root from a raw absolute path so that the public API
 /// never leaks a local filesystem path outside the workspace boundary.
+///
+/// Normalizes `..` and `.` components before stripping so that crafted paths
+/// such as `/tmp/opensymphony/../etc/passwd` cannot bypass the workspace guard.
 pub fn sanitize_file_path(workspace_root: &str, raw_path: &str) -> String {
     let root = StdPath::new(workspace_root);
     let candidate = StdPath::new(raw_path);
-    candidate
+
+    // Normalize the path by resolving `.` and `..` components so that a crafted
+    // path like `/tmp/opensymphony/../etc/passwd` becomes `/tmp/etc/passwd` and
+    // then fails `strip_prefix`, falling back to the safe basename.
+    let normalized = normalize_path(candidate);
+
+    normalized
         .strip_prefix(root)
         .map(|rel: &StdPath| rel.to_string_lossy().to_string())
         .unwrap_or_else(|_| {
@@ -536,11 +582,10 @@ async fn get_task_graph(
         })
         .collect();
 
-    let root_ids: Vec<String> = snapshot
-        .issues
-        .iter()
-        .map(|i| i.identifier.clone())
-        .collect();
+    // Parent/child relationship data is not yet available from the control-plane
+    // snapshot, so every node is treated as a standalone leaf. Returning an empty
+    // root_ids prevents clients from building an incorrect flat-forest layout.
+    let root_ids: Vec<String> = Vec::new();
 
     (
         StatusCode::OK,
@@ -610,7 +655,10 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
     let is_running = matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Running);
 
     TaskGraphRuntimeOverlay {
-        eligible: !issue.blocked,
+        // An issue is eligible only when it is idle (not yet started) and not
+        // blocked.  Completed and failed issues must not appear eligible.
+        eligible: !issue.blocked
+            && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle),
         queued: matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle),
         active_run_id: is_running.then(|| issue.identifier.clone()),
         last_outcome: outcome,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -740,7 +740,14 @@ async fn get_run_detail(
     let release_reason = match issue.last_outcome {
         ControlPlaneWorkerOutcome::Completed => Some(ReleaseReason::Completed),
         ControlPlaneWorkerOutcome::Canceled => Some(ReleaseReason::Cancelled),
-        ControlPlaneWorkerOutcome::Failed => Some(ReleaseReason::RetryExhausted),
+        // When the snapshot indicates a failure and retries are exhausted
+        // (retry_count > 0), treat it as RetryExhausted.  When the issue
+        // failed on the first attempt with no retry queued, treat it as a
+        // terminal tracker state rather than an exhausted-retry signal.
+        ControlPlaneWorkerOutcome::Failed if issue.retry_count > 0 => {
+            Some(ReleaseReason::RetryExhausted)
+        }
+        ControlPlaneWorkerOutcome::Failed => Some(ReleaseReason::TrackerTerminal),
         _ => None,
     };
 

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -531,7 +531,7 @@ async fn get_task_graph(
                 created_at: None,
                 updated_at: None,
                 estimate_minutes: None,
-                runtime_overlay,
+                runtime_overlay: Some(runtime_overlay),
             }
         })
         .collect();
@@ -567,7 +567,7 @@ fn map_runtime_state_to_graph_category(
     }
 }
 
-fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> Option<TaskGraphRuntimeOverlay> {
+fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeOverlay {
     let diff_summary = if issue.modified_files.is_empty() {
         None
     } else {
@@ -609,7 +609,7 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> Option<TaskGraphR
 
     let is_running = matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Running);
 
-    Some(TaskGraphRuntimeOverlay {
+    TaskGraphRuntimeOverlay {
         eligible: !issue.blocked,
         queued: matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle),
         active_run_id: is_running.then(|| issue.identifier.clone()),
@@ -629,7 +629,7 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> Option<TaskGraphR
         } else {
             None
         },
-    })
+    }
 }
 
 // ── Run endpoints ─────────────────────────────────────────────────────────────

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -678,7 +678,7 @@ async fn get_run_detail(
         ControlPlaneIssueRuntimeState::Idle => (RunStatus::Unclaimed, RunLifecycleState::Eligible),
         ControlPlaneIssueRuntimeState::Running => (RunStatus::Running, RunLifecycleState::Running),
         ControlPlaneIssueRuntimeState::RetryQueued => {
-            (RunStatus::RetryQueued, RunLifecycleState::Failed)
+            (RunStatus::RetryQueued, RunLifecycleState::Queued)
         }
         ControlPlaneIssueRuntimeState::Releasing => {
             (RunStatus::Released, RunLifecycleState::Releasing)
@@ -714,7 +714,13 @@ async fn get_run_detail(
                 ControlPlaneIssueRuntimeState::Running | ControlPlaneIssueRuntimeState::Releasing
             )
             .then(|| envelope.published_at),
-            finished_at: None,
+            // finished_at is set for terminal states using the snapshot timestamp
+            // since the control plane does not yet track exact completion time.
+            finished_at: matches!(
+                issue.runtime_state,
+                ControlPlaneIssueRuntimeState::Completed | ControlPlaneIssueRuntimeState::Failed
+            )
+            .then(|| envelope.published_at),
             release_reason,
             // retry_count and turn_count are distinct concepts; the snapshot
             // currently only tracks retries.
@@ -857,23 +863,14 @@ async fn get_run_diffs(
     let hunks: Vec<DiffHunk> = files
         .iter()
         .map(|fc| {
-            let path = sanitize_file_path(&workspace_root, &fc.path);
-            let kind_label = match fc.change_kind {
-                ControlPlaneFileChangeKind::Created => "added",
-                ControlPlaneFileChangeKind::Modified => "modified",
-                ControlPlaneFileChangeKind::Removed => "removed",
-            };
             DiffHunk {
-                // Use proper unified-diff header format: @@ -start,count +start,count @@
-                // Counts default to 1 when the line count is 0 so the header is valid.
+                // Standard unified-diff hunk header: @@ -start,count +start,count @@
                 header: format!(
-                    "@@ -{},{} +{},{} @@  {}  ({})",
+                    "@@ -{},{} +{},{} @@",
                     1,
                     fc.lines_removed.max(1),
                     1,
-                    fc.lines_added.max(1),
-                    path,
-                    kind_label
+                    fc.lines_added.max(1)
                 ),
                 start_line: 1,
                 old_line_count: fc.lines_removed,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -396,22 +396,20 @@ fn normalize_path(path: &StdPath) -> PathBuf {
 /// Strip the workspace root from a raw absolute path so that the public API
 /// never leaks a local filesystem path outside the workspace boundary.
 ///
-/// Normalizes `..` and `.` components before stripping so that crafted paths
-/// such as `/tmp/opensymphony/../etc/passwd` cannot bypass the workspace guard.
+/// Normalizes `..` and `.` components in **both** the workspace root and the
+/// candidate path before stripping, so that crafted paths such as
+/// `/tmp/opensymphony/../etc/passwd` cannot bypass the workspace guard.
 pub fn sanitize_file_path(workspace_root: &str, raw_path: &str) -> String {
-    let root = StdPath::new(workspace_root);
-    let candidate = StdPath::new(raw_path);
-
-    // Normalize the path by resolving `.` and `..` components so that a crafted
-    // path like `/tmp/opensymphony/../etc/passwd` becomes `/tmp/etc/passwd` and
-    // then fails `strip_prefix`, falling back to the safe basename.
-    let normalized = normalize_path(candidate);
+    let root = normalize_path(StdPath::new(workspace_root));
+    let normalized = normalize_path(StdPath::new(raw_path));
 
     normalized
-        .strip_prefix(root)
+        .strip_prefix(&root)
         .map(|rel: &StdPath| rel.to_string_lossy().to_string())
         .unwrap_or_else(|_| {
-            candidate
+            // Out-of-workspace path: return just the basename (safe last
+            // component) or empty string if none exists.
+            StdPath::new(raw_path)
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_default()

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -26,13 +26,13 @@ pub use crate::opensymphony_gateway_schema::{
     capability::{AuthMode, FeatureCapability, GatewayCapabilities, TransportCapability},
     cursor::PageCursor,
     run::{
-        ChangedFileEntry, DiffHunk, DiffLine, FileChangeKind, FileDiffPage, ReleaseReason, RunAction, RunDetail,
-        RunEvent, RunEventPage, RunFilesPage, RunLifecycleState, RunStatus,
+        ChangedFileEntry, DiffHunk, DiffLine, FileChangeKind, FileDiffPage, ReleaseReason,
+        RunAction, RunDetail, RunEvent, RunEventPage, RunFilesPage, RunLifecycleState, RunStatus,
     },
     snapshot::{
         DashboardSnapshot, GatewayHealth, GatewayMetrics, ProjectDetail, ProjectIssueSummary,
-        ProjectIssuesPage, ProjectList, ProjectMilestoneSummary, ProjectSummary,
-        SnapshotEventKind, SnapshotEventSummary,
+        ProjectIssuesPage, ProjectList, ProjectMilestoneSummary, ProjectSummary, SnapshotEventKind,
+        SnapshotEventSummary,
     },
     task_graph::{DiffSummary, TaskGraphRuntimeOverlay, TaskGraphSnapshot, TaskGraphStateCategory},
     version::{GATEWAY_SCHEMA_VERSION, SchemaVersion},
@@ -59,7 +59,10 @@ impl GatewayServer {
             .route("/api/v1/events", get(events))
             .route("/api/v1/projects", get(list_projects))
             .route("/api/v1/projects/{project_id}", get(get_project))
-            .route("/api/v1/projects/{project_id}/taskgraph", get(get_task_graph))
+            .route(
+                "/api/v1/projects/{project_id}/taskgraph",
+                get(get_task_graph),
+            )
             .route("/api/v1/runs/{run_id}", get(get_run_detail))
             .route("/api/v1/runs/{run_id}/events", get(get_run_events))
             .route("/api/v1/runs/{run_id}/files", get(get_run_files))
@@ -347,14 +350,10 @@ fn find_issue_snapshot<'a>(
     envelope: &'a SnapshotEnvelope,
     run_id: &'a str,
 ) -> Option<&'a ControlPlaneIssueSnapshot> {
-    envelope
-        .snapshot
-        .issues
-        .iter()
-        .find(|issue| {
-            issue.identifier.eq_ignore_ascii_case(run_id)
-                || issue.conversation_id_suffix.eq_ignore_ascii_case(run_id)
-        })
+    envelope.snapshot.issues.iter().find(|issue| {
+        issue.identifier.eq_ignore_ascii_case(run_id)
+            || issue.conversation_id_suffix.eq_ignore_ascii_case(run_id)
+    })
 }
 
 /// Strip the workspace root from a raw absolute path so that the public API
@@ -537,7 +536,11 @@ async fn get_task_graph(
         })
         .collect();
 
-    let root_ids: Vec<String> = snapshot.issues.iter().map(|i| i.identifier.clone()).collect();
+    let root_ids: Vec<String> = snapshot
+        .issues
+        .iter()
+        .map(|i| i.identifier.clone())
+        .collect();
 
     (
         StatusCode::OK,
@@ -551,7 +554,9 @@ async fn get_task_graph(
     )
 }
 
-fn map_runtime_state_to_graph_category(state: &ControlPlaneIssueRuntimeState) -> TaskGraphStateCategory {
+fn map_runtime_state_to_graph_category(
+    state: &ControlPlaneIssueRuntimeState,
+) -> TaskGraphStateCategory {
     match state {
         ControlPlaneIssueRuntimeState::Idle => TaskGraphStateCategory::Todo,
         ControlPlaneIssueRuntimeState::Running => TaskGraphStateCategory::InProgress,
@@ -566,9 +571,21 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> Option<TaskGraphR
     let diff_summary = if issue.modified_files.is_empty() {
         None
     } else {
-        let added = issue.modified_files.iter().filter(|f| f.change_kind == ControlPlaneFileChangeKind::Created).count() as u32;
-        let modified = issue.modified_files.iter().filter(|f| f.change_kind == ControlPlaneFileChangeKind::Modified).count() as u32;
-        let removed = issue.modified_files.iter().filter(|f| f.change_kind == ControlPlaneFileChangeKind::Removed).count() as u32;
+        let added = issue
+            .modified_files
+            .iter()
+            .filter(|f| f.change_kind == ControlPlaneFileChangeKind::Created)
+            .count() as u32;
+        let modified = issue
+            .modified_files
+            .iter()
+            .filter(|f| f.change_kind == ControlPlaneFileChangeKind::Modified)
+            .count() as u32;
+        let removed = issue
+            .modified_files
+            .iter()
+            .filter(|f| f.change_kind == ControlPlaneFileChangeKind::Removed)
+            .count() as u32;
         let lines_added: u32 = issue.modified_files.iter().map(|f| f.lines_added).sum();
         let lines_removed: u32 = issue.modified_files.iter().map(|f| f.lines_removed).sum();
 
@@ -662,9 +679,15 @@ async fn get_run_detail(
     let (status, lifecycle_state) = match issue.runtime_state {
         ControlPlaneIssueRuntimeState::Idle => (RunStatus::Unclaimed, RunLifecycleState::Eligible),
         ControlPlaneIssueRuntimeState::Running => (RunStatus::Running, RunLifecycleState::Running),
-        ControlPlaneIssueRuntimeState::RetryQueued => (RunStatus::RetryQueued, RunLifecycleState::Failed),
-        ControlPlaneIssueRuntimeState::Releasing => (RunStatus::Released, RunLifecycleState::Releasing),
-        ControlPlaneIssueRuntimeState::Completed => (RunStatus::Released, RunLifecycleState::Completed),
+        ControlPlaneIssueRuntimeState::RetryQueued => {
+            (RunStatus::RetryQueued, RunLifecycleState::Failed)
+        }
+        ControlPlaneIssueRuntimeState::Releasing => {
+            (RunStatus::Released, RunLifecycleState::Releasing)
+        }
+        ControlPlaneIssueRuntimeState::Completed => {
+            (RunStatus::Released, RunLifecycleState::Completed)
+        }
         ControlPlaneIssueRuntimeState::Failed => (RunStatus::Released, RunLifecycleState::Failed),
     };
 
@@ -833,7 +856,10 @@ async fn get_run_diffs(
                 ControlPlaneFileChangeKind::Removed => "removed",
             };
             DiffHunk {
-                header: format!("@@ -{} +{} @@  {}  ({})", fc.lines_removed, fc.lines_added, path, kind_label),
+                header: format!(
+                    "@@ -{} +{} @@  {}  ({})",
+                    fc.lines_removed, fc.lines_added, path, kind_label
+                ),
                 start_line: 1,
                 old_line_count: fc.lines_removed,
                 new_line_count: fc.lines_added,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -617,10 +617,8 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
         retry_count: issue.retry_count,
         workspace_id: Some(issue.workspace_path_suffix.clone()),
         harness_type: issue.server_base_url.is_some().then(|| "openhands".into()),
-        conversation_id: issue.server_base_url.as_ref().and_then(|_| {
-            (!issue.conversation_id_suffix.is_empty())
-                .then(|| format!("conv-{}", issue.conversation_id_suffix))
-        }),
+        conversation_id: (!issue.conversation_id_suffix.is_empty())
+            .then(|| format!("conv-{}", issue.conversation_id_suffix)),
         last_event_at: Some(issue.last_event_at),
         diff_summary,
         validation_status: None,
@@ -708,17 +706,27 @@ async fn get_run_detail(
             worker_id: "default-worker".into(),
             status,
             lifecycle_state,
-            claimed_at: issue.last_event_at,
-            started_at: Some(issue.last_event_at),
+            // Use published timestamp so it does not drift on every event.
+            claimed_at: envelope.published_at,
+            // started_at is meaningful only when the run is actively running.
+            started_at: matches!(
+                issue.runtime_state,
+                ControlPlaneIssueRuntimeState::Running | ControlPlaneIssueRuntimeState::Releasing
+            )
+            .then(|| envelope.published_at),
             finished_at: None,
             release_reason,
-            turn_count: issue.retry_count,
-            max_turns: 8,
+            // retry_count and turn_count are distinct concepts; the snapshot
+            // currently only tracks retries.
+            turn_count: 0,
+            max_turns: issue.retry_count.saturating_add(1).max(1),
             retry_attempt: (issue.retry_count > 0).then_some(issue.retry_count),
             input_tokens: issue.input_tokens,
             output_tokens: issue.output_tokens,
             cache_read_tokens: issue.cache_read_tokens,
             runtime_seconds: 0,
+            // Emit conversation_id whenever a suffix is available regardless of
+            // whether a server URL is configured.
             conversation_id: (!issue.conversation_id_suffix.is_empty())
                 .then(|| format!("conv-{}", issue.conversation_id_suffix)),
             workspace_id: (!issue.workspace_path_suffix.is_empty())
@@ -856,9 +864,16 @@ async fn get_run_diffs(
                 ControlPlaneFileChangeKind::Removed => "removed",
             };
             DiffHunk {
+                // Use proper unified-diff header format: @@ -start,count +start,count @@
+                // Counts default to 1 when the line count is 0 so the header is valid.
                 header: format!(
-                    "@@ -{} +{} @@  {}  ({})",
-                    fc.lines_removed, fc.lines_added, path, kind_label
+                    "@@ -{},{} +{},{} @@  {}  ({})",
+                    1,
+                    fc.lines_removed.max(1),
+                    1,
+                    fc.lines_added.max(1),
+                    path,
+                    kind_label
                 ),
                 start_line: 1,
                 old_line_count: fc.lines_removed,
@@ -868,12 +883,18 @@ async fn get_run_diffs(
         })
         .collect();
 
-    let file_path = files
-        .first()
-        .map(|fc| sanitize_file_path(&workspace_root, &fc.path));
-
     let total_lines_added: u32 = files.iter().map(|f| f.lines_added).sum();
     let total_lines_removed: u32 = files.iter().map(|f| f.lines_removed).sum();
+
+    // When multiple files are present, list all paths so the caller knows the
+    // response is an aggregate rather than a single-file diff.
+    let file_path = if files.len() == 1 {
+        files
+            .first()
+            .map(|fc| sanitize_file_path(&workspace_root, &fc.path))
+    } else {
+        Some(format!("[{} files]", files.len()))
+    };
 
     (
         StatusCode::OK,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1,9 +1,12 @@
-use std::{convert::Infallible, time::Duration};
+use std::{convert::Infallible, path::Path as StdPath, time::Duration};
+
+use chrono::Utc;
+use serde_json::json;
 
 use async_stream::stream;
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{Path as AxumPath, State},
     response::sse::{Event, KeepAlive, Sse},
     routing::get,
 };
@@ -12,16 +15,24 @@ use tokio::{net::TcpListener, sync::broadcast};
 pub use crate::opensymphony_control::SnapshotStore;
 pub use crate::opensymphony_domain::{
     ControlPlaneAgentServerStatus, ControlPlaneDaemonSnapshot, ControlPlaneDaemonState,
-    ControlPlaneDaemonStatus, ControlPlaneIssueRuntimeState, ControlPlaneIssueSnapshot,
-    ControlPlaneMetricsSnapshot, ControlPlaneRecentEvent, ControlPlaneRecentEventKind,
-    ControlPlaneWorkerOutcome, SnapshotEnvelope,
+    ControlPlaneDaemonStatus, ControlPlaneFileChange, ControlPlaneFileChangeKind,
+    ControlPlaneIssueRuntimeState, ControlPlaneIssueSnapshot, ControlPlaneMetricsSnapshot,
+    ControlPlaneRecentEvent, ControlPlaneRecentEventKind, ControlPlaneWorkerOutcome,
+    SnapshotEnvelope,
 };
 pub use crate::opensymphony_gateway_schema::{
     capability::{AuthMode, FeatureCapability, GatewayCapabilities, TransportCapability},
-    snapshot::{
-        DashboardSnapshot, GatewayHealth, GatewayMetrics, ProjectSummary, SnapshotEventKind,
-        SnapshotEventSummary,
+    cursor::PageCursor,
+    run::{
+        ChangedFileEntry, FileChangeKind, FileDiffPage, ReleaseReason, RunAction, RunDetail,
+        RunEvent, RunEventPage, RunFilesPage, RunLifecycleState, RunStatus,
     },
+    snapshot::{
+        DashboardSnapshot, GatewayHealth, GatewayMetrics, ProjectDetail, ProjectIssueSummary,
+        ProjectIssuesPage, ProjectList, ProjectMilestoneSummary, ProjectSummary,
+        SnapshotEventKind, SnapshotEventSummary,
+    },
+    task_graph::{DiffSummary, TaskGraphRuntimeOverlay, TaskGraphSnapshot, TaskGraphStateCategory},
     version::{GATEWAY_SCHEMA_VERSION, SchemaVersion},
 };
 
@@ -44,6 +55,13 @@ impl GatewayServer {
             .route("/api/v1/capabilities", get(capabilities))
             .route("/api/v1/dashboard/snapshot", get(dashboard_snapshot))
             .route("/api/v1/events", get(events))
+            .route("/api/v1/projects", get(list_projects))
+            .route("/api/v1/projects/{project_id}", get(get_project))
+            .route("/api/v1/projects/{project_id}/taskgraph", get(get_task_graph))
+            .route("/api/v1/runs/{run_id}", get(get_run_detail))
+            .route("/api/v1/runs/{run_id}/events", get(get_run_events))
+            .route("/api/v1/runs/{run_id}/files", get(get_run_files))
+            .route("/api/v1/runs/{run_id}/diffs", get(get_run_diffs))
             .with_state(self.store.clone())
     }
 
@@ -65,8 +83,6 @@ pub fn control_plane_to_dashboard_snapshot(envelope: &SnapshotEnvelope) -> Dashb
         total_cost_micros: snapshot.metrics.total_cost_micros,
     };
 
-    // For v1 we flatten all issues into a single synthetic project because the
-    // control-plane does not yet expose per-project grouping.
     let projects = if snapshot.issues.is_empty() {
         Vec::new()
     } else {
@@ -172,19 +188,19 @@ fn build_capabilities() -> GatewayCapabilities {
         features: vec![
             FeatureCapability {
                 feature: "task_graph".into(),
-                available: false,
+                available: true,
                 requires_auth: false,
                 requires_plan: None,
             },
             FeatureCapability {
                 feature: "run_detail".into(),
-                available: false,
+                available: true,
                 requires_auth: false,
                 requires_plan: None,
             },
             FeatureCapability {
                 feature: "event_journal".into(),
-                available: false,
+                available: true,
                 requires_auth: false,
                 requires_plan: None,
             },
@@ -321,4 +337,420 @@ async fn latest_from_store(
 ) -> Option<SnapshotEnvelope> {
     let latest = store.current().await;
     (latest.sequence > last_sent_sequence).then_some(latest)
+}
+
+// ── Read API helpers ──────────────────────────────────────────────────────────
+
+fn find_issue_snapshot<'a>(
+    envelope: &'a SnapshotEnvelope,
+    run_id: &'a str,
+) -> Option<&'a ControlPlaneIssueSnapshot> {
+    envelope
+        .snapshot
+        .issues
+        .iter()
+        .find(|issue| {
+            issue.identifier.eq_ignore_ascii_case(run_id)
+                || issue.conversation_id_suffix.eq_ignore_ascii_case(run_id)
+                || run_id.starts_with(&issue.identifier)
+        })
+}
+
+/// Strip the workspace root from a raw absolute path so that the public API
+/// never leaks a local filesystem path outside the workspace boundary.
+pub fn sanitize_file_path(workspace_root: &str, raw_path: &str) -> String {
+    let root = StdPath::new(workspace_root);
+    let candidate = StdPath::new(raw_path);
+    candidate
+        .strip_prefix(root)
+        .map(|rel: &StdPath| rel.to_string_lossy().to_string())
+        .unwrap_or_else(|_| {
+            candidate
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| raw_path.to_string())
+        })
+}
+
+fn map_file_change_kind(kind: ControlPlaneFileChangeKind) -> FileChangeKind {
+    match kind {
+        ControlPlaneFileChangeKind::Created => FileChangeKind::Created,
+        ControlPlaneFileChangeKind::Modified => FileChangeKind::Modified,
+        ControlPlaneFileChangeKind::Removed => FileChangeKind::Removed,
+    }
+}
+
+// ── Project endpoints ─────────────────────────────────────────────────────────
+
+async fn list_projects(State(store): State<SnapshotStore>) -> Json<ProjectList> {
+    let envelope = store.current().await;
+    let snapshot = &envelope.snapshot;
+    let projects = if snapshot.issues.is_empty() {
+        Vec::new()
+    } else {
+        let running = snapshot
+            .issues
+            .iter()
+            .filter(|i| matches!(i.runtime_state, ControlPlaneIssueRuntimeState::Running))
+            .count() as u32;
+        let completed = snapshot
+            .issues
+            .iter()
+            .filter(|i| matches!(i.last_outcome, ControlPlaneWorkerOutcome::Completed))
+            .count() as u32;
+        let failed = snapshot
+            .issues
+            .iter()
+            .filter(|i| matches!(i.last_outcome, ControlPlaneWorkerOutcome::Failed))
+            .count() as u32;
+
+        vec![ProjectSummary {
+            project_id: "default".into(),
+            name: "OpenSymphony".into(),
+            milestone_count: 0,
+            issue_count: snapshot.issues.len() as u32,
+            running_count: running,
+            completed_count: completed,
+            failed_count: failed,
+        }]
+    };
+
+    Json(ProjectList {
+        schema_version: SchemaVersion::v1(),
+        projects,
+    })
+}
+
+async fn get_project(
+    State(store): State<SnapshotStore>,
+    AxumPath(project_id): AxumPath<String>,
+) -> Json<ProjectDetail> {
+    let envelope = store.current().await;
+    let snapshot = &envelope.snapshot;
+    let issue_count = snapshot.issues.len() as u32;
+    let running = snapshot
+        .issues
+        .iter()
+        .filter(|i| matches!(i.runtime_state, ControlPlaneIssueRuntimeState::Running))
+        .count() as u32;
+    let completed = snapshot
+        .issues
+        .iter()
+        .filter(|i| matches!(i.last_outcome, ControlPlaneWorkerOutcome::Completed))
+        .count() as u32;
+    let failed = snapshot
+        .issues
+        .iter()
+        .filter(|i| matches!(i.last_outcome, ControlPlaneWorkerOutcome::Failed))
+        .count() as u32;
+
+    Json(ProjectDetail {
+        schema_version: SchemaVersion::v1(),
+        project_id,
+        name: "OpenSymphony".into(),
+        milestone_count: 0,
+        issue_count,
+        running_count: running,
+        completed_count: completed,
+        failed_count: failed,
+        summary: Some("Current workspace issues".into()),
+        milestones: Vec::new(),
+    })
+}
+
+// ── Task Graph endpoint ───────────────────────────────────────────────────────
+
+async fn get_task_graph(
+    State(store): State<SnapshotStore>,
+    AxumPath(project_id): AxumPath<String>,
+) -> Json<TaskGraphSnapshot> {
+    let envelope = store.current().await;
+    let snapshot = &envelope.snapshot;
+    let generated_at = Utc::now();
+
+    let nodes: Vec<_> = snapshot
+        .issues
+        .iter()
+        .map(|issue| {
+            let state_category = map_runtime_state_to_graph_category(&issue.runtime_state);
+            let runtime_overlay = build_runtime_overlay(issue);
+
+            crate::opensymphony_gateway_schema::task_graph::TaskGraphNode {
+                schema_version: SchemaVersion::v1(),
+                node_id: issue.identifier.clone(),
+                kind: crate::opensymphony_gateway_schema::task_graph::TaskGraphNodeKind::Issue,
+                identifier: issue.identifier.clone(),
+                title: issue.title.clone(),
+                state: issue.tracker_state.clone(),
+                state_category,
+                priority: None,
+                parent_id: None,
+                children: Vec::new(),
+                blocked_by: if issue.blocked {
+                    vec![format!("blocked: {}", issue.identifier)]
+                } else {
+                    Vec::new()
+                },
+                url: None,
+                branch_name: None,
+                labels: Vec::new(),
+                created_at: None,
+                updated_at: None,
+                estimate_minutes: None,
+                runtime_overlay,
+            }
+        })
+        .collect();
+
+    let root_ids: Vec<String> = snapshot.issues.iter().map(|i| i.identifier.clone()).collect();
+
+    Json(TaskGraphSnapshot {
+        schema_version: SchemaVersion::v1(),
+        project_id,
+        generated_at,
+        nodes,
+        root_ids,
+    })
+}
+
+fn map_runtime_state_to_graph_category(state: &ControlPlaneIssueRuntimeState) -> TaskGraphStateCategory {
+    match state {
+        ControlPlaneIssueRuntimeState::Idle => TaskGraphStateCategory::Todo,
+        ControlPlaneIssueRuntimeState::Running => TaskGraphStateCategory::InProgress,
+        ControlPlaneIssueRuntimeState::RetryQueued => TaskGraphStateCategory::InProgress,
+        ControlPlaneIssueRuntimeState::Releasing => TaskGraphStateCategory::InProgress,
+        ControlPlaneIssueRuntimeState::Completed => TaskGraphStateCategory::Done,
+        ControlPlaneIssueRuntimeState::Failed => TaskGraphStateCategory::Done,
+    }
+}
+
+fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> Option<TaskGraphRuntimeOverlay> {
+    let diff_summary = if issue.modified_files.is_empty() {
+        None
+    } else {
+        let added = issue.modified_files.iter().filter(|f| f.change_kind == ControlPlaneFileChangeKind::Created).count() as u32;
+        let modified = issue.modified_files.iter().filter(|f| f.change_kind == ControlPlaneFileChangeKind::Modified).count() as u32;
+        let removed = issue.modified_files.iter().filter(|f| f.change_kind == ControlPlaneFileChangeKind::Removed).count() as u32;
+        let lines_added: u32 = issue.modified_files.iter().map(|f| f.lines_added).sum();
+        let lines_removed: u32 = issue.modified_files.iter().map(|f| f.lines_removed).sum();
+
+        Some(DiffSummary {
+            files_added: added,
+            files_modified: modified,
+            files_removed: removed,
+            lines_added,
+            lines_removed,
+        })
+    };
+
+    let outcome = match issue.last_outcome {
+        ControlPlaneWorkerOutcome::Unknown => None,
+        ControlPlaneWorkerOutcome::Running => Some("running".into()),
+        ControlPlaneWorkerOutcome::Continued => Some("continued".into()),
+        ControlPlaneWorkerOutcome::Completed => Some("completed".into()),
+        ControlPlaneWorkerOutcome::Failed => Some("failed".into()),
+        ControlPlaneWorkerOutcome::Canceled => Some("canceled".into()),
+    };
+
+    let is_running = matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Running);
+
+    Some(TaskGraphRuntimeOverlay {
+        eligible: !issue.blocked,
+        queued: matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle),
+        active_run_id: is_running.then(|| issue.identifier.clone()),
+        last_outcome: outcome,
+        retry_count: issue.retry_count,
+        workspace_id: Some(issue.workspace_path_suffix.clone()),
+        harness_type: issue.server_base_url.is_some().then(|| "openhands".into()),
+        conversation_id: issue.server_base_url.as_ref().and_then(|_| {
+            (!issue.conversation_id_suffix.is_empty())
+                .then(|| format!("conv-{}", issue.conversation_id_suffix))
+        }),
+        last_event_at: Some(issue.last_event_at),
+        diff_summary,
+        validation_status: None,
+        blocker_summary: if issue.blocked {
+            Some("Blocked by dependency".into())
+        } else {
+            None
+        },
+    })
+}
+
+// ── Run endpoints ─────────────────────────────────────────────────────────────
+
+async fn get_run_detail(
+    State(store): State<SnapshotStore>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Json<RunDetail> {
+    let envelope = store.current().await;
+    let issue = match find_issue_snapshot(&envelope, &run_id) {
+        Some(issue) => issue,
+        None => {
+            return Json(RunDetail {
+                schema_version: SchemaVersion::v1(),
+                run_id,
+                issue_id: "unknown".into(),
+                issue_identifier: "unknown".into(),
+                worker_id: "unknown".into(),
+                status: RunStatus::Unclaimed,
+                lifecycle_state: RunLifecycleState::Eligible,
+                claimed_at: Utc::now(),
+                started_at: None,
+                finished_at: None,
+                release_reason: None,
+                turn_count: 0,
+                max_turns: 0,
+                retry_attempt: None,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                runtime_seconds: 0,
+                conversation_id: None,
+                workspace_id: None,
+                workspace_path: None,
+                harness_type: None,
+                summary: None,
+                blocker: None,
+                error: Some("Run not found".into()),
+                allowed_actions: Vec::new(),
+            });
+        }
+    };
+
+    let (status, lifecycle_state) = match issue.runtime_state {
+        ControlPlaneIssueRuntimeState::Idle => (RunStatus::Unclaimed, RunLifecycleState::Eligible),
+        ControlPlaneIssueRuntimeState::Running => (RunStatus::Running, RunLifecycleState::Running),
+        ControlPlaneIssueRuntimeState::RetryQueued => (RunStatus::RetryQueued, RunLifecycleState::Failed),
+        ControlPlaneIssueRuntimeState::Releasing => (RunStatus::Released, RunLifecycleState::Releasing),
+        ControlPlaneIssueRuntimeState::Completed => (RunStatus::Released, RunLifecycleState::Completed),
+        ControlPlaneIssueRuntimeState::Failed => (RunStatus::Released, RunLifecycleState::Failed),
+    };
+
+    let release_reason = match issue.last_outcome {
+        ControlPlaneWorkerOutcome::Completed => Some(ReleaseReason::Completed),
+        ControlPlaneWorkerOutcome::Canceled => Some(ReleaseReason::Cancelled),
+        ControlPlaneWorkerOutcome::Failed => Some(ReleaseReason::RetryExhausted),
+        _ => None,
+    };
+
+    Json(RunDetail {
+        schema_version: SchemaVersion::v1(),
+        run_id: issue.identifier.clone(),
+        issue_id: issue.identifier.clone(),
+        issue_identifier: issue.identifier.clone(),
+        worker_id: "default-worker".into(),
+        status,
+        lifecycle_state,
+        claimed_at: issue.last_event_at,
+        started_at: Some(issue.last_event_at),
+        finished_at: None,
+        release_reason,
+        turn_count: issue.retry_count,
+        max_turns: 8,
+        retry_attempt: (issue.retry_count > 0).then_some(issue.retry_count),
+        input_tokens: issue.input_tokens,
+        output_tokens: issue.output_tokens,
+        cache_read_tokens: issue.cache_read_tokens,
+        runtime_seconds: 0,
+        conversation_id: (!issue.conversation_id_suffix.is_empty())
+            .then(|| format!("conv-{}", issue.conversation_id_suffix)),
+        workspace_id: (!issue.workspace_path_suffix.is_empty())
+            .then(|| issue.workspace_path_suffix.clone()),
+        workspace_path: None,
+        harness_type: issue.server_base_url.as_ref().map(|_| "openhands".into()),
+        summary: None,
+        blocker: issue.blocked.then(|| "Blocked by dependency".into()),
+        error: None,
+        allowed_actions: Vec::new(),
+    })
+}
+
+async fn get_run_events(
+    State(store): State<SnapshotStore>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Json<RunEventPage> {
+    let envelope = store.current().await;
+    let events: Vec<RunEvent> = match find_issue_snapshot(&envelope, &run_id) {
+        Some(issue) => issue
+            .recent_events
+            .iter()
+            .enumerate()
+            .map(|(idx, evt)| RunEvent {
+                sequence: idx as u64 + 1,
+                event_id: evt.event_id.clone(),
+                happened_at: evt.happened_at,
+                kind: evt.kind.clone(),
+                summary: evt.summary.clone(),
+                payload: Some(json!({"kind": evt.kind})),
+                raw_payload: Some(json!({"kind": evt.kind, "summary": evt.summary})),
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+
+    Json(RunEventPage {
+        schema_version: SchemaVersion::v1(),
+        run_id,
+        next_cursor: None,
+        events,
+    })
+}
+
+async fn get_run_files(
+    State(store): State<SnapshotStore>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Json<RunFilesPage> {
+    let envelope = store.current().await;
+    let workspace_root = envelope.snapshot.daemon.workspace_root.clone();
+    let files: Vec<ChangedFileEntry> = match find_issue_snapshot(&envelope, &run_id) {
+        Some(issue) => issue
+            .modified_files
+            .iter()
+            .map(|fc| ChangedFileEntry {
+                path: sanitize_file_path(&workspace_root, &fc.path),
+                change_kind: map_file_change_kind(fc.change_kind),
+                lines_added: fc.lines_added,
+                lines_removed: fc.lines_removed,
+                size_bytes: None,
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+
+    Json(RunFilesPage {
+        schema_version: SchemaVersion::v1(),
+        run_id,
+        next_cursor: None,
+        files,
+    })
+}
+
+async fn get_run_diffs(
+    State(store): State<SnapshotStore>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Json<FileDiffPage> {
+    let envelope = store.current().await;
+    let workspace_root = envelope.snapshot.daemon.workspace_root.clone();
+    let files: Vec<&ControlPlaneFileChange> = match find_issue_snapshot(&envelope, &run_id) {
+        Some(issue) => issue.modified_files.iter().collect(),
+        None => Vec::new(),
+    };
+
+    let file_path = files
+        .first()
+        .map(|fc| sanitize_file_path(&workspace_root, &fc.path));
+
+    let total_lines_added: u32 = files.iter().map(|f| f.lines_added).sum();
+    let total_lines_removed: u32 = files.iter().map(|f| f.lines_removed).sum();
+
+    Json(FileDiffPage {
+        schema_version: SchemaVersion::v1(),
+        run_id,
+        file_path: file_path.unwrap_or_default(),
+        next_cursor: None,
+        hunks: Vec::new(),
+        total_lines_added,
+        total_lines_removed,
+    })
 }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -668,11 +668,12 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
         active_run_id: is_running.then(|| issue.identifier.clone()),
         last_outcome: outcome,
         retry_count: issue.retry_count,
-        workspace_id: Some(issue.workspace_path_suffix.clone()),
+        workspace_id: (!issue.workspace_path_suffix.is_empty())
+            .then(|| issue.workspace_path_suffix.clone()),
         harness_type: issue.server_base_url.is_some().then(|| "openhands".into()),
         conversation_id: (!issue.conversation_id_suffix.is_empty())
             .then(|| format!("conv-{}", issue.conversation_id_suffix)),
-        last_event_at: Some(issue.last_event_at),
+        last_event_at: (issue.last_event_at.timestamp() != 0).then_some(issue.last_event_at),
         diff_summary,
         validation_status: None,
         blocker_summary: if issue.blocked {
@@ -923,16 +924,18 @@ async fn get_run_diffs(
     let hunks: Vec<DiffHunk> = files
         .iter()
         .map(|fc| {
+            // Build a synthetic hunk header.  When a file is entirely new
+            // (0 lines removed) or entirely deleted (0 lines added), the
+            // header reflects the correct start,count pairs so parsers won't
+            // choke on `@@ -1,0 +1,N @@` or `@@ -1,N +1,0 @@`.
+            let old_start = if fc.lines_removed > 0 { 1 } else { 0 };
+            let new_start = if fc.lines_added > 0 { 1 } else { 0 };
             DiffHunk {
-                // Standard unified-diff hunk header: @@ -start,count +start,count @@
                 header: format!(
                     "@@ -{},{} +{},{} @@",
-                    1,
-                    fc.lines_removed.max(1),
-                    1,
-                    fc.lines_added.max(1)
+                    old_start, fc.lines_removed, new_start, fc.lines_added
                 ),
-                start_line: 1,
+                start_line: if fc.lines_removed > 0 { 1 } else { 0 },
                 old_line_count: fc.lines_removed,
                 new_line_count: fc.lines_added,
                 lines: Vec::new(),

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -7,6 +7,8 @@ use async_stream::stream;
 use axum::{
     Json, Router,
     extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
     response::sse::{Event, KeepAlive, Sse},
     routing::get,
 };
@@ -24,7 +26,7 @@ pub use crate::opensymphony_gateway_schema::{
     capability::{AuthMode, FeatureCapability, GatewayCapabilities, TransportCapability},
     cursor::PageCursor,
     run::{
-        ChangedFileEntry, FileChangeKind, FileDiffPage, ReleaseReason, RunAction, RunDetail,
+        ChangedFileEntry, DiffHunk, DiffLine, FileChangeKind, FileDiffPage, ReleaseReason, RunAction, RunDetail,
         RunEvent, RunEventPage, RunFilesPage, RunLifecycleState, RunStatus,
     },
     snapshot::{
@@ -352,7 +354,6 @@ fn find_issue_snapshot<'a>(
         .find(|issue| {
             issue.identifier.eq_ignore_ascii_case(run_id)
                 || issue.conversation_id_suffix.eq_ignore_ascii_case(run_id)
-                || run_id.starts_with(&issue.identifier)
         })
 }
 
@@ -368,7 +369,7 @@ pub fn sanitize_file_path(workspace_root: &str, raw_path: &str) -> String {
             candidate
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
-                .unwrap_or_else(|| raw_path.to_string())
+                .unwrap_or_default()
         })
 }
 
@@ -424,7 +425,26 @@ async fn list_projects(State(store): State<SnapshotStore>) -> Json<ProjectList> 
 async fn get_project(
     State(store): State<SnapshotStore>,
     AxumPath(project_id): AxumPath<String>,
-) -> Json<ProjectDetail> {
+) -> impl IntoResponse {
+    // Only the "default" project is supported; reject unknown project IDs.
+    if project_id != "default" {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ProjectDetail {
+                schema_version: SchemaVersion::v1(),
+                project_id,
+                name: String::new(),
+                milestone_count: 0,
+                issue_count: 0,
+                running_count: 0,
+                completed_count: 0,
+                failed_count: 0,
+                summary: Some("Project not found".into()),
+                milestones: Vec::new(),
+            }),
+        );
+    }
+
     let envelope = store.current().await;
     let snapshot = &envelope.snapshot;
     let issue_count = snapshot.issues.len() as u32;
@@ -444,18 +464,21 @@ async fn get_project(
         .filter(|i| matches!(i.last_outcome, ControlPlaneWorkerOutcome::Failed))
         .count() as u32;
 
-    Json(ProjectDetail {
-        schema_version: SchemaVersion::v1(),
-        project_id,
-        name: "OpenSymphony".into(),
-        milestone_count: 0,
-        issue_count,
-        running_count: running,
-        completed_count: completed,
-        failed_count: failed,
-        summary: Some("Current workspace issues".into()),
-        milestones: Vec::new(),
-    })
+    (
+        StatusCode::OK,
+        Json(ProjectDetail {
+            schema_version: SchemaVersion::v1(),
+            project_id,
+            name: "OpenSymphony".into(),
+            milestone_count: 0,
+            issue_count,
+            running_count: running,
+            completed_count: completed,
+            failed_count: failed,
+            summary: Some("Current workspace issues".into()),
+            milestones: Vec::new(),
+        }),
+    )
 }
 
 // ── Task Graph endpoint ───────────────────────────────────────────────────────
@@ -463,7 +486,21 @@ async fn get_project(
 async fn get_task_graph(
     State(store): State<SnapshotStore>,
     AxumPath(project_id): AxumPath<String>,
-) -> Json<TaskGraphSnapshot> {
+) -> impl IntoResponse {
+    // Only the "default" project is supported; reject unknown project IDs.
+    if project_id != "default" {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(TaskGraphSnapshot {
+                schema_version: SchemaVersion::v1(),
+                project_id,
+                generated_at: Utc::now(),
+                nodes: Vec::new(),
+                root_ids: Vec::new(),
+            }),
+        );
+    }
+
     let envelope = store.current().await;
     let snapshot = &envelope.snapshot;
     let generated_at = Utc::now();
@@ -486,11 +523,9 @@ async fn get_task_graph(
                 priority: None,
                 parent_id: None,
                 children: Vec::new(),
-                blocked_by: if issue.blocked {
-                    vec![format!("blocked: {}", issue.identifier)]
-                } else {
-                    Vec::new()
-                },
+                // Dependency info not yet available from the control-plane snapshot;
+                // return an empty vector instead of self-referential placeholder data.
+                blocked_by: Vec::new(),
                 url: None,
                 branch_name: None,
                 labels: Vec::new(),
@@ -504,13 +539,16 @@ async fn get_task_graph(
 
     let root_ids: Vec<String> = snapshot.issues.iter().map(|i| i.identifier.clone()).collect();
 
-    Json(TaskGraphSnapshot {
-        schema_version: SchemaVersion::v1(),
-        project_id,
-        generated_at,
-        nodes,
-        root_ids,
-    })
+    (
+        StatusCode::OK,
+        Json(TaskGraphSnapshot {
+            schema_version: SchemaVersion::v1(),
+            project_id,
+            generated_at,
+            nodes,
+            root_ids,
+        }),
+    )
 }
 
 fn map_runtime_state_to_graph_category(state: &ControlPlaneIssueRuntimeState) -> TaskGraphStateCategory {
@@ -582,39 +620,42 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> Option<TaskGraphR
 async fn get_run_detail(
     State(store): State<SnapshotStore>,
     AxumPath(run_id): AxumPath<String>,
-) -> Json<RunDetail> {
+) -> impl IntoResponse {
     let envelope = store.current().await;
     let issue = match find_issue_snapshot(&envelope, &run_id) {
         Some(issue) => issue,
         None => {
-            return Json(RunDetail {
-                schema_version: SchemaVersion::v1(),
-                run_id,
-                issue_id: "unknown".into(),
-                issue_identifier: "unknown".into(),
-                worker_id: "unknown".into(),
-                status: RunStatus::Unclaimed,
-                lifecycle_state: RunLifecycleState::Eligible,
-                claimed_at: Utc::now(),
-                started_at: None,
-                finished_at: None,
-                release_reason: None,
-                turn_count: 0,
-                max_turns: 0,
-                retry_attempt: None,
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_read_tokens: 0,
-                runtime_seconds: 0,
-                conversation_id: None,
-                workspace_id: None,
-                workspace_path: None,
-                harness_type: None,
-                summary: None,
-                blocker: None,
-                error: Some("Run not found".into()),
-                allowed_actions: Vec::new(),
-            });
+            return (
+                StatusCode::NOT_FOUND,
+                Json(RunDetail {
+                    schema_version: SchemaVersion::v1(),
+                    run_id,
+                    issue_id: String::new(),
+                    issue_identifier: String::new(),
+                    worker_id: String::new(),
+                    status: RunStatus::Unclaimed,
+                    lifecycle_state: RunLifecycleState::Eligible,
+                    claimed_at: Utc::now(),
+                    started_at: None,
+                    finished_at: None,
+                    release_reason: None,
+                    turn_count: 0,
+                    max_turns: 0,
+                    retry_attempt: None,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_tokens: 0,
+                    runtime_seconds: 0,
+                    conversation_id: None,
+                    workspace_id: None,
+                    workspace_path: None,
+                    harness_type: None,
+                    summary: None,
+                    blocker: None,
+                    error: Some("Run not found".into()),
+                    allowed_actions: Vec::new(),
+                }),
+            );
         }
     };
 
@@ -634,42 +675,45 @@ async fn get_run_detail(
         _ => None,
     };
 
-    Json(RunDetail {
-        schema_version: SchemaVersion::v1(),
-        run_id: issue.identifier.clone(),
-        issue_id: issue.identifier.clone(),
-        issue_identifier: issue.identifier.clone(),
-        worker_id: "default-worker".into(),
-        status,
-        lifecycle_state,
-        claimed_at: issue.last_event_at,
-        started_at: Some(issue.last_event_at),
-        finished_at: None,
-        release_reason,
-        turn_count: issue.retry_count,
-        max_turns: 8,
-        retry_attempt: (issue.retry_count > 0).then_some(issue.retry_count),
-        input_tokens: issue.input_tokens,
-        output_tokens: issue.output_tokens,
-        cache_read_tokens: issue.cache_read_tokens,
-        runtime_seconds: 0,
-        conversation_id: (!issue.conversation_id_suffix.is_empty())
-            .then(|| format!("conv-{}", issue.conversation_id_suffix)),
-        workspace_id: (!issue.workspace_path_suffix.is_empty())
-            .then(|| issue.workspace_path_suffix.clone()),
-        workspace_path: None,
-        harness_type: issue.server_base_url.as_ref().map(|_| "openhands".into()),
-        summary: None,
-        blocker: issue.blocked.then(|| "Blocked by dependency".into()),
-        error: None,
-        allowed_actions: Vec::new(),
-    })
+    (
+        StatusCode::OK,
+        Json(RunDetail {
+            schema_version: SchemaVersion::v1(),
+            run_id: issue.identifier.clone(),
+            issue_id: issue.identifier.clone(),
+            issue_identifier: issue.identifier.clone(),
+            worker_id: "default-worker".into(),
+            status,
+            lifecycle_state,
+            claimed_at: issue.last_event_at,
+            started_at: Some(issue.last_event_at),
+            finished_at: None,
+            release_reason,
+            turn_count: issue.retry_count,
+            max_turns: 8,
+            retry_attempt: (issue.retry_count > 0).then_some(issue.retry_count),
+            input_tokens: issue.input_tokens,
+            output_tokens: issue.output_tokens,
+            cache_read_tokens: issue.cache_read_tokens,
+            runtime_seconds: 0,
+            conversation_id: (!issue.conversation_id_suffix.is_empty())
+                .then(|| format!("conv-{}", issue.conversation_id_suffix)),
+            workspace_id: (!issue.workspace_path_suffix.is_empty())
+                .then(|| issue.workspace_path_suffix.clone()),
+            workspace_path: None,
+            harness_type: issue.server_base_url.as_ref().map(|_| "openhands".into()),
+            summary: None,
+            blocker: issue.blocked.then(|| "Blocked by dependency".into()),
+            error: None,
+            allowed_actions: Vec::new(),
+        }),
+    )
 }
 
 async fn get_run_events(
     State(store): State<SnapshotStore>,
     AxumPath(run_id): AxumPath<String>,
-) -> Json<RunEventPage> {
+) -> impl IntoResponse {
     let envelope = store.current().await;
     let events: Vec<RunEvent> = match find_issue_snapshot(&envelope, &run_id) {
         Some(issue) => issue
@@ -686,21 +730,34 @@ async fn get_run_events(
                 raw_payload: Some(json!({"kind": evt.kind, "summary": evt.summary})),
             })
             .collect(),
-        None => Vec::new(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(RunEventPage {
+                    schema_version: SchemaVersion::v1(),
+                    run_id,
+                    next_cursor: None,
+                    events: Vec::new(),
+                }),
+            );
+        }
     };
 
-    Json(RunEventPage {
-        schema_version: SchemaVersion::v1(),
-        run_id,
-        next_cursor: None,
-        events,
-    })
+    (
+        StatusCode::OK,
+        Json(RunEventPage {
+            schema_version: SchemaVersion::v1(),
+            run_id,
+            next_cursor: None,
+            events,
+        }),
+    )
 }
 
 async fn get_run_files(
     State(store): State<SnapshotStore>,
     AxumPath(run_id): AxumPath<String>,
-) -> Json<RunFilesPage> {
+) -> impl IntoResponse {
     let envelope = store.current().await;
     let workspace_root = envelope.snapshot.daemon.workspace_root.clone();
     let files: Vec<ChangedFileEntry> = match find_issue_snapshot(&envelope, &run_id) {
@@ -715,27 +772,75 @@ async fn get_run_files(
                 size_bytes: None,
             })
             .collect(),
-        None => Vec::new(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(RunFilesPage {
+                    schema_version: SchemaVersion::v1(),
+                    run_id,
+                    next_cursor: None,
+                    files: Vec::new(),
+                }),
+            );
+        }
     };
 
-    Json(RunFilesPage {
-        schema_version: SchemaVersion::v1(),
-        run_id,
-        next_cursor: None,
-        files,
-    })
+    (
+        StatusCode::OK,
+        Json(RunFilesPage {
+            schema_version: SchemaVersion::v1(),
+            run_id,
+            next_cursor: None,
+            files,
+        }),
+    )
 }
 
 async fn get_run_diffs(
     State(store): State<SnapshotStore>,
     AxumPath(run_id): AxumPath<String>,
-) -> Json<FileDiffPage> {
+) -> impl IntoResponse {
     let envelope = store.current().await;
     let workspace_root = envelope.snapshot.daemon.workspace_root.clone();
     let files: Vec<&ControlPlaneFileChange> = match find_issue_snapshot(&envelope, &run_id) {
         Some(issue) => issue.modified_files.iter().collect(),
-        None => Vec::new(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(FileDiffPage {
+                    schema_version: SchemaVersion::v1(),
+                    run_id,
+                    file_path: String::new(),
+                    next_cursor: None,
+                    hunks: Vec::new(),
+                    total_lines_added: 0,
+                    total_lines_removed: 0,
+                }),
+            );
+        }
     };
+
+    // Build a summary hunk per changed file from the control-plane metadata.
+    // Full unified diff content is not yet available from the snapshot;
+    // the hunk header and line counts provide callers with change summaries.
+    let hunks: Vec<DiffHunk> = files
+        .iter()
+        .map(|fc| {
+            let path = sanitize_file_path(&workspace_root, &fc.path);
+            let kind_label = match fc.change_kind {
+                ControlPlaneFileChangeKind::Created => "added",
+                ControlPlaneFileChangeKind::Modified => "modified",
+                ControlPlaneFileChangeKind::Removed => "removed",
+            };
+            DiffHunk {
+                header: format!("@@ -{} +{} @@  {}  ({})", fc.lines_removed, fc.lines_added, path, kind_label),
+                start_line: 1,
+                old_line_count: fc.lines_removed,
+                new_line_count: fc.lines_added,
+                lines: Vec::new(),
+            }
+        })
+        .collect();
 
     let file_path = files
         .first()
@@ -744,13 +849,16 @@ async fn get_run_diffs(
     let total_lines_added: u32 = files.iter().map(|f| f.lines_added).sum();
     let total_lines_removed: u32 = files.iter().map(|f| f.lines_removed).sum();
 
-    Json(FileDiffPage {
-        schema_version: SchemaVersion::v1(),
-        run_id,
-        file_path: file_path.unwrap_or_default(),
-        next_cursor: None,
-        hunks: Vec::new(),
-        total_lines_added,
-        total_lines_removed,
-    })
+    (
+        StatusCode::OK,
+        Json(FileDiffPage {
+            schema_version: SchemaVersion::v1(),
+            run_id,
+            file_path: file_path.unwrap_or_default(),
+            next_cursor: None,
+            hunks,
+            total_lines_added,
+            total_lines_removed,
+        }),
+    )
 }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -657,8 +657,14 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
     // blocked.  Completed and failed issues must not appear eligible.
     let is_eligible =
         !issue.blocked && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle);
-    // A blocked issue cannot be queued even if its runtime state is Idle.
-    let is_queued = is_eligible;
+    // Queued means the issue is actively waiting to be picked up by a worker.
+    // This covers both idle+unblocked issues and issues that have been
+    // explicitly placed on the retry queue.
+    let is_queued = is_eligible
+        || matches!(
+            issue.runtime_state,
+            ControlPlaneIssueRuntimeState::RetryQueued
+        );
 
     TaskGraphRuntimeOverlay {
         eligible: is_eligible,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -653,13 +653,18 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
     };
 
     let is_running = matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Running);
+    // An issue is eligible only when it is idle (not yet started) and not
+    // blocked.  Completed and failed issues must not appear eligible.
+    let is_eligible =
+        !issue.blocked && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle);
+    // A blocked issue cannot be queued even if its runtime state is Idle.
+    let is_queued = is_eligible;
 
     TaskGraphRuntimeOverlay {
-        // An issue is eligible only when it is idle (not yet started) and not
-        // blocked.  Completed and failed issues must not appear eligible.
-        eligible: !issue.blocked
-            && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle),
-        queued: matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle),
+        eligible: is_eligible,
+        queued: is_queued,
+        // active_run_id maps to the gateway run identifier (the Linear issue
+        // identifier), which is the key used by the /runs/{run_id} endpoints.
         active_run_id: is_running.then(|| issue.identifier.clone()),
         last_outcome: outcome,
         retry_count: issue.retry_count,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -407,9 +407,10 @@ pub fn sanitize_file_path(workspace_root: &str, raw_path: &str) -> String {
         .strip_prefix(&root)
         .map(|rel: &StdPath| rel.to_string_lossy().to_string())
         .unwrap_or_else(|_| {
-            // Out-of-workspace path: return just the basename (safe last
-            // component) or empty string if none exists.
-            StdPath::new(raw_path)
+            // Out-of-workspace path: use the NORMALIZED path to extract the
+            // basename, so that crafted paths like `/tmp/opensymphony/..` do
+            // not leak traversal components (`..`) into the public API.
+            normalized
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_default()
@@ -656,13 +657,15 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
     let is_eligible =
         !issue.blocked && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle);
     // Queued means the issue is actively waiting to be picked up by a worker.
-    // This covers both idle+unblocked issues and issues that have been
-    // explicitly placed on the retry queue.
-    let is_queued = is_eligible
-        || matches!(
-            issue.runtime_state,
-            ControlPlaneIssueRuntimeState::RetryQueued
-        );
+    // Blocked issues must never appear queued, regardless of state:
+    // a blocked Idle issue is not schedulable, and a blocked RetryQueued
+    // issue is waiting on its blocker to clear before retry.
+    let is_queued = !issue.blocked
+        && (matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle)
+            || matches!(
+                issue.runtime_state,
+                ControlPlaneIssueRuntimeState::RetryQueued
+            ));
 
     TaskGraphRuntimeOverlay {
         eligible: is_eligible,

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -488,7 +488,8 @@ async fn gateway_serves_task_graph() {
         .runtime_overlay
         .as_ref()
         .expect("task graph node should have runtime overlay");
-    assert!(overlay.eligible);
+    // Running issues are NOT eligible (only Idle issues are eligible).
+    assert!(!overlay.eligible);
     assert_eq!(overlay.active_run_id, Some("COE-255".into()));
 
     server_task.abort();
@@ -641,4 +642,192 @@ fn sanitize_file_path_falls_back_to_basename_for_unsafe_path() {
     let result =
         opensymphony::opensymphony_gateway::sanitize_file_path("/tmp/opensymphony", "/etc/passwd");
     assert_eq!(result, "passwd");
+}
+
+// ── Path traversal tests ─────────────────────────────────────────────────────
+
+#[test]
+fn sanitize_file_path_blocks_path_traversal_via_dotdot() {
+    let result = opensymphony::opensymphony_gateway::sanitize_file_path(
+        "/tmp/opensymphony",
+        "/tmp/opensymphony/../etc/passwd",
+    );
+    // The traversal escapes the workspace root, so the fallback basename
+    // (`passwd`) is returned instead of leaking `../etc/passwd`.
+    assert_eq!(result, "passwd");
+}
+
+#[test]
+fn sanitize_file_path_blocks_nested_path_traversal() {
+    let result = opensymphony::opensymphony_gateway::sanitize_file_path(
+        "/tmp/opensymphony",
+        "/tmp/opensymphony/COE-255/../../etc/passwd",
+    );
+    assert_eq!(result, "passwd");
+}
+
+// ── 404 negative-path tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn gateway_returns_404_for_unknown_project() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{address}/api/v1/projects/nonexistent"))
+        .send()
+        .await
+        .expect("fetch unknown project");
+
+    assert_eq!(resp.status(), 404);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_returns_404_for_unknown_project_task_graph() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "http://{address}/api/v1/projects/nonexistent/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch unknown task graph");
+
+    assert_eq!(resp.status(), 404);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_returns_404_for_unknown_run() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{address}/api/v1/runs/UNKNOWN-999"))
+        .send()
+        .await
+        .expect("fetch unknown run");
+
+    assert_eq!(resp.status(), 404);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_returns_404_for_unknown_run_events() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{address}/api/v1/runs/UNKNOWN-999/events"))
+        .send()
+        .await
+        .expect("fetch unknown run events");
+
+    assert_eq!(resp.status(), 404);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_returns_404_for_unknown_run_files() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{address}/api/v1/runs/UNKNOWN-999/files"))
+        .send()
+        .await
+        .expect("fetch unknown run files");
+
+    assert_eq!(resp.status(), 404);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_returns_404_for_unknown_run_diffs() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{address}/api/v1/runs/UNKNOWN-999/diffs"))
+        .send()
+        .await
+        .expect("fetch unknown run diffs");
+
+    assert_eq!(resp.status(), 404);
+
+    server_task.abort();
 }

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -825,6 +825,37 @@ fn sanitize_file_path_blocks_nested_path_traversal() {
     assert_eq!(result, "passwd");
 }
 
+// Workspace root normalization: a crafted root that tries to escape its own
+// boundary is normalized before the strip, so the file still resolves safely.
+#[test]
+fn sanitize_file_path_normalizes_workspace_root() {
+    let result = opensymphony::opensymphony_gateway::sanitize_file_path(
+        "/tmp/other/../opensymphony",
+        "/tmp/opensymphony/COE-255/src/main.rs",
+    );
+    assert_eq!(result, "COE-255/src/main.rs");
+}
+
+// When both root and file contain `..` components, normalization on both sides
+// prevents a crafted root from widening the accepted prefix.
+#[test]
+fn sanitize_file_path_normalizes_both_sides() {
+    let result = opensymphony::opensymphony_gateway::sanitize_file_path(
+        "/tmp/opensymphony/../opensymphony",
+        "/tmp/other/../opensymphony/../etc/passwd",
+    );
+    // Normalized: root=/tmp/opensymphony, file=/tmp/etc/passwd → escapes root
+    assert_eq!(result, "passwd");
+}
+
+// Empty string file name fallback: a raw path that is only a root dir yields
+// an empty string instead of leaking the workspace root.
+#[test]
+fn sanitize_file_path_empty_fallback_for_root_only_path() {
+    let result = opensymphony::opensymphony_gateway::sanitize_file_path("/tmp/opensymphony", "/");
+    assert_eq!(result, "");
+}
+
 // ── 404 negative-path tests ───────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -6,10 +6,11 @@ use opensymphony::opensymphony_domain::{
     ControlPlaneConversationEvent as ConversationEvent,
     ControlPlaneDaemonSnapshot as DaemonSnapshot, ControlPlaneDaemonState as DaemonState,
     ControlPlaneDaemonStatus as DaemonStatus, ControlPlaneFileChange as FileChange,
-    ControlPlaneFileChangeKind as FileChangeKind, ControlPlaneIssueRuntimeState as IssueRuntimeState,
-    ControlPlaneIssueSnapshot as IssueSnapshot, ControlPlaneMetricsSnapshot as MetricsSnapshot,
-    ControlPlaneRecentEvent as RecentEvent, ControlPlaneRecentEventKind as RecentEventKind,
-    ControlPlaneWorkerOutcome as WorkerOutcome, SnapshotEnvelope,
+    ControlPlaneFileChangeKind as FileChangeKind,
+    ControlPlaneIssueRuntimeState as IssueRuntimeState, ControlPlaneIssueSnapshot as IssueSnapshot,
+    ControlPlaneMetricsSnapshot as MetricsSnapshot, ControlPlaneRecentEvent as RecentEvent,
+    ControlPlaneRecentEventKind as RecentEventKind, ControlPlaneWorkerOutcome as WorkerOutcome,
+    SnapshotEnvelope,
 };
 use opensymphony::opensymphony_gateway::{
     GatewayCapabilities, GatewayServer, control_plane_to_dashboard_snapshot,
@@ -965,10 +966,8 @@ async fn gateway_returns_404_for_unknown_run_diffs() {
     assert_eq!(resp.status(), 404);
 
     // Assert the 404 response body is well-formed
-    let body: opensymphony::opensymphony_gateway_schema::run::FileDiffPage = resp
-        .json()
-        .await
-        .expect("decode 404 run diffs body");
+    let body: opensymphony::opensymphony_gateway_schema::run::FileDiffPage =
+        resp.json().await.expect("decode 404 run diffs body");
     assert_eq!(body.run_id, "UNKNOWN-999");
     assert!(body.hunks.is_empty());
 
@@ -1160,9 +1159,7 @@ async fn gateway_run_detail_failed_without_retries() {
     // Failed with retry_count == 0 should map to TrackerTerminal, not RetryExhausted
     assert_eq!(
         response.release_reason,
-        Some(
-            opensymphony::opensymphony_gateway_schema::run::ReleaseReason::TrackerTerminal
-        )
+        Some(opensymphony::opensymphony_gateway_schema::run::ReleaseReason::TrackerTerminal)
     );
     // Finished at should be set for terminal states
     assert!(response.finished_at.is_some());
@@ -1198,9 +1195,7 @@ async fn gateway_run_detail_completed_state() {
     assert_eq!(response.run_id, "COE-301");
     assert_eq!(
         response.release_reason,
-        Some(
-            opensymphony::opensymphony_gateway_schema::run::ReleaseReason::Completed
-        )
+        Some(opensymphony::opensymphony_gateway_schema::run::ReleaseReason::Completed)
     );
     assert!(response.finished_at.is_some());
 

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -229,6 +229,29 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 64,
                 cache_read_tokens: 0,
             },
+            // Blocked Idle issue: NOT eligible AND NOT queued
+            IssueSnapshot {
+                identifier: "COE-304".to_owned(),
+                title: "Blocked idle task".to_owned(),
+                tracker_state: "Todo".to_owned(),
+                runtime_state: IssueRuntimeState::Idle,
+                last_outcome: WorkerOutcome::Unknown,
+                last_event_at: now,
+                conversation_id_suffix: String::new(),
+                workspace_path_suffix: String::new(),
+                retry_count: 0,
+                blocked: true,
+                server_base_url: None,
+                transport_target: None,
+                http_auth_mode: None,
+                websocket_auth_mode: None,
+                websocket_query_param_name: None,
+                recent_events: Vec::new(),
+                modified_files: Vec::new(),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+            },
         ],
         recent_events: vec![RecentEvent {
             happened_at: now,
@@ -1345,6 +1368,25 @@ async fn gateway_task_graph_queued_vs_eligible() {
         "Failed issue must not be eligible"
     );
     assert!(!failed_overlay.queued, "Failed issue must not be queued");
+
+    // Blocked Idle → NOT eligible AND NOT queued (blocked overrides Idle)
+    let blocked_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-304")
+        .expect("COE-304 node should exist");
+    let blocked_overlay = blocked_node
+        .runtime_overlay
+        .as_ref()
+        .expect("overlay present");
+    assert!(
+        !blocked_overlay.eligible,
+        "Blocked Idle issue must not be eligible"
+    );
+    assert!(
+        !blocked_overlay.queued,
+        "Blocked Idle issue must not be queued (blocked overrides)"
+    );
 
     server_task.abort();
 }

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -382,3 +382,256 @@ async fn gateway_and_control_plane_are_reachable() {
     gateway_task.abort();
     control_task.abort();
 }
+
+// ── Read API endpoint tests ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn gateway_serves_project_list() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/projects"))
+        .send()
+        .await
+        .expect("fetch projects")
+        .json::<opensymphony::opensymphony_gateway_schema::snapshot::ProjectList>()
+        .await
+        .expect("decode project list");
+
+    assert_eq!(response.schema_version.major, 1);
+    assert_eq!(response.projects.len(), 1);
+    assert_eq!(response.projects[0].project_id, "default");
+    assert_eq!(response.projects[0].name, "OpenSymphony");
+    assert_eq!(response.projects[0].issue_count, 1);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_project_detail() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/projects/default"))
+        .send()
+        .await
+        .expect("fetch project detail")
+        .json::<opensymphony::opensymphony_gateway_schema::snapshot::ProjectDetail>()
+        .await
+        .expect("decode project detail");
+
+    assert_eq!(response.project_id, "default");
+    assert_eq!(response.name, "OpenSymphony");
+    assert_eq!(response.issue_count, 1);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_task_graph() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/projects/default/taskgraph"))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    assert_eq!(response.schema_version.major, 1);
+    assert_eq!(response.project_id, "default");
+    assert_eq!(response.nodes.len(), 1);
+    assert_eq!(response.nodes[0].identifier, "COE-255");
+    // Verify runtime overlay is present
+    assert!(response.nodes[0].runtime_overlay.is_some());
+    let overlay = response.nodes[0].runtime_overlay.as_ref().unwrap();
+    assert!(overlay.eligible);
+    assert_eq!(overlay.active_run_id, Some("COE-255".into()));
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_detail() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-255"))
+        .send()
+        .await
+        .expect("fetch run detail")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunDetail>()
+        .await
+        .expect("decode run detail");
+
+    assert_eq!(response.run_id, "COE-255");
+    assert_eq!(response.issue_identifier, "COE-255");
+    assert_eq!(
+        response.status,
+        opensymphony::opensymphony_gateway_schema::run::RunStatus::Running
+    );
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_events() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-255/events"))
+        .send()
+        .await
+        .expect("fetch run events")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunEventPage>()
+        .await
+        .expect("decode run events");
+
+    assert_eq!(response.schema_version.major, 1);
+    assert_eq!(response.run_id, "COE-255");
+    // The fixture has no recent_events for the issue, so page is empty
+    assert!(response.events.is_empty());
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_files() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-255/files"))
+        .send()
+        .await
+        .expect("fetch run files")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunFilesPage>()
+        .await
+        .expect("decode run files");
+
+    assert_eq!(response.schema_version.major, 1);
+    assert_eq!(response.run_id, "COE-255");
+    // The fixture has no modified_files, so page is empty
+    assert!(response.files.is_empty());
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_diffs() {
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-255/diffs"))
+        .send()
+        .await
+        .expect("fetch run diffs")
+        .json::<opensymphony::opensymphony_gateway_schema::run::FileDiffPage>()
+        .await
+        .expect("decode run diffs");
+
+    assert_eq!(response.schema_version.major, 1);
+    assert_eq!(response.run_id, "COE-255");
+    assert!(response.hunks.is_empty());
+
+    server_task.abort();
+}
+
+#[test]
+fn sanitize_file_path_strips_workspace_root() {
+    let result =
+        opensymphony::opensymphony_gateway::sanitize_file_path("/tmp/opensymphony", "/tmp/opensymphony/COE-255/src/main.rs");
+    assert_eq!(result, "COE-255/src/main.rs");
+}
+
+#[test]
+fn sanitize_file_path_falls_back_to_basename_for_unsafe_path() {
+    let result =
+        opensymphony::opensymphony_gateway::sanitize_file_path("/tmp/opensymphony", "/etc/passwd");
+    assert_eq!(result, "passwd");
+}

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -206,6 +206,29 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 128,
                 cache_read_tokens: 0,
             },
+            // RetryQueued issue: queued but NOT eligible (not idle)
+            IssueSnapshot {
+                identifier: "COE-303".to_owned(),
+                title: "Retry queued task".to_owned(),
+                tracker_state: "In Progress".to_owned(),
+                runtime_state: IssueRuntimeState::RetryQueued,
+                last_outcome: WorkerOutcome::Failed,
+                last_event_at: now,
+                conversation_id_suffix: "c0e303".to_owned(),
+                workspace_path_suffix: "COE-303".to_owned(),
+                retry_count: 1,
+                blocked: false,
+                server_base_url: Some("http://127.0.0.1:3003".to_owned()),
+                transport_target: Some("loopback".to_owned()),
+                http_auth_mode: Some("none".to_owned()),
+                websocket_auth_mode: Some("none".to_owned()),
+                websocket_query_param_name: None,
+                recent_events: Vec::new(),
+                modified_files: Vec::new(),
+                input_tokens: 256,
+                output_tokens: 64,
+                cache_read_tokens: 0,
+            },
         ],
         recent_events: vec![RecentEvent {
             happened_at: now,
@@ -1198,6 +1221,99 @@ async fn gateway_run_detail_completed_state() {
         Some(opensymphony::opensymphony_gateway_schema::run::ReleaseReason::Completed)
     );
     assert!(response.finished_at.is_some());
+
+    server_task.abort();
+}
+
+// ── Runtime overlay: queued vs eligible semantics ──────────────────────────────
+
+#[tokio::test]
+async fn gateway_task_graph_queued_vs_eligible() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    // Idle + not blocked → eligible AND queued
+    let idle_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-300")
+        .expect("COE-300 node should exist");
+    let idle_overlay = idle_node.runtime_overlay.as_ref().expect("overlay present");
+    assert!(
+        idle_overlay.eligible,
+        "Idle unblocked issue should be eligible"
+    );
+    assert!(idle_overlay.queued, "Idle unblocked issue should be queued");
+
+    // RetryQueued → queued BUT NOT eligible (not in Idle state)
+    let retry_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-303")
+        .expect("COE-303 node should exist");
+    let retry_overlay = retry_node
+        .runtime_overlay
+        .as_ref()
+        .expect("overlay present");
+    assert!(
+        !retry_overlay.eligible,
+        "RetryQueued issue must NOT be eligible (not idle)"
+    );
+    assert!(
+        retry_overlay.queued,
+        "RetryQueued issue must be queued (waiting for retry)"
+    );
+
+    // Completed → neither eligible nor queued
+    let done_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-301")
+        .expect("COE-301 node should exist");
+    let done_overlay = done_node.runtime_overlay.as_ref().expect("overlay present");
+    assert!(
+        !done_overlay.eligible,
+        "Completed issue must not be eligible"
+    );
+    assert!(!done_overlay.queued, "Completed issue must not be queued");
+
+    // Failed → neither eligible nor queued
+    let failed_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-302")
+        .expect("COE-302 node should exist");
+    let failed_overlay = failed_node
+        .runtime_overlay
+        .as_ref()
+        .expect("overlay present");
+    assert!(
+        !failed_overlay.eligible,
+        "Failed issue must not be eligible"
+    );
+    assert!(!failed_overlay.queued, "Failed issue must not be queued");
 
     server_task.abort();
 }

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -484,7 +484,10 @@ async fn gateway_serves_task_graph() {
     assert_eq!(response.nodes[0].identifier, "COE-255");
     // Verify runtime overlay is present
     assert!(response.nodes[0].runtime_overlay.is_some());
-    let overlay = response.nodes[0].runtime_overlay.as_ref().unwrap();
+    let overlay = response.nodes[0]
+        .runtime_overlay
+        .as_ref()
+        .expect("task graph node should have runtime overlay");
     assert!(overlay.eligible);
     assert_eq!(overlay.active_run_id, Some("COE-255".into()));
 

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -3,8 +3,10 @@ use futures_util::StreamExt;
 use opensymphony::opensymphony_control::{ControlPlaneServer, SnapshotStore};
 use opensymphony::opensymphony_domain::{
     ControlPlaneAgentServerStatus as AgentServerStatus,
+    ControlPlaneConversationEvent as ConversationEvent,
     ControlPlaneDaemonSnapshot as DaemonSnapshot, ControlPlaneDaemonState as DaemonState,
-    ControlPlaneDaemonStatus as DaemonStatus, ControlPlaneIssueRuntimeState as IssueRuntimeState,
+    ControlPlaneDaemonStatus as DaemonStatus, ControlPlaneFileChange as FileChange,
+    ControlPlaneFileChangeKind as FileChangeKind, ControlPlaneIssueRuntimeState as IssueRuntimeState,
     ControlPlaneIssueSnapshot as IssueSnapshot, ControlPlaneMetricsSnapshot as MetricsSnapshot,
     ControlPlaneRecentEvent as RecentEvent, ControlPlaneRecentEventKind as RecentEventKind,
     ControlPlaneWorkerOutcome as WorkerOutcome, SnapshotEnvelope,
@@ -77,6 +79,139 @@ fn fixture_envelope(step: u64) -> SnapshotEnvelope {
         sequence: step + 1,
         published_at: snapshot.generated_at,
         snapshot,
+    }
+}
+
+/// Second fixture variant: one Idle issue, one Completed issue with events
+/// and modified files, and one Failed issue (first attempt, no retries).
+fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
+    let now = Utc::now();
+    DaemonSnapshot {
+        generated_at: now,
+        daemon: DaemonStatus {
+            state: DaemonState::Ready,
+            last_poll_at: now,
+            workspace_root: "/tmp/opensymphony".to_owned(),
+            status_line: "ready".to_owned(),
+        },
+        agent_server: AgentServerStatus {
+            reachable: true,
+            base_url: "http://127.0.0.1:3000".to_owned(),
+            conversation_count: 2,
+            status_line: "healthy".to_owned(),
+        },
+        metrics: MetricsSnapshot {
+            running_issues: 1,
+            retry_queue_depth: 0,
+            input_tokens: 2048,
+            output_tokens: 2048,
+            cache_read_tokens: 512,
+            total_tokens: 4096 + step,
+            total_cost_micros: 120_000,
+        },
+        issues: vec![
+            // Idle issue (eligible for execution)
+            IssueSnapshot {
+                identifier: "COE-300".to_owned(),
+                title: "Idle task".to_owned(),
+                tracker_state: "Todo".to_owned(),
+                runtime_state: IssueRuntimeState::Idle,
+                last_outcome: WorkerOutcome::Unknown,
+                last_event_at: now,
+                conversation_id_suffix: String::new(),
+                workspace_path_suffix: String::new(),
+                retry_count: 0,
+                blocked: false,
+                server_base_url: None,
+                transport_target: None,
+                http_auth_mode: None,
+                websocket_auth_mode: None,
+                websocket_query_param_name: None,
+                recent_events: Vec::new(),
+                modified_files: Vec::new(),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+            },
+            // Completed issue with events and modified files
+            IssueSnapshot {
+                identifier: "COE-301".to_owned(),
+                title: "Completed task".to_owned(),
+                tracker_state: "Done".to_owned(),
+                runtime_state: IssueRuntimeState::Completed,
+                last_outcome: WorkerOutcome::Completed,
+                last_event_at: now,
+                conversation_id_suffix: "c0e301".to_owned(),
+                workspace_path_suffix: "COE-301".to_owned(),
+                retry_count: 0,
+                blocked: false,
+                server_base_url: Some("http://127.0.0.1:3001".to_owned()),
+                transport_target: Some("loopback".to_owned()),
+                http_auth_mode: Some("none".to_owned()),
+                websocket_auth_mode: Some("none".to_owned()),
+                websocket_query_param_name: None,
+                recent_events: vec![
+                    ConversationEvent {
+                        event_id: "evt-1".to_owned(),
+                        happened_at: now,
+                        kind: "worker_started".to_owned(),
+                        summary: "worker started".to_owned(),
+                    },
+                    ConversationEvent {
+                        event_id: "evt-2".to_owned(),
+                        happened_at: now,
+                        kind: "worker_completed".to_owned(),
+                        summary: "worker completed".to_owned(),
+                    },
+                ],
+                modified_files: vec![
+                    FileChange {
+                        path: "/tmp/opensymphony/COE-301/src/main.rs".to_owned(),
+                        change_kind: FileChangeKind::Modified,
+                        lines_added: 10,
+                        lines_removed: 3,
+                    },
+                    FileChange {
+                        path: "/tmp/opensymphony/COE-301/src/lib.rs".to_owned(),
+                        change_kind: FileChangeKind::Created,
+                        lines_added: 42,
+                        lines_removed: 0,
+                    },
+                ],
+                input_tokens: 2048,
+                output_tokens: 1024,
+                cache_read_tokens: 256,
+            },
+            // Failed issue, first attempt (no retries exhausted)
+            IssueSnapshot {
+                identifier: "COE-302".to_owned(),
+                title: "Failed task".to_owned(),
+                tracker_state: "In Progress".to_owned(),
+                runtime_state: IssueRuntimeState::Failed,
+                last_outcome: WorkerOutcome::Failed,
+                last_event_at: now,
+                conversation_id_suffix: "c0e302".to_owned(),
+                workspace_path_suffix: "COE-302".to_owned(),
+                retry_count: 0,
+                blocked: false,
+                server_base_url: Some("http://127.0.0.1:3002".to_owned()),
+                transport_target: Some("loopback".to_owned()),
+                http_auth_mode: Some("none".to_owned()),
+                websocket_auth_mode: Some("none".to_owned()),
+                websocket_query_param_name: None,
+                recent_events: Vec::new(),
+                modified_files: Vec::new(),
+                input_tokens: 512,
+                output_tokens: 128,
+                cache_read_tokens: 0,
+            },
+        ],
+        recent_events: vec![RecentEvent {
+            happened_at: now,
+            issue_identifier: Some("COE-301".to_owned()),
+            kind: RecentEventKind::WorkerCompleted,
+            summary: format!("completed step {step}"),
+        }],
     }
 }
 
@@ -828,6 +963,246 @@ async fn gateway_returns_404_for_unknown_run_diffs() {
         .expect("fetch unknown run diffs");
 
     assert_eq!(resp.status(), 404);
+
+    // Assert the 404 response body is well-formed
+    let body: opensymphony::opensymphony_gateway_schema::run::FileDiffPage = resp
+        .json()
+        .await
+        .expect("decode 404 run diffs body");
+    assert_eq!(body.run_id, "UNKNOWN-999");
+    assert!(body.hunks.is_empty());
+
+    server_task.abort();
+}
+
+// ── Rich fixture tests (non-Running states, file/diff data) ────────────────────
+
+#[tokio::test]
+async fn gateway_serves_run_files_with_modified_files() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-301/files"))
+        .send()
+        .await
+        .expect("fetch run files with data")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunFilesPage>()
+        .await
+        .expect("decode run files");
+
+    assert_eq!(response.run_id, "COE-301");
+    assert_eq!(response.files.len(), 2);
+    // Files should have workspace root stripped
+    let paths: Vec<_> = response.files.iter().map(|f| f.path.as_str()).collect();
+    assert!(paths.contains(&"COE-301/src/main.rs"));
+    assert!(paths.contains(&"COE-301/src/lib.rs"));
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_diffs_with_modified_files() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-301/diffs"))
+        .send()
+        .await
+        .expect("fetch run diffs with data")
+        .json::<opensymphony::opensymphony_gateway_schema::run::FileDiffPage>()
+        .await
+        .expect("decode run diffs");
+
+    assert_eq!(response.run_id, "COE-301");
+    // Multi-file diff should show count label instead of single path
+    assert_eq!(response.file_path, "[2 files]");
+    assert_eq!(response.hunks.len(), 2);
+    assert_eq!(response.total_lines_added, 52);
+    assert_eq!(response.total_lines_removed, 3);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_events_with_data() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-301/events"))
+        .send()
+        .await
+        .expect("fetch run events with data")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunEventPage>()
+        .await
+        .expect("decode run events");
+
+    assert_eq!(response.run_id, "COE-301");
+    assert_eq!(response.events.len(), 2);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_task_graph_eligible_for_idle_issue() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    // Find the idle issue overlay
+    let idle_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-300")
+        .expect("COE-300 node should exist");
+    let overlay = idle_node.runtime_overlay.as_ref().expect("overlay present");
+    // Idle + not blocked = eligible
+    assert!(overlay.eligible);
+    assert!(overlay.queued);
+
+    // Completed issue should NOT be eligible
+    let done_node = response
+        .nodes
+        .iter()
+        .find(|n| n.identifier == "COE-301")
+        .expect("COE-301 node should exist");
+    let done_overlay = done_node.runtime_overlay.as_ref().expect("overlay present");
+    assert!(!done_overlay.eligible);
+
+    // root_ids should be empty (no parent/child data available)
+    assert!(response.root_ids.is_empty());
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_run_detail_failed_without_retries() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-302"))
+        .send()
+        .await
+        .expect("fetch failed run detail")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunDetail>()
+        .await
+        .expect("decode run detail");
+
+    assert_eq!(response.run_id, "COE-302");
+    // Failed with retry_count == 0 should map to TrackerTerminal, not RetryExhausted
+    assert_eq!(
+        response.release_reason,
+        Some(
+            opensymphony::opensymphony_gateway_schema::run::ReleaseReason::TrackerTerminal
+        )
+    );
+    // Finished at should be set for terminal states
+    assert!(response.finished_at.is_some());
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_run_detail_completed_state() {
+    let store = SnapshotStore::new(fixture_snapshot_rich(0));
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{address}/api/v1/runs/COE-301"))
+        .send()
+        .await
+        .expect("fetch completed run detail")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunDetail>()
+        .await
+        .expect("decode run detail");
+
+    assert_eq!(response.run_id, "COE-301");
+    assert_eq!(
+        response.release_reason,
+        Some(
+            opensymphony::opensymphony_gateway_schema::run::ReleaseReason::Completed
+        )
+    );
+    assert!(response.finished_at.is_some());
 
     server_task.abort();
 }

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -468,7 +468,9 @@ async fn gateway_serves_task_graph() {
 
     let client = reqwest::Client::new();
     let response = client
-        .get(format!("http://{address}/api/v1/projects/default/taskgraph"))
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
         .send()
         .await
         .expect("fetch task graph")
@@ -624,8 +626,10 @@ async fn gateway_serves_run_diffs() {
 
 #[test]
 fn sanitize_file_path_strips_workspace_root() {
-    let result =
-        opensymphony::opensymphony_gateway::sanitize_file_path("/tmp/opensymphony", "/tmp/opensymphony/COE-255/src/main.rs");
+    let result = opensymphony::opensymphony_gateway::sanitize_file_path(
+        "/tmp/opensymphony",
+        "/tmp/opensymphony/COE-255/src/main.rs",
+    );
     assert_eq!(result, "COE-255/src/main.rs");
 }
 


### PR DESCRIPTION
Implement read API endpoints for projects, task graph nodes, run details, run event history, changed files, and diffs.

## Evidence

### Gateway Endpoint Tests (30 gateway + 21 schema = 51 total tests)

All 30 gateway endpoint tests pass including:
- `gateway_serves_capabilities_and_dashboard_snapshot`
- `gateway_serves_project_list`, `gateway_serves_project_detail`
- `gateway_serves_task_graph`, `gateway_serves_run_detail`
- `gateway_serves_run_events`, `gateway_serves_run_files`, `gateway_serves_run_diffs`
- `gateway_serves_run_events_with_data` (rich fixture with 2 events)
- `gateway_serves_run_files_with_modified_files` (rich fixture with 2 files)
- `gateway_serves_run_diffs_with_modified_files` (rich fixture with multi-file diff)
- `gateway_run_detail_completed_state` (release_reason=completed, finished_at set)
- `gateway_run_detail_failed_without_retries` (release_reason=tracker_terminal)
- `gateway_task_graph_eligible_for_idle_issue` (eligible=true for Idle, false for Completed, root_ids empty)
- `control_plane_to_dashboard_snapshot_maps_all_fields`

### Negative Path Tests (8 tests)

- Unknown project → 404 with well-formed `ProjectDetail` body
- Unknown task graph → 404 with empty `TaskGraphSnapshot` body
- Unknown run → 404 with `RunDetail` body containing requested `run_id`
- Unknown run events → 404 with empty `RunEventPage` body
- Unknown run files → 404 with empty `RunFilesPage` body
- Unknown run diffs → 404 with empty `FileDiffPage` body, verified `run_id` field
- Path traversal `../etc/passwd` → blocked, falls back to basename
- Path traversal `../../etc/shadow` → blocked, falls back to basename

### Clippy + Fmt

- `cargo clippy` — 0 warnings
- `cargo fmt --check` — clean (no diffs)
