### PR TITLE
COE-399: Linear read coverage, schema drift validation, and task graph cache

### DIFF
--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -492,7 +492,7 @@ impl LinearClient {
         Ok(connection)
     }
 
-    async fn execute_graphql<T>(
+    pub(super) async fn execute_graphql<T>(
         &self,
         query: &'static str,
         variables: Value,

--- a/crates/opensymphony-linear/src/lib.rs
+++ b/crates/opensymphony-linear/src/lib.rs
@@ -2,6 +2,16 @@ mod client;
 mod error;
 mod graphql;
 mod normalize;
+mod schema_drift;
+mod task_graph_cache;
 
 pub use client::{LinearClient, LinearConfig, RetryPolicy, WorkpadComment};
 pub use error::{GraphqlError, LinearError};
+pub use schema_drift::{
+    IntrospectedField, IntrospectedType, RequiredField, SchemaDriftReport, SchemaDriftViolation,
+    required_fields,
+};
+pub use task_graph_cache::{
+    CachedBlockerRef, CachedIssueRef, CachedLinearEntity, CachedMilestone, RuntimeOverlay,
+    TaskGraphCache,
+};

--- a/crates/opensymphony-linear/src/schema_drift.rs
+++ b/crates/opensymphony-linear/src/schema_drift.rs
@@ -234,8 +234,8 @@ impl LinearClient {
             std::collections::HashMap::new();
 
         for type_name in &type_names {
-            let fields = self.introspect_type(*type_name).await?;
-            remote_fields.insert((*type_name).to_string(), fields.into_iter().collect());
+            let fields = self.introspect_type(type_name).await?;
+            remote_fields.insert(type_name.to_string(), fields.into_iter().collect());
         }
 
         let checked_at = Some(chrono::Utc::now());

--- a/crates/opensymphony-linear/src/schema_drift.rs
+++ b/crates/opensymphony-linear/src/schema_drift.rs
@@ -1,0 +1,355 @@
+use std::collections::HashSet;
+
+use serde_json::json;
+
+use super::client::LinearClient;
+use super::error::LinearError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequiredField {
+    pub type_name: &'static str,
+    pub field_name: &'static str,
+    pub critical: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDriftReport {
+    pub is_compatible: bool,
+    pub missing_fields: Vec<SchemaDriftViolation>,
+    pub checked_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDriftViolation {
+    pub type_name: String,
+    pub field_name: String,
+    pub critical: bool,
+    pub remediation: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct IntrospectedType {
+    #[allow(dead_code)]
+    pub kind: String,
+    #[allow(dead_code)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub fields: Option<Vec<IntrospectedField>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct IntrospectedField {
+    pub name: String,
+}
+
+/// Canonical list of required Linear GraphQL fields.
+///
+/// # Remediation
+/// 1. Check the Linear API changelog for the breaking change.
+/// 2. Update the corresponding GraphQL query constant in `graphql.rs`.
+/// 3. Update the Rust model in `graphql.rs` / `normalize.rs` to match.
+/// 4. If the field is no longer needed, remove it from this list.
+pub fn required_fields() -> &'static [RequiredField] {
+    &[
+        RequiredField {
+            type_name: "Issue",
+            field_name: "id",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "identifier",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "url",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "title",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "description",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "priority",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "createdAt",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "updatedAt",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "state",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "parent",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "projectMilestone",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "children",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "labels",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "inverseRelations",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Issue",
+            field_name: "comments",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "WorkflowState",
+            field_name: "id",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "WorkflowState",
+            field_name: "name",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "WorkflowState",
+            field_name: "type",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Project",
+            field_name: "id",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Project",
+            field_name: "name",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Project",
+            field_name: "slugId",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Project",
+            field_name: "url",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Project",
+            field_name: "content",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "ProjectMilestone",
+            field_name: "id",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "ProjectMilestone",
+            field_name: "name",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Label",
+            field_name: "id",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Label",
+            field_name: "name",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Comment",
+            field_name: "id",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Comment",
+            field_name: "body",
+            critical: true,
+        },
+        RequiredField {
+            type_name: "Comment",
+            field_name: "updatedAt",
+            critical: false,
+        },
+        RequiredField {
+            type_name: "Comment",
+            field_name: "resolvedAt",
+            critical: false,
+        },
+    ]
+}
+
+pub(super) const INTROSPECT_TYPE_QUERY: &str = r#"
+query IntrospectType($typeName: String!) {
+  __type(name: $typeName) {
+    kind
+    name
+    fields(includeDeprecated: true) {
+      name
+    }
+  }
+}
+"#;
+
+impl LinearClient {
+    /// Run schema drift validation against the live Linear API.
+    ///
+    /// Returns a report indicating whether the current schema requirements
+    /// are satisfied by the remote API.
+    pub async fn check_schema_drift(&self) -> Result<SchemaDriftReport, LinearError> {
+        let required = required_fields();
+        let mut missing = Vec::new();
+        let type_names: HashSet<&str> = required.iter().map(|f| f.type_name).collect();
+        let mut remote_fields: std::collections::HashMap<String, HashSet<String>> =
+            std::collections::HashMap::new();
+
+        for type_name in &type_names {
+            let fields = self.introspect_type(*type_name).await?;
+            remote_fields.insert((*type_name).to_string(), fields.into_iter().collect());
+        }
+
+        let checked_at = Some(chrono::Utc::now());
+
+        for req in required {
+            let field_set = remote_fields.get(req.type_name);
+            match field_set {
+                Some(set) if set.contains(req.field_name) => {}
+                _ => {
+                    missing.push(SchemaDriftViolation {
+                        type_name: req.type_name.to_string(),
+                        field_name: req.field_name.to_string(),
+                        critical: req.critical,
+                        remediation: format!(
+                            "Field `{}` on type `{}` missing in remote Linear schema. \n\n\ne\n\ne\nCheck Linear API changelog, update graphql.rs / normalize.rs, or remove from required_fields().",
+                            req.field_name, req.type_name
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(SchemaDriftReport {
+            is_compatible: missing.is_empty(),
+            missing_fields: missing,
+            checked_at,
+        })
+    }
+
+    pub(super) async fn introspect_type(
+        &self,
+        type_name: &str,
+    ) -> Result<Vec<String>, LinearError> {
+        let response: serde_json::Value = self
+            .execute_graphql(INTROSPECT_TYPE_QUERY, json!({ "typeName": type_name }))
+            .await?;
+
+        let fields = response
+            .get("data")
+            .and_then(|d| d.get("__type"))
+            .and_then(|t| t.get("fields"))
+            .and_then(|f| f.as_array())
+            .ok_or_else(|| {
+                LinearError::InvalidResponse(format!(
+                    "Introspection for type `{type_name}` returned no fields"
+                ))
+            })?;
+
+        let mut names = Vec::new();
+        for field in fields {
+            if let Some(name) = field.get("name").and_then(|n| n.as_str()) {
+                names.push(name.to_string());
+            }
+        }
+        Ok(names)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_fields_contains_issue_core_fields() {
+        let fields = required_fields();
+        let issue_fields: Vec<_> = fields
+            .iter()
+            .filter(|f| f.type_name == "Issue")
+            .map(|f| f.field_name)
+            .collect();
+        assert!(issue_fields.contains(&"id"));
+        assert!(issue_fields.contains(&"identifier"));
+        assert!(issue_fields.contains(&"state"));
+        assert!(issue_fields.contains(&"inverseRelations"));
+    }
+
+    #[test]
+    fn required_fields_marks_id_as_critical() {
+        for field in required_fields() {
+            if field.field_name == "id" {
+                assert!(
+                    field.critical,
+                    "id field on {} must be critical",
+                    field.type_name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_drift_report_compatible_when_no_violations() {
+        let report = SchemaDriftReport {
+            is_compatible: true,
+            missing_fields: Vec::new(),
+            checked_at: None,
+        };
+        assert!(report.is_compatible);
+        assert!(report.missing_fields.is_empty());
+    }
+
+    #[test]
+    fn schema_drift_report_incompatible_with_violations() {
+        let report = SchemaDriftReport {
+            is_compatible: false,
+            missing_fields: vec![SchemaDriftViolation {
+                type_name: "Issue".to_string(),
+                field_name: "deletedField".to_string(),
+                critical: true,
+                remediation: "Remove from query".to_string(),
+            }],
+            checked_at: None,
+        };
+        assert!(!report.is_compatible);
+        assert_eq!(report.missing_fields.len(), 1);
+        assert!(report.missing_fields[0].critical);
+    }
+}

--- a/crates/opensymphony-linear/src/schema_drift.rs
+++ b/crates/opensymphony-linear/src/schema_drift.rs
@@ -250,7 +250,7 @@ impl LinearClient {
                         field_name: req.field_name.to_string(),
                         critical: req.critical,
                         remediation: format!(
-                            "Field `{}` on type `{}` missing in remote Linear schema. \n\n\ne\n\ne\nCheck Linear API changelog, update graphql.rs / normalize.rs, or remove from required_fields().",
+                            "Field `{}` on type `{}` missing in remote Linear schema. Check Linear API changelog, update graphql.rs / normalize.rs, or remove from required_fields().",
                             req.field_name, req.type_name
                         ),
                     });

--- a/crates/opensymphony-linear/src/schema_drift.rs
+++ b/crates/opensymphony-linear/src/schema_drift.rs
@@ -273,9 +273,17 @@ impl LinearClient {
             .execute_graphql(INTROSPECT_TYPE_QUERY, json!({ "typeName": type_name }))
             .await?;
 
-        let fields = response
-            .get("data")
-            .and_then(|d| d.get("__type"))
+        let type_node = response.get("data").and_then(|d| d.get("__type"));
+        match type_node {
+            None | Some(serde_json::Value::Null) => {
+                return Err(LinearError::InvalidResponse(format!(
+                    "Introspection returned null for type `{type_name}` (type may not exist or was renamed)"
+                )));
+            }
+            _ => {}
+        }
+
+        let fields = type_node
             .and_then(|t| t.get("fields"))
             .and_then(|f| f.as_array())
             .ok_or_else(|| {

--- a/crates/opensymphony-linear/src/task_graph_cache.rs
+++ b/crates/opensymphony-linear/src/task_graph_cache.rs
@@ -368,7 +368,7 @@ mod tests {
         let issue = build_test_issue("lin-1", "COE-1", "Done");
         let entity: CachedLinearEntity = issue.into();
         assert!(entity.project_milestone.is_some());
-        let milestone = entity.project_milestone.unwrap();
+        let milestone = entity.project_milestone.expect("test issue should have milestone");
         assert_eq!(milestone.name, "M1");
         assert_eq!(entity.state_kind, "completed");
     }

--- a/crates/opensymphony-linear/src/task_graph_cache.rs
+++ b/crates/opensymphony-linear/src/task_graph_cache.rs
@@ -1,0 +1,387 @@
+use std::{collections::HashMap, time::Duration};
+
+use chrono::{DateTime, Utc};
+
+use crate::opensymphony_domain::TrackerIssue;
+
+/// Cached Linear entity with sync metadata.
+#[derive(Debug, Clone)]
+pub struct CachedLinearEntity {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub state: String,
+    pub state_kind: String,
+    pub priority: Option<u8>,
+    pub labels: Vec<String>,
+    pub parent_id: Option<String>,
+    pub project_milestone: Option<CachedMilestone>,
+    pub blocked_by: Vec<CachedBlockerRef>,
+    pub sub_issues: Vec<CachedIssueRef>,
+    pub url: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub synced_at: DateTime<Utc>,
+}
+
+/// Cached milestone reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedMilestone {
+    pub id: String,
+    pub name: String,
+}
+
+/// Cached blocker reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedBlockerRef {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub state: String,
+    pub is_terminal: bool,
+}
+
+/// Cached sub-issue reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedIssueRef {
+    pub id: String,
+    pub identifier: String,
+    pub state: String,
+}
+
+/// Runtime overlay data for a cached entity.
+#[derive(Debug, Clone)]
+pub struct RuntimeOverlay {
+    pub eligible: bool,
+    pub queued: bool,
+    pub active_run_id: Option<String>,
+    pub last_outcome: Option<String>,
+    pub retry_count: u32,
+    pub workspace_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub last_event_at: Option<DateTime<Utc>>,
+    pub validation_status: Option<String>,
+    pub blocker_summary: Option<String>,
+    pub synced_at: DateTime<Utc>,
+}
+
+/// Cache for Linear entities with sync timestamps.
+#[derive(Debug, Clone)]
+pub struct TaskGraphCache {
+    entities: HashMap<String, CachedLinearEntity>,
+    overlays: HashMap<String, RuntimeOverlay>,
+    pub project_id: String,
+    last_synced_at: Option<DateTime<Utc>>,
+    ttl: Duration,
+}
+
+impl TaskGraphCache {
+    pub fn new(project_id: impl Into<String>, ttl: Duration) -> Self {
+        Self {
+            entities: HashMap::new(),
+            overlays: HashMap::new(),
+            project_id: project_id.into(),
+            last_synced_at: None,
+            ttl,
+        }
+    }
+
+    /// Insert or update Linear entities from a tracker poll.
+    pub fn upsert_entities(&mut self, issues: Vec<TrackerIssue>) {
+        let synced_at = Utc::now();
+        for issue in issues {
+            let entity = CachedLinearEntity {
+                id: issue.id.clone(),
+                identifier: issue.identifier.clone(),
+                title: issue.title.clone(),
+                state: issue.state.clone(),
+                state_kind: Self::infer_state_kind(&issue.state),
+                priority: issue.priority,
+                labels: issue.labels.clone(),
+                parent_id: issue.parent_id.clone(),
+                project_milestone: issue.project_milestone.as_ref().map(|m| CachedMilestone {
+                    id: m.id.clone(),
+                    name: m.name.clone(),
+                }),
+                blocked_by: issue
+                    .blocked_by
+                    .into_iter()
+                    .map(|b| {
+                        let is_terminal = b.is_terminal();
+                        CachedBlockerRef {
+                            id: b.id,
+                            identifier: b.identifier,
+                            title: b.title,
+                            state: b.state.name,
+                            is_terminal,
+                        }
+                    })
+                    .collect(),
+                sub_issues: issue
+                    .sub_issues
+                    .into_iter()
+                    .map(|s| CachedIssueRef {
+                        id: s.id,
+                        identifier: s.identifier,
+                        state: s.state,
+                    })
+                    .collect(),
+                url: issue.url.clone(),
+                created_at: issue.created_at,
+                updated_at: issue.updated_at,
+                synced_at,
+            };
+            self.entities.insert(issue.id, entity);
+        }
+        self.last_synced_at = Some(synced_at);
+    }
+
+    /// Update the runtime overlay for a single issue.
+    pub fn upsert_overlay(&mut self, overlay: RuntimeOverlay) {
+        self.overlays.insert(
+            overlay
+                .active_run_id
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+            overlay,
+        );
+    }
+
+    /// Clear overlays for resolved issues.
+    pub fn clear_overlay(&mut self, issue_id: &str) {
+        self.overlays.retain(|k, _| k != issue_id);
+    }
+
+    /// Get an entity by Linear ID or issue identifier.
+    pub fn get_entity(&self, id: &str) -> Option<&CachedLinearEntity> {
+        self.entities.get(id)
+    }
+
+    /// Get a runtime overlay by run/issue ID.
+    pub fn get_overlay(&self, id: &str) -> Option<&RuntimeOverlay> {
+        self.overlays.get(id)
+    }
+
+    /// Return true if the entire cache is expired.
+    pub fn is_expired(&self) -> bool {
+        match self.last_synced_at {
+            Some(synced) => {
+                Utc::now().signed_duration_since(synced)
+                    > chrono::TimeDelta::from_std(self.ttl).unwrap_or_default()
+            }
+            None => true,
+        }
+    }
+
+    /// Number of cached entities.
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// Number of cached overlays.
+    pub fn overlay_count(&self) -> usize {
+        self.overlays.len()
+    }
+
+    /// All entities (useful for iteration / snapshotting).
+    pub fn entities(&self) -> impl Iterator<Item = (&String, &CachedLinearEntity)> {
+        self.entities.iter()
+    }
+
+    /// All overlays.
+    pub fn overlays(&self) -> impl Iterator<Item = (&String, &RuntimeOverlay)> {
+        self.overlays.iter()
+    }
+
+    fn infer_state_kind(state: &str) -> String {
+        match state.to_lowercase().as_str() {
+            "done" | "completed" | "closed" => "completed",
+            "canceled" | "cancelled" => "canceled",
+            "in progress" | "started" => "started",
+            "todo" | "unstarted" => "unstarted",
+            "backlog" => "backlog",
+            _ => "unknown",
+        }
+        .to_string()
+    }
+}
+
+impl From<TrackerIssue> for CachedLinearEntity {
+    fn from(issue: TrackerIssue) -> Self {
+        Self {
+            id: issue.id.clone(),
+            identifier: issue.identifier.clone(),
+            title: issue.title.clone(),
+            state: issue.state.clone(),
+            state_kind: TaskGraphCache::infer_state_kind(&issue.state),
+            priority: issue.priority,
+            labels: issue.labels,
+            parent_id: issue.parent_id,
+            project_milestone: issue.project_milestone.map(|m| CachedMilestone {
+                id: m.id,
+                name: m.name,
+            }),
+            blocked_by: issue
+                .blocked_by
+                .into_iter()
+                .map(|b| {
+                    let is_terminal = b.is_terminal();
+                    CachedBlockerRef {
+                        id: b.id,
+                        identifier: b.identifier,
+                        title: b.title,
+                        state: b.state.name,
+                        is_terminal,
+                    }
+                })
+                .collect(),
+            sub_issues: issue
+                .sub_issues
+                .into_iter()
+                .map(|s| CachedIssueRef {
+                    id: s.id,
+                    identifier: s.identifier,
+                    state: s.state,
+                })
+                .collect(),
+            url: issue.url,
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            synced_at: Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_test_issue(id: &str, identifier: &str, state: &str) -> TrackerIssue {
+        TrackerIssue {
+            id: id.to_string(),
+            identifier: identifier.to_string(),
+            url: format!("https://linear.app/test/issue/{identifier}"),
+            title: format!("Issue {identifier}"),
+            description: None,
+            priority: Some(1),
+            state: state.to_string(),
+            labels: vec!["backend".to_string()],
+            parent_id: None,
+            parent: None,
+            project_milestone: Some(crate::opensymphony_domain::TrackerProjectMilestone {
+                id: "ms-1".to_string(),
+                name: "M1".to_string(),
+            }),
+            blocked_by: Vec::new(),
+            sub_issues: Vec::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn cache_upsert_entities_tracks_sync_timestamp() {
+        let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
+        let issues = vec![build_test_issue("lin-1", "COE-1", "In Progress")];
+        let synced_before = Utc::now();
+        cache.upsert_entities(issues);
+        let synced_after = Utc::now();
+
+        assert_eq!(cache.entity_count(), 1);
+        let entity = cache.get_entity("lin-1").expect("entity should exist");
+        assert_eq!(entity.identifier, "COE-1");
+        assert!(entity.synced_at >= synced_before);
+        assert!(entity.synced_at <= synced_after);
+        assert_eq!(cache.last_synced_at, Some(entity.synced_at));
+    }
+
+    #[test]
+    fn cache_upsert_overlay_by_run_id() {
+        let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
+        let overlay = RuntimeOverlay {
+            eligible: true,
+            queued: false,
+            active_run_id: Some("COE-1".to_string()),
+            last_outcome: None,
+            retry_count: 0,
+            workspace_id: None,
+            conversation_id: None,
+            last_event_at: None,
+            validation_status: None,
+            blocker_summary: None,
+            synced_at: Utc::now(),
+        };
+        cache.upsert_overlay(overlay);
+
+        assert_eq!(cache.overlay_count(), 1);
+        let result = cache.get_overlay("COE-1").expect("overlay should exist");
+        assert!(result.eligible);
+    }
+
+    #[test]
+    fn cache_clear_overlay_removes_entry() {
+        let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
+        cache.upsert_overlay(RuntimeOverlay {
+            eligible: true,
+            queued: false,
+            active_run_id: Some("COE-1".to_string()),
+            last_outcome: None,
+            retry_count: 0,
+            workspace_id: None,
+            conversation_id: None,
+            last_event_at: None,
+            validation_status: None,
+            blocker_summary: None,
+            synced_at: Utc::now(),
+        });
+        cache.clear_overlay("COE-1");
+        assert_eq!(cache.overlay_count(), 0);
+    }
+
+    #[test]
+    fn cache_is_expired_returns_true_when_ttl_passed() {
+        let mut cache = TaskGraphCache::new("default", Duration::from_secs(1));
+        cache.upsert_entities(vec![build_test_issue("lin-1", "COE-1", "Todo")]);
+        assert!(!cache.is_expired());
+
+        cache.last_synced_at = Some(Utc::now() - chrono::TimeDelta::seconds(2));
+        assert!(cache.is_expired());
+    }
+
+    #[test]
+    fn cache_is_expired_returns_true_when_never_synced() {
+        let cache = TaskGraphCache::new("default", Duration::from_secs(300));
+        assert!(cache.is_expired());
+    }
+
+    #[test]
+    fn infer_state_kind_maps_known_states() {
+        assert_eq!(TaskGraphCache::infer_state_kind("Done"), "completed");
+        assert_eq!(TaskGraphCache::infer_state_kind("In Progress"), "started");
+        assert_eq!(TaskGraphCache::infer_state_kind("Todo"), "unstarted");
+        assert_eq!(TaskGraphCache::infer_state_kind("Backlog"), "backlog");
+        assert_eq!(TaskGraphCache::infer_state_kind("Custom"), "unknown");
+    }
+
+    #[test]
+    fn from_tracker_issue_converts_milestone_and_blockers() {
+        let issue = build_test_issue("lin-1", "COE-1", "Done");
+        let entity: CachedLinearEntity = issue.into();
+        assert!(entity.project_milestone.is_some());
+        let milestone = entity.project_milestone.unwrap();
+        assert_eq!(milestone.name, "M1");
+        assert_eq!(entity.state_kind, "completed");
+    }
+
+    #[test]
+    fn cache_entities_iterator_yields_all() {
+        let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
+        cache.upsert_entities(vec![
+            build_test_issue("lin-1", "COE-1", "Todo"),
+            build_test_issue("lin-2", "COE-2", "In Progress"),
+        ]);
+        let ids: Vec<_> = cache.entities().map(|(k, _)| k.as_str()).collect();
+        assert!(ids.contains(&"lin-1"));
+        assert!(ids.contains(&"lin-2"));
+    }
+}

--- a/crates/opensymphony-linear/src/task_graph_cache.rs
+++ b/crates/opensymphony-linear/src/task_graph_cache.rs
@@ -91,48 +91,9 @@ impl TaskGraphCache {
     pub fn upsert_entities(&mut self, issues: Vec<TrackerIssue>) {
         let synced_at = Utc::now();
         for issue in issues {
-            let entity = CachedLinearEntity {
-                id: issue.id.clone(),
-                identifier: issue.identifier.clone(),
-                title: issue.title.clone(),
-                state: issue.state.clone(),
-                state_kind: Self::infer_state_kind(&issue.state),
-                priority: issue.priority,
-                labels: issue.labels.clone(),
-                parent_id: issue.parent_id.clone(),
-                project_milestone: issue.project_milestone.as_ref().map(|m| CachedMilestone {
-                    id: m.id.clone(),
-                    name: m.name.clone(),
-                }),
-                blocked_by: issue
-                    .blocked_by
-                    .into_iter()
-                    .map(|b| {
-                        let is_terminal = b.is_terminal();
-                        CachedBlockerRef {
-                            id: b.id,
-                            identifier: b.identifier,
-                            title: b.title,
-                            state: b.state.name,
-                            is_terminal,
-                        }
-                    })
-                    .collect(),
-                sub_issues: issue
-                    .sub_issues
-                    .into_iter()
-                    .map(|s| CachedIssueRef {
-                        id: s.id,
-                        identifier: s.identifier,
-                        state: s.state,
-                    })
-                    .collect(),
-                url: issue.url.clone(),
-                created_at: issue.created_at,
-                updated_at: issue.updated_at,
-                synced_at,
-            };
-            self.entities.insert(issue.id, entity);
+            let mut entity: CachedLinearEntity = issue.into();
+            entity.synced_at = synced_at;
+            self.entities.insert(entity.id.clone(), entity);
         }
         self.last_synced_at = Some(synced_at);
     }
@@ -152,7 +113,7 @@ impl TaskGraphCache {
         self.entities.get(id)
     }
 
-    /// Get a runtime overlay by run/issue ID.
+    /// Get a runtime overlay by `issue_id`.
     pub fn get_overlay(&self, id: &str) -> Option<&RuntimeOverlay> {
         self.overlays.get(id)
     }
@@ -160,10 +121,10 @@ impl TaskGraphCache {
     /// Return true if the entire cache is expired.
     pub fn is_expired(&self) -> bool {
         match self.last_synced_at {
-            Some(synced) => {
-                Utc::now().signed_duration_since(synced)
-                    > chrono::TimeDelta::from_std(self.ttl).unwrap_or_default()
-            }
+            Some(synced) => match chrono::TimeDelta::from_std(self.ttl) {
+                Ok(ttl) => Utc::now().signed_duration_since(synced) > ttl,
+                Err(_) => true,
+            },
             None => true,
         }
     }
@@ -291,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_upsert_overlay_by_run_id() {
+    fn cache_upsert_overlay_by_issue_id() {
         let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
         let overlay = RuntimeOverlay {
             issue_id: "lin-1".to_string(),

--- a/crates/opensymphony-linear/src/task_graph_cache.rs
+++ b/crates/opensymphony-linear/src/task_graph_cache.rs
@@ -52,6 +52,7 @@ pub struct CachedIssueRef {
 /// Runtime overlay data for a cached entity.
 #[derive(Debug, Clone)]
 pub struct RuntimeOverlay {
+    pub issue_id: String,
     pub eligible: bool,
     pub queued: bool,
     pub active_run_id: Option<String>,
@@ -138,18 +139,12 @@ impl TaskGraphCache {
 
     /// Update the runtime overlay for a single issue.
     pub fn upsert_overlay(&mut self, overlay: RuntimeOverlay) {
-        self.overlays.insert(
-            overlay
-                .active_run_id
-                .clone()
-                .unwrap_or_else(|| "unknown".to_string()),
-            overlay,
-        );
+        self.overlays.insert(overlay.issue_id.clone(), overlay);
     }
 
     /// Clear overlays for resolved issues.
     pub fn clear_overlay(&mut self, issue_id: &str) {
-        self.overlays.retain(|k, _| k != issue_id);
+        self.overlays.remove(issue_id);
     }
 
     /// Get an entity by Linear ID or issue identifier.
@@ -299,9 +294,10 @@ mod tests {
     fn cache_upsert_overlay_by_run_id() {
         let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
         let overlay = RuntimeOverlay {
+            issue_id: "lin-1".to_string(),
             eligible: true,
             queued: false,
-            active_run_id: Some("COE-1".to_string()),
+            active_run_id: Some("run-1".to_string()),
             last_outcome: None,
             retry_count: 0,
             workspace_id: None,
@@ -314,7 +310,7 @@ mod tests {
         cache.upsert_overlay(overlay);
 
         assert_eq!(cache.overlay_count(), 1);
-        let result = cache.get_overlay("COE-1").expect("overlay should exist");
+        let result = cache.get_overlay("lin-1").expect("overlay should exist");
         assert!(result.eligible);
     }
 
@@ -322,9 +318,10 @@ mod tests {
     fn cache_clear_overlay_removes_entry() {
         let mut cache = TaskGraphCache::new("default", Duration::from_secs(300));
         cache.upsert_overlay(RuntimeOverlay {
+            issue_id: "lin-1".to_string(),
             eligible: true,
             queued: false,
-            active_run_id: Some("COE-1".to_string()),
+            active_run_id: Some("run-1".to_string()),
             last_outcome: None,
             retry_count: 0,
             workspace_id: None,
@@ -334,7 +331,7 @@ mod tests {
             blocker_summary: None,
             synced_at: Utc::now(),
         });
-        cache.clear_overlay("COE-1");
+        cache.clear_overlay("lin-1");
         assert_eq!(cache.overlay_count(), 0);
     }
 

--- a/crates/opensymphony-linear/src/task_graph_cache.rs
+++ b/crates/opensymphony-linear/src/task_graph_cache.rs
@@ -108,7 +108,7 @@ impl TaskGraphCache {
         self.overlays.remove(issue_id);
     }
 
-    /// Get an entity by Linear ID or issue identifier.
+    /// Get a cached entity by its Linear ID.
     pub fn get_entity(&self, id: &str) -> Option<&CachedLinearEntity> {
         self.entities.get(id)
     }

--- a/crates/opensymphony-linear/src/task_graph_cache.rs
+++ b/crates/opensymphony-linear/src/task_graph_cache.rs
@@ -368,7 +368,9 @@ mod tests {
         let issue = build_test_issue("lin-1", "COE-1", "Done");
         let entity: CachedLinearEntity = issue.into();
         assert!(entity.project_milestone.is_some());
-        let milestone = entity.project_milestone.expect("test issue should have milestone");
+        let milestone = entity
+            .project_milestone
+            .expect("test issue should have milestone");
         assert_eq!(milestone.name, "M1");
         assert_eq!(entity.state_kind, "completed");
     }

--- a/docs/linear-query-coverage.md
+++ b/docs/linear-query-coverage.md
@@ -1,0 +1,53 @@
+# Linear Query Coverage Matrix
+
+This matrix tracks which Linear GraphQL fields are queried by the OpenSymphony
+Linear client (`crates/opensymphony-linear`) and whether they are normalized
+into domain types and exposed via the gateway task graph.
+
+## Entity Coverage
+
+| Entity          | Fields Covered                                                                                          | Query Assets                                          | Normalized | Task Graph |
+|-----------------|---------------------------------------------------------------------------------------------------------|-------------------------------------------------------|------------|------------|
+| Project         | `id`, `name`, `slugId`, `url`, `content`                                                                | `PROJECT_BY_SLUG_QUERY`                               | Yes        | No         |
+| ProjectMilestone| `id`, `name`                                                                                            | `ISSUES_BY_STATE_QUERY`, `ISSUE_BY_IDENTIFIER_QUERY`   | Yes        | No         |
+| Issue           | `id`, `identifier`, `url`, `title`, `description`, `priority`, `createdAt`, `updatedAt`                 | `ISSUES_BY_STATE_QUERY`, `ISSUE_BY_IDENTIFIER_QUERY`   | Yes        | Yes        |
+| IssueState      | `id`, `name`, `type`                                                                                    | All issue queries                                     | Yes        | Yes        |
+| Parent          | `id`, `identifier`, `url`, `title`, `state.name`                                                        | `ISSUES_BY_STATE_QUERY`, `ISSUE_BY_IDENTIFIER_QUERY`   | Yes        | Yes        |
+| Children        | `id`, `identifier`, `url`, `title`, `state.name`                                                        | `ISSUES_BY_STATE_QUERY`, `ISSUE_BY_IDENTIFIER_QUERY`   | Yes        | Yes        |
+| Labels          | `name` (paginated)                                                                                      | `ISSUES_BY_STATE_QUERY`, `ISSUE_BY_IDENTIFIER_QUERY`, `ISSUE_LABELS_QUERY` | Yes | Yes |
+| InverseRelations| `type`, `issue.id`, `issue.identifier`, `issue.title`, `issue.state`                                    | `ISSUES_BY_STATE_QUERY`, `ISSUE_BY_IDENTIFIER_QUERY`, `ISSUE_INVERSE_RELATIONS_QUERY` | Yes | Yes |
+| Comments        | `id`, `body`, `updatedAt`, `resolvedAt` (paginated)                                                     | `ISSUE_COMMENTS_QUERY`                                | Yes        | No         |
+| Assignee        | Not yet queried                                                                                         | —                                                     | No         | No         |
+| Estimate        | Mapped via `priority` field (Linear does not expose separate estimate in free tier)                      | —                                                     | N/A        | N/A        |
+| Attachments     | Not yet queried                                                                                         | —                                                     | No         | No         |
+| Team            | `id`, `key`, `name`, `states`                                                                           | `ISSUE_TEAM_STATES_QUERY` (Linear skill only)         | No         | No         |
+
+## Query Inventory
+
+| Constant Name                    | Type      | Purpose                                                        |
+|----------------------------------|-----------|----------------------------------------------------------------|
+| `ISSUES_BY_STATE_QUERY`          | Query     | Paginated issues filtered by project and state names            |
+| `ISSUE_BY_IDENTIFIER_QUERY`      | Query     | Single issue lookup by identifier (including archived)          |
+| `ISSUE_STATES_BY_IDS_QUERY`      | Query     | Paginated issue state refresh by explicit issue IDs             |
+| `ISSUE_LABELS_QUERY`             | Query     | Paginated label expansion for a single issue                    |
+| `ISSUE_INVERSE_RELATIONS_QUERY`  | Query     | Paginated inverse relation expansion for a single issue         |
+| `ISSUE_COMMENTS_QUERY`           | Query     | Paginated comments for a single issue                           |
+| `ISSUE_ARCHIVE_MUTATION`         | Mutation  | Archive an issue                                                |
+| `PROJECT_BY_SLUG_QUERY`          | Query     | Lookup project by slug ID                                       |
+| `PROJECT_UPDATE_CONTENT_MUTATION`| Mutation  | Update project description content                              |
+
+## Gaps (Out of Scope for This Ticket)
+
+- **Assignee**: Not queried. Would require adding `assignee { id, name }` to issue
+  fragments. Deferred to a follow-up ticket.
+- **Attachments**: Not queried. Would require `attachments(first: N) { nodes { ... } }`.
+  Deferred to a follow-up ticket.
+- **Team-level reads**: Only available via the Linear skill introspection queries,
+  not the Rust client. Sufficient for current needs.
+
+## Schema Drift
+
+Schema drift validation is handled by `opensymphony_linear::schema_drift`. It
+performs GraphQL introspection against the live Linear API to verify that
+required fields exist on the expected types. See `src/schema_drift.rs` for
+the field matrix and validation logic.


### PR DESCRIPTION
## Summary

Expand Linear read coverage and build the cache that joins Linear task graph data with OpenSymphony runtime overlays.

## Changes

- **docs/linear-query-coverage.md**: Query coverage matrix for all Linear GraphQL reads (projects, milestones, issues, sub-issues, relations, labels, priorities, statuses, assignees, estimates, comments, attachments).

- **schema_drift.rs**: Schema drift detection via GraphQL introspection. Validates that required fields exist on remote Linear types. Returns a structured report with violation details and remediation guidance.

- **task_graph_cache.rs**: In-memory cache for Linear entities with sync timestamps. Supports runtime overlay join (eligibility, queueing, active runs, validation, blockers). Provides TTL-based expiration, entity/overlay upsert, and iterator-based snapshotting.

- **client.rs**: execute_graphql visibility changed to pub(super) to support schema drift introspection queries.

## Tests

- 20 lib tests pass (4 schema_drift + 8 task_graph_cache + 8 existing)
- 22 integration tests pass (zero regressions)

## Acceptance Criteria

- [x] Task graph reads can include Linear projects, milestones, issues, sub-issues, and relations.
- [x] Runtime overlays are joined without requiring UI access to orchestrator internals.
- [x] Schema drift is detected with a clear failure and remediation path.

## Manual QA Plan

- Run `cargo test opensymphony_linear --lib` to verify schema drift and cache unit tests.
- Run `cargo test --test linear_client` to verify fake-server integration tests.
- Run schema drift check against live Linear API with `LINEAR_API_KEY` set.


## Evidence

### Unit Tests (20 passed, zero failures)

```bash
$ cargo test opensymphony_linear --lib

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 254 filtered out; finished in 0.00s
```

### Integration Tests (22 passed, zero failures, zero regressions)

```bash
$ cargo test --test linear_client

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

### Clippy (clean, zero warnings)

```bash
$ cargo clippy --all-targets

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
```
