### PR TITLE
fix(gateway): restore web asset serving routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ thiserror.workspace = true
 time.workspace = true
 tokio-tungstenite.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -96,6 +97,7 @@ thiserror = "2"
 time = "=0.3.47"
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
+tokio-util = { version = "0.7", features = ["io"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -16,8 +16,8 @@ use axum::{
         ws::{Message, WebSocket},
     },
     http::StatusCode,
-    response::IntoResponse,
     response::sse::{Event, KeepAlive, Sse},
+    response::{IntoResponse, Response},
     routing::get,
 };
 use tokio::{net::TcpListener, sync::broadcast};
@@ -183,6 +183,7 @@ pub struct GatewayState {
     pub store: SnapshotStore,
     pub journal: InMemoryEventJournal,
     pub broker: StreamBroker,
+    pub web_assets_dir: Option<String>,
 }
 
 impl axum::extract::FromRef<GatewayState> for SnapshotStore {
@@ -198,6 +199,7 @@ pub struct GatewayServer {
     store: SnapshotStore,
     journal: InMemoryEventJournal,
     broker: StreamBroker,
+    web_assets_dir: Option<String>,
 }
 
 impl GatewayServer {
@@ -208,6 +210,7 @@ impl GatewayServer {
             journal: journal.clone(),
             broker: StreamBroker::new(journal),
             store,
+            web_assets_dir: None,
         }
     }
 
@@ -221,7 +224,14 @@ impl GatewayServer {
             store,
             journal,
             broker,
+            web_assets_dir: None,
         }
+    }
+
+    /// Enable serving of the built web client from the given directory.
+    pub fn with_web_assets(mut self, dir: impl Into<String>) -> Self {
+        self.web_assets_dir = Some(dir.into());
+        self
     }
 
     /// Extract the journal and broker so the caller can keep clones for testing.
@@ -234,8 +244,9 @@ impl GatewayServer {
             store: self.store.clone(),
             journal: self.journal.clone(),
             broker: self.broker.clone(),
+            web_assets_dir: self.web_assets_dir.clone(),
         };
-        Router::new()
+        let mut router = Router::new()
             .route("/api/v1/capabilities", get(capabilities))
             .route("/api/v1/dashboard/snapshot", get(dashboard_snapshot))
             .route("/api/v1/events", get(events))
@@ -250,8 +261,16 @@ impl GatewayServer {
             .route("/api/v1/runs/{run_id}", get(get_run_detail))
             .route("/api/v1/runs/{run_id}/events", get(get_run_events))
             .route("/api/v1/runs/{run_id}/files", get(get_run_files))
-            .route("/api/v1/runs/{run_id}/diffs", get(get_run_diffs))
-            .with_state(state)
+            .route("/api/v1/runs/{run_id}/diffs", get(get_run_diffs));
+
+        if self.web_assets_dir.is_some() {
+            router = router
+                .route("/app", get(web_asset_handler))
+                .route("/app/", get(web_asset_handler))
+                .route("/app/{*path}", get(web_asset_handler));
+        }
+
+        router.with_state(state)
     }
 
     pub async fn serve(self, listener: TcpListener) -> std::io::Result<()> {
@@ -992,6 +1011,143 @@ pub fn sanitize_file_path(workspace_root: &str, raw_path: &str) -> String {
                 .map(|name| name.to_string_lossy().to_string())
                 .unwrap_or_default()
         })
+}
+
+/// Resolve the requested path and verify it stays inside the assets directory.
+fn resolve_safe_asset_path(assets_dir: &str, rest: &str) -> Option<PathBuf> {
+    if StdPath::new(rest).is_absolute() {
+        return None;
+    }
+
+    let base = StdPath::new(assets_dir);
+    let candidate = base.join(rest);
+    match (candidate.canonicalize(), base.canonicalize()) {
+        (Ok(resolved), Ok(base_resolved)) => {
+            if resolved == base_resolved || resolved.starts_with(&base_resolved) {
+                Some(resolved)
+            } else {
+                None
+            }
+        }
+        _ => {
+            if candidate
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
+                None
+            } else {
+                Some(candidate)
+            }
+        }
+    }
+}
+
+async fn serve_index_html(assets_dir: &str) -> Option<Response> {
+    let index_path = StdPath::new(assets_dir).join("index.html");
+    serve_file(&index_path).await.ok()
+}
+
+async fn web_asset_handler(
+    State(state): State<GatewayState>,
+    path: Option<AxumPath<String>>,
+) -> Response {
+    let Some(assets_dir) = state.web_assets_dir.as_deref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let rest = path.map(|p| p.0).unwrap_or_default();
+    if rest.is_empty() {
+        return serve_index_html(assets_dir)
+            .await
+            .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
+    let Some(safe_path) = resolve_safe_asset_path(assets_dir, &rest) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    if safe_path.is_file() {
+        return match serve_file(&safe_path).await {
+            Ok(resp) => resp,
+            Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        };
+    }
+
+    if !path_has_known_extension(&rest) {
+        return serve_index_html(assets_dir)
+            .await
+            .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
+    StatusCode::NOT_FOUND.into_response()
+}
+
+fn path_has_known_extension(path: &str) -> bool {
+    if let Some(dot_pos) = path.rfind('.')
+        && let Some(ext) = path.get(dot_pos + 1..)
+    {
+        return matches!(
+            ext.to_lowercase().as_str(),
+            "html"
+                | "css"
+                | "js"
+                | "json"
+                | "png"
+                | "jpg"
+                | "jpeg"
+                | "gif"
+                | "svg"
+                | "ico"
+                | "woff"
+                | "woff2"
+                | "ttf"
+                | "eot"
+                | "otf"
+                | "map"
+                | "txt"
+                | "xml"
+                | "webp"
+                | "mp4"
+                | "webm"
+                | "mp3"
+                | "wav"
+                | "flac"
+                | "pdf"
+                | "zip"
+                | "gz"
+                | "tar"
+                | "bz2"
+        );
+    }
+    false
+}
+
+async fn serve_file(path: &StdPath) -> Result<Response, std::io::Error> {
+    let bytes = tokio::fs::read(path).await?;
+    let content_type = mime_type(path);
+    Ok(([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response())
+}
+
+fn mime_type(path: &StdPath) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("html") => "text/html; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("js") => "application/javascript; charset=utf-8",
+        Some("json") => "application/json; charset=utf-8",
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("svg") => "image/svg+xml",
+        Some("ico") => "image/x-icon",
+        Some("woff") => "font/woff",
+        Some("woff2") => "font/woff2",
+        Some("ttf") => "font/ttf",
+        Some("eot") => "application/vnd.ms-fontobject",
+        Some("otf") => "font/otf",
+        Some("map") => "application/json; charset=utf-8",
+        Some("txt") => "text/plain; charset=utf-8",
+        _ => "application/octet-stream",
+    }
 }
 
 fn map_file_change_kind(kind: ControlPlaneFileChangeKind) -> FileChangeKind {

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1084,44 +1084,42 @@ async fn web_asset_handler(
     StatusCode::NOT_FOUND.into_response()
 }
 
+const KNOWN_ASSET_MIME_TYPES: &[(&str, &str)] = &[
+    ("html", "text/html; charset=utf-8"),
+    ("css", "text/css; charset=utf-8"),
+    ("js", "application/javascript; charset=utf-8"),
+    ("json", "application/json"),
+    ("png", "image/png"),
+    ("jpg", "image/jpeg"),
+    ("jpeg", "image/jpeg"),
+    ("gif", "image/gif"),
+    ("svg", "image/svg+xml"),
+    ("ico", "image/x-icon"),
+    ("woff", "font/woff"),
+    ("woff2", "font/woff2"),
+    ("ttf", "font/ttf"),
+    ("eot", "application/vnd.ms-fontobject"),
+    ("otf", "font/otf"),
+    ("map", "application/json"),
+    ("txt", "text/plain; charset=utf-8"),
+    ("xml", "application/xml"),
+    ("webp", "image/webp"),
+    ("mp4", "video/mp4"),
+    ("webm", "video/webm"),
+    ("mp3", "audio/mpeg"),
+    ("wav", "audio/wav"),
+    ("flac", "audio/flac"),
+    ("pdf", "application/pdf"),
+    ("zip", "application/zip"),
+    ("gz", "application/gzip"),
+    ("tar", "application/x-tar"),
+    ("bz2", "application/x-bzip2"),
+];
+
 fn path_has_known_extension(path: &str) -> bool {
-    if let Some(dot_pos) = path.rfind('.')
-        && let Some(ext) = path.get(dot_pos + 1..)
-    {
-        return matches!(
-            ext.to_lowercase().as_str(),
-            "html"
-                | "css"
-                | "js"
-                | "json"
-                | "png"
-                | "jpg"
-                | "jpeg"
-                | "gif"
-                | "svg"
-                | "ico"
-                | "woff"
-                | "woff2"
-                | "ttf"
-                | "eot"
-                | "otf"
-                | "map"
-                | "txt"
-                | "xml"
-                | "webp"
-                | "mp4"
-                | "webm"
-                | "mp3"
-                | "wav"
-                | "flac"
-                | "pdf"
-                | "zip"
-                | "gz"
-                | "tar"
-                | "bz2"
-        );
-    }
-    false
+    path.rsplit_once('.')
+        .and_then(|(_, ext)| mime_type_for_extension(ext))
+        .is_some()
 }
 
 async fn serve_file(path: &StdPath) -> Result<Response, std::io::Error> {
@@ -1133,25 +1131,16 @@ async fn serve_file(path: &StdPath) -> Result<Response, std::io::Error> {
 }
 
 fn mime_type(path: &StdPath) -> &'static str {
-    match path.extension().and_then(|e| e.to_str()) {
-        Some("html") => "text/html; charset=utf-8",
-        Some("css") => "text/css; charset=utf-8",
-        Some("js") => "application/javascript; charset=utf-8",
-        Some("json") => "application/json; charset=utf-8",
-        Some("png") => "image/png",
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("gif") => "image/gif",
-        Some("svg") => "image/svg+xml",
-        Some("ico") => "image/x-icon",
-        Some("woff") => "font/woff",
-        Some("woff2") => "font/woff2",
-        Some("ttf") => "font/ttf",
-        Some("eot") => "application/vnd.ms-fontobject",
-        Some("otf") => "font/otf",
-        Some("map") => "application/json; charset=utf-8",
-        Some("txt") => "text/plain; charset=utf-8",
-        _ => "application/octet-stream",
-    }
+    path.extension()
+        .and_then(|e| e.to_str())
+        .and_then(mime_type_for_extension)
+        .unwrap_or("application/octet-stream")
+}
+
+fn mime_type_for_extension(extension: &str) -> Option<&'static str> {
+    KNOWN_ASSET_MIME_TYPES
+        .iter()
+        .find_map(|(known, mime)| known.eq_ignore_ascii_case(extension).then_some(*mime))
 }
 
 fn map_file_change_kind(kind: ControlPlaneFileChangeKind) -> FileChangeKind {
@@ -1784,5 +1773,30 @@ mod tests {
 
         assert_eq!(value["event_id"], "evt_ws_frame");
         assert_eq!(value["sequence"], 7);
+    }
+
+    #[test]
+    fn web_asset_mime_table_is_the_extension_source_of_truth() {
+        let mut seen = std::collections::BTreeSet::new();
+
+        for (extension, mime) in KNOWN_ASSET_MIME_TYPES {
+            assert!(!extension.is_empty(), "extension should not be empty");
+            assert_ne!(*mime, "application/octet-stream");
+            assert!(seen.insert(*extension), "duplicate extension: {extension}");
+            assert!(path_has_known_extension(&format!("asset.{extension}")));
+            assert_eq!(
+                mime_type(StdPath::new(&format!("asset.{extension}"))),
+                *mime
+            );
+        }
+
+        assert!(path_has_known_extension("asset.MP4"));
+        assert_eq!(mime_type(StdPath::new("asset.MP4")), "video/mp4");
+        assert!(!path_has_known_extension("route/without-extension"));
+        assert!(!path_has_known_extension("asset.unknown"));
+        assert_eq!(
+            mime_type(StdPath::new("asset.unknown")),
+            "application/octet-stream"
+        );
     }
 }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use async_stream::stream;
 use axum::{
     Json, Router,
+    body::Body,
     extract::{
         Path as AxumPath, State,
         ws::{Message, WebSocket},
@@ -21,6 +22,7 @@ use axum::{
     routing::get,
 };
 use tokio::{net::TcpListener, sync::broadcast};
+use tokio_util::io::ReaderStream;
 
 use crate::opensymphony_domain::{EventStream, InMemoryEventJournal, StreamBroker};
 use crate::opensymphony_gateway_schema::{
@@ -1123,9 +1125,11 @@ fn path_has_known_extension(path: &str) -> bool {
 }
 
 async fn serve_file(path: &StdPath) -> Result<Response, std::io::Error> {
-    let bytes = tokio::fs::read(path).await?;
+    let file = tokio::fs::File::open(path).await?;
+    let stream = ReaderStream::new(file);
+    let body = Body::from_stream(stream);
     let content_type = mime_type(path);
-    Ok(([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response())
+    Ok(([(axum::http::header::CONTENT_TYPE, content_type)], body).into_response())
 }
 
 fn mime_type(path: &StdPath) -> &'static str {

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -417,6 +417,8 @@ async fn gateway_serves_configured_web_assets() {
     .expect("write index.html");
     std::fs::write(assets.path().join("app.js"), "console.log('opensymphony');")
         .expect("write app.js");
+    std::fs::write(assets.path().join("demo.mp4"), b"fake mp4").expect("write demo.mp4");
+    std::fs::write(assets.path().join("report.pdf"), b"%PDF-1.7").expect("write report.pdf");
 
     let store = SnapshotStore::new(fixture_snapshot(0));
     let server =
@@ -474,6 +476,34 @@ async fn gateway_serves_configured_web_assets() {
             .await
             .expect("read app js body")
             .contains("opensymphony")
+    );
+
+    let app_video = client
+        .get(format!("http://{address}/app/demo.mp4"))
+        .send()
+        .await
+        .expect("fetch app video");
+    assert_eq!(app_video.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        app_video
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("video/mp4")
+    );
+
+    let app_pdf = client
+        .get(format!("http://{address}/app/report.pdf"))
+        .send()
+        .await
+        .expect("fetch app pdf");
+    assert_eq!(app_pdf.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        app_pdf
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/pdf")
     );
 
     let spa_route = client

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -408,6 +408,134 @@ async fn gateway_serves_capabilities_and_dashboard_snapshot() {
 }
 
 #[tokio::test]
+async fn gateway_serves_configured_web_assets() {
+    let assets = tempfile::tempdir().expect("create assets tempdir");
+    std::fs::write(
+        assets.path().join("index.html"),
+        "<main>OpenSymphony</main>",
+    )
+    .expect("write index.html");
+    std::fs::write(assets.path().join("app.js"), "console.log('opensymphony');")
+        .expect("write app.js");
+
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server =
+        GatewayServer::new(store).with_web_assets(assets.path().to_string_lossy().to_string());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+
+    let app_root = client
+        .get(format!("http://{address}/app"))
+        .send()
+        .await
+        .expect("fetch app root");
+    assert_eq!(app_root.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        app_root
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/html; charset=utf-8")
+    );
+    assert!(
+        app_root
+            .text()
+            .await
+            .expect("read app root body")
+            .contains("OpenSymphony")
+    );
+
+    let app_js = client
+        .get(format!("http://{address}/app/app.js"))
+        .send()
+        .await
+        .expect("fetch app js");
+    assert_eq!(app_js.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        app_js
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/javascript; charset=utf-8")
+    );
+    assert!(
+        app_js
+            .text()
+            .await
+            .expect("read app js body")
+            .contains("opensymphony")
+    );
+
+    let spa_route = client
+        .get(format!("http://{address}/app/projects/COE-393"))
+        .send()
+        .await
+        .expect("fetch spa route");
+    assert_eq!(spa_route.status(), reqwest::StatusCode::OK);
+    assert!(
+        spa_route
+            .text()
+            .await
+            .expect("read spa route body")
+            .contains("OpenSymphony")
+    );
+
+    let missing_asset = client
+        .get(format!("http://{address}/app/missing.js"))
+        .send()
+        .await
+        .expect("fetch missing asset");
+    assert_eq!(missing_asset.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_web_assets_reject_path_traversal() {
+    let root = tempfile::tempdir().expect("create tempdir");
+    let assets_dir = root.path().join("assets");
+    std::fs::create_dir(&assets_dir).expect("create assets dir");
+    std::fs::write(assets_dir.join("index.html"), "<main>OpenSymphony</main>")
+        .expect("write index.html");
+    std::fs::write(root.path().join("secret.txt"), "secret").expect("write secret");
+
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server =
+        GatewayServer::new(store).with_web_assets(assets_dir.to_string_lossy().to_string());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{address}/app/%2e%2e/secret.txt"))
+        .send()
+        .await
+        .expect("fetch traversal attempt");
+
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+    assert_ne!(response.text().await.expect("read response body"), "secret");
+
+    server_task.abort();
+}
+
+#[tokio::test]
 /// SSE endpoint now streams journal events (not snapshot updates).
 /// This test verifies the SSE transport works with journal events and
 /// delivers new events appended after the stream opens.

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -482,6 +482,13 @@ async fn gateway_serves_configured_web_assets() {
         .await
         .expect("fetch spa route");
     assert_eq!(spa_route.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        spa_route
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/html; charset=utf-8")
+    );
     assert!(
         spa_route
             .text()


### PR DESCRIPTION
## Summary
- restores optional `/app` static web asset serving on the journal-enabled gateway
- keeps `/app`, `/app/`, and `/app/{*path}` behind `GatewayServer::with_web_assets`
- streams asset responses instead of buffering whole files in memory
- centralizes asset MIME handling and adds regression tests for static files, media/PDF MIME types, SPA fallback, and path traversal rejection

## Context
PR #91 preserved the Tauri desktop app files from #93, but the gateway rewrite dropped pre-existing web asset serving support that was already in the #91 merge base. This restores that gateway behavior on top of current `main`.

## Evidence
`gateway_serves_configured_web_assets` starts a real `GatewayServer` on `127.0.0.1:0` with a temporary web asset directory, then fetches `/app`, `/app/app.js`, `/app/demo.mp4`, `/app/report.pdf`, `/app/projects/COE-393`, and `/app/missing.js` through `reqwest`. It verifies HTTP status codes, HTML/JS/video/PDF content types, SPA fallback behavior, and missing-asset 404 behavior.

```text
$ cargo test -p opensymphony --test gateway gateway_serves_configured_web_assets -- --nocapture
running 1 test
test gateway::gateway_serves_configured_web_assets ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 40 filtered out; finished in 0.01s
```

`web_asset_mime_table_is_the_extension_source_of_truth` verifies the extension fallback gate and response MIME lookup both use the same MIME table, rejects duplicate extensions, rejects implicit `application/octet-stream` mappings for known assets, and confirms case-insensitive lookup.

```text
$ cargo test -p opensymphony opensymphony_gateway::tests::web_asset_mime_table_is_the_extension_source_of_truth -- --nocapture
running 1 test
test opensymphony_gateway::tests::web_asset_mime_table_is_the_extension_source_of_truth ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 333 filtered out; finished in 0.00s
```

Full verification:

```text
$ cargo fmt --check
$ git diff --check
$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.40s

$ cargo test --workspace
test result: ok. 334 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
...
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
...
Doc-tests opensymphony
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
