### PR TITLE
COE-448: Add scoped memory server context

### DIFF
--- a/.agents/skills/opensymphony-memory/SKILL.md
+++ b/.agents/skills/opensymphony-memory/SKILL.md
@@ -22,6 +22,7 @@ Run the smallest command that answers the question:
 
 ```bash
 opensymphony memory context --issue COE-456
+opensymphony memory context --issue COE-456 --paths crates/opensymphony-openhands --include-code-intel
 opensymphony memory related --issue COE-456
 opensymphony memory related --paths crates/opensymphony-openhands
 opensymphony memory related --area openhands-runtime

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -189,24 +189,25 @@ workflow.
     - Check off items that are already done.
     - Expand/fix the plan so it is comprehensive for current scope.
     - Ensure `Acceptance Criteria` and `Validation` are current and still make sense for the task.
-4.  Start work by writing/updating a hierarchical plan in the workpad comment.
-5.  Ensure the workpad includes a compact environment stamp at the top as a code fence line:
+4.  Before planning implementation details, load pre-implementation memory context with `opensymphony memory context --issue {{ issue.identifier }}` when memory is configured, and treat the result as advisory context.
+5.  Start work by writing/updating a hierarchical plan in the workpad comment.
+6.  Ensure the workpad includes a compact environment stamp at the top as a code fence line:
     - Format: `<host>:<abs-workdir>@<short-sha>`
     - Example: `devbox-01:/home/dev-user/code/symphony-workspaces/MT-32@7bdde33bc`
     - Do not include metadata already inferable from Linear issue fields (`issue ID`, `status`, `branch`, `PR link`).
-6.  Add explicit acceptance criteria and TODOs in checklist form in the same comment.
+7.  Add explicit acceptance criteria and TODOs in checklist form in the same comment.
     - If changes are user-facing, include a UI walkthrough acceptance criterion that describes the end-to-end user path to validate.
     - If changes touch app files or app behavior, add explicit app-specific flow checks to `Acceptance Criteria` in the workpad (for example: launch path, changed interaction path, and expected result path).
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
-7.  Run a principal-style self-review of the plan and refine it in the comment.
-8.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-9.  After initial file discovery, run read-only memory lookups such as `opensymphony memory related --paths <path1>,<path2>` for touched areas when memory is configured, and record useful references in the workpad.
-10. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
+8.  Run a principal-style self-review of the plan and refine it in the comment.
+9.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
+10. After initial file discovery, re-run `opensymphony memory context --issue {{ issue.identifier }} --paths <path1>,<path2> --include-code-intel` for touched areas when memory is configured, and record useful references in the workpad.
+11. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
       - resulting `HEAD` short SHA.
-11. Compact context and proceed to execution.
+12. Compact context and proceed to execution.
 
 ## PR feedback sweep protocol (required)
 

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1937,6 +1937,7 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             conversation_count: 3,
             status_line: "local agent-server healthy".to_owned(),
         },
+        memory_server: Default::default(),
         metrics: MetricsSnapshot {
             running_issues,
             retry_queue_depth,

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1,5 +1,6 @@
 use std::{
-    fs,
+    env, fs,
+    net::SocketAddr,
     path::{Path, PathBuf},
     process::{self, ExitCode},
 };
@@ -8,22 +9,26 @@ use chrono::{NaiveDate, Utc};
 use clap::{Args, Subcommand};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use tokio::task::JoinHandle;
 
 use crate::{
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
     opensymphony_memory::{
-        ArchivePlan, CommentEvidence, DocsSyncPlan, IssueEvidence, IssueSelection, LintSeverity,
-        MemoryConfig, MemoryContextOptions, MemoryError, SourceFile,
-        archive_blocking_warning_count, brief, context_for_issue_with_options, docs_for_area,
-        expand_issue_range, lint, load_source_file, mark_archived, plan_archive, plan_capture,
-        plan_docs_sync, plan_memory_init, related_by_area, related_by_issue, related_by_paths,
-        render_archive_plan, render_capture_dry_run, search, status, write_capture_plan,
-        write_docs_sync_plan, write_memory_init_plan,
+        ArchivePlan, CodeIntelIndex, CommentEvidence, DocsSyncPlan, IssueEvidence,
+        IssueLinkEvidence, IssueSelection, KnowledgeScope, KnowledgeScopeKind, LintSeverity,
+        MemoryConfig, MemoryContextOptions, MemoryError, MemoryReindexReport, MemoryScopeFilter,
+        SourceFile, archive_blocking_warning_count, brief, context_for_issue_with_options,
+        docs_for_area, expand_issue_range, lint, load_source_file, mark_archived, plan_archive,
+        plan_capture, plan_docs_sync, plan_memory_init, refresh_memory_index,
+        related_by_area_with_scope, related_by_issue_with_scope, related_by_paths_with_scope,
+        render_archive_plan, render_capture_dry_run, search_with_scope, status_with_scope,
+        write_capture_plan, write_docs_sync_plan, write_memory_init_plan,
     },
     opensymphony_openhands::{
         ConversationMoveOutcome, IssueConversationManifest, OpenHandsConversationStorePaths,
     },
+    opensymphony_planning::CodebaseAnalyzer,
     opensymphony_workflow::WorkflowDefinition,
     opensymphony_workspace::{CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig},
 };
@@ -151,6 +156,10 @@ struct SyncDocsArgs {
 
 #[derive(Debug, Args)]
 struct StatusArgs {
+    #[command(flatten)]
+    scope: ScopeArgs,
+    #[arg(long, help = "Filter by issue/work item")]
+    issue: Option<String>,
     #[arg(long, help = "Filter by milestone")]
     milestone: Option<String>,
     #[arg(long, help = "Filter by area")]
@@ -165,6 +174,14 @@ struct ShowArgs {
 
 #[derive(Debug, Args)]
 struct SearchArgs {
+    #[command(flatten)]
+    scope: ScopeArgs,
+    #[arg(long, help = "Filter by issue/work item")]
+    issue: Option<String>,
+    #[arg(long, help = "Filter by milestone")]
+    milestone: Option<String>,
+    #[arg(long, help = "Filter by area")]
+    area: Option<String>,
     #[arg(help = "Search query")]
     query: String,
     #[arg(long, default_value = "10", help = "Maximum results")]
@@ -173,8 +190,12 @@ struct SearchArgs {
 
 #[derive(Debug, Args)]
 struct RelatedArgs {
+    #[command(flatten)]
+    scope: ScopeArgs,
     #[arg(long, help = "Find memory related to this issue")]
     issue: Option<String>,
+    #[arg(long, help = "Filter related memory by milestone")]
+    milestone: Option<String>,
     #[arg(long, help = "Find memory related to this area")]
     area: Option<String>,
     #[arg(long, value_delimiter = ',', help = "Find memory related to paths")]
@@ -185,14 +206,26 @@ struct RelatedArgs {
 
 #[derive(Debug, Args)]
 struct DocsArgs {
+    #[command(flatten)]
+    scope: ScopeArgs,
+    #[arg(long, help = "Issue/work item scope identifier")]
+    issue: Option<String>,
+    #[arg(long, help = "Milestone scope identifier")]
+    milestone: Option<String>,
     #[arg(long, help = "Area slug")]
     area: String,
 }
 
 #[derive(Debug, Args)]
 struct ContextArgs {
+    #[command(flatten)]
+    scope: ScopeArgs,
     #[arg(long, help = "Issue identifier")]
     issue: String,
+    #[arg(long, help = "Milestone scope identifier")]
+    milestone: Option<String>,
+    #[arg(long, help = "Area scope slug")]
+    area: Option<String>,
     #[arg(
         long,
         value_delimiter = ',',
@@ -205,20 +238,43 @@ struct ContextArgs {
         help = "Code paths to use for path-matched memory"
     )]
     paths: Vec<PathBuf>,
+    #[arg(long, help = "Append code-intelligence context for --paths")]
+    include_code_intel: bool,
     #[arg(long, default_value = "20", help = "Maximum selected memory briefs")]
     limit: usize,
+}
+
+#[derive(Debug, Args, Default, Clone)]
+struct ScopeArgs {
+    #[arg(long, help = "Project set scope identifier")]
+    project_set: Option<String>,
+    #[arg(long, help = "Project scope identifier")]
+    project: Option<String>,
+    #[arg(long, help = "Repository scope identifier or path")]
+    repo: Option<String>,
+    #[arg(
+        long,
+        help = "Allow queries outside the default current project set scope"
+    )]
+    all_accessible: bool,
 }
 
 #[derive(Debug, Args)]
 struct ServeArgs {
     #[arg(long, default_value = "127.0.0.1:8765", help = "Bind address")]
-    addr: String,
+    addr: SocketAddr,
     #[arg(
         long,
         env = "OPENSYMPHONY_MEMORY_TOKEN",
-        help = "Optional bearer token"
+        help = "Optional read-only bearer token"
     )]
     token: Option<String>,
+    #[arg(
+        long,
+        env = "OPENSYMPHONY_MEMORY_ADMIN_TOKEN",
+        help = "Optional admin bearer token for capture, sync, lint, and reindex tools"
+    )]
+    admin_token: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -497,7 +553,7 @@ pub(crate) async fn auto_capture_terminal(
 }
 
 async fn run_memory(args: MemoryArgs) -> Result<(), MemoryError> {
-    let repo_root = std::env::current_dir().map_err(|source| MemoryError::ReadFile {
+    let repo_root = env::current_dir().map_err(|source| MemoryError::ReadFile {
         path: PathBuf::from("."),
         source,
     })?;
@@ -505,6 +561,13 @@ async fn run_memory(args: MemoryArgs) -> Result<(), MemoryError> {
         config: config_path,
         command,
     } = args;
+    if let Some(endpoint) = env::var("OPENSYMPHONY_MEMORY_ENDPOINT")
+        .ok()
+        .and_then(|value| non_empty(&value))
+        && let Some((tool_name, arguments)) = remote_memory_tool_request(&command)
+    {
+        return run_remote_memory_tool(&endpoint, tool_name, arguments).await;
+    }
     match command {
         MemoryCommand::Init(args) => run_init(&repo_root, config_path.as_deref(), args),
         MemoryCommand::Capture(args) => {
@@ -708,13 +771,20 @@ fn run_sync_docs(config: &MemoryConfig, args: SyncDocsArgs) -> Result<(), Memory
 }
 
 fn run_status(config: &MemoryConfig, args: StatusArgs) -> Result<(), MemoryError> {
-    let report = status(
+    let scope = scope_filter(
+        &args.scope,
+        args.issue.as_deref(),
+        args.milestone.as_deref(),
+        args.area.as_deref(),
+    );
+    let report = status_with_scope(
         config,
         &IssueSelection {
-            milestone: args.milestone,
-            area: args.area,
+            milestone: args.milestone.clone(),
+            area: args.area.clone(),
             ..IssueSelection::default()
         },
+        &scope,
     )?;
     println!("# Memory Status\n");
     println!("Issues captured: {}", report.issue_count);
@@ -757,18 +827,30 @@ fn run_show(config: &MemoryConfig, args: ShowArgs, mode: ShowMode) -> Result<(),
 }
 
 fn run_search(config: &MemoryConfig, args: SearchArgs) -> Result<(), MemoryError> {
-    let results = search(config, &args.query, args.limit)?;
+    let scope = scope_filter(
+        &args.scope,
+        args.issue.as_deref(),
+        args.milestone.as_deref(),
+        args.area.as_deref(),
+    );
+    let results = search_with_scope(config, &args.query, args.limit, &scope)?;
     print_search_results(config, &results);
     Ok(())
 }
 
 fn run_related(config: &MemoryConfig, args: RelatedArgs) -> Result<(), MemoryError> {
+    let scope = scope_filter(
+        &args.scope,
+        None,
+        args.milestone.as_deref(),
+        args.area.as_deref(),
+    );
     let results = if let Some(issue) = args.issue {
-        related_by_issue(config, &issue, args.limit)?
+        related_by_issue_with_scope(config, &issue, args.limit, &scope)?
     } else if let Some(area) = args.area {
-        related_by_area(config, &area, args.limit)?
+        related_by_area_with_scope(config, &area, args.limit, &scope)?
     } else if !args.paths.is_empty() {
-        related_by_paths(config, &args.paths, args.limit)?
+        related_by_paths_with_scope(config, &args.paths, args.limit, &scope)?
     } else {
         return Err(MemoryError::InvalidInput(
             "provide one of --issue, --area, or --paths".to_string(),
@@ -779,6 +861,12 @@ fn run_related(config: &MemoryConfig, args: RelatedArgs) -> Result<(), MemoryErr
 }
 
 fn run_docs(config: &MemoryConfig, args: DocsArgs) -> Result<(), MemoryError> {
+    let _scope = scope_filter(
+        &args.scope,
+        args.issue.as_deref(),
+        args.milestone.as_deref(),
+        Some(args.area.as_str()),
+    );
     println!("{}", docs_for_area(config, &args.area)?);
     Ok(())
 }
@@ -804,14 +892,251 @@ async fn run_context(
         paths: args.paths,
         limit: args.limit,
     };
+    let scope = scope_filter(
+        &args.scope,
+        Some(options.issue.as_str()),
+        args.milestone.as_deref(),
+        args.area.as_deref(),
+    );
     for warning in warnings {
         println!("> Warning: {warning}\n");
     }
-    println!(
-        "{}",
-        context_for_issue_with_options(config, &source, &options)?
-    );
+    let mut context = context_for_issue_with_options(config, &source, &options)?;
+    if args.include_code_intel {
+        append_code_intel_context(config, &mut context, &scope, &options.paths, options.limit)?;
+    }
+    println!("{context}");
     Ok(())
+}
+
+fn remote_memory_tool_request(command: &MemoryCommand) -> Option<(&'static str, Value)> {
+    match command {
+        MemoryCommand::Capture(args) => Some((
+            "memory.capture",
+            json!({
+                "issue": args.issue.clone(),
+                "issues": args.issues.clone(),
+                "issuesFile": args.issues_file.as_ref().map(|path| path.display().to_string()),
+                "issueRange": args.issue_range.clone(),
+                "noGithub": args.no_github,
+                "dryRun": args.dry_run,
+                "force": args.force
+            }),
+        )),
+        MemoryCommand::Import(args) => Some((
+            "memory.capture",
+            json!({
+                "issue": args.issue.clone(),
+                "issues": args.issues.clone(),
+                "issuesFile": args.issues_file.as_ref().map(|path| path.display().to_string()),
+                "issueRange": args.issue_range.clone(),
+                "beforeIssue": args.before_issue.clone(),
+                "milestone": args.milestone.clone(),
+                "state": args.state.clone(),
+                "beforeDate": args.before_date.map(|date| date.to_string()),
+                "sourceFile": args.source_file.display().to_string(),
+                "dryRun": args.dry_run,
+                "force": args.force
+            }),
+        )),
+        MemoryCommand::SyncDocs(args) => Some((
+            "memory.sync_docs",
+            json!({
+                "issues": args.issues.clone(),
+                "issuesFile": args.issues_file.as_ref().map(|path| path.display().to_string()),
+                "sinceLastSync": args.since_last_sync,
+                "area": args.area.clone(),
+                "dryRun": args.dry_run,
+                "withDiagrams": args.with_diagrams
+            }),
+        )),
+        MemoryCommand::Lint(args) => {
+            Some(("memory.lint", json!({ "publicDocs": args.public_docs })))
+        }
+        MemoryCommand::Brief(args) => {
+            Some(("memory.brief", json!({ "issue": args.issue.clone() })))
+        }
+        MemoryCommand::Search(args) => Some((
+            "memory.search",
+            with_scope_json(
+                &args.scope,
+                json!({
+                    "issue": args.issue.clone(),
+                    "milestone": args.milestone.clone(),
+                    "area": args.area.clone(),
+                    "query": args.query.clone(),
+                    "limit": args.limit
+                }),
+            ),
+        )),
+        MemoryCommand::Related(args) => Some((
+            "memory.related",
+            with_scope_json(
+                &args.scope,
+                json!({
+                    "issue": args.issue.clone(),
+                    "milestone": args.milestone.clone(),
+                    "area": args.area.clone(),
+                    "paths": path_strings(&args.paths),
+                    "limit": args.limit
+                }),
+            ),
+        )),
+        MemoryCommand::Docs(args) => Some((
+            "memory.docs",
+            with_scope_json(
+                &args.scope,
+                json!({
+                    "issue": args.issue.clone(),
+                    "milestone": args.milestone.clone(),
+                    "area": args.area.clone()
+                }),
+            ),
+        )),
+        MemoryCommand::Status(args) => Some((
+            "memory.status",
+            with_scope_json(
+                &args.scope,
+                json!({
+                    "issue": args.issue.clone(),
+                    "area": args.area.clone(),
+                    "milestone": args.milestone.clone()
+                }),
+            ),
+        )),
+        MemoryCommand::Context(args) => Some((
+            "memory.context",
+            with_scope_json(
+                &args.scope,
+                json!({
+                    "issue": args.issue.clone(),
+                    "milestone": args.milestone.clone(),
+                    "area": args.area.clone(),
+                    "include": args.include.clone(),
+                    "paths": path_strings(&args.paths),
+                    "includeCodeIntel": args.include_code_intel,
+                    "limit": args.limit
+                }),
+            ),
+        )),
+        _ => None,
+    }
+}
+
+async fn run_remote_memory_tool(
+    endpoint: &str,
+    tool_name: &str,
+    arguments: Value,
+) -> Result<(), MemoryError> {
+    let client = reqwest::Client::new();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "opensymphony-cli",
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": arguments
+        }
+    });
+    let mut builder = client.post(endpoint).json(&request);
+    let token = if is_admin_memory_tool(tool_name) {
+        env::var("OPENSYMPHONY_MEMORY_ADMIN_TOKEN")
+            .ok()
+            .and_then(|value| non_empty(&value))
+            .or_else(|| {
+                env::var("OPENSYMPHONY_MEMORY_TOKEN")
+                    .ok()
+                    .and_then(|value| non_empty(&value))
+            })
+    } else {
+        env::var("OPENSYMPHONY_MEMORY_TOKEN")
+            .ok()
+            .and_then(|value| non_empty(&value))
+    };
+    if let Some(token) = token {
+        builder = builder.bearer_auth(token);
+    }
+    let response = builder.send().await.map_err(|error| {
+        MemoryError::InvalidInput(format!("failed to call memory server {endpoint}: {error}"))
+    })?;
+    let status = response.status();
+    let payload = response.json::<Value>().await.map_err(|error| {
+        MemoryError::InvalidInput(format!(
+            "memory server response was not valid JSON: {error}"
+        ))
+    })?;
+    if !status.is_success() {
+        return Err(MemoryError::InvalidInput(format!(
+            "memory server returned HTTP {status}: {payload}"
+        )));
+    }
+    if let Some(error) = payload.get("error") {
+        return Err(MemoryError::InvalidInput(format!(
+            "memory server tool {tool_name} failed: {error}"
+        )));
+    }
+    let result = payload.get("result").cloned().ok_or_else(|| {
+        MemoryError::InvalidInput("memory server response omitted result".to_string())
+    })?;
+    print_remote_memory_result(result)?;
+    Ok(())
+}
+
+fn print_remote_memory_result(result: Value) -> Result<(), MemoryError> {
+    if let Some(text) = result
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|content| content.first())
+        .and_then(|item| item.get("text"))
+        .and_then(Value::as_str)
+    {
+        println!("{text}");
+        return Ok(());
+    }
+    let pretty = serde_json::to_string_pretty(&result)?;
+    println!("{pretty}");
+    Ok(())
+}
+
+fn path_strings(paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect()
+}
+
+fn with_scope_json(scope: &ScopeArgs, mut arguments: Value) -> Value {
+    if let Value::Object(map) = &mut arguments {
+        map.insert(
+            "projectSet".to_string(),
+            json!(
+                scope
+                    .project_set
+                    .clone()
+                    .or_else(|| env_scope_value("OPENSYMPHONY_MEMORY_PROJECT_SET"))
+            ),
+        );
+        map.insert(
+            "project".to_string(),
+            json!(
+                scope
+                    .project
+                    .clone()
+                    .or_else(|| env_scope_value("OPENSYMPHONY_MEMORY_PROJECT"))
+            ),
+        );
+        map.insert(
+            "repo".to_string(),
+            json!(
+                scope
+                    .repo
+                    .clone()
+                    .or_else(|| env_scope_value("OPENSYMPHONY_MEMORY_EXECUTION_REPO"))
+            ),
+        );
+        map.insert("allAccessible".to_string(), json!(scope.all_accessible));
+    }
+    arguments
 }
 
 fn run_lint(config: &MemoryConfig, args: LintArgs) -> Result<(), MemoryError> {
@@ -841,7 +1166,19 @@ fn run_lint(config: &MemoryConfig, args: LintArgs) -> Result<(), MemoryError> {
 #[derive(Clone)]
 struct MemoryServerState {
     config: MemoryConfig,
-    token: Option<String>,
+    auth: MemoryServerAuth,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct MemoryServerAuth {
+    read_token: Option<String>,
+    admin_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemoryServerAccess {
+    Read,
+    Admin,
 }
 
 #[derive(Debug, Deserialize)]
@@ -854,36 +1191,103 @@ struct MemoryMcpRequest {
 }
 
 async fn run_serve(config: MemoryConfig, args: ServeArgs) -> Result<(), MemoryError> {
-    let listener = tokio::net::TcpListener::bind(&args.addr)
-        .await
-        .map_err(|error| {
-            MemoryError::InvalidInput(format!(
-                "failed to bind memory server {}: {error}",
-                args.addr
-            ))
-        })?;
-    let state = MemoryServerState {
+    let handle = start_memory_server_with_auth(
         config,
-        token: args.token,
-    };
+        args.addr,
+        MemoryServerAuth {
+            read_token: args.token,
+            admin_token: args.admin_token,
+        },
+    )
+    .await?;
+    println!(
+        "OpenSymphony memory server listening on {}",
+        handle.endpoint()
+    );
+    handle.wait().await
+}
+
+pub(crate) struct MemoryServerHandle {
+    endpoint: String,
+    task: JoinHandle<Result<(), String>>,
+}
+
+impl MemoryServerHandle {
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub(crate) fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+
+    pub(crate) fn abort(&self) {
+        self.task.abort();
+    }
+
+    pub(crate) async fn wait(self) -> Result<(), MemoryError> {
+        match self.task.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => Err(MemoryError::InvalidInput(error)),
+            Err(error) if error.is_cancelled() => Ok(()),
+            Err(error) => Err(MemoryError::InvalidInput(format!(
+                "memory server task failed: {error}"
+            ))),
+        }
+    }
+}
+
+pub(crate) async fn start_memory_server(
+    config: MemoryConfig,
+    addr: SocketAddr,
+    token: Option<String>,
+) -> Result<MemoryServerHandle, MemoryError> {
+    start_memory_server_with_auth(
+        config,
+        addr,
+        MemoryServerAuth {
+            read_token: token,
+            admin_token: None,
+        },
+    )
+    .await
+}
+
+async fn start_memory_server_with_auth(
+    config: MemoryConfig,
+    addr: SocketAddr,
+    auth: MemoryServerAuth,
+) -> Result<MemoryServerHandle, MemoryError> {
+    let listener = tokio::net::TcpListener::bind(addr).await.map_err(|error| {
+        MemoryError::InvalidInput(format!("failed to bind memory server {addr}: {error}"))
+    })?;
+    let local_addr = listener.local_addr().map_err(|error| {
+        MemoryError::InvalidInput(format!("failed to read memory server address: {error}"))
+    })?;
+    let state = MemoryServerState { config, auth };
     let app = axum::Router::new()
         .route("/health", axum::routing::get(memory_server_health))
         .route("/mcp", axum::routing::post(memory_server_mcp))
         .with_state(state);
-    println!(
-        "OpenSymphony memory server listening on http://{}",
-        args.addr
-    );
-    axum::serve(listener, app)
-        .await
-        .map_err(|error| MemoryError::InvalidInput(format!("memory server failed: {error}")))
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .map_err(|error| format!("memory server failed: {error}"))
+    });
+    Ok(MemoryServerHandle {
+        endpoint: format!("http://{local_addr}/mcp"),
+        task,
+    })
 }
 
-async fn memory_server_health() -> axum::Json<Value> {
+async fn memory_server_health(
+    axum::extract::State(state): axum::extract::State<MemoryServerState>,
+) -> axum::Json<Value> {
     axum::Json(json!({
         "status": "ok",
         "protocol": "mcp-streamable-http-2025-06-18",
-        "mode": "read_only"
+        "mode": if state.auth.admin_token.is_some() { "read_write" } else { "read_only" },
+        "adminTools": state.auth.admin_token.is_some()
     }))
 }
 
@@ -892,7 +1296,9 @@ async fn memory_server_mcp(
     headers: axum::http::HeaderMap,
     axum::Json(request): axum::Json<MemoryMcpRequest>,
 ) -> (axum::http::StatusCode, axum::Json<Value>) {
-    if let Err(response) = authorize_memory_request(&headers, state.token.as_deref()) {
+    if let Err(response) =
+        authorize_memory_request(&headers, &state.auth, required_access_for_request(&request))
+    {
         return response;
     }
     let id = request.id.clone();
@@ -903,16 +1309,9 @@ async fn memory_server_mcp(
             "capabilities": { "tools": {} }
         })),
         "tools/list" => Ok(json!({
-            "tools": [
-                { "name": "memory.context", "description": "Build a pre-implementation memory context bundle" },
-                { "name": "memory.search", "description": "Search captured issue memory" },
-                { "name": "memory.related", "description": "Find related issue memory by issue, area, or paths" },
-                { "name": "memory.brief", "description": "Return a compact issue memory brief" },
-                { "name": "memory.docs", "description": "Return topic documentation for an area" },
-                { "name": "memory.status", "description": "Return capture and docs-sync status" }
-            ]
+            "tools": memory_tool_descriptors()
         })),
-        "tools/call" => call_memory_tool(&state.config, request.params),
+        "tools/call" => call_memory_tool(&state.config, request.params).await,
         other => Err(MemoryError::InvalidInput(format!(
             "unsupported MCP method `{other}`"
         ))),
@@ -934,9 +1333,51 @@ async fn memory_server_mcp(
     }
 }
 
+fn required_access_for_request(request: &MemoryMcpRequest) -> MemoryServerAccess {
+    if request.method == "tools/call"
+        && request
+            .params
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(is_admin_memory_tool)
+    {
+        MemoryServerAccess::Admin
+    } else {
+        MemoryServerAccess::Read
+    }
+}
+
+fn memory_tool_descriptors() -> Vec<Value> {
+    vec![
+        json!({ "name": "memory.context", "description": "Build a pre-implementation memory context bundle", "access": "read" }),
+        json!({ "name": "memory.search", "description": "Search captured issue memory", "access": "read" }),
+        json!({ "name": "memory.related", "description": "Find related issue memory by issue, area, or paths", "access": "read" }),
+        json!({ "name": "memory.brief", "description": "Return a compact issue memory brief", "access": "read" }),
+        json!({ "name": "memory.docs", "description": "Return topic documentation for an area", "access": "read" }),
+        json!({ "name": "memory.status", "description": "Return capture and docs-sync status", "access": "read" }),
+        json!({ "name": "memory.capture", "description": "Capture completed issue evidence into memory", "access": "admin" }),
+        json!({ "name": "memory.sync_docs", "description": "Sync captured memory into topic docs", "access": "admin" }),
+        json!({ "name": "memory.lint", "description": "Lint memory and docs", "access": "admin" }),
+        json!({ "name": "memory.reindex", "description": "Refresh memory catalog schema and generated indexes", "access": "admin" }),
+        json!({ "name": "memory.ingest_code_intel", "description": "Generate code-intelligence artifacts for future ingestion", "access": "admin" }),
+    ]
+}
+
+fn is_admin_memory_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "memory.capture"
+            | "memory.sync_docs"
+            | "memory.lint"
+            | "memory.reindex"
+            | "memory.ingest_code_intel"
+    )
+}
+
 fn authorize_memory_request(
     headers: &axum::http::HeaderMap,
-    token: Option<&str>,
+    auth: &MemoryServerAuth,
+    required_access: MemoryServerAccess,
 ) -> Result<(), (axum::http::StatusCode, axum::Json<Value>)> {
     if let Some(origin) = headers
         .get(axum::http::header::ORIGIN)
@@ -953,14 +1394,34 @@ fn authorize_memory_request(
             })),
         ));
     }
-    let Some(expected) = token.and_then(non_empty) else {
-        return Ok(());
-    };
-    let authorized = headers
+    let bearer = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("Bearer "))
-        .is_some_and(|value| value == expected);
+        .and_then(|value| value.strip_prefix("Bearer "));
+    let authorized = match required_access {
+        MemoryServerAccess::Read => match non_empty_str(auth.read_token.as_deref()) {
+            Some(read_token) => {
+                bearer == Some(read_token)
+                    || non_empty_str(auth.admin_token.as_deref())
+                        .is_some_and(|admin_token| bearer == Some(admin_token))
+            }
+            None => true,
+        },
+        MemoryServerAccess::Admin => {
+            let Some(admin_token) = non_empty_str(auth.admin_token.as_deref()) else {
+                return Err((
+                    axum::http::StatusCode::FORBIDDEN,
+                    axum::Json(json!({
+                        "error": {
+                            "code": "admin_token_required",
+                            "message": "memory server admin token is required for admin tools"
+                        }
+                    })),
+                ));
+            };
+            bearer == Some(admin_token)
+        }
+    };
     if authorized {
         Ok(())
     } else {
@@ -969,11 +1430,15 @@ fn authorize_memory_request(
             axum::Json(json!({
                 "error": {
                     "code": "unauthorized",
-                    "message": "memory server token is required"
+                    "message": "memory server token is required for this tool"
                 }
             })),
         ))
     }
+}
+
+fn non_empty_str(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 fn origin_is_localhost(origin: &str) -> bool {
@@ -986,7 +1451,7 @@ fn origin_is_localhost(origin: &str) -> bool {
         || origin.starts_with("https://[::1]")
 }
 
-fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, MemoryError> {
+async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, MemoryError> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
@@ -996,7 +1461,7 @@ fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, Memor
         "memory.context" => {
             let issue = required_string_arg(&arguments, "issue")?;
             let options = MemoryContextOptions {
-                issue,
+                issue: issue.clone(),
                 explicit_includes: string_list_arg(&arguments, "include"),
                 paths: string_list_arg(&arguments, "paths")
                     .into_iter()
@@ -1004,20 +1469,35 @@ fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, Memor
                     .collect(),
                 limit: usize_arg(&arguments, "limit", 20),
             };
-            let text = context_for_issue_with_options(config, &SourceFile::default(), &options)?;
+            let source = context_source_from_mcp(&arguments);
+            let mut text = context_for_issue_with_options(config, &source, &options)?;
+            if bool_arg(&arguments, "includeCodeIntel")
+                || bool_arg(&arguments, "include_code_intel")
+            {
+                append_code_intel_context(
+                    config,
+                    &mut text,
+                    &scope_filter_from_mcp(&arguments, true),
+                    &options.paths,
+                    options.limit,
+                )?;
+            }
             Ok(mcp_text(text))
         }
         "memory.search" => {
             let query = required_string_arg(&arguments, "query")?;
-            let results = search(config, &query, usize_arg(&arguments, "limit", 10))?;
+            let scope = scope_filter_from_mcp(&arguments, true);
+            let results =
+                search_with_scope(config, &query, usize_arg(&arguments, "limit", 10), &scope)?;
             Ok(json!({ "results": search_results_json(config, &results) }))
         }
         "memory.related" => {
             let limit = usize_arg(&arguments, "limit", 10);
+            let scope = scope_filter_from_mcp(&arguments, false);
             let results = if let Some(issue) = optional_string_arg(&arguments, "issue") {
-                related_by_issue(config, &issue, limit)?
+                related_by_issue_with_scope(config, &issue, limit, &scope)?
             } else if let Some(area) = optional_string_arg(&arguments, "area") {
-                related_by_area(config, &area, limit)?
+                related_by_area_with_scope(config, &area, limit, &scope)?
             } else {
                 let paths = string_list_arg(&arguments, "paths")
                     .into_iter()
@@ -1028,7 +1508,7 @@ fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, Memor
                         "memory.related requires issue, area, or paths".to_string(),
                     ));
                 }
-                related_by_paths(config, &paths, limit)?
+                related_by_paths_with_scope(config, &paths, limit, &scope)?
             };
             Ok(json!({ "results": search_results_json(config, &results) }))
         }
@@ -1041,13 +1521,15 @@ fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, Memor
             Ok(mcp_text(docs_for_area(config, &area)?))
         }
         "memory.status" => {
-            let report = status(
+            let scope = scope_filter_from_mcp(&arguments, true);
+            let report = status_with_scope(
                 config,
                 &IssueSelection {
                     area: optional_string_arg(&arguments, "area"),
                     milestone: optional_string_arg(&arguments, "milestone"),
                     ..IssueSelection::default()
                 },
+                &scope,
             )?;
             Ok(json!({
                 "issueCount": report.issue_count,
@@ -1065,10 +1547,151 @@ fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, Memor
                 })).collect::<Vec<_>>()
             }))
         }
+        "memory.capture" => call_memory_capture_tool(config, &arguments).await,
+        "memory.sync_docs" => call_memory_sync_docs_tool(config, &arguments),
+        "memory.lint" => call_memory_lint_tool(config, &arguments),
+        "memory.reindex" => call_memory_reindex_tool(config),
+        "memory.ingest_code_intel" => call_memory_ingest_code_intel_tool(config, &arguments),
         other => Err(MemoryError::InvalidInput(format!(
             "unsupported memory tool `{other}`"
         ))),
     }
+}
+
+async fn call_memory_capture_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let identifiers = issue_ids_from_mcp(config, arguments)?;
+    if identifiers.is_empty() {
+        return Err(MemoryError::InvalidInput(
+            "memory.capture requires issue, issues, issuesFile, or issueRange".to_string(),
+        ));
+    }
+    let source = if let Some(source_file) = optional_string_arg(arguments, "sourceFile")
+        .or_else(|| optional_string_arg(arguments, "source_file"))
+    {
+        load_source_file(&repo_existing_path(config, &source_file)?)?
+    } else {
+        load_linear_source(&config.repo_root, None, &identifiers).await?
+    };
+    let selection = IssueSelection {
+        identifiers,
+        milestone: optional_string_arg(arguments, "milestone"),
+        state: optional_string_arg(arguments, "state"),
+        before_date: optional_string_arg(arguments, "beforeDate")
+            .or_else(|| optional_string_arg(arguments, "before_date"))
+            .map(|value| NaiveDate::parse_from_str(&value, "%Y-%m-%d"))
+            .transpose()
+            .map_err(|error| MemoryError::InvalidInput(format!("invalid beforeDate: {error}")))?,
+        before_issue: optional_string_arg(arguments, "beforeIssue")
+            .or_else(|| optional_string_arg(arguments, "before_issue")),
+        area: optional_string_arg(arguments, "area"),
+        since_last_sync: false,
+    };
+    let write = !bool_arg(arguments, "dryRun") && !bool_arg(arguments, "dry_run");
+    let discover_github = !bool_arg(arguments, "noGithub") && !bool_arg(arguments, "no_github");
+    let plan = plan_capture(config, &source, &selection, write, discover_github)?;
+    if !write {
+        return Ok(json!({
+            "dryRun": true,
+            "plan": capture_plan_json(config, &plan)
+        }));
+    }
+    let report = write_capture_plan(config, &plan, bool_arg(arguments, "force"))?;
+    Ok(json!({
+        "dryRun": false,
+        "plan": capture_plan_json(config, &plan),
+        "write": capture_write_report_json(config, report)
+    }))
+}
+
+fn call_memory_sync_docs_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let selection = IssueSelection {
+        identifiers: issue_ids_from_mcp(config, arguments)?,
+        area: optional_string_arg(arguments, "area"),
+        since_last_sync: bool_arg(arguments, "sinceLastSync")
+            || bool_arg(arguments, "since_last_sync"),
+        ..IssueSelection::default()
+    };
+    let write = !bool_arg(arguments, "dryRun") && !bool_arg(arguments, "dry_run");
+    let with_diagrams = bool_arg(arguments, "withDiagrams") || bool_arg(arguments, "with_diagrams");
+    let plan = plan_docs_sync(config, &selection, write, with_diagrams)?;
+    if !write {
+        return Ok(json!({
+            "dryRun": true,
+            "plan": docs_sync_plan_json(config, &plan),
+            "written": []
+        }));
+    }
+    let written = write_docs_sync_plan(config, &plan)?;
+    Ok(json!({
+        "dryRun": false,
+        "plan": docs_sync_plan_json(config, &plan),
+        "written": paths_for_json(config, &written)
+    }))
+}
+
+fn call_memory_lint_tool(config: &MemoryConfig, arguments: &Value) -> Result<Value, MemoryError> {
+    let report = lint(
+        config,
+        bool_arg(arguments, "publicDocs") || bool_arg(arguments, "public_docs"),
+    )?;
+    Ok(json!({
+        "findingCount": report.findings.len(),
+        "findings": report.findings.into_iter().map(|finding| {
+            json!({
+                "severity": match finding.severity {
+                    LintSeverity::Warn => "warn",
+                    LintSeverity::Error => "error",
+                },
+                "path": finding.path.as_ref().map(|path| path_for_json(config, path)),
+                "message": finding.message,
+                "nextCommand": finding.next_command
+            })
+        }).collect::<Vec<_>>()
+    }))
+}
+
+fn call_memory_reindex_tool(config: &MemoryConfig) -> Result<Value, MemoryError> {
+    Ok(memory_reindex_report_json(
+        config,
+        refresh_memory_index(config)?,
+    ))
+}
+
+fn call_memory_ingest_code_intel_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let scope = scope_filter_from_mcp(arguments, false);
+    let paths = string_list_arg(arguments, "paths")
+        .into_iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    let limit = usize_arg(arguments, "limit", 10);
+    let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
+    let scope_refs = scope_refs_for_context(&scope, &paths);
+    let artifacts = CodebaseAnalyzer::new(repo_root).code_context(&paths, &scope_refs, limit)?;
+    Ok(json!({
+        "persisted": false,
+        "artifactCount": artifacts.len(),
+        "artifacts": artifacts.into_iter().map(|artifact| json!({
+            "provider": artifact.provider,
+            "kind": artifact.kind,
+            "title": artifact.title,
+            "path": artifact.path.as_ref().map(|path| path_for_json(config, path)),
+            "commitSha": artifact.commit_sha,
+            "summary": artifact.summary,
+            "sourceRefs": artifact.source_refs.into_iter().map(|source| json!({
+                "kind": source.kind,
+                "id": source.id
+            })).collect::<Vec<_>>()
+        })).collect::<Vec<_>>()
+    }))
 }
 
 fn mcp_text(text: String) -> Value {
@@ -1091,6 +1714,329 @@ fn search_results_json(
             })
         })
         .collect()
+}
+
+fn capture_plan_json(
+    config: &MemoryConfig,
+    plan: &crate::opensymphony_memory::CapturePlan,
+) -> Value {
+    json!({
+        "write": plan.write,
+        "selected": plan.selected.iter().map(|issue| json!({
+            "issueKey": issue.issue.identifier.clone(),
+            "title": issue.issue.title.clone(),
+            "capsulePath": path_for_json(config, &issue.capsule_path),
+            "areas": issue.areas.clone(),
+            "docsTargets": paths_for_json(config, &issue.docs_targets),
+            "alreadyCaptured": issue.already_captured,
+            "stale": issue.stale,
+            "warningCount": issue.warnings.len(),
+            "warnings": issue.warnings.clone()
+        })).collect::<Vec<_>>(),
+        "warnings": plan.warnings.clone()
+    })
+}
+
+fn capture_write_report_json(
+    config: &MemoryConfig,
+    report: crate::opensymphony_memory::CaptureWriteReport,
+) -> Value {
+    json!({
+        "writtenCapsules": paths_for_json(config, &report.written_capsules),
+        "indexPath": path_for_json(config, &report.index_path),
+        "markdownIndexes": paths_for_json(config, &report.markdown_indexes),
+        "milestoneNodes": paths_for_json(config, &report.milestone_nodes),
+        "warnings": report.warnings
+    })
+}
+
+fn docs_sync_plan_json(config: &MemoryConfig, plan: &DocsSyncPlan) -> Value {
+    json!({
+        "write": plan.write,
+        "selectedIssueKeys": plan.selected_issue_keys.clone(),
+        "warnings": plan.warnings.clone(),
+        "targets": plan.targets.iter().map(|target| json!({
+            "area": target.area.clone(),
+            "title": target.title.clone(),
+            "path": path_for_json(config, &target.path),
+            "visibility": target.visibility.as_str(),
+            "create": target.create,
+            "issueKeys": target.issue_keys.clone(),
+            "diff": target.diff.clone()
+        })).collect::<Vec<_>>()
+    })
+}
+
+fn memory_reindex_report_json(config: &MemoryConfig, report: MemoryReindexReport) -> Value {
+    json!({
+        "issueCount": report.issue_count,
+        "indexPath": path_for_json(config, &report.index_path),
+        "markdownIndexes": paths_for_json(config, &report.markdown_indexes)
+    })
+}
+
+fn issue_ids_from_mcp(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Vec<String>, MemoryError> {
+    let issue = optional_string_arg(arguments, "issue")
+        .or_else(|| optional_string_arg(arguments, "workItem"))
+        .or_else(|| optional_string_arg(arguments, "work_item"));
+    let issues = arguments.get("issues").and_then(|value| match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Array(_) => Some(string_list_arg(arguments, "issues").join(",")),
+        _ => None,
+    });
+    let issues_file = optional_string_arg(arguments, "issuesFile")
+        .or_else(|| optional_string_arg(arguments, "issues_file"))
+        .map(|path| repo_existing_path(config, &path))
+        .transpose()?;
+    let issue_range = optional_string_arg(arguments, "issueRange")
+        .or_else(|| optional_string_arg(arguments, "issue_range"));
+    collect_issue_ids(
+        issue.as_deref(),
+        issues.as_deref(),
+        issues_file.as_deref(),
+        issue_range.as_deref(),
+    )
+}
+
+fn paths_for_json(config: &MemoryConfig, paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| path_for_json(config, path))
+        .collect()
+}
+
+fn repo_existing_path(config: &MemoryConfig, value: &str) -> Result<PathBuf, MemoryError> {
+    let path = PathBuf::from(value);
+    let candidate = if path.is_absolute() {
+        path
+    } else {
+        config.repo_root.join(path)
+    };
+    let resolved = candidate
+        .canonicalize()
+        .map_err(|source| MemoryError::ResolvePath {
+            path: candidate.clone(),
+            source,
+        })?;
+    let repo_root = config
+        .repo_root
+        .canonicalize()
+        .map_err(|source| MemoryError::ResolvePath {
+            path: config.repo_root.clone(),
+            source,
+        })?;
+    if !resolved.starts_with(&repo_root) {
+        return Err(MemoryError::PathOutsideRepo {
+            path: resolved,
+            repo_root,
+        });
+    }
+    Ok(resolved)
+}
+
+fn context_source_from_mcp(arguments: &Value) -> SourceFile {
+    let Some(current_issue) = arguments.get("currentIssue") else {
+        return SourceFile::default();
+    };
+    let identifier = optional_string_arg(current_issue, "identifier")
+        .or_else(|| optional_string_arg(arguments, "issue"))
+        .unwrap_or_default();
+    if identifier.is_empty() {
+        return SourceFile::default();
+    }
+    SourceFile {
+        issues: vec![IssueEvidence {
+            id: optional_string_arg(current_issue, "id"),
+            identifier,
+            title: optional_string_arg(current_issue, "title").unwrap_or_default(),
+            description: optional_string_arg(current_issue, "description"),
+            state: optional_string_arg(current_issue, "state"),
+            labels: string_list_arg(current_issue, "labels"),
+            children: issue_links_arg(current_issue, "children"),
+            blocked_by: issue_links_arg(current_issue, "blockedBy"),
+            ..IssueEvidence::default()
+        }],
+        ..SourceFile::default()
+    }
+}
+
+fn issue_links_arg(arguments: &Value, key: &str) -> Vec<IssueLinkEvidence> {
+    arguments
+        .get(key)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| {
+            let identifier = optional_string_arg(value, "identifier")?;
+            Some(IssueLinkEvidence {
+                id: optional_string_arg(value, "id"),
+                identifier,
+                state: optional_string_arg(value, "state"),
+                ..IssueLinkEvidence::default()
+            })
+        })
+        .collect()
+}
+
+fn append_code_intel_context(
+    config: &MemoryConfig,
+    output: &mut String,
+    scope: &MemoryScopeFilter,
+    paths: &[PathBuf],
+    limit: usize,
+) -> Result<(), MemoryError> {
+    let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
+    let scope_refs = scope_refs_for_context(scope, paths);
+    let artifacts = CodebaseAnalyzer::new(repo_root).code_context(paths, &scope_refs, limit)?;
+    output.push_str("\n## Code Intelligence\n\n");
+    if artifacts.is_empty() {
+        output.push_str("- No code-intelligence artifacts found.\n");
+        return Ok(());
+    }
+    for artifact in artifacts {
+        output.push_str(&format!("### {}: {}\n\n", artifact.kind, artifact.title));
+        output.push_str(&format!("- Provider: {}\n", artifact.provider));
+        if let Some(path) = &artifact.path {
+            output.push_str(&format!("- Path: {}\n", path_for_json(config, path)));
+        }
+        if let Some(commit_sha) = &artifact.commit_sha {
+            output.push_str(&format!("- Commit: {commit_sha}\n"));
+        }
+        if !artifact.source_refs.is_empty() {
+            let sources = artifact
+                .source_refs
+                .iter()
+                .map(|source| format!("{}:{}", source.kind, source.id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            output.push_str(&format!("- Sources: {sources}\n"));
+        }
+        output.push('\n');
+        output.push_str(&artifact.summary);
+        output.push_str("\n\n");
+    }
+    Ok(())
+}
+
+fn resolve_code_intel_repo(
+    config: &MemoryConfig,
+    repo: Option<&str>,
+) -> Result<PathBuf, MemoryError> {
+    let Some(repo) = repo.and_then(non_empty) else {
+        return Ok(config.repo_root.clone());
+    };
+    let path = PathBuf::from(&repo);
+    let candidate = if path.is_absolute() {
+        path
+    } else {
+        config.repo_root.join(path)
+    };
+    if !candidate.is_dir() {
+        return Err(MemoryError::InvalidInput(format!(
+            "context repo `{repo}` did not resolve to a directory at {}",
+            candidate.display()
+        )));
+    }
+    Ok(candidate)
+}
+
+fn scope_refs_for_context(scope: &MemoryScopeFilter, paths: &[PathBuf]) -> Vec<KnowledgeScope> {
+    let mut refs = Vec::new();
+    push_scope_ref(
+        &mut refs,
+        KnowledgeScopeKind::ProjectSet,
+        scope.project_set.as_deref(),
+    );
+    push_scope_ref(
+        &mut refs,
+        KnowledgeScopeKind::Project,
+        scope.project.as_deref(),
+    );
+    push_scope_ref(
+        &mut refs,
+        KnowledgeScopeKind::Milestone,
+        scope.milestone.as_deref(),
+    );
+    push_scope_ref(
+        &mut refs,
+        KnowledgeScopeKind::WorkItem,
+        scope.issue.as_deref(),
+    );
+    push_scope_ref(
+        &mut refs,
+        KnowledgeScopeKind::Repository,
+        scope.repo.as_deref(),
+    );
+    push_scope_ref(&mut refs, KnowledgeScopeKind::Area, scope.area.as_deref());
+    for path in paths {
+        refs.push(KnowledgeScope {
+            kind: KnowledgeScopeKind::CodePath,
+            id: path.display().to_string(),
+            label: None,
+        });
+    }
+    refs
+}
+
+fn push_scope_ref(refs: &mut Vec<KnowledgeScope>, kind: KnowledgeScopeKind, id: Option<&str>) {
+    if let Some(id) = id.and_then(non_empty) {
+        refs.push(KnowledgeScope {
+            kind,
+            id,
+            label: None,
+        });
+    }
+}
+
+fn scope_filter(
+    scope: &ScopeArgs,
+    issue: Option<&str>,
+    milestone: Option<&str>,
+    area: Option<&str>,
+) -> MemoryScopeFilter {
+    MemoryScopeFilter {
+        project_set: scope
+            .project_set
+            .as_deref()
+            .and_then(non_empty)
+            .or_else(|| env_scope_value("OPENSYMPHONY_MEMORY_PROJECT_SET")),
+        project: scope
+            .project
+            .as_deref()
+            .and_then(non_empty)
+            .or_else(|| env_scope_value("OPENSYMPHONY_MEMORY_PROJECT")),
+        milestone: milestone.and_then(non_empty),
+        issue: issue.and_then(non_empty),
+        repo: scope
+            .repo
+            .as_deref()
+            .and_then(non_empty)
+            .or_else(|| env_scope_value("OPENSYMPHONY_MEMORY_EXECUTION_REPO")),
+        area: area.and_then(non_empty),
+        all_accessible: scope.all_accessible,
+    }
+}
+
+fn env_scope_value(name: &str) -> Option<String> {
+    env::var(name).ok().and_then(|value| non_empty(&value))
+}
+
+fn scope_filter_from_mcp(arguments: &Value, include_issue: bool) -> MemoryScopeFilter {
+    MemoryScopeFilter {
+        project_set: optional_string_arg(arguments, "projectSet"),
+        project: optional_string_arg(arguments, "project"),
+        milestone: optional_string_arg(arguments, "milestone"),
+        issue: include_issue
+            .then(|| optional_string_arg(arguments, "issue"))
+            .flatten(),
+        repo: optional_string_arg(arguments, "repo"),
+        area: optional_string_arg(arguments, "area"),
+        all_accessible: bool_arg(arguments, "allAccessible")
+            || bool_arg(arguments, "all_accessible"),
+    }
 }
 
 fn path_for_json(config: &MemoryConfig, path: &Path) -> String {
@@ -1133,8 +2079,12 @@ fn usize_arg(arguments: &Value, key: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+fn bool_arg(arguments: &Value, key: &str) -> bool {
+    arguments.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
 async fn run_archive(args: ArchiveArgs) -> Result<(), MemoryError> {
-    let repo_root = std::env::current_dir().map_err(|source| MemoryError::ReadFile {
+    let repo_root = env::current_dir().map_err(|source| MemoryError::ReadFile {
         path: PathBuf::from("."),
         source,
     })?;
@@ -2015,10 +2965,8 @@ fn issue_evidence_from_tracker(
     }
 }
 
-fn issue_link_from_tracker_ref(
-    issue: &TrackerIssueRef,
-) -> crate::opensymphony_memory::IssueLinkEvidence {
-    crate::opensymphony_memory::IssueLinkEvidence {
+fn issue_link_from_tracker_ref(issue: &TrackerIssueRef) -> IssueLinkEvidence {
+    IssueLinkEvidence {
         id: Some(issue.id.clone()),
         identifier: issue.identifier.clone(),
         title: issue.title.clone(),
@@ -2027,10 +2975,8 @@ fn issue_link_from_tracker_ref(
     }
 }
 
-fn issue_link_from_tracker_blocker(
-    issue: &TrackerIssueBlocker,
-) -> crate::opensymphony_memory::IssueLinkEvidence {
-    crate::opensymphony_memory::IssueLinkEvidence {
+fn issue_link_from_tracker_blocker(issue: &TrackerIssueBlocker) -> IssueLinkEvidence {
+    IssueLinkEvidence {
         id: Some(issue.id.clone()),
         identifier: issue.identifier.clone(),
         title: Some(issue.title.clone()),
@@ -2131,9 +3077,106 @@ fn print_search_results(
 #[cfg(test)]
 mod tests {
     use super::{
-        LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, replace_or_append_managed_section,
+        LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, MemoryMcpRequest, MemoryServerAccess,
+        MemoryServerAuth, authorize_memory_request, context_source_from_mcp,
+        memory_tool_descriptors, replace_or_append_managed_section, required_access_for_request,
         trim_auto_memory_status_log,
     };
+    use axum::http::{HeaderMap, HeaderValue, header};
+    use serde_json::json;
+
+    #[test]
+    fn mcp_tool_list_exposes_context_and_admin_tools_without_code_context() {
+        let names = memory_tool_descriptors()
+            .into_iter()
+            .filter_map(|tool| {
+                tool.get("name")
+                    .and_then(|name| name.as_str())
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"memory.context".to_string()));
+        assert!(names.contains(&"memory.capture".to_string()));
+        assert!(names.contains(&"memory.sync_docs".to_string()));
+        assert!(names.contains(&"memory.reindex".to_string()));
+        assert!(!names.iter().any(|name| name.contains("code_context")));
+        assert!(!names.iter().any(|name| name.contains("code-context")));
+    }
+
+    #[test]
+    fn mcp_admin_tools_require_admin_access() {
+        let read_request = MemoryMcpRequest {
+            id: json!("test"),
+            method: "tools/call".to_string(),
+            params: json!({ "name": "memory.context" }),
+        };
+        let admin_request = MemoryMcpRequest {
+            id: json!("test"),
+            method: "tools/call".to_string(),
+            params: json!({ "name": "memory.capture" }),
+        };
+
+        assert_eq!(
+            required_access_for_request(&read_request),
+            MemoryServerAccess::Read
+        );
+        assert_eq!(
+            required_access_for_request(&admin_request),
+            MemoryServerAccess::Admin
+        );
+    }
+
+    #[test]
+    fn admin_authorization_does_not_accept_worker_read_token() {
+        let auth = MemoryServerAuth {
+            read_token: Some("read-token".to_string()),
+            admin_token: Some("admin-token".to_string()),
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer read-token"),
+        );
+
+        assert!(authorize_memory_request(&headers, &auth, MemoryServerAccess::Read).is_ok());
+        let blocked = authorize_memory_request(&headers, &auth, MemoryServerAccess::Admin)
+            .expect_err("admin tools need admin token");
+        assert_eq!(blocked.0, axum::http::StatusCode::UNAUTHORIZED);
+
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer admin-token"),
+        );
+        assert!(authorize_memory_request(&headers, &auth, MemoryServerAccess::Admin).is_ok());
+    }
+
+    #[test]
+    fn mcp_context_source_preserves_worker_issue_graph() {
+        let source = context_source_from_mcp(&json!({
+            "issue": "COE-999",
+            "currentIssue": {
+                "id": "issue-999",
+                "identifier": "COE-999",
+                "title": "Memory context",
+                "description": "Use deterministic facts.",
+                "state": "In Progress",
+                "labels": ["area:memory"],
+                "children": [
+                    { "id": "issue-101", "identifier": "COE-101", "state": "Done" }
+                ],
+                "blockedBy": [
+                    { "id": "issue-100", "identifier": "COE-100", "state": "Done" }
+                ]
+            }
+        }));
+
+        assert_eq!(source.issues.len(), 1);
+        assert_eq!(source.issues[0].identifier, "COE-999");
+        assert_eq!(source.issues[0].labels, vec!["area:memory"]);
+        assert_eq!(source.issues[0].children[0].identifier, "COE-101");
+        assert_eq!(source.issues[0].blocked_by[0].identifier, "COE-100");
+    }
 
     #[test]
     fn managed_linear_memory_status_replaces_existing_section() {

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -20,8 +20,8 @@ use crate::{
         IssueLinkEvidence, IssueSelection, KnowledgeScope, KnowledgeScopeKind, LintSeverity,
         MemoryConfig, MemoryContextOptions, MemoryError, MemoryReindexReport, MemoryScopeFilter,
         SourceFile, archive_blocking_warning_count, brief, context_for_issue_with_options,
-        docs_for_area, expand_issue_range, lint, load_source_file, mark_archived, plan_archive,
-        plan_capture, plan_docs_sync, plan_memory_init, refresh_memory_index,
+        docs_for_area_with_scope, expand_issue_range, lint, load_source_file, mark_archived,
+        plan_archive, plan_capture, plan_docs_sync, plan_memory_init, refresh_memory_index,
         related_by_area_with_scope, related_by_issue_with_scope, related_by_paths_with_scope,
         render_archive_plan, render_capture_dry_run, search_with_scope, status_with_scope,
         write_capture_plan, write_docs_sync_plan, write_memory_init_plan,
@@ -865,13 +865,13 @@ fn run_related(config: &MemoryConfig, args: RelatedArgs) -> Result<(), MemoryErr
 }
 
 fn run_docs(config: &MemoryConfig, args: DocsArgs) -> Result<(), MemoryError> {
-    let _scope = scope_filter(
+    let scope = scope_filter(
         &args.scope,
         args.issue.as_deref(),
         args.milestone.as_deref(),
         Some(args.area.as_str()),
     );
-    println!("{}", docs_for_area(config, &args.area)?);
+    println!("{}", docs_for_area_with_scope(config, &args.area, &scope)?);
     Ok(())
 }
 
@@ -1563,7 +1563,11 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
         }
         "memory.docs" => {
             let area = required_string_arg(&arguments, "area")?;
-            Ok(mcp_text(docs_for_area(config, &area)?))
+            Ok(mcp_text(docs_for_area_with_scope(
+                config,
+                &area,
+                &scope_filter_from_mcp(&arguments, false),
+            )?))
         }
         "memory.status" => {
             let scope = scope_filter_from_mcp(&arguments, true);

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -16,15 +16,16 @@ use crate::{
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
     opensymphony_memory::{
-        ArchivePlan, CodeIntelIndex, CommentEvidence, DocsSyncPlan, IssueEvidence,
-        IssueLinkEvidence, IssueSelection, KnowledgeScope, KnowledgeScopeKind, LintSeverity,
-        MemoryConfig, MemoryContextOptions, MemoryError, MemoryReindexReport, MemoryScopeFilter,
-        SourceFile, archive_blocking_warning_count, brief, context_for_issue_with_options,
-        docs_for_area_with_scope, expand_issue_range, lint, load_source_file, mark_archived,
-        plan_archive, plan_capture, plan_docs_sync, plan_memory_init, refresh_memory_index,
-        related_by_area_with_scope, related_by_issue_with_scope, related_by_paths_with_scope,
-        render_archive_plan, render_capture_dry_run, search_with_scope, status_with_scope,
-        write_capture_plan, write_docs_sync_plan, write_memory_init_plan,
+        ArchivePlan, CodeIntelArtifact, CodeIntelIndex, CommentEvidence, DocsSyncPlan,
+        IssueEvidence, IssueLinkEvidence, IssueSelection, KnowledgeScope, KnowledgeScopeKind,
+        LintSeverity, MemoryConfig, MemoryContextOptions, MemoryError, MemoryReindexReport,
+        MemoryScopeFilter, SourceFile, archive_blocking_warning_count, brief,
+        context_for_issue_with_options, docs_for_area_with_scope, expand_issue_range, lint,
+        load_source_file, mark_archived, plan_archive, plan_capture, plan_docs_sync,
+        plan_memory_init, refresh_memory_index, related_by_area_with_scope,
+        related_by_issue_with_scope, related_by_paths_with_scope, render_archive_plan,
+        render_capture_dry_run, search_with_scope, status_with_scope, write_capture_plan,
+        write_docs_sync_plan, write_memory_init_plan,
     },
     opensymphony_openhands::{
         ConversationMoveOutcome, IssueConversationManifest, OpenHandsConversationStorePaths,
@@ -1058,26 +1059,53 @@ async fn run_remote_memory_tool(
         MemoryError::InvalidInput(format!("failed to call memory server {endpoint}: {error}"))
     })?;
     let status = response.status();
-    let payload = response.json::<Value>().await.map_err(|error| {
+    let body = response.text().await.map_err(|error| {
+        MemoryError::InvalidInput(format!(
+            "failed to read memory server response body: {error}"
+        ))
+    })?;
+    let result = parse_remote_memory_response(status, &body, tool_name)?;
+    print_remote_memory_result(result)?;
+    Ok(())
+}
+
+fn parse_remote_memory_response(
+    status: reqwest::StatusCode,
+    body: &str,
+    tool_name: &str,
+) -> Result<Value, MemoryError> {
+    if !status.is_success() {
+        return Err(MemoryError::InvalidInput(format!(
+            "memory server returned HTTP {status}: {}",
+            remote_response_error_detail(body)
+        )));
+    }
+    let payload = serde_json::from_str::<Value>(body).map_err(|error| {
         MemoryError::InvalidInput(format!(
             "memory server response was not valid JSON: {error}"
         ))
     })?;
-    if !status.is_success() {
-        return Err(MemoryError::InvalidInput(format!(
-            "memory server returned HTTP {status}: {payload}"
-        )));
-    }
     if let Some(error) = payload.get("error") {
         return Err(MemoryError::InvalidInput(format!(
             "memory server tool {tool_name} failed: {error}"
         )));
     }
-    let result = payload.get("result").cloned().ok_or_else(|| {
+    payload.get("result").cloned().ok_or_else(|| {
         MemoryError::InvalidInput("memory server response omitted result".to_string())
-    })?;
-    print_remote_memory_result(result)?;
-    Ok(())
+    })
+}
+
+fn remote_response_error_detail(body: &str) -> String {
+    serde_json::from_str::<Value>(body)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|_| {
+            let trimmed = body.trim();
+            if trimmed.is_empty() {
+                "<empty body>".to_string()
+            } else {
+                trimmed.to_string()
+            }
+        })
 }
 
 fn remote_memory_tool_token_from_env(tool_name: &str) -> Result<Option<String>, MemoryError> {
@@ -1310,12 +1338,17 @@ async fn start_memory_server_with_auth(
 async fn memory_server_health(
     axum::extract::State(state): axum::extract::State<MemoryServerState>,
 ) -> axum::Json<Value> {
-    axum::Json(json!({
+    axum::Json(memory_server_health_payload(&state.auth))
+}
+
+fn memory_server_health_payload(auth: &MemoryServerAuth) -> Value {
+    let admin_tools = non_empty_str(auth.admin_token.as_deref()).is_some();
+    json!({
         "status": "ok",
         "protocol": "mcp-streamable-http-2025-06-18",
-        "mode": if state.auth.admin_token.is_some() { "read_write" } else { "read_only" },
-        "adminTools": state.auth.admin_token.is_some()
-    }))
+        "mode": if admin_tools { "read_write" } else { "read_only" },
+        "adminTools": admin_tools
+    })
 }
 
 async fn memory_server_mcp(
@@ -1519,13 +1552,14 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
             if bool_arg(&arguments, "includeCodeIntel")
                 || bool_arg(&arguments, "include_code_intel")
             {
-                append_code_intel_context(
-                    config,
-                    &mut text,
-                    &scope_filter_from_mcp(&arguments, true),
-                    &options.paths,
+                text = append_code_intel_context_blocking(
+                    config.clone(),
+                    text,
+                    scope_filter_from_mcp(&arguments, true),
+                    options.paths.clone(),
                     options.limit,
-                )?;
+                )
+                .await?;
             }
             Ok(mcp_text(text))
         }
@@ -1600,7 +1634,7 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
         "memory.sync_docs" => call_memory_sync_docs_tool(config, &arguments),
         "memory.lint" => call_memory_lint_tool(config, &arguments),
         "memory.reindex" => call_memory_reindex_tool(config),
-        "memory.ingest_code_intel" => call_memory_ingest_code_intel_tool(config, &arguments),
+        "memory.ingest_code_intel" => call_memory_ingest_code_intel_tool(config, &arguments).await,
         other => Err(MemoryError::InvalidInput(format!(
             "unsupported memory tool `{other}`"
         ))),
@@ -1712,7 +1746,7 @@ fn call_memory_reindex_tool(config: &MemoryConfig) -> Result<Value, MemoryError>
     ))
 }
 
-fn call_memory_ingest_code_intel_tool(
+async fn call_memory_ingest_code_intel_tool(
     config: &MemoryConfig,
     arguments: &Value,
 ) -> Result<Value, MemoryError> {
@@ -1724,7 +1758,7 @@ fn call_memory_ingest_code_intel_tool(
     let limit = usize_arg(arguments, "limit", 10);
     let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
     let scope_refs = scope_refs_for_context(&scope, &paths);
-    let artifacts = CodebaseAnalyzer::new(repo_root).code_context(&paths, &scope_refs, limit)?;
+    let artifacts = code_intel_artifacts_blocking(repo_root, paths, scope_refs, limit).await?;
     Ok(json!({
         "persisted": false,
         "artifactCount": artifacts.len(),
@@ -1940,10 +1974,48 @@ fn append_code_intel_context(
     let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
     let scope_refs = scope_refs_for_context(scope, paths);
     let artifacts = CodebaseAnalyzer::new(repo_root).code_context(paths, &scope_refs, limit)?;
+    append_code_intel_artifacts(config, output, artifacts);
+    Ok(())
+}
+
+async fn append_code_intel_context_blocking(
+    config: MemoryConfig,
+    mut output: String,
+    scope: MemoryScopeFilter,
+    paths: Vec<PathBuf>,
+    limit: usize,
+) -> Result<String, MemoryError> {
+    let repo_root = resolve_code_intel_repo(&config, scope.repo.as_deref())?;
+    let scope_refs = scope_refs_for_context(&scope, &paths);
+    let artifacts = code_intel_artifacts_blocking(repo_root, paths, scope_refs, limit).await?;
+    append_code_intel_artifacts(&config, &mut output, artifacts);
+    Ok(output)
+}
+
+async fn code_intel_artifacts_blocking(
+    repo_root: PathBuf,
+    paths: Vec<PathBuf>,
+    scope_refs: Vec<KnowledgeScope>,
+    limit: usize,
+) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    tokio::task::spawn_blocking(move || {
+        CodebaseAnalyzer::new(repo_root).code_context(&paths, &scope_refs, limit)
+    })
+    .await
+    .map_err(|error| {
+        MemoryError::InvalidInput(format!("code-intelligence analysis task failed: {error}"))
+    })?
+}
+
+fn append_code_intel_artifacts(
+    config: &MemoryConfig,
+    output: &mut String,
+    artifacts: Vec<CodeIntelArtifact>,
+) {
     output.push_str("\n## Code Intelligence\n\n");
     if artifacts.is_empty() {
         output.push_str("- No code-intelligence artifacts found.\n");
-        return Ok(());
+        return;
     }
     for artifact in artifacts {
         output.push_str(&format!("### {}: {}\n\n", artifact.kind, artifact.title));
@@ -1967,7 +2039,6 @@ fn append_code_intel_context(
         output.push_str(&artifact.summary);
         output.push_str("\n\n");
     }
-    Ok(())
 }
 
 fn resolve_code_intel_repo(
@@ -3123,9 +3194,9 @@ mod tests {
     use super::{
         LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, MemoryMcpRequest, MemoryServerAccess,
         MemoryServerAuth, authorize_memory_request, context_source_from_mcp,
-        memory_tool_descriptors, origin_is_localhost, remote_memory_tool_token,
-        replace_or_append_managed_section, required_access_for_request, resolve_code_intel_repo,
-        trim_auto_memory_status_log,
+        memory_server_health_payload, memory_tool_descriptors, origin_is_localhost,
+        parse_remote_memory_response, remote_memory_tool_token, replace_or_append_managed_section,
+        required_access_for_request, resolve_code_intel_repo, trim_auto_memory_status_log,
     };
     use crate::opensymphony_memory::{MemoryConfig, MemoryError};
     use axum::http::{HeaderMap, HeaderValue, header};
@@ -3219,6 +3290,25 @@ mod tests {
     }
 
     #[test]
+    fn health_reports_admin_tools_only_for_non_empty_admin_token() {
+        let empty_admin = MemoryServerAuth {
+            read_token: Some("read-token".to_string()),
+            admin_token: Some("   ".to_string()),
+        };
+        let empty_payload = memory_server_health_payload(&empty_admin);
+        assert_eq!(empty_payload["mode"], "read_only");
+        assert_eq!(empty_payload["adminTools"], false);
+
+        let configured_admin = MemoryServerAuth {
+            read_token: Some("read-token".to_string()),
+            admin_token: Some("admin-token".to_string()),
+        };
+        let configured_payload = memory_server_health_payload(&configured_admin);
+        assert_eq!(configured_payload["mode"], "read_write");
+        assert_eq!(configured_payload["adminTools"], true);
+    }
+
+    #[test]
     fn localhost_origin_check_rejects_prefix_spoofing() {
         assert!(origin_is_localhost("http://localhost:3333"));
         assert!(origin_is_localhost("https://127.0.0.1"));
@@ -3268,6 +3358,21 @@ mod tests {
     #[test]
     fn remote_client_timeout_outlasts_server_tool_timeout() {
         assert!(super::REMOTE_MEMORY_TOOL_TIMEOUT > super::MEMORY_MCP_TOOL_TIMEOUT);
+    }
+
+    #[test]
+    fn remote_response_reports_http_status_before_json_parse_errors() {
+        let error = parse_remote_memory_response(
+            reqwest::StatusCode::BAD_GATEWAY,
+            "upstream unavailable",
+            "memory.context",
+        )
+        .expect_err("HTTP failure should report status");
+
+        assert!(matches!(error, MemoryError::InvalidInput(message)
+                if message.contains("HTTP 502 Bad Gateway")
+                    && message.contains("upstream unavailable")
+                    && !message.contains("not valid JSON")));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -34,8 +34,8 @@ use crate::{
     opensymphony_workspace::{CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig},
 };
 
-const REMOTE_MEMORY_TOOL_TIMEOUT: Duration = Duration::from_secs(120);
 const MEMORY_MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
+const REMOTE_MEMORY_TOOL_TIMEOUT: Duration = Duration::from_secs(330);
 
 #[derive(Debug, Args)]
 pub struct MemoryArgs {
@@ -3263,6 +3263,11 @@ mod tests {
         })
         .expect("read tool can use admin token when no read token exists");
         assert_eq!(token, Some("admin-token".to_string()));
+    }
+
+    #[test]
+    fn remote_client_timeout_outlasts_server_tool_timeout() {
+        assert!(super::REMOTE_MEMORY_TOOL_TIMEOUT > super::MEMORY_MCP_TOOL_TIMEOUT);
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -3,6 +3,7 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     process::{self, ExitCode},
+    time::Duration,
 };
 
 use chrono::{NaiveDate, Utc};
@@ -32,6 +33,9 @@ use crate::{
     opensymphony_workflow::WorkflowDefinition,
     opensymphony_workspace::{CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig},
 };
+
+const REMOTE_MEMORY_TOOL_TIMEOUT: Duration = Duration::from_secs(120);
+const MEMORY_MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Debug, Args)]
 pub struct MemoryArgs {
@@ -1028,7 +1032,14 @@ async fn run_remote_memory_tool(
     tool_name: &str,
     arguments: Value,
 ) -> Result<(), MemoryError> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(REMOTE_MEMORY_TOOL_TIMEOUT)
+        .build()
+        .map_err(|error| {
+            MemoryError::InvalidInput(format!(
+                "failed to configure memory server client timeout: {error}"
+            ))
+        })?;
     let request = json!({
         "jsonrpc": "2.0",
         "id": "opensymphony-cli",
@@ -1039,20 +1050,7 @@ async fn run_remote_memory_tool(
         }
     });
     let mut builder = client.post(endpoint).json(&request);
-    let token = if is_admin_memory_tool(tool_name) {
-        env::var("OPENSYMPHONY_MEMORY_ADMIN_TOKEN")
-            .ok()
-            .and_then(|value| non_empty(&value))
-            .or_else(|| {
-                env::var("OPENSYMPHONY_MEMORY_TOKEN")
-                    .ok()
-                    .and_then(|value| non_empty(&value))
-            })
-    } else {
-        env::var("OPENSYMPHONY_MEMORY_TOKEN")
-            .ok()
-            .and_then(|value| non_empty(&value))
-    };
+    let token = remote_memory_tool_token_from_env(tool_name)?;
     if let Some(token) = token {
         builder = builder.bearer_auth(token);
     }
@@ -1080,6 +1078,35 @@ async fn run_remote_memory_tool(
     })?;
     print_remote_memory_result(result)?;
     Ok(())
+}
+
+fn remote_memory_tool_token_from_env(tool_name: &str) -> Result<Option<String>, MemoryError> {
+    remote_memory_tool_token(tool_name, |name| env::var(name).ok())
+}
+
+fn remote_memory_tool_token<F>(
+    tool_name: &str,
+    mut read_env: F,
+) -> Result<Option<String>, MemoryError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    if is_admin_memory_tool(tool_name) {
+        return read_env("OPENSYMPHONY_MEMORY_ADMIN_TOKEN")
+            .and_then(|value| non_empty(&value))
+            .map(Some)
+            .ok_or_else(|| {
+                MemoryError::InvalidInput(format!(
+                    "OPENSYMPHONY_MEMORY_ADMIN_TOKEN is required for remote admin memory tool `{tool_name}`"
+                ))
+            });
+    }
+
+    Ok(read_env("OPENSYMPHONY_MEMORY_TOKEN")
+        .and_then(|value| non_empty(&value))
+        .or_else(|| {
+            read_env("OPENSYMPHONY_MEMORY_ADMIN_TOKEN").and_then(|value| non_empty(&value))
+        }))
 }
 
 fn print_remote_memory_result(result: Value) -> Result<(), MemoryError> {
@@ -1311,7 +1338,18 @@ async fn memory_server_mcp(
         "tools/list" => Ok(json!({
             "tools": memory_tool_descriptors()
         })),
-        "tools/call" => call_memory_tool(&state.config, request.params).await,
+        "tools/call" => match tokio::time::timeout(
+            MEMORY_MCP_TOOL_TIMEOUT,
+            call_memory_tool(&state.config, request.params),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(MemoryError::InvalidInput(format!(
+                "memory tool call exceeded {} second timeout",
+                MEMORY_MCP_TOOL_TIMEOUT.as_secs()
+            ))),
+        },
         other => Err(MemoryError::InvalidInput(format!(
             "unsupported MCP method `{other}`"
         ))),
@@ -1399,14 +1437,18 @@ fn authorize_memory_request(
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.strip_prefix("Bearer "));
     let authorized = match required_access {
-        MemoryServerAccess::Read => match non_empty_str(auth.read_token.as_deref()) {
-            Some(read_token) => {
-                bearer == Some(read_token)
-                    || non_empty_str(auth.admin_token.as_deref())
-                        .is_some_and(|admin_token| bearer == Some(admin_token))
+        MemoryServerAccess::Read => {
+            let read_token = non_empty_str(auth.read_token.as_deref());
+            let admin_token = non_empty_str(auth.admin_token.as_deref());
+            match (read_token, admin_token) {
+                (Some(read_token), Some(admin_token)) => {
+                    bearer == Some(read_token) || bearer == Some(admin_token)
+                }
+                (Some(read_token), None) => bearer == Some(read_token),
+                (None, Some(admin_token)) => bearer == Some(admin_token),
+                (None, None) => true,
             }
-            None => true,
-        },
+        }
         MemoryServerAccess::Admin => {
             let Some(admin_token) = non_empty_str(auth.admin_token.as_deref()) else {
                 return Err((
@@ -1442,13 +1484,16 @@ fn non_empty_str(value: Option<&str>) -> Option<&str> {
 }
 
 fn origin_is_localhost(origin: &str) -> bool {
-    let origin = origin.trim().to_ascii_lowercase();
-    origin.starts_with("http://127.0.0.1")
-        || origin.starts_with("http://localhost")
-        || origin.starts_with("http://[::1]")
-        || origin.starts_with("https://127.0.0.1")
-        || origin.starts_with("https://localhost")
-        || origin.starts_with("https://[::1]")
+    let Ok(origin) = url::Url::parse(origin.trim()) else {
+        return false;
+    };
+    if !matches!(origin.scheme(), "http" | "https") {
+        return false;
+    }
+    matches!(
+        origin.host_str(),
+        Some("localhost" | "127.0.0.1" | "::1" | "[::1]")
+    )
 }
 
 async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, MemoryError> {
@@ -1928,19 +1973,14 @@ fn resolve_code_intel_repo(
     let Some(repo) = repo.and_then(non_empty) else {
         return Ok(config.repo_root.clone());
     };
-    let path = PathBuf::from(&repo);
-    let candidate = if path.is_absolute() {
-        path
-    } else {
-        config.repo_root.join(path)
-    };
-    if !candidate.is_dir() {
+    let resolved = repo_existing_path(config, &repo)?;
+    if !resolved.is_dir() {
         return Err(MemoryError::InvalidInput(format!(
             "context repo `{repo}` did not resolve to a directory at {}",
-            candidate.display()
+            resolved.display()
         )));
     }
-    Ok(candidate)
+    Ok(resolved)
 }
 
 fn scope_refs_for_context(scope: &MemoryScopeFilter, paths: &[PathBuf]) -> Vec<KnowledgeScope> {
@@ -3079,11 +3119,14 @@ mod tests {
     use super::{
         LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, MemoryMcpRequest, MemoryServerAccess,
         MemoryServerAuth, authorize_memory_request, context_source_from_mcp,
-        memory_tool_descriptors, replace_or_append_managed_section, required_access_for_request,
+        memory_tool_descriptors, origin_is_localhost, remote_memory_tool_token,
+        replace_or_append_managed_section, required_access_for_request, resolve_code_intel_repo,
         trim_auto_memory_status_log,
     };
+    use crate::opensymphony_memory::{MemoryConfig, MemoryError};
     use axum::http::{HeaderMap, HeaderValue, header};
     use serde_json::json;
+    use tempfile::TempDir;
 
     #[test]
     fn mcp_tool_list_exposes_context_and_admin_tools_without_code_context() {
@@ -3149,6 +3192,73 @@ mod tests {
             HeaderValue::from_static("Bearer admin-token"),
         );
         assert!(authorize_memory_request(&headers, &auth, MemoryServerAccess::Admin).is_ok());
+    }
+
+    #[test]
+    fn read_authorization_requires_admin_token_when_only_admin_auth_is_configured() {
+        let auth = MemoryServerAuth {
+            read_token: None,
+            admin_token: Some("admin-token".to_string()),
+        };
+        let headers = HeaderMap::new();
+
+        let blocked = authorize_memory_request(&headers, &auth, MemoryServerAccess::Read)
+            .expect_err("admin-only auth should protect read tools too");
+        assert_eq!(blocked.0, axum::http::StatusCode::UNAUTHORIZED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer admin-token"),
+        );
+        assert!(authorize_memory_request(&headers, &auth, MemoryServerAccess::Read).is_ok());
+    }
+
+    #[test]
+    fn localhost_origin_check_rejects_prefix_spoofing() {
+        assert!(origin_is_localhost("http://localhost:3333"));
+        assert!(origin_is_localhost("https://127.0.0.1"));
+        assert!(origin_is_localhost("http://[::1]:3333"));
+
+        assert!(!origin_is_localhost("http://localhost.evil.com"));
+        assert!(!origin_is_localhost("https://127.0.0.1.evil.com"));
+        assert!(!origin_is_localhost("ftp://localhost"));
+    }
+
+    #[test]
+    fn code_intel_repo_resolution_stays_inside_repo_root() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("config");
+        std::fs::create_dir(repo.path().join("service")).expect("service dir");
+        let resolved = resolve_code_intel_repo(&config, Some("service")).expect("inside repo");
+        assert!(resolved.starts_with(repo.path().canonicalize().expect("canonical repo")));
+
+        let outside = TempDir::new().expect("outside repo");
+        let error = resolve_code_intel_repo(
+            &config,
+            Some(outside.path().to_str().expect("outside path")),
+        )
+        .expect_err("outside repo must be rejected");
+        assert!(matches!(error, MemoryError::PathOutsideRepo { .. }));
+    }
+
+    #[test]
+    fn remote_admin_tool_requires_admin_token_without_read_fallback() {
+        let error = remote_memory_tool_token("memory.capture", |name| match name {
+            "OPENSYMPHONY_MEMORY_TOKEN" => Some("read-token".to_string()),
+            _ => None,
+        })
+        .expect_err("admin tool should fail before sending read token");
+        assert!(
+            matches!(error, MemoryError::InvalidInput(message) if message.contains("OPENSYMPHONY_MEMORY_ADMIN_TOKEN"))
+        );
+
+        let token = remote_memory_tool_token("memory.context", |name| match name {
+            "OPENSYMPHONY_MEMORY_ADMIN_TOKEN" => Some("admin-token".to_string()),
+            _ => None,
+        })
+        .expect("read tool can use admin token when no read token exists");
+        assert_eq!(token, Some("admin-token".to_string()));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -16,9 +16,10 @@ use crate::opensymphony_linear::{LinearClient, LinearConfig, LinearError, Workpa
 use crate::opensymphony_openhands::{
     ConversationMoveOutcome, ConversationStoreKind, IssueConversationManifest, IssueSessionError,
     IssueSessionObserver, IssueSessionResult, IssueSessionRunner, IssueSessionRunnerConfig,
-    LocalServerSupervisor, LocalServerTooling, OPENHANDS_CONVERSATIONS_PATH_ENV, OpenHandsClient,
-    OpenHandsConversationStorePaths, OpenHandsError, SupervisedServerConfig, SupervisorConfig,
-    TransportConfig, WorkpadComment as SessionWorkpadComment, WorkpadCommentSource,
+    LocalServerSupervisor, LocalServerTooling, MemoryWorkerAccess,
+    OPENHANDS_CONVERSATIONS_PATH_ENV, OpenHandsClient, OpenHandsConversationStorePaths,
+    OpenHandsError, SupervisedServerConfig, SupervisorConfig, TransportConfig,
+    WorkpadComment as SessionWorkpadComment, WorkpadCommentSource,
 };
 use crate::opensymphony_orchestrator::{
     RecoveryRecord, TrackerBackend, WorkerAbortReason, WorkerBackend, WorkerLaunch,
@@ -40,8 +41,8 @@ use tokio::{
 use url::Url;
 
 use super::{
-    RunCommandError, config::RunRuntimeConfig, datetime_to_timestamp_ms, now_timestamp,
-    timestamp_to_datetime,
+    RunCommandError, RuntimeMemoryEnv, config::RunRuntimeConfig, datetime_to_timestamp_ms,
+    now_timestamp, timestamp_to_datetime,
 };
 
 const DEFAULT_WORKER_LAUNCH_TIMEOUT: Duration = Duration::from_secs(60);
@@ -438,6 +439,7 @@ pub(super) fn build_workspace_manager_config(
 pub(super) async fn build_runtime_transport(
     runtime: &RunRuntimeConfig,
     prepared_tooling: Option<LocalServerTooling>,
+    memory_env: Option<&RuntimeMemoryEnv>,
 ) -> Result<(TransportConfig, Option<LocalServerSupervisor>), RunCommandError> {
     let transport = TransportConfig::from_workflow(&runtime.workflow, &ProcessEnvironment)?;
     let local_server = &runtime.workflow.extensions.openhands.local_server;
@@ -483,6 +485,9 @@ pub(super) async fn build_runtime_transport(
             OPENHANDS_CONVERSATIONS_PATH_ENV.to_string(),
             conversation_store.active.display().to_string(),
         );
+    }
+    if let Some(memory_env) = memory_env {
+        inject_memory_env(&mut config.extra_env, memory_env);
     }
     config.startup_timeout = Duration::from_millis(local_server.startup_timeout_ms);
     config.probe.path = local_server.readiness_probe_path.clone();
@@ -616,6 +621,7 @@ impl RuntimeWorkerBackend {
         client: OpenHandsClient,
         workflow: Arc<ResolvedWorkflow>,
         workspace_manager: Arc<WorkspaceManager>,
+        memory_env: Option<RuntimeMemoryEnv>,
     ) -> Self {
         let (updates_tx, updates_rx) = mpsc::unbounded_channel();
         let workpad_comment_source = match build_linear_client(&workflow) {
@@ -635,7 +641,8 @@ impl RuntimeWorkerBackend {
             client,
             workflow: workflow.clone(),
             workspace_manager,
-            runner_config: IssueSessionRunnerConfig::from_workflow(&workflow),
+            runner_config: IssueSessionRunnerConfig::from_workflow(&workflow)
+                .with_memory(memory_env.as_ref().map(memory_access_from_runtime)),
             workpad_comment_source,
             launch_timeout: DEFAULT_WORKER_LAUNCH_TIMEOUT,
             updates_tx,
@@ -792,6 +799,40 @@ impl RuntimeWorkerBackend {
                 Err(CliWorkerError::LaunchTimeout(self.launch_timeout))
             }
         }
+    }
+}
+
+fn inject_memory_env(
+    env: &mut std::collections::BTreeMap<String, String>,
+    memory: &RuntimeMemoryEnv,
+) {
+    env.insert(
+        "OPENSYMPHONY_MEMORY_ENDPOINT".to_string(),
+        memory.endpoint.clone(),
+    );
+    env.insert(
+        "OPENSYMPHONY_MEMORY_PROJECT".to_string(),
+        memory.project.clone(),
+    );
+    env.insert(
+        "OPENSYMPHONY_MEMORY_PROJECT_SET".to_string(),
+        memory.project.clone(),
+    );
+    env.insert(
+        "OPENSYMPHONY_MEMORY_EXECUTION_REPO".to_string(),
+        memory.execution_repo.clone(),
+    );
+    if let Some(token) = &memory.token {
+        env.insert("OPENSYMPHONY_MEMORY_TOKEN".to_string(), token.clone());
+    }
+}
+
+fn memory_access_from_runtime(memory: &RuntimeMemoryEnv) -> MemoryWorkerAccess {
+    MemoryWorkerAccess {
+        endpoint: memory.endpoint.clone(),
+        token: memory.token.clone(),
+        project: Some(memory.project.clone()),
+        execution_repo: Some(memory.execution_repo.clone()),
     }
 }
 
@@ -1012,7 +1053,7 @@ fn issue_descriptor(issue: &NormalizedIssue) -> IssueDescriptor {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, future::pending, path::Path};
+    use std::{collections::BTreeMap, fs, future::pending, path::Path};
 
     use crate::opensymphony_domain::{
         ConversationId, IssueId, IssueIdentifier, IssueState, IssueStateCategory, RunAttempt,
@@ -1037,6 +1078,42 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn memory_env_injection_sets_worker_cli_scope() {
+        let memory = RuntimeMemoryEnv {
+            endpoint: "http://127.0.0.1:8765/mcp".to_string(),
+            token: Some("read-token".to_string()),
+            project: "project-alpha".to_string(),
+            execution_repo: "/tmp/project-alpha/services/api".to_string(),
+        };
+        let mut env = BTreeMap::new();
+
+        inject_memory_env(&mut env, &memory);
+
+        assert_eq!(
+            env.get("OPENSYMPHONY_MEMORY_ENDPOINT").map(String::as_str),
+            Some("http://127.0.0.1:8765/mcp")
+        );
+        assert_eq!(
+            env.get("OPENSYMPHONY_MEMORY_TOKEN").map(String::as_str),
+            Some("read-token")
+        );
+        assert_eq!(
+            env.get("OPENSYMPHONY_MEMORY_PROJECT").map(String::as_str),
+            Some("project-alpha")
+        );
+        assert_eq!(
+            env.get("OPENSYMPHONY_MEMORY_PROJECT_SET")
+                .map(String::as_str),
+            Some("project-alpha")
+        );
+        assert_eq!(
+            env.get("OPENSYMPHONY_MEMORY_EXECUTION_REPO")
+                .map(String::as_str),
+            Some("/tmp/project-alpha/services/api")
+        );
+    }
+
     #[tokio::test]
     async fn start_worker_reports_workspace_setup_failures_before_launch() {
         let tempdir = TempDir::new().expect("tempdir should exist");
@@ -1052,6 +1129,7 @@ mod tests {
             OpenHandsClient::new(TransportConfig::new("http://127.0.0.1:1")),
             workflow,
             workspace_manager,
+            None,
         );
 
         let issue = sample_issue();
@@ -1304,10 +1382,11 @@ Run the scheduler.
             memory: super::super::config::RunMemoryConfig {
                 auto_capture: true,
                 auto_archive: false,
+                server: None,
             },
         };
 
-        let error = match build_runtime_transport(&runtime, None).await {
+        let error = match build_runtime_transport(&runtime, None, None).await {
             Ok(_) => panic!("external targets should reject launcher overrides"),
             Err(error) => error,
         };
@@ -1334,6 +1413,7 @@ Run the scheduler.
             OpenHandsClient::new(TransportConfig::new("http://127.0.0.1:1")),
             workflow,
             workspace_manager,
+            None,
         );
 
         let workspace = sample_workspace(&workspace_root);

--- a/crates/opensymphony-cli/src/orchestrator_run/config.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/config.rs
@@ -16,6 +16,8 @@ use super::{RunArgs, RunCommandError};
 
 const DEFAULT_CONFIG_FILE: &str = "config.yaml";
 const DEFAULT_CONTROL_PLANE_BIND: &str = "127.0.0.1:2468";
+const DEFAULT_MEMORY_SERVER_BIND: &str = "127.0.0.1:0";
+const DEFAULT_MEMORY_TOKEN_ENV: &str = "OPENSYMPHONY_MEMORY_TOKEN";
 
 #[derive(Debug, Default, Deserialize)]
 struct RunConfigFile {
@@ -47,11 +49,24 @@ struct RunMemoryConfigFile {
     auto_capture: Option<bool>,
     #[serde(default)]
     auto_archive: Option<bool>,
+    #[serde(default)]
+    serve: Option<bool>,
+    #[serde(default)]
+    bind: Option<String>,
+    #[serde(default)]
+    token_env: Option<String>,
 }
 
 pub(super) struct RunMemoryConfig {
     pub(super) auto_capture: bool,
     pub(super) auto_archive: bool,
+    pub(super) server: Option<RunMemoryServerConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RunMemoryServerConfig {
+    pub(super) bind: SocketAddr,
+    pub(super) token: Option<String>,
 }
 
 pub(super) struct RunRuntimeConfig {
@@ -123,9 +138,43 @@ pub(super) async fn resolve_runtime_config(
         .as_ref()
         .map(|tool_dir| OpenHandsConversationStorePaths::for_tool_dir(tool_dir, &target_repo))
         .transpose()?;
+    let memory_config_exists = target_repo
+        .join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE)
+        .is_file();
+    let auto_capture = config.memory.auto_capture.unwrap_or(true);
+    let serve_memory = config.memory.serve.unwrap_or(memory_config_exists);
+    let memory_server = if serve_memory {
+        let memory_bind_value = config
+            .memory
+            .bind
+            .as_deref()
+            .unwrap_or(DEFAULT_MEMORY_SERVER_BIND);
+        let memory_bind =
+            memory_bind_value
+                .parse()
+                .map_err(|source| RunCommandError::InvalidBind {
+                    value: memory_bind_value.to_string(),
+                    source,
+                })?;
+        let memory_token_env = config
+            .memory
+            .token_env
+            .as_deref()
+            .unwrap_or(DEFAULT_MEMORY_TOKEN_ENV);
+        let memory_token = env::var(memory_token_env)
+            .ok()
+            .and_then(|value| non_empty(&value));
+        Some(RunMemoryServerConfig {
+            bind: memory_bind,
+            token: memory_token,
+        })
+    } else {
+        None
+    };
     let memory = RunMemoryConfig {
-        auto_capture: config.memory.auto_capture.unwrap_or(true),
+        auto_capture,
         auto_archive: config.memory.auto_archive.unwrap_or(false),
+        server: memory_server,
     };
     validate_memory_bootstrap(&target_repo, &memory)?;
 
@@ -145,7 +194,7 @@ fn validate_memory_bootstrap(
     target_repo: &Path,
     memory: &RunMemoryConfig,
 ) -> Result<(), RunCommandError> {
-    if !memory.auto_capture {
+    if !memory.auto_capture && memory.server.is_none() {
         return Ok(());
     }
     let path = target_repo.join(DEFAULT_PRIVATE_MEMORY_CONFIG_FILE);
@@ -192,6 +241,18 @@ fn resolve_run_config(
         .take()
         .map(|value| expand_run_value(path, value))
         .transpose()?;
+    config.memory.bind = config
+        .memory
+        .bind
+        .take()
+        .map(|value| expand_run_value(path, value))
+        .transpose()?;
+    config.memory.token_env = config
+        .memory
+        .token_env
+        .take()
+        .map(|value| expand_run_value(path, value))
+        .transpose()?;
     Ok(config)
 }
 
@@ -210,6 +271,11 @@ fn resolve_relative_to(base: &Path, path: &Path) -> PathBuf {
     }
 }
 
+fn non_empty(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,6 +286,7 @@ mod tests {
         let memory = RunMemoryConfig {
             auto_capture: true,
             auto_archive: false,
+            server: None,
         };
 
         let result = validate_memory_bootstrap(repo.path(), &memory);
@@ -236,6 +303,7 @@ mod tests {
         let memory = RunMemoryConfig {
             auto_capture: false,
             auto_archive: false,
+            server: None,
         };
 
         validate_memory_bootstrap(repo.path(), &memory).expect("disabled auto-capture should pass");
@@ -252,8 +320,29 @@ mod tests {
         let memory = RunMemoryConfig {
             auto_capture: true,
             auto_archive: false,
+            server: None,
         };
 
         validate_memory_bootstrap(repo.path(), &memory).expect("memory config should satisfy run");
+    }
+
+    #[test]
+    fn memory_bootstrap_is_required_when_memory_server_is_enabled() {
+        let repo = tempfile::tempdir().expect("temp repo should exist");
+        let memory = RunMemoryConfig {
+            auto_capture: false,
+            auto_archive: false,
+            server: Some(RunMemoryServerConfig {
+                bind: "127.0.0.1:0".parse().expect("valid bind"),
+                token: None,
+            }),
+        };
+
+        let result = validate_memory_bootstrap(repo.path(), &memory);
+
+        assert!(matches!(
+            result,
+            Err(RunCommandError::MissingMemoryConfig { .. })
+        ));
     }
 }

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -34,7 +34,10 @@ use self::{
         build_tracker_backend, build_workspace_manager_config, prepare_active_conversation_store,
     },
     config::{RunRuntimeConfig, resolve_runtime_config},
-    snapshot::{current_agent_server_status, map_snapshot, push_recent_event, terminal_state_set},
+    snapshot::{
+        current_agent_server_status, current_memory_server_status, map_snapshot, push_recent_event,
+        terminal_state_set,
+    },
 };
 
 #[derive(Debug, Args, Clone)]
@@ -98,6 +101,8 @@ enum RunCommandError {
     ToolingSetupRequired { tool_dir: PathBuf, detail: String },
     #[error("failed to start local OpenHands supervisor: {0}")]
     Supervisor(#[from] crate::opensymphony_openhands::SupervisorError),
+    #[error("failed to start memory server: {0}")]
+    MemoryServer(#[from] crate::opensymphony_memory::MemoryError),
     #[error("failed to build scheduler configuration: {0}")]
     SchedulerConfig(#[from] SchedulerError),
     #[error("failed to bind control-plane listener: {0}")]
@@ -171,8 +176,27 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         );
     }
 
-    let (transport, mut supervisor) =
-        build_runtime_transport(&runtime, managed_local_preparation.tooling).await?;
+    let memory_server = start_runtime_memory_server(&runtime).await?;
+    let memory_env = memory_server.as_ref().map(|server| RuntimeMemoryEnv {
+        endpoint: server.endpoint().to_string(),
+        token: runtime
+            .memory
+            .server
+            .as_ref()
+            .and_then(|server| server.token.clone()),
+        project: runtime.workflow.config.tracker.project_slug.clone(),
+        execution_repo: runtime.target_repo.display().to_string(),
+    });
+    if let Some(env) = &memory_env {
+        info!(endpoint = %env.endpoint, "started OpenSymphony memory server");
+    }
+
+    let (transport, mut supervisor) = build_runtime_transport(
+        &runtime,
+        managed_local_preparation.tooling,
+        memory_env.as_ref(),
+    )
+    .await?;
     let client = crate::opensymphony_openhands::OpenHandsClient::new(transport);
     client.openapi_probe().await?;
 
@@ -180,6 +204,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         client.clone(),
         Arc::new(runtime.workflow.clone()),
         workspace_manager,
+        memory_env.clone(),
     );
     let mut scheduler = Scheduler::new(
         tracker,
@@ -196,12 +221,22 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         format!("loaded {}", runtime.workflow_path.display()),
         Utc::now(),
     );
+    if let Some(env) = &memory_env {
+        push_recent_event(
+            &mut recent_events,
+            RecentEventKind::SnapshotPublished,
+            None,
+            format!("memory server listening at {}", env.endpoint),
+            Utc::now(),
+        );
+    }
 
     let initial_snapshot = map_snapshot(
         &scheduler.snapshot(now_timestamp()),
         runtime.workflow.config.workspace.root.as_path(),
         &terminal_state_set(&runtime.workflow),
         current_agent_server_status(&mut supervisor, client.base_url()),
+        current_memory_server_status(memory_server.as_ref()),
         &recent_events,
     );
 
@@ -216,6 +251,9 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         _ = tokio::signal::ctrl_c() => {
             info!("received shutdown signal");
             server_task.abort();
+            if let Some(server) = &memory_server {
+                server.abort();
+            }
             if let Some(mut supervisor) = supervisor {
                 let _ = supervisor.stop();
             }
@@ -226,6 +264,9 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                 Ok(Ok(())) => {
                     if let Some(mut supervisor) = supervisor {
                         let _ = supervisor.stop();
+                    }
+                    if let Some(server) = &memory_server {
+                        server.abort();
                     }
                     return Ok(());
                 }
@@ -253,6 +294,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
             runtime.workflow.config.workspace.root.as_path(),
             &terminal_state_set(&runtime.workflow),
             current_agent_server_status(&mut supervisor, client.base_url()),
+            current_memory_server_status(memory_server.as_ref()),
             &recent_events,
         ))
         .await;
@@ -305,6 +347,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             runtime.workflow.config.workspace.root.as_path(),
                             &terminal_state_set(&runtime.workflow),
                             current_agent_server_status(&mut supervisor, client.base_url()),
+                            current_memory_server_status(memory_server.as_ref()),
                             &recent_events,
                         )).await;
                         if !auto_capture_candidates.is_empty() {
@@ -324,11 +367,14 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             publish_auto_capture_event(
                                 auto_capture_result,
                                 &snapshot,
-                                &runtime,
-                                &mut supervisor,
-                                client.base_url(),
-                                &mut recent_events,
-                                &store,
+                                SnapshotPublishContext {
+                                    runtime: &runtime,
+                                    supervisor: &mut supervisor,
+                                    agent_server_base_url: client.base_url(),
+                                    memory_server: memory_server.as_ref(),
+                                    recent_events: &mut recent_events,
+                                    store: &store,
+                                },
                             ).await;
                         }
                     }
@@ -347,6 +393,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             runtime.workflow.config.workspace.root.as_path(),
                             &terminal_state_set(&runtime.workflow),
                             current_agent_server_status(&mut supervisor, client.base_url()),
+                            current_memory_server_status(memory_server.as_ref()),
                             &recent_events,
                         )).await;
                     }
@@ -356,6 +403,9 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     }
 
     server_task.abort();
+    if let Some(server) = &memory_server {
+        server.abort();
+    }
     if let Some(mut supervisor) = supervisor {
         let _ = supervisor.stop();
     }
@@ -363,26 +413,54 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RuntimeMemoryEnv {
+    pub(super) endpoint: String,
+    pub(super) token: Option<String>,
+    pub(super) project: String,
+    pub(super) execution_repo: String,
+}
+
+async fn start_runtime_memory_server(
+    runtime: &RunRuntimeConfig,
+) -> Result<Option<super::memory::MemoryServerHandle>, RunCommandError> {
+    let Some(server) = runtime.memory.server.as_ref() else {
+        return Ok(None);
+    };
+    let config = crate::opensymphony_memory::MemoryConfig::load(&runtime.target_repo, None)?;
+    super::memory::start_memory_server(config, server.bind, server.token.clone())
+        .await
+        .map(Some)
+        .map_err(RunCommandError::MemoryServer)
+}
+
 async fn publish_auto_capture_event(
     result: Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
     snapshot: &OrchestratorSnapshot,
-    runtime: &RunRuntimeConfig,
-    supervisor: &mut Option<crate::opensymphony_openhands::LocalServerSupervisor>,
-    agent_server_base_url: &str,
-    recent_events: &mut VecDeque<RecentEvent>,
-    store: &SnapshotStore,
+    context: SnapshotPublishContext<'_>,
 ) {
-    if record_auto_capture_recent_event(recent_events, result) {
-        store
+    if record_auto_capture_recent_event(context.recent_events, result) {
+        context
+            .store
             .publish(map_snapshot(
                 snapshot,
-                runtime.workflow.config.workspace.root.as_path(),
-                &terminal_state_set(&runtime.workflow),
-                current_agent_server_status(supervisor, agent_server_base_url),
-                recent_events,
+                context.runtime.workflow.config.workspace.root.as_path(),
+                &terminal_state_set(&context.runtime.workflow),
+                current_agent_server_status(context.supervisor, context.agent_server_base_url),
+                current_memory_server_status(context.memory_server),
+                context.recent_events,
             ))
             .await;
     }
+}
+
+struct SnapshotPublishContext<'a> {
+    runtime: &'a RunRuntimeConfig,
+    supervisor: &'a mut Option<crate::opensymphony_openhands::LocalServerSupervisor>,
+    agent_server_base_url: &'a str,
+    memory_server: Option<&'a super::memory::MemoryServerHandle>,
+    recent_events: &'a mut VecDeque<RecentEvent>,
+    store: &'a SnapshotStore,
 }
 
 fn record_auto_capture_recent_event(

--- a/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
@@ -7,7 +7,8 @@ use std::{
 
 use crate::opensymphony_control::{
     AgentServerStatus, ConversationEvent, DaemonSnapshot, DaemonState, DaemonStatus,
-    IssueRuntimeState, IssueSnapshot, MetricsSnapshot, RecentEvent, RecentEventKind, WorkerOutcome,
+    IssueRuntimeState, IssueSnapshot, MemoryServerStatus, MetricsSnapshot, RecentEvent,
+    RecentEventKind, WorkerOutcome,
 };
 use crate::opensymphony_domain::{
     HealthStatus, IssueIdentifier, OrchestratorSnapshot, SchedulerStatus, WorkerOutcomeKind,
@@ -25,6 +26,7 @@ pub(super) fn map_snapshot(
     workspace_root: &Path,
     terminal_states: &HashSet<String>,
     agent_server: AgentServerStatus,
+    memory_server: MemoryServerStatus,
     recent_events: &VecDeque<RecentEvent>,
 ) -> DaemonSnapshot {
     let generated_at = timestamp_to_datetime(snapshot.generated_at);
@@ -47,6 +49,7 @@ pub(super) fn map_snapshot(
             ),
         },
         agent_server,
+        memory_server,
         metrics: MetricsSnapshot {
             running_issues: snapshot.daemon.running_issue_count as u32,
             retry_queue_depth: snapshot.daemon.retry_queue_count as u32,
@@ -62,6 +65,25 @@ pub(super) fn map_snapshot(
             .map(|issue| map_issue(issue, terminal_states, generated_at))
             .collect(),
         recent_events: recent_events.iter().cloned().collect(),
+    }
+}
+
+pub(super) fn current_memory_server_status(
+    memory_server: Option<&super::super::memory::MemoryServerHandle>,
+) -> MemoryServerStatus {
+    let Some(memory_server) = memory_server else {
+        return MemoryServerStatus::default();
+    };
+    let reachable = !memory_server.is_finished();
+    MemoryServerStatus {
+        enabled: true,
+        reachable,
+        endpoint: Some(memory_server.endpoint().to_string()),
+        status_line: if reachable {
+            "listening".to_string()
+        } else {
+            "stopped".to_string()
+        },
     }
 }
 
@@ -461,6 +483,7 @@ tracker:
                 conversation_count: 1,
                 status_line: "healthy".to_owned(),
             },
+            crate::opensymphony_control::MemoryServerStatus::default(),
             &std::collections::VecDeque::new(),
         );
 

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -155,6 +155,151 @@ fn memory_init_dry_run_does_not_write_files() {
 }
 
 #[test]
+fn memory_context_can_include_code_intelligence_without_a_separate_cli_command() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    fs::create_dir_all(repo.path().join("src")).expect("src dir should write");
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn answer() -> u8 { 42 }\n",
+    )
+    .expect("source file should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "context",
+            "--issue",
+            "COE-999",
+            "--paths",
+            "src/lib.rs",
+            "--include-code-intel",
+        ],
+    );
+
+    assert_success(&output, "context with code intelligence");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("# Memory Context: COE-999"));
+    assert!(stdout.contains("## Code Intelligence"));
+    assert!(stdout.contains("Repository summary"));
+
+    let help = run(repo.path(), ["memory", "--help"]);
+    assert_success(&help, "memory help");
+    assert!(
+        !String::from_utf8_lossy(&help.stdout).contains("code-context"),
+        "memory help should keep context as the agent-facing command"
+    );
+}
+
+#[test]
+fn memory_read_commands_use_mcp_endpoint_when_configured() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    let server = TinyGraphqlServer::start([
+        r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"content":[{"type":"text","text":"remote brief"}]}}"#,
+    ]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["memory", "brief", "COE-123"])
+        .current_dir(repo.path())
+        .env("OPENSYMPHONY_MEMORY_ENDPOINT", &server.base_url)
+        .output()
+        .expect("command should run");
+
+    assert_success(&output, "remote memory brief");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("remote brief"));
+    let requests = server.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].contains("\"method\":\"tools/call\""));
+    assert!(requests[0].contains("\"name\":\"memory.brief\""));
+    assert!(requests[0].contains("\"issue\":\"COE-123\""));
+}
+
+#[test]
+fn memory_read_commands_forward_worker_scope_to_mcp_endpoint() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    let server = TinyGraphqlServer::start([
+        r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"results":[]}}"#,
+    ]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["memory", "search", "shared"])
+        .current_dir(repo.path())
+        .env("OPENSYMPHONY_MEMORY_ENDPOINT", &server.base_url)
+        .env("OPENSYMPHONY_MEMORY_PROJECT", "project-alpha")
+        .env("OPENSYMPHONY_MEMORY_EXECUTION_REPO", "services/api")
+        .output()
+        .expect("command should run");
+
+    assert_success(&output, "remote memory search");
+    let requests = server.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].contains("\"name\":\"memory.search\""));
+    assert!(requests[0].contains("\"query\":\"shared\""));
+    assert!(requests[0].contains("\"project\":\"project-alpha\""));
+    assert!(requests[0].contains("\"repo\":\"services/api\""));
+}
+
+#[test]
+fn memory_admin_commands_can_use_mcp_endpoint() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    let server = TinyGraphqlServer::start([
+        r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"findingCount":0,"findings":[]}}"#,
+    ]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["memory", "lint", "--public-docs"])
+        .current_dir(repo.path())
+        .env("OPENSYMPHONY_MEMORY_ENDPOINT", &server.base_url)
+        .env("OPENSYMPHONY_MEMORY_ADMIN_TOKEN", "admin-token")
+        .output()
+        .expect("command should run");
+
+    assert_success(&output, "remote memory lint");
+    let requests = server.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].contains("\"name\":\"memory.lint\""));
+    assert!(requests[0].contains("\"publicDocs\":true"));
+}
+
+#[test]
+fn memory_search_defaults_cross_repo_and_repo_filters_by_changed_paths() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    fs::write(repo.path().join("source.yaml"), multi_repo_source())
+        .expect("source evidence should write");
+
+    assert_success(
+        &run(
+            repo.path(),
+            [
+                "memory",
+                "import",
+                "--issues",
+                "COE-201,COE-202",
+                "--source-file",
+                "source.yaml",
+            ],
+        ),
+        "capture multi-repo fixture",
+    );
+
+    let cross_repo = run(repo.path(), ["memory", "search", "shared"]);
+    assert_success(&cross_repo, "cross-repo search");
+    let stdout = String::from_utf8_lossy(&cross_repo.stdout);
+    assert!(stdout.contains("COE-201"));
+    assert!(stdout.contains("COE-202"));
+
+    let api_only = run(
+        repo.path(),
+        ["memory", "search", "--repo", "services/api", "shared"],
+    );
+    assert_success(&api_only, "repo-scoped search");
+    let stdout = String::from_utf8_lossy(&api_only.stdout);
+    assert!(stdout.contains("COE-201"));
+    assert!(!stdout.contains("COE-202"));
+}
+
+#[test]
 fn sync_docs_requires_configured_area_mapping() {
     let repo = TempDir::new().expect("temp repo should exist");
     fs::write(repo.path().join("source.yaml"), candidate_only_source())
@@ -1159,6 +1304,43 @@ prs:
     merge_sha: abcdef1234567890
     changed_files:
       - path: README.md
+        change_kind: modified
+"#
+}
+
+fn multi_repo_source() -> &'static str {
+    r#"
+issues:
+  - identifier: COE-201
+    title: Shared broker API work
+    url: https://linear.app/example/issue/COE-201
+    description: Shared broker update in the API service.
+    state: Done
+    labels:
+      - runtime
+    linked_prs:
+      - 201
+  - identifier: COE-202
+    title: Shared broker web work
+    url: https://linear.app/example/issue/COE-202
+    description: Shared broker update in the web service.
+    state: Done
+    labels:
+      - runtime
+    linked_prs:
+      - 202
+prs:
+  - number: 201
+    title: COE-201 shared broker api
+    url: https://github.com/example/repo/pull/201
+    changed_files:
+      - path: services/api/src/broker.rs
+        change_kind: modified
+  - number: 202
+    title: COE-202 shared broker web
+    url: https://github.com/example/repo/pull/202
+    changed_files:
+      - path: services/web/src/broker.ts
         change_kind: modified
 "#
 }

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -300,6 +300,66 @@ fn memory_search_defaults_cross_repo_and_repo_filters_by_changed_paths() {
 }
 
 #[test]
+fn memory_docs_applies_repo_scope_before_returning_area_doc() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    fs::write(repo.path().join("source.yaml"), multi_repo_source())
+        .expect("source evidence should write");
+    assert_success(
+        &run(
+            repo.path(),
+            [
+                "memory",
+                "import",
+                "--issues",
+                "COE-201,COE-202",
+                "--source-file",
+                "source.yaml",
+            ],
+        ),
+        "capture multi-repo fixture",
+    );
+    assert_success(
+        &run(
+            repo.path(),
+            ["memory", "sync-docs", "--area", "openhands-runtime"],
+        ),
+        "sync scoped docs",
+    );
+
+    let api_docs = run(
+        repo.path(),
+        [
+            "memory",
+            "docs",
+            "--area",
+            "openhands-runtime",
+            "--repo",
+            "services/api",
+        ],
+    );
+    assert_success(&api_docs, "docs with matching repo scope");
+    assert!(String::from_utf8_lossy(&api_docs.stdout).contains("# OpenHands Runtime"));
+
+    let mobile_docs = run(
+        repo.path(),
+        [
+            "memory",
+            "docs",
+            "--area",
+            "openhands-runtime",
+            "--repo",
+            "services/mobile",
+        ],
+    );
+    assert_failure(&mobile_docs, "docs with non-matching repo scope");
+    assert!(
+        String::from_utf8_lossy(&mobile_docs.stderr)
+            .contains("no captured memory for area `openhands-runtime`")
+    );
+}
+
+#[test]
 fn sync_docs_requires_configured_area_mapping() {
     let repo = TempDir::new().expect("temp repo should exist");
     fs::write(repo.path().join("source.yaml"), candidate_only_source())

--- a/crates/opensymphony-cli/tests/tui.rs
+++ b/crates/opensymphony-cli/tests/tui.rs
@@ -30,6 +30,7 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             conversation_count: 1,
             status_line: "healthy".to_owned(),
         },
+        memory_server: Default::default(),
         metrics: MetricsSnapshot {
             running_issues: 1,
             retry_queue_depth: 0,

--- a/crates/opensymphony-control/src/lib.rs
+++ b/crates/opensymphony-control/src/lib.rs
@@ -28,6 +28,7 @@ pub use crate::opensymphony_domain::{
     ControlPlaneDaemonStatus as DaemonStatus, ControlPlaneFileChange as FileChange,
     ControlPlaneFileChangeKind as FileChangeKind,
     ControlPlaneIssueRuntimeState as IssueRuntimeState, ControlPlaneIssueSnapshot as IssueSnapshot,
+    ControlPlaneMemoryServerStatus as MemoryServerStatus,
     ControlPlaneMetricsSnapshot as MetricsSnapshot, ControlPlaneRecentEvent as RecentEvent,
     ControlPlaneRecentEventKind as RecentEventKind, ControlPlaneWorkerOutcome as WorkerOutcome,
 };
@@ -425,6 +426,7 @@ mod tests {
                 conversation_count: 2,
                 status_line: "healthy".to_owned(),
             },
+            memory_server: Default::default(),
             metrics: MetricsSnapshot {
                 running_issues: 1,
                 retry_queue_depth: 0,

--- a/crates/opensymphony-control/tests/control_plane.rs
+++ b/crates/opensymphony-control/tests/control_plane.rs
@@ -34,6 +34,7 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             conversation_count: 2,
             status_line: "healthy".to_owned(),
         },
+        memory_server: Default::default(),
         metrics: MetricsSnapshot {
             running_issues: 1,
             retry_queue_depth: 0,

--- a/crates/opensymphony-domain/src/control_plane.rs
+++ b/crates/opensymphony-domain/src/control_plane.rs
@@ -13,6 +13,8 @@ pub struct ControlPlaneDaemonSnapshot {
     pub generated_at: DateTime<Utc>,
     pub daemon: ControlPlaneDaemonStatus,
     pub agent_server: ControlPlaneAgentServerStatus,
+    #[serde(default)]
+    pub memory_server: ControlPlaneMemoryServerStatus,
     pub metrics: ControlPlaneMetricsSnapshot,
     pub issues: Vec<ControlPlaneIssueSnapshot>,
     pub recent_events: Vec<ControlPlaneRecentEvent>,
@@ -47,6 +49,26 @@ pub struct ControlPlaneAgentServerStatus {
     pub base_url: String,
     pub conversation_count: u32,
     pub status_line: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ControlPlaneMemoryServerStatus {
+    pub enabled: bool,
+    pub reachable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    pub status_line: String,
+}
+
+impl Default for ControlPlaneMemoryServerStatus {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            reachable: false,
+            endpoint: None,
+            status_line: "disabled".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -14,8 +14,8 @@ pub use control_plane::{
     ControlPlaneAgentServerStatus, ControlPlaneConversationEvent, ControlPlaneDaemonSnapshot,
     ControlPlaneDaemonState, ControlPlaneDaemonStatus, ControlPlaneFileChange,
     ControlPlaneFileChangeKind, ControlPlaneIssueRuntimeState, ControlPlaneIssueSnapshot,
-    ControlPlaneMetricsSnapshot, ControlPlaneRecentEvent, ControlPlaneRecentEventKind,
-    ControlPlaneWorkerOutcome, SnapshotEnvelope,
+    ControlPlaneMemoryServerStatus, ControlPlaneMetricsSnapshot, ControlPlaneRecentEvent,
+    ControlPlaneRecentEventKind, ControlPlaneWorkerOutcome, SnapshotEnvelope,
 };
 pub use identifiers::{
     ConversationId, IdentifierError, IssueId, IssueIdentifier, TrackerStateId, WorkerId,

--- a/crates/opensymphony-domain/tests/snapshot_serialization.rs
+++ b/crates/opensymphony-domain/tests/snapshot_serialization.rs
@@ -30,6 +30,7 @@ fn fixture() -> SnapshotEnvelope {
                 conversation_count: 2,
                 status_line: "healthy".to_owned(),
             },
+            memory_server: Default::default(),
             metrics: MetricsSnapshot {
                 running_issues: 1,
                 retry_queue_depth: 0,
@@ -77,6 +78,10 @@ fn snapshot_envelope_round_trips_through_json() {
 
     let encoded = serde_json::to_value(&envelope).expect("serialize snapshot envelope to json");
     assert_eq!(encoded["snapshot"]["daemon"]["state"], "ready");
+    assert_eq!(
+        encoded["snapshot"]["memory_server"]["status_line"],
+        "disabled"
+    );
     assert_eq!(
         encoded["snapshot"]["issues"][0]["runtime_state"],
         "retry_queued"

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -34,6 +34,7 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             conversation_count: 2,
             status_line: "healthy".to_owned(),
         },
+        memory_server: Default::default(),
         metrics: MetricsSnapshot {
             running_issues: 1,
             retry_queue_depth: 0,
@@ -101,6 +102,7 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
             conversation_count: 2,
             status_line: "healthy".to_owned(),
         },
+        memory_server: Default::default(),
         metrics: MetricsSnapshot {
             running_issues: 1,
             retry_queue_depth: 0,

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -347,6 +347,7 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
                 source_hash: row.get(7)?,
                 warning_count: row.get::<_, i64>(8)? as usize,
                 docs_sync_status: row.get(9)?,
+                changed_files: Vec::new(),
                 body: row.get(10)?,
             })
         })
@@ -371,6 +372,13 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
                 source,
             }
         })?;
+        issue.changed_files =
+            load_issue_changed_files(&connection, &issue.issue_key).map_err(|source| {
+                MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                }
+            })?;
     }
     Ok(issues)
 }
@@ -387,6 +395,22 @@ fn load_issue_areas(
         areas.push(row?);
     }
     Ok(areas)
+}
+
+fn load_issue_changed_files(
+    connection: &Connection,
+    issue_key: &str,
+) -> Result<Vec<PathBuf>, duckdb::Error> {
+    let mut statement = connection
+        .prepare("SELECT file_path FROM changed_files WHERE issue_key = ? ORDER BY file_path")?;
+    let rows = statement.query_map(params![issue_key], |row| {
+        Ok(PathBuf::from(row.get::<_, String>(0)?))
+    })?;
+    let mut paths = Vec::new();
+    for row in rows {
+        paths.push(row?);
+    }
+    Ok(paths)
 }
 
 fn find_indexed_issue(
@@ -429,6 +453,23 @@ fn write_markdown_indexes(config: &MemoryConfig) -> Result<Vec<PathBuf>, MemoryE
     write_file(&log_path, &log)?;
 
     Ok(vec![index_path, log_path])
+}
+
+pub fn refresh_memory_index(config: &MemoryConfig) -> Result<MemoryReindexReport, MemoryError> {
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    drop(connection);
+
+    let issue_count = load_indexed_issues(config)?.len();
+    let markdown_indexes = write_markdown_indexes(config)?;
+    Ok(MemoryReindexReport {
+        issue_count,
+        index_path: config.index_path.clone(),
+        markdown_indexes,
+    })
 }
 
 fn write_milestone_nodes(

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -617,12 +617,37 @@ pub struct SearchResult {
     pub snippet: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryScopeFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_set: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub milestone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub area: Option<String>,
+    #[serde(default)]
+    pub all_accessible: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusReport {
     pub issue_count: usize,
     pub warning_count: usize,
     pub docs_pending_count: usize,
     pub issues: Vec<StatusIssue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryReindexReport {
+    pub issue_count: usize,
+    pub index_path: PathBuf,
+    pub markdown_indexes: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -707,6 +732,7 @@ struct IndexedIssue {
     source_hash: String,
     warning_count: usize,
     docs_sync_status: String,
+    changed_files: Vec<PathBuf>,
     body: String,
 }
 

--- a/crates/opensymphony-memory/src/query.rs
+++ b/crates/opensymphony-memory/src/query.rs
@@ -205,6 +205,14 @@ pub fn related_by_paths_with_scope(
 }
 
 pub fn docs_for_area(config: &MemoryConfig, area: &str) -> Result<String, MemoryError> {
+    docs_for_area_with_scope(config, area, &MemoryScopeFilter::default())
+}
+
+pub fn docs_for_area_with_scope(
+    config: &MemoryConfig,
+    area: &str,
+    scope: &MemoryScopeFilter,
+) -> Result<String, MemoryError> {
     let area = config.area_or_default(area);
     if !area.docs_target.exists() {
         return Err(MemoryError::InvalidInput(format!(
@@ -213,7 +221,25 @@ pub fn docs_for_area(config: &MemoryConfig, area: &str) -> Result<String, Memory
             area.docs_target.display()
         )));
     }
+    if docs_scope_requires_index_check(scope) {
+        let mut scoped = scope.clone();
+        scoped.area = Some(area.slug.clone());
+        let issues = load_indexed_issues(config)?;
+        if !issues
+            .iter()
+            .any(|issue| indexed_issue_matches_scope(config, issue, &scoped))
+        {
+            return Err(MemoryError::InvalidInput(format!(
+                "no captured memory for area `{}` in the requested docs scope",
+                area.slug
+            )));
+        }
+    }
     read_to_string(&area.docs_target)
+}
+
+fn docs_scope_requires_index_check(scope: &MemoryScopeFilter) -> bool {
+    scope.issue.is_some() || scope.milestone.is_some() || scope.repo.is_some()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/opensymphony-memory/src/query.rs
+++ b/crates/opensymphony-memory/src/query.rs
@@ -26,6 +26,15 @@ pub fn search(
     query: &str,
     limit: usize,
 ) -> Result<Vec<SearchResult>, MemoryError> {
+    search_with_scope(config, query, limit, &MemoryScopeFilter::default())
+}
+
+pub fn search_with_scope(
+    config: &MemoryConfig,
+    query: &str,
+    limit: usize,
+    scope: &MemoryScopeFilter,
+) -> Result<Vec<SearchResult>, MemoryError> {
     let terms = normalize_query_terms(query);
     if terms.is_empty() {
         return Err(MemoryError::InvalidInput(
@@ -34,7 +43,10 @@ pub fn search(
     }
 
     let mut scored = Vec::new();
-    for indexed in load_indexed_issues(config)? {
+    for indexed in load_indexed_issues(config)?
+        .into_iter()
+        .filter(|issue| indexed_issue_matches_scope(config, issue, scope))
+    {
         let haystack = format!(
             "{} {} {} {}",
             indexed.issue_key,
@@ -78,12 +90,24 @@ pub fn related_by_issue(
     issue_key: &str,
     limit: usize,
 ) -> Result<Vec<SearchResult>, MemoryError> {
+    related_by_issue_with_scope(config, issue_key, limit, &MemoryScopeFilter::default())
+}
+
+pub fn related_by_issue_with_scope(
+    config: &MemoryConfig,
+    issue_key: &str,
+    limit: usize,
+    scope: &MemoryScopeFilter,
+) -> Result<Vec<SearchResult>, MemoryError> {
     let issue_key = normalize_issue_key(issue_key);
     let indexed = find_indexed_issue(config, &issue_key)?
         .ok_or_else(|| MemoryError::InvalidInput(format!("no capsule found for {issue_key}")))?;
     let mut related = Vec::new();
     let indexed_areas = indexed.areas();
-    for candidate in load_indexed_issues(config)? {
+    for candidate in load_indexed_issues(config)?
+        .into_iter()
+        .filter(|issue| indexed_issue_matches_scope(config, issue, scope))
+    {
         if candidate.issue_key == issue_key {
             continue;
         }
@@ -123,9 +147,21 @@ pub fn related_by_area(
     area: &str,
     limit: usize,
 ) -> Result<Vec<SearchResult>, MemoryError> {
+    related_by_area_with_scope(config, area, limit, &MemoryScopeFilter::default())
+}
+
+pub fn related_by_area_with_scope(
+    config: &MemoryConfig,
+    area: &str,
+    limit: usize,
+    scope: &MemoryScopeFilter,
+) -> Result<Vec<SearchResult>, MemoryError> {
     let area = slugify(area);
     let mut results = Vec::new();
-    for candidate in load_indexed_issues(config)? {
+    for candidate in load_indexed_issues(config)?
+        .into_iter()
+        .filter(|issue| indexed_issue_matches_scope(config, issue, scope))
+    {
         let areas = candidate.areas();
         if areas.iter().any(|candidate_area| candidate_area == &area) {
             results.push(SearchResult {
@@ -147,6 +183,15 @@ pub fn related_by_paths(
     paths: &[PathBuf],
     limit: usize,
 ) -> Result<Vec<SearchResult>, MemoryError> {
+    related_by_paths_with_scope(config, paths, limit, &MemoryScopeFilter::default())
+}
+
+pub fn related_by_paths_with_scope(
+    config: &MemoryConfig,
+    paths: &[PathBuf],
+    limit: usize,
+    scope: &MemoryScopeFilter,
+) -> Result<Vec<SearchResult>, MemoryError> {
     let terms = paths
         .iter()
         .flat_map(|path| {
@@ -156,7 +201,7 @@ pub fn related_by_paths(
         })
         .filter_map(|value| normalize_optional(&value))
         .collect::<Vec<_>>();
-    search(config, &terms.join(" "), limit)
+    search_with_scope(config, &terms.join(" "), limit, scope)
 }
 
 pub fn docs_for_area(config: &MemoryConfig, area: &str) -> Result<String, MemoryError> {
@@ -585,7 +630,9 @@ fn render_memory_context(
     output.push_str("## Guidance\n\n");
     output.push_str("- Treat memory as context, not as authority over current code.\n");
     output.push_str("- Inspect referenced docs and current files before editing.\n");
-    output.push_str("- Run path-specific memory/code-context queries after file discovery.\n");
+    output.push_str(
+        "- Re-run `opensymphony memory context --paths ... --include-code-intel` after file discovery.\n",
+    );
     output.push_str("- Use `opensymphony debug ");
     output.push_str(issue_key);
     output.push_str("` only when the original agent conversation is needed.\n");
@@ -604,7 +651,16 @@ pub fn status(
     config: &MemoryConfig,
     selection: &IssueSelection,
 ) -> Result<StatusReport, MemoryError> {
+    status_with_scope(config, selection, &MemoryScopeFilter::default())
+}
+
+pub fn status_with_scope(
+    config: &MemoryConfig,
+    selection: &IssueSelection,
+    scope: &MemoryScopeFilter,
+) -> Result<StatusReport, MemoryError> {
     let mut issues = load_indexed_issues(config)?;
+    issues.retain(|issue| indexed_issue_matches_scope(config, issue, scope));
     if let Some(area) = selection.area.as_ref().map(|area| slugify(area)) {
         issues.retain(|issue| issue.areas().contains(&area));
     }
@@ -645,6 +701,62 @@ pub fn status(
         docs_pending_count,
         issues: status_issues,
     })
+}
+
+fn indexed_issue_matches_scope(
+    config: &MemoryConfig,
+    issue: &IndexedIssue,
+    scope: &MemoryScopeFilter,
+) -> bool {
+    if let Some(issue_key) = scope.issue.as_ref().map(|issue| normalize_issue_key(issue))
+        && issue.issue_key != issue_key
+    {
+        return false;
+    }
+    if let Some(milestone) = scope.milestone.as_ref().and_then(|value| normalize_optional(value))
+        && issue.milestone.as_deref() != Some(milestone.as_str())
+    {
+        return false;
+    }
+    if let Some(area) = scope.area.as_ref().map(|area| slugify(area))
+        && !issue.areas().contains(&area)
+    {
+        return false;
+    }
+    if let Some(repo) = scope.repo.as_ref().and_then(|value| normalize_optional(value))
+        && !indexed_issue_matches_repo(config, issue, &repo)
+    {
+        return false;
+    }
+    true
+}
+
+fn indexed_issue_matches_repo(config: &MemoryConfig, issue: &IndexedIssue, repo: &str) -> bool {
+    let repo = repo_scope_prefix(config, repo);
+    if repo.is_empty() || repo == "." {
+        return true;
+    }
+    issue.changed_files.iter().any(|path| {
+        let path = path.to_string_lossy();
+        path == repo || path.starts_with(&format!("{repo}/"))
+    })
+}
+
+fn repo_scope_prefix(config: &MemoryConfig, repo: &str) -> String {
+    let path = PathBuf::from(repo);
+    let relative = if path.is_absolute() {
+        path.strip_prefix(&config.repo_root)
+            .map(Path::to_path_buf)
+            .unwrap_or(path)
+    } else {
+        path
+    };
+    relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().to_string())
+        .filter(|component| component != ".")
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, MemoryError> {

--- a/crates/opensymphony-openhands/src/lib.rs
+++ b/crates/opensymphony-openhands/src/lib.rs
@@ -29,8 +29,9 @@ pub use models::{
 pub use session::{
     ConversationLaunchProfile, IssueConversationManifest, IssueSessionContext, IssueSessionError,
     IssueSessionObserver, IssueSessionPromptKind, IssueSessionResult, IssueSessionReusePolicy,
-    IssueSessionRunner, IssueSessionRunnerConfig, LlmConfigFingerprint, RUNTIME_CONTRACT_VERSION,
-    RehydrationOptions, RehydrationResult, WorkpadComment, WorkpadCommentSource,
+    IssueSessionRunner, IssueSessionRunnerConfig, LlmConfigFingerprint, MemoryWorkerAccess,
+    RUNTIME_CONTRACT_VERSION, RehydrationOptions, RehydrationResult, WorkpadComment,
+    WorkpadCommentSource,
 };
 pub use supervisor::{
     ExternalServerConfig, LaunchOwnership, LocalServerSupervisor, ProbeConfig, ServerMode,

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -24,7 +24,7 @@ use crate::opensymphony_workspace::{
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::time::{Instant, timeout_at};
 use tracing::debug;
@@ -78,6 +78,15 @@ pub struct IssueSessionRunnerConfig {
     /// independent of progress-based idle detection.
     pub total_runtime_cap_ms: Option<Duration>,
     pub finished_drain_timeout: Duration,
+    pub memory: Option<MemoryWorkerAccess>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryWorkerAccess {
+    pub endpoint: String,
+    pub token: Option<String>,
+    pub project: Option<String>,
+    pub execution_repo: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -287,6 +296,7 @@ impl Default for IssueSessionRunnerConfig {
             terminal_wait_timeout: Duration::from_secs(300),
             total_runtime_cap_ms: None,
             finished_drain_timeout: Duration::from_millis(100),
+            memory: None,
         }
     }
 }
@@ -310,7 +320,13 @@ impl IssueSessionRunnerConfig {
             // Future hook: not yet exposed in workflow agent config.
             total_runtime_cap_ms: None,
             finished_drain_timeout: Duration::from_millis(100),
+            memory: None,
         }
+    }
+
+    pub fn with_memory(mut self, memory: Option<MemoryWorkerAccess>) -> Self {
+        self.memory = memory;
+        self
     }
 }
 
@@ -1466,7 +1482,13 @@ impl IssueSessionRunner {
                 .apply_runtime_snapshot(&active_session.stream);
         }
 
-        if let Err(error) = write_memory_context_artifact(workspace_manager, workspace, issue).await
+        if let Err(error) = write_memory_context_artifact(
+            workspace_manager,
+            workspace,
+            issue,
+            self.config.memory.as_ref(),
+        )
+        .await
         {
             debug!(
                 %error,
@@ -2821,7 +2843,16 @@ async fn write_memory_context_artifact(
     workspace_manager: &WorkspaceManager,
     workspace: &WorkspaceHandle,
     issue: &NormalizedIssue,
+    memory: Option<&MemoryWorkerAccess>,
 ) -> Result<(), String> {
+    if let Some(memory) = memory {
+        let context = fetch_memory_context_from_server(memory, issue).await?;
+        return workspace_manager
+            .write_text_artifact(workspace, &workspace.memory_context_path(), &context)
+            .await
+            .map_err(|error| format!("failed to write memory context artifact: {error}"));
+    }
+
     let config = MemoryConfig::load(workspace.workspace_path(), None).map_err(|error| {
         format!(
             "failed to load memory config from {}: {error}",
@@ -2876,6 +2907,83 @@ async fn write_memory_context_artifact(
         .write_text_artifact(workspace, &workspace.memory_context_path(), &context)
         .await
         .map_err(|error| format!("failed to write memory context artifact: {error}"))
+}
+
+async fn fetch_memory_context_from_server(
+    memory: &MemoryWorkerAccess,
+    issue: &NormalizedIssue,
+) -> Result<String, String> {
+    let mut arguments = json!({
+        "issue": issue.identifier.to_string(),
+        "limit": 20,
+        "currentIssue": {
+            "id": issue.id.to_string(),
+            "identifier": issue.identifier.to_string(),
+            "title": issue.title.clone(),
+            "description": issue.description.clone(),
+            "state": issue.state.name.clone(),
+            "labels": issue.labels.clone(),
+            "children": issue.sub_issues.iter().map(|child| json!({
+                "id": child.id.to_string(),
+                "identifier": child.identifier.to_string(),
+                "state": child.state.clone(),
+            })).collect::<Vec<_>>(),
+            "blockedBy": issue.blocked_by.iter().filter_map(|blocker| {
+                blocker.identifier.as_ref().map(|identifier| json!({
+                    "id": blocker.id.as_ref().map(ToString::to_string),
+                    "identifier": identifier.to_string(),
+                    "state": blocker.state.clone(),
+                }))
+            }).collect::<Vec<_>>(),
+        },
+    });
+    if let Value::Object(map) = &mut arguments {
+        if let Some(project) = &memory.project {
+            map.insert("project".to_string(), json!(project));
+            map.insert("projectSet".to_string(), json!(project));
+        }
+        if let Some(repo) = &memory.execution_repo {
+            map.insert("repo".to_string(), json!(repo));
+        }
+    }
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "opensymphony-worker-context",
+        "method": "tools/call",
+        "params": {
+            "name": "memory.context",
+            "arguments": arguments
+        }
+    });
+    let client = reqwest::Client::new();
+    let mut builder = client.post(&memory.endpoint).json(&request);
+    if let Some(token) = &memory.token {
+        builder = builder.bearer_auth(token);
+    }
+    let response = builder
+        .send()
+        .await
+        .map_err(|error| format!("failed to call memory server: {error}"))?;
+    let status = response.status();
+    let payload = response
+        .json::<Value>()
+        .await
+        .map_err(|error| format!("memory server response was not valid JSON: {error}"))?;
+    if !status.is_success() {
+        return Err(format!("memory server returned HTTP {status}: {payload}"));
+    }
+    if let Some(error) = payload.get("error") {
+        return Err(format!("memory server returned an MCP error: {error}"));
+    }
+    payload
+        .get("result")
+        .and_then(|result| result.get("content"))
+        .and_then(Value::as_array)
+        .and_then(|content| content.first())
+        .and_then(|item| item.get("text"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| "memory server response omitted text content".to_string())
 }
 
 fn build_session_context(
@@ -3247,10 +3355,14 @@ fn finished_stream_error_is_tolerable(error: &OpenHandsError) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{collections::HashSet, sync::Arc};
 
-    use crate::opensymphony_domain::WorkerOutcomeKind;
+    use crate::opensymphony_domain::{
+        BlockerRef, IssueRef, IssueState, IssueStateCategory, WorkerOutcomeKind,
+    };
     use crate::opensymphony_testkit::FakeOpenHandsServer;
+    use axum::{Json, Router, extract::State, routing::post};
+    use tokio::{net::TcpListener, sync::Mutex};
 
     use super::super::TransportConfig;
     use super::*;
@@ -3260,6 +3372,109 @@ mod tests {
             Ok(value) => value,
             Err(error) => panic!("{error}"),
         }
+    }
+
+    #[tokio::test]
+    async fn fetch_memory_context_from_server_calls_mcp_context_with_worker_scope() {
+        let requests = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("memory test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("memory test listener should expose an address");
+        let app = Router::new()
+            .route("/mcp", post(memory_test_mcp))
+            .with_state(requests.clone());
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("memory test server should run");
+        });
+        let access = MemoryWorkerAccess {
+            endpoint: format!("http://{address}/mcp"),
+            token: Some("read-token".to_string()),
+            project: Some("project-alpha".to_string()),
+            execution_repo: Some("/tmp/repo-alpha".to_string()),
+        };
+
+        let issue = NormalizedIssue {
+            id: must(IssueId::new("issue-999")),
+            identifier: must(IssueIdentifier::new("COE-999")),
+            title: "Memory server context".to_string(),
+            description: Some("Use deterministic worker issue facts.".to_string()),
+            priority: None,
+            state: IssueState {
+                id: None,
+                name: "In Progress".to_string(),
+                category: IssueStateCategory::Active,
+            },
+            branch_name: None,
+            url: None,
+            labels: vec!["area:memory".to_string()],
+            parent_id: None,
+            blocked_by: vec![BlockerRef {
+                id: Some(must(IssueId::new("issue-100"))),
+                identifier: Some(must(IssueIdentifier::new("COE-100"))),
+                state: Some("Done".to_string()),
+                created_at: None,
+                updated_at: None,
+            }],
+            sub_issues: vec![IssueRef {
+                id: must(IssueId::new("issue-101")),
+                identifier: must(IssueIdentifier::new("COE-101")),
+                state: "Done".to_string(),
+            }],
+            created_at: None,
+            updated_at: None,
+        };
+
+        let context = fetch_memory_context_from_server(&access, &issue)
+            .await
+            .expect("memory server context should load");
+
+        assert_eq!(context, "# Memory Context: COE-999\n");
+        let requests = requests.lock().await;
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert_eq!(request["method"], "tools/call");
+        assert_eq!(request["params"]["name"], "memory.context");
+        assert_eq!(request["params"]["arguments"]["issue"], "COE-999");
+        assert_eq!(
+            request["params"]["arguments"]["currentIssue"]["labels"][0],
+            "area:memory"
+        );
+        assert_eq!(
+            request["params"]["arguments"]["currentIssue"]["children"][0]["identifier"],
+            "COE-101"
+        );
+        assert_eq!(
+            request["params"]["arguments"]["currentIssue"]["blockedBy"][0]["identifier"],
+            "COE-100"
+        );
+        assert_eq!(request["params"]["arguments"]["project"], "project-alpha");
+        assert_eq!(
+            request["params"]["arguments"]["projectSet"],
+            "project-alpha"
+        );
+        assert_eq!(request["params"]["arguments"]["repo"], "/tmp/repo-alpha");
+        task.abort();
+    }
+
+    async fn memory_test_mcp(
+        State(requests): State<Arc<Mutex<Vec<Value>>>>,
+        Json(request): Json<Value>,
+    ) -> Json<Value> {
+        requests.lock().await.push(request.clone());
+        Json(json!({
+            "jsonrpc": "2.0",
+            "id": request.get("id").cloned().unwrap_or(Value::Null),
+            "result": {
+                "content": [
+                    { "type": "text", "text": "# Memory Context: COE-999\n" }
+                ]
+            }
+        }))
     }
 
     #[tokio::test]
@@ -3321,6 +3536,7 @@ mod tests {
                 terminal_wait_timeout: Duration::from_millis(25),
                 total_runtime_cap_ms: None,
                 finished_drain_timeout: Duration::from_millis(25),
+                memory: None,
             },
         );
 

--- a/crates/opensymphony-planning/src/codebase.rs
+++ b/crates/opensymphony-planning/src/codebase.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -332,16 +333,30 @@ impl RepoWalker {
         dir: &Path,
         inventory: &mut BTreeMap<PathBuf, usize>,
     ) -> Result<(), CodebaseAnalysisError> {
-        let entries = fs::read_dir(dir).map_err(|e| CodebaseAnalysisError::Io {
-            path: dir.display().to_string(),
-            source: e,
-        })?;
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied && dir != self.root => {
+                return Ok(());
+            }
+            Err(source) => {
+                return Err(CodebaseAnalysisError::Io {
+                    path: dir.display().to_string(),
+                    source,
+                });
+            }
+        };
 
         for entry in entries {
-            let entry = entry.map_err(|e| CodebaseAnalysisError::Io {
-                path: dir.display().to_string(),
-                source: e,
-            })?;
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == io::ErrorKind::PermissionDenied => continue,
+                Err(source) => {
+                    return Err(CodebaseAnalysisError::Io {
+                        path: dir.display().to_string(),
+                        source,
+                    });
+                }
+            };
             let path = entry.path();
 
             // Use entry.file_type() to avoid following symlinks, preventing infinite loops.
@@ -900,7 +915,7 @@ pub enum CodebaseAnalysisError {
     Io {
         path: String,
         #[source]
-        source: std::io::Error,
+        source: io::Error,
     },
     #[error("TOML parse error in {path}: {source}")]
     Toml {
@@ -1180,5 +1195,34 @@ serde = {{ workspace = true }}"#
             }
             other => panic!("expected NotADirectory, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn analyze_skips_unreadable_subdirectories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().expect("temp dir");
+        let root = create_test_repo(&tmp);
+        let unreadable = root
+            .join("tools")
+            .join("openhands-server")
+            .join("workspace");
+        fs::create_dir_all(&unreadable).unwrap();
+        let mut permissions = fs::metadata(&unreadable).unwrap().permissions();
+        permissions.set_mode(0o000);
+        fs::set_permissions(&unreadable, permissions).unwrap();
+
+        let analyzer = CodebaseAnalyzer::new(&root);
+        let result = analyzer.analyze();
+
+        let mut permissions = fs::metadata(&unreadable).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&unreadable, permissions).unwrap();
+
+        assert!(
+            result.is_ok(),
+            "codebase analysis should ignore unreadable generated workspaces"
+        );
     }
 }

--- a/crates/opensymphony-planning/src/codebase.rs
+++ b/crates/opensymphony-planning/src/codebase.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
@@ -196,6 +197,7 @@ impl CodeIntelIndex for CodebaseAnalyzer {
             .map(|path| path.to_string_lossy().trim_matches('/').to_string())
             .filter(|path| !path.is_empty())
             .collect::<Vec<_>>();
+        let commit_sha = git_commit_sha(&self.root);
         let mut artifacts = Vec::new();
 
         for package in &analysis.packages {
@@ -211,9 +213,13 @@ impl CodeIntelIndex for CodebaseAnalyzer {
                 provider: "codebase-analyzer".to_string(),
                 kind: "package".to_string(),
                 scope_refs: scope_refs.to_vec(),
-                source_refs: Vec::new(),
+                source_refs: vec![MemorySourceRef {
+                    kind: "path".to_string(),
+                    id: package.relative_path.clone(),
+                    url: None,
+                }],
                 path: Some(PathBuf::from(&package.relative_path)),
-                commit_sha: None,
+                commit_sha: commit_sha.clone(),
                 title: package.name.clone(),
                 summary: format!(
                     "{:?} package with {} declared dependency signal(s)",
@@ -236,9 +242,13 @@ impl CodeIntelIndex for CodebaseAnalyzer {
                 provider: "codebase-analyzer".to_string(),
                 kind: "convention".to_string(),
                 scope_refs: scope_refs.to_vec(),
-                source_refs: Vec::new(),
+                source_refs: vec![MemorySourceRef {
+                    kind: "path".to_string(),
+                    id: convention.evidence_path.clone(),
+                    url: None,
+                }],
                 path: Some(PathBuf::from(&convention.evidence_path)),
-                commit_sha: None,
+                commit_sha: commit_sha.clone(),
                 title: convention.area.clone(),
                 summary: convention.description.clone(),
             });
@@ -255,7 +265,7 @@ impl CodeIntelIndex for CodebaseAnalyzer {
                     url: None,
                 }],
                 path: None,
-                commit_sha: None,
+                commit_sha: commit_sha.clone(),
                 title: "Repository summary".to_string(),
                 summary: format!(
                     "{} files, {} Rust files, {} TypeScript files, build systems: {}",
@@ -270,6 +280,19 @@ impl CodeIntelIndex for CodebaseAnalyzer {
         artifacts.truncate(limit.max(1));
         Ok(artifacts)
     }
+}
+
+fn git_commit_sha(root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
 }
 
 /// Walks a directory tree and returns relative paths for each file.

--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -342,6 +342,9 @@ impl TuiState {
             .map(agent_server_status_summary)
             .unwrap_or_else(|| "agent=--".to_owned());
         let mut header = vec!["OpenSymphony".to_owned(), daemon, agent];
+        if let Some(memory) = snapshot.and_then(memory_server_visible_status_summary) {
+            header.push(memory);
+        }
         header.push(connection_status_summary(self));
         header.push(format!("seq={sequence}"));
         header.push(format!("focus={}", self.focus.label()));
@@ -579,6 +582,16 @@ impl TuiState {
                 agent_style,
             ));
             spans.push(Span::raw(" | "));
+
+            if let Some(memory) = memory_server_visible_status_summary(snap) {
+                let memory_style = if snap.snapshot.memory_server.reachable {
+                    Style::new().fg(GREEN)
+                } else {
+                    Style::new().fg(RED)
+                };
+                spans.push(Span::styled(memory, memory_style));
+                spans.push(Span::raw(" | "));
+            }
         } else {
             spans.push(Span::styled("daemon=--", Style::new().dim()));
             spans.push(Span::raw(" | "));
@@ -3039,6 +3052,29 @@ fn agent_server_status_summary(snapshot: &SnapshotEnvelope) -> String {
     )
 }
 
+fn memory_server_status_summary(snapshot: &SnapshotEnvelope) -> String {
+    let memory_server = &snapshot.snapshot.memory_server;
+    let base = if !memory_server.enabled {
+        "memory=off".to_owned()
+    } else if memory_server.reachable {
+        "memory=up".to_owned()
+    } else {
+        "memory=down".to_owned()
+    };
+    status_segment(
+        base,
+        informative_status(&memory_server.status_line, &["disabled", "listening"]),
+    )
+}
+
+fn memory_server_visible_status_summary(snapshot: &SnapshotEnvelope) -> Option<String> {
+    snapshot
+        .snapshot
+        .memory_server
+        .enabled
+        .then(|| memory_server_status_summary(snapshot))
+}
+
 fn status_segment(base: String, detail: Option<&str>) -> String {
     match detail {
         Some(detail) => format!("{base} ({detail})"),
@@ -3865,9 +3901,11 @@ mod tests {
         ControlPlaneDaemonSnapshot as DaemonSnapshot, ControlPlaneDaemonState as DaemonState,
         ControlPlaneDaemonStatus as DaemonStatus, ControlPlaneFileChange,
         ControlPlaneFileChangeKind, ControlPlaneIssueRuntimeState as IssueRuntimeState,
-        ControlPlaneIssueSnapshot as IssueSnapshot, ControlPlaneMetricsSnapshot as MetricsSnapshot,
-        ControlPlaneRecentEvent as RecentEvent, ControlPlaneRecentEventKind as RecentEventKind,
-        ControlPlaneWorkerOutcome as WorkerOutcome, SnapshotEnvelope,
+        ControlPlaneIssueSnapshot as IssueSnapshot,
+        ControlPlaneMemoryServerStatus as MemoryServerStatus,
+        ControlPlaneMetricsSnapshot as MetricsSnapshot, ControlPlaneRecentEvent as RecentEvent,
+        ControlPlaneRecentEventKind as RecentEventKind, ControlPlaneWorkerOutcome as WorkerOutcome,
+        SnapshotEnvelope,
     };
     use chrono::{TimeZone, Utc};
     use ftui::{
@@ -3943,6 +3981,7 @@ mod tests {
                     conversation_count: issue_count as u32,
                     status_line: "healthy".to_owned(),
                 },
+                memory_server: Default::default(),
                 metrics: MetricsSnapshot {
                     running_issues: 1,
                     retry_queue_depth: 0,
@@ -4266,6 +4305,23 @@ mod tests {
         let header = rendered.lines().next().expect("header row");
         assert!(header.contains("daemon=degraded"));
         assert!(header.contains("agent=down"));
+    }
+
+    #[test]
+    fn header_surfaces_enabled_memory_server_health() {
+        let mut state = TuiState::default();
+        let mut snapshot = fixture(8, 3);
+        snapshot.snapshot.memory_server = MemoryServerStatus {
+            enabled: true,
+            reachable: true,
+            endpoint: Some("http://127.0.0.1:8765/mcp".to_owned()),
+            status_line: "listening".to_owned(),
+        };
+        state.reduce(TuiAction::SnapshotReceived(Box::new(snapshot)));
+
+        let rendered = state.render_text(140, 22);
+        let header = rendered.lines().next().expect("header row");
+        assert!(header.contains("memory=up"));
     }
 
     #[test]

--- a/crates/opensymphony-tui/tests/reducer.rs
+++ b/crates/opensymphony-tui/tests/reducer.rs
@@ -43,6 +43,7 @@ fn fixture_with_identifiers(sequence: u64, identifiers: &[String]) -> SnapshotEn
                 conversation_count: identifiers.len() as u32,
                 status_line: "healthy".to_owned(),
             },
+            memory_server: Default::default(),
             metrics: MetricsSnapshot {
                 running_issues: 1,
                 retry_queue_depth: 0,

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -32,11 +32,17 @@ Use `--dry-run` on write commands when you want a non-writing preview.
 memory:
   auto_capture: true
   auto_archive: false
+  serve: true
+  bind: 127.0.0.1:0
 ```
 
 `auto_capture` defaults to `true`. `auto_archive` defaults to `false`; when it
 is enabled, OpenSymphony archives only after fresh capture succeeds with no
-blocking warnings.
+blocking warnings. `serve` starts the local memory server during
+`opensymphony run` when memory is initialized. The default bind address uses an
+ephemeral loopback port, and workers receive the resulting MCP endpoint through
+`OPENSYMPHONY_MEMORY_ENDPOINT`. Workers receive only the normal read token;
+admin tools require a separate `OPENSYMPHONY_MEMORY_ADMIN_TOKEN`.
 
 Initialize the shared memory policy and learned ontology file once:
 
@@ -204,17 +210,24 @@ capsule, and selects captured memory from deterministic buckets: explicit
 includes, blocking predecessors, completed children, completed siblings, path
 matches, and canonical area matches. It strips each selected brief's
 `Documentation impact` section and appends one deduplicated section at the end.
-When `opensymphony run` starts a worker, it writes the same style of kickoff
-bundle to `.opensymphony/generated/memory-context.md` inside the issue
-workspace.
+When `opensymphony run` starts a worker, it asks the supervised memory server
+for the same style of kickoff bundle and writes it to
+`.opensymphony/generated/memory-context.md` inside the issue workspace. If the
+server is disabled, the runner falls back to direct local memory reads.
 
 Read commands open the DuckDB index in read-only mode and do not run migrations.
 Startup and write paths own schema creation or migration.
 
-`memory serve` exposes the read-only command set through a local MCP-style
-Streamable HTTP JSON-RPC endpoint at `/mcp`. V1 is intentionally read-only and
-supports `memory.context`, `memory.search`, `memory.related`, `memory.brief`,
-`memory.docs`, and `memory.status`; admin tools remain CLI-only write paths.
+`memory serve` exposes the memory command set through a local MCP-style
+Streamable HTTP JSON-RPC endpoint at `/mcp`. CLI commands call that endpoint
+when `OPENSYMPHONY_MEMORY_ENDPOINT` is set; otherwise they use offline direct
+mode. Read tools are `memory.context`, `memory.search`, `memory.related`,
+`memory.brief`, `memory.docs`, and `memory.status`. Admin tools are
+`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`, and
+`memory.ingest_code_intel`; these require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or
+`--admin-token` on `opensymphony memory serve`. `memory.context` remains the
+agent-facing context command; code intelligence is included through
+`--include-code-intel`, not a separate CLI command.
 
 Docs sync writes stable topic docs by default and prints stat-style output with
 file paths, line counts, and changed-line totals:

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -225,9 +225,10 @@ mode. Read tools are `memory.context`, `memory.search`, `memory.related`,
 `memory.brief`, `memory.docs`, and `memory.status`. Admin tools are
 `memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`, and
 `memory.ingest_code_intel`; these require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or
-`--admin-token` on `opensymphony memory serve`. `memory.context` remains the
-agent-facing context command; code intelligence is included through
-`--include-code-intel`, not a separate CLI command.
+`--admin-token` on `opensymphony memory serve`. If an admin token is configured
+without a separate read token, the admin token also protects read tools.
+`memory.context` builds the agent kickoff bundle. Add `--include-code-intel`
+to include available codebase-analysis artifacts alongside selected memory.
 
 Docs sync writes stable topic docs by default and prints stat-style output with
 file paths, line counts, and changed-line totals:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -180,10 +180,18 @@ Read commands such as `memory status`, `memory brief`, `memory related`, and
 migrations. Run capture, import, docs sync, or reindex-style admin operations
 serially if a local DuckDB writer is active.
 
-For worker or tool access, `opensymphony memory serve --addr 127.0.0.1:8765`
-starts a read-only local HTTP endpoint with MCP-style `initialize`,
-`tools/list`, and `tools/call` JSON-RPC methods. Set
-`OPENSYMPHONY_MEMORY_TOKEN` or pass `--token` to require bearer-token access.
+For worker or tool access, `opensymphony run` starts the read-only memory server
+when memory is initialized and `memory.serve` is not disabled. The supervised
+server binds to loopback on an ephemeral port by default, reports the endpoint
+through the control-plane recent events, and passes
+`OPENSYMPHONY_MEMORY_ENDPOINT` into managed local OpenHands workers. Manual
+operation is also available with `opensymphony memory serve --addr
+127.0.0.1:8765`, which exposes MCP-style `initialize`, `tools/list`, and
+`tools/call` JSON-RPC methods at `/mcp`. Set `OPENSYMPHONY_MEMORY_TOKEN` or
+pass `--token` to require bearer-token access for read tools. Admin tools
+(`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`, and
+`memory.ingest_code_intel`) require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or
+`--admin-token`; do not inject that token into ordinary worker environments.
 
 Linear archival is a separate command and is guarded by captured memory:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -191,7 +191,8 @@ operation is also available with `opensymphony memory serve --addr
 pass `--token` to require bearer-token access for read tools. Admin tools
 (`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`, and
 `memory.ingest_code_intel`) require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or
-`--admin-token`; do not inject that token into ordinary worker environments.
+`--admin-token`. When only the admin token is configured, it also gates read
+tools; do not inject that token into ordinary worker environments.
 
 Linear archival is a separate command and is guarded by captured memory:
 

--- a/docs/tasks/multi-repo-memory-server-with-code-intelligence.md
+++ b/docs/tasks/multi-repo-memory-server-with-code-intelligence.md
@@ -1,0 +1,101 @@
+# Multi-Repo Memory Server And Code Intelligence Plan
+
+## Summary
+
+Revise the memory server design so **repository is a facet, not the top-level memory taxonomy**. The canonical scope is the OpenSymphony work graph: organization or local instance, project set, projects, milestones, issues, sub-issues, and only then repository checkouts attached to executable terminal work items.
+
+Keep **MCP over Streamable HTTP** as the canonical agent/CLI protocol. It still fits local and hosted modes, works across future virtualized workspaces, and mirrors the way DeepWiki exposes codebase context through MCP. External references used for product-shape inspiration only: [MCP transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports), [DeepWiki](https://cognition.ai/blog/deepwiki), [DeepWiki MCP](https://cognition.ai/blog/deepwiki-mcp-server), [Codemaps](https://cognition.ai/blog/codemaps), [DuckDB concurrency](https://duckdb.org/docs/current/connect/concurrency.html).
+
+## Domain Model
+
+- Introduce a **Knowledge Scope** model:
+  - `LocalInstance | Organization`
+  - `ProjectSet`
+  - `Project`
+  - `Milestone`
+  - `WorkItem` with kind `issue | sub_issue`
+  - `Repository`
+  - `CodePath`
+  - `Area`
+- A `Repository` is an execution/input facet. It is not the memory root.
+- Terminal executable work items may have exactly one `execution_repo_id`; non-terminal issues and milestones may reference many repos for cross-cutting design, architecture, and planning memory.
+- Every memory record stores `scope_refs[]`, not a single repo foreign key. Search defaults to the current `ProjectSet` and may be filtered or widened by project, milestone, work item, repo, path, area, source kind, and visibility.
+- Existing issue capsules become `MemoryRecord { kind: issue_capsule, scope_refs, source_refs, visibility, body_ref, indexed_at }`.
+
+## Storage And Retrieval Architecture
+
+- Split memory into provider boundaries:
+  - `MemoryCatalog`: relational metadata, scope refs, source refs, visibility, freshness, and audit state. DuckDB remains the initial local backend.
+  - `DocumentStore`: Markdown capsules, generated docs, summaries, and private source snapshots. Local FS first; object storage later.
+  - `LexicalIndex`: current text search over capsules/docs.
+  - `VectorIndex`: optional provider, initially `Noop`; future Qdrant implementation.
+  - `CodeIntelIndex`: provider interface for code graph, embeddings, wiki-style docs, symbols, call/dependency maps, and path-level summaries.
+  - `FusionRetriever`: combines lexical memory, vector results, code graph hits, and code-intelligence summaries into ranked context.
+- Move DuckDB migrations to startup/write paths only. Read APIs must not mutate `schema_version`.
+- Keep direct file/DB mode only as offline admin fallback. Normal `opensymphony run` and worker usage goes through the memory server.
+
+## Protocol And CLI
+
+- MCP endpoint:
+  - local: `http://127.0.0.1:<port>/mcp`
+  - hosted: `/api/v1/memory/mcp`
+- Read-only tools:
+  - `memory.context({ work_item?, scope?, paths?, limit?, include_code_intel? })`
+  - `memory.search({ query, scope?, filters?, limit? })`
+  - `memory.related({ work_item?, paths?, area?, scope?, limit? })`
+  - `memory.brief({ work_item })`
+  - `memory.docs({ area, scope? })`
+  - `memory.status({ scope?, filters? })`
+  - Code-intelligence retrieval is exposed through `memory.context` rather than
+    a separate CLI command, so agents keep one context-loading path.
+- Admin tools require elevated token capabilities:
+  - `memory.capture`
+  - `memory.sync_docs`
+  - `memory.lint`
+  - `memory.reindex`
+  - `memory.ingest_code_intel`
+- CLI commands call the MCP server when `OPENSYMPHONY_MEMORY_ENDPOINT` is present; otherwise they use offline direct mode.
+- Add CLI scope flags consistently: `--project-set`, `--project`, `--milestone`, `--issue`, `--repo`, `--area`, `--all-accessible`.
+- Worker env injection provides endpoint, token, current project set, current work item, and execution repo. Agents should use `opensymphony memory ...`, not read `.opensymphony/memory` directly.
+
+## Code Intelligence Integration
+
+- Treat DeepWiki/Codemaps as inspiration for a clean-room OpenSymphony capability: generated architecture docs, code maps, source links, summaries, dependency/call graphs, and queryable code understanding.
+- Add `CodeIntelProvider` with initial implementation wrapping the existing repository `CodebaseAnalyzer`.
+- Future providers:
+  - Qdrant-backed multi-vector embeddings.
+  - Colleague code graph adapter.
+  - Generated wiki/code-map artifacts.
+  - Symbol/dependency/call graph providers.
+- Store code-intelligence artifacts as first-class memory records with `repo_id`, `commit_sha`, `paths`, `symbols`, `generator_kind`, `artifact_kind`, `visibility`, and `freshness`.
+- Retrieval must cite source refs: issue key, PR, doc path, repo, commit SHA, file path, symbol, or generated artifact id.
+- Do not couple memory query APIs to DuckDB, Markdown, Qdrant, or a specific code graph schema.
+
+## Workflow And Runtime Changes
+
+- Update `WORKFLOW.md` template:
+  - First implementation step: run `opensymphony memory context --issue {{ issue.identifier }}`.
+  - After initial file discovery: run `opensymphony memory context --issue {{ issue.identifier }} --paths <paths> --include-code-intel`.
+  - Treat memory as context, not authority over current code, tests, or specs.
+- Update the project/workspace model so checkout selection happens only for terminal executable work items.
+- Add memory server health to diagnostics/control plane.
+- In hosted mode, tokens enforce scope and visibility; virtualized workspaces receive only read-only memory tokens unless explicitly elevated.
+
+## Test Plan
+
+- Multi-repo fixture: one project set, two projects, three repos, cross-cutting milestone memory, and terminal sub-issues each bound to one execution repo.
+- Search tests prove default project-set search returns cross-repo memory and `--repo` acts only as a filter.
+- Scheduling/config tests enforce one execution repo for terminal work items.
+- MCP contract tests cover tools, resources, capability filtering, scope filtering, and stable error codes.
+- Concurrency tests run parallel read clients while capture/reindex executes without DuckDB lock leakage.
+- Code-intel provider tests cover current `CodebaseAnalyzer`, `memory.context`
+  code-intelligence inclusion, provider fusion ordering, source citations,
+  stale commit detection, and no-provider fallback.
+- Security tests verify private memory is hidden across project/org boundaries and hosted tokens cannot widen scope beyond authorization.
+
+## Assumptions
+
+- V1 memory server supports local project sets with a single local instance identity; hosted organization/tenant identity is additive later.
+- Qdrant and code graph integrations are planned extension providers, not mandatory for the first memory-server slice.
+- Existing repo-local `.opensymphony/memory` data is migrated or registered as one source within the broader project-set catalog.
+- MCP remains the agent/CLI protocol; REST may exist only for health, diagnostics, and gateway integration.


### PR DESCRIPTION
## Summary

Implements COE-448: the first scoped OpenSymphony memory server slice, deterministic pre-implementation `opensymphony memory context`, worker memory bootstrap, and code-intelligence provider seams.

## Changes

- Added KnowledgeScope/MemoryRecord/provider abstractions, scoped memory query APIs, cross-repo search behavior, and DuckDB read-only paths for normal reads.
- Added `opensymphony memory serve` with MCP-style read tools, admin tools behind a separate admin token, and CLI forwarding through `OPENSYMPHONY_MEMORY_ENDPOINT`.
- Reworked `opensymphony memory context --issue ...` into the agent-facing context compiler, including deterministic related-memory buckets, missing-capsule reporting, Documentation impact deduplication, and optional `--include-code-intel` enrichment.
- Supervised the memory server from `opensymphony run`, injected worker memory scope env, wrote workspace memory-context artifacts through the server, and surfaced memory health in control/TUI snapshots.
- Hardened the memory MCP server review paths: localhost Origin validation, code-intel repo containment, admin-token/read-token boundaries, client/server call timeouts, scoped docs pass-through, and unreadable code-intel subtree handling.
- Updated `WORKFLOW.md`, the memory skill, and memory/operations docs; added the consolidated memory-server/code-intelligence plan under `docs/tasks/`.

## Review Response

- Fixed the localhost Origin prefix bypass by parsing origins and accepting only `http`/`https` loopback hosts.
- Constrained `memory.ingest_code_intel` / `--include-code-intel` repository resolution to canonical paths under `repo_root`.
- Made read tools require the admin token when an admin token is configured without a separate read token.
- Added a 330s remote CLI request timeout and a 300s MCP `tools/call` timeout, with a guard test ensuring the client outlasts the server timeout.
- Removed client-side fallback from admin token to read token for admin tool calls.
- Fixed `memory docs` / MCP `memory.docs` so issue, milestone, and repo scope filters are applied before returning an area doc.
- Kept the large `memory.rs` split as a follow-up refactor; this PR now isolates the security-sensitive paths with focused tests without adding a broad mechanical move.

## Evidence

### Test output

```bash
cargo test
# pass: 373 lib tests plus integration suites; `tests/memory.rs` now has 24 tests including scoped docs

cargo fmt --check
# pass

cargo clippy --all-targets -- -D warnings
# pass

git diff --check
# pass
```

### Runtime evidence

```bash
target/debug/opensymphony memory serve --addr 127.0.0.1:18765 --token read-token
# OpenSymphony memory server listening on http://127.0.0.1:18765/mcp

curl -sS http://127.0.0.1:18765/health
# {"adminTools":false,"mode":"read_only","protocol":"mcp-streamable-http-2025-06-18","status":"ok"}

curl -sS -H 'Authorization: Bearer read-token' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"tools","method":"tools/list","params":{}}' \
  http://127.0.0.1:18765/mcp | jq -r '.result.tools[] | "\(.name) \(.access)"'
# memory.context read
# memory.search read
# memory.related read
# memory.brief read
# memory.docs read
# memory.status read
# memory.capture admin
# memory.sync_docs admin
# memory.lint admin
# memory.reindex admin
# memory.ingest_code_intel admin

curl -sS -o /dev/null -w '%{http_code}\n' \
  -H 'Origin: http://localhost.evil.com' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"bad-origin","method":"tools/list","params":{}}' \
  http://127.0.0.1:18765/mcp
# 403

OPENSYMPHONY_MEMORY_ENDPOINT=http://127.0.0.1:18765/mcp \
OPENSYMPHONY_MEMORY_TOKEN=read-token \
target/debug/opensymphony memory context --issue COE-448 \
  --include COE-413 --include COE-434 \
  --paths crates/opensymphony-cli/src/memory.rs \
  --include-code-intel --limit 5
# # Memory Context: COE-448
# ## Explicit Includes
# ### COE-413: Implementation Plan Generator Stage
# ### COE-434: Long-running harness liveness and scheduler/runtime ownership contract
# ## Documentation impact
# ## Code Intelligence
# ### repository-summary: Repository summary

target/debug/opensymphony memory docs --area memory --repo crates/opensymphony-cli | sed -n '1,3p'
# # Project Memory
#
# OpenSymphony project memory turns completed Linear work into durable development

target/debug/opensymphony memory docs --area memory --repo services/mobile
# opensymphony memory failed: no captured memory for area `memory` in the requested docs scope

curl -sS -H 'Authorization: Bearer read-token' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"docs-ok","method":"tools/call","params":{"name":"memory.docs","arguments":{"area":"memory","repo":"crates/opensymphony-cli"}}}' \
  http://127.0.0.1:18765/mcp | jq -r '.result.content[0].text' | sed -n '1,3p'
# # Project Memory
#
# OpenSymphony project memory turns completed Linear work into durable development

curl -sS -H 'Authorization: Bearer read-token' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"docs-miss","method":"tools/call","params":{"name":"memory.docs","arguments":{"area":"memory","repo":"services/mobile"}}}' \
  http://127.0.0.1:18765/mcp | jq -r '.error.message'
# no captured memory for area `memory` in the requested docs scope
```

### Interface verification

Verified that the public agent kickoff command is `opensymphony memory context`, and code intelligence is requested with `--include-code-intel` as part of that context bundle. Verified that Linear labels use the canonical `area:<slug>` form while captured memory stores/searches the stripped slug, such as `memory`.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

- [COE-448](https://linear.app/trilogy-ai-coe/issue/COE-448/multi-repo-memory-server-and-deterministic-context)

## Additional notes

The hosted/Qdrant/code-graph pieces remain extension-provider follow-ups; this PR establishes the local protocol, worker bootstrap, deterministic context compiler, and provider boundaries first.

