### PR TITLE
feat(COE-397): Gateway API Client, Transport Adapters, and Reducers

### DIFF
--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -7,9 +7,19 @@ import type {
   TaskGraphSnapshot,
   GatewayCapabilities,
   TransportProfile,
+  ActionDispatch,
+  ActionReceipt,
+  ApprovalRequest,
+  PlanningSessionSummary,
+  RunStatus,
+  ReleaseReason,
+  GatewayHealth,
+  StreamCursor,
+  PageCursor,
 } from "@opensymphony/gateway-schema";
 
 export { HttpGatewayTransport } from "./transports.js";
+export { MockGatewayTransport } from "./mock.js";
 
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {
@@ -19,11 +29,11 @@ export interface GatewayTransport {
   snapshot(): Promise<DashboardSnapshot>;
   taskGraph(projectId: string): Promise<TaskGraphSnapshot>;
   runDetail(runId: string): Promise<RunDetail>;
-  runEvents(runId: string): Promise<RunEventPage>;
+  runEvents(runId: string, cursor?: PageCursor): Promise<RunEventPage>;
   terminalSnapshot(runId: string, terminalId: string): Promise<TerminalSnapshot>;
 
   /** Subscribe to gateway event stream; returns an async iterable. */
-  events(): AsyncIterable<GatewayEnvelope>;
+  events(fromCursor?: { sequence: number; partition: string }): AsyncIterable<GatewayEnvelope>;
 
   /** Subscribe to terminal frame stream for a run. */
   terminalFrames(runId: string): AsyncIterable<GatewayEnvelope>;
@@ -31,8 +41,63 @@ export interface GatewayTransport {
   close(): Promise<void>;
 }
 
+/** Extended transport with action dispatch support. */
+export interface ActionCapableTransport extends GatewayTransport {
+  dispatchAction(action: ActionDispatch): Promise<ActionReceipt>;
+  cancelRun(runId: string): Promise<ActionReceipt>;
+  retryRun(runId: string): Promise<ActionReceipt>;
+  resumeRun(runId: string): Promise<ActionReceipt>;
+}
+
 export interface GatewayTransportConfig {
   baseUri: string;
   authToken?: string;
   transport?: TransportProfile;
 }
+
+/** Connection state tracked by the client. */
+export type ConnectionState =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "degraded"
+  | "reconnecting"
+  | "failed";
+
+/** Run phase liveness state from the client's perspective. */
+export type RunPhaseState =
+  | "active"
+  | "quiet"
+  | "degraded"
+  | "stalled"
+  | "retry_queued"
+  | "cancelled"
+  | "detached";
+
+/** Diagnostic info about the current stream health. */
+export interface StreamHealth {
+  healthy: boolean;
+  lastEventAt: string | null;
+  reconnectAttempts: number;
+  eventsSinceReconnect: number;
+}
+
+export type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  RunDetail,
+  RunEventPage,
+  TerminalSnapshot,
+  TaskGraphSnapshot,
+  GatewayCapabilities,
+  ActionDispatch,
+  ActionReceipt,
+  ApprovalRequest,
+  PlanningSessionSummary,
+  RunStatus,
+  ReleaseReason,
+  GatewayHealth,
+  StreamCursor,
+  PageCursor,
+  TransportProfile,
+};

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -198,6 +198,8 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   async *terminalFrames(runId: string): AsyncIterable<GatewayEnvelope> {
     const frames = this.mockTerminalFrames.get(runId) ?? [];
     for (const frame of frames) {
+      this.lastEventTimestamp = Date.now();
+      this.reconnectAttemptsCount = 0;
       yield frame;
     }
   }
@@ -226,6 +228,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
       correlation_id: `cancel-${runId}-${crypto.randomUUID()}`,
       action_kind: "cancel",
       target_entity: { entity_kind: "run", entity_id: runId },
+      idempotency_key: `cancel-${runId}`,
     });
   }
 
@@ -235,6 +238,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
       correlation_id: `retry-${runId}-${crypto.randomUUID()}`,
       action_kind: "retry",
       target_entity: { entity_kind: "run", entity_id: runId },
+      idempotency_key: `retry-${runId}`,
     });
   }
 
@@ -244,6 +248,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
       correlation_id: `resume-${runId}-${crypto.randomUUID()}`,
       action_kind: "resume",
       target_entity: { entity_kind: "run", entity_id: runId },
+      idempotency_key: `resume-${runId}`,
     });
   }
 

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -1,0 +1,294 @@
+import type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  RunDetail,
+  RunEventPage,
+  TerminalSnapshot,
+  TaskGraphSnapshot,
+  GatewayCapabilities,
+  ActionDispatch,
+  ActionReceipt,
+  PageCursor,
+} from "@opensymphony/gateway-schema";
+import type { GatewayTransport, ActionCapableTransport } from "./index.js";
+
+/** Deterministic mock transport for tests. */
+export class MockGatewayTransport implements GatewayTransport, ActionCapableTransport {
+  readonly baseUri: string;
+
+  private mockHealth: GatewayCapabilities;
+  private mockSnapshot: DashboardSnapshot;
+  private mockTaskGraph: TaskGraphSnapshot;
+  private mockRunDetail: Map<string, RunDetail>;
+  private mockRunEvents: Map<string, RunEventPage>;
+  private mockTerminalSnapshot: Map<string, TerminalSnapshot>;
+  private mockEvents: GatewayEnvelope[] = [];
+  private mockTerminalFrames: Map<string, GatewayEnvelope[]> = new Map();
+  private mockActionReceipts: Map<string, ActionReceipt> = new Map();
+  private closedFlag = false;
+
+  // Stream health simulation.
+  private streamHealthyFlag = true;
+  private lastEventTimestamp: number | null = null;
+  private reconnectAttemptsCount = 0;
+
+  constructor(opts?: {
+    baseUri?: string;
+    health?: Partial<GatewayCapabilities>;
+    snapshot?: Partial<DashboardSnapshot>;
+    taskGraph?: Partial<TaskGraphSnapshot>;
+    runDetails?: RunDetail[];
+    runEvents?: RunEventPage[];
+    terminalSnapshots?: TerminalSnapshot[];
+    events?: GatewayEnvelope[];
+    terminalFrames?: { runId: string; frames: GatewayEnvelope[] }[];
+    actionReceipts?: { correlationId: string; receipt: ActionReceipt }[];
+    streamHealthy?: boolean;
+  }) {
+    this.baseUri = opts?.baseUri ?? "http://mock-gateway.local";
+
+    this.mockHealth = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      gateway_version: "1.0.0-mock",
+      supported_api_versions: ["v1"],
+      transports: [
+        {
+          transport: "loopback_http",
+          modes: ["local"],
+          supported_encodings: ["utf8"],
+          bidirectional: false,
+        },
+      ],
+      features: [
+        { feature: "events", available: true, requires_auth: false },
+        { feature: "terminal", available: true, requires_auth: false },
+        { feature: "actions", available: true, requires_auth: true },
+      ],
+      auth_modes: ["none", "api_key"],
+      max_event_page_size: 1000,
+      max_terminal_frame_batch: 500,
+      ...(opts?.health ?? {}),
+    };
+
+    this.mockSnapshot = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      generated_at: new Date().toISOString(),
+      sequence: 1,
+      health: "healthy",
+      metrics: {
+        running_issue_count: 0,
+        retry_queue_depth: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cache_read_tokens: 0,
+        total_cost_micros: 0,
+      },
+      projects: [],
+      recent_events: [],
+      ...(opts?.snapshot ?? {}),
+    };
+
+    this.mockTaskGraph = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      project_id: "mock-project",
+      generated_at: new Date().toISOString(),
+      nodes: [],
+      root_ids: [],
+      ...(opts?.taskGraph ?? {}),
+    };
+
+    this.mockRunDetail = new Map();
+    for (const run of opts?.runDetails ?? []) {
+      this.mockRunDetail.set(run.run_id, run);
+    }
+
+    this.mockRunEvents = new Map();
+    for (const page of opts?.runEvents ?? []) {
+      this.mockRunEvents.set(page.run_id, page);
+    }
+
+    this.mockTerminalSnapshot = new Map();
+    for (const snap of opts?.terminalSnapshots ?? []) {
+      this.mockTerminalSnapshot.set(snap.terminal_session_id, snap);
+    }
+
+    this.mockEvents = opts?.events ?? [];
+    for (const tf of opts?.terminalFrames ?? []) {
+      this.mockTerminalFrames.set(tf.runId, tf.frames);
+    }
+
+    for (const ar of opts?.actionReceipts ?? []) {
+      this.mockActionReceipts.set(ar.correlationId, ar.receipt);
+    }
+
+    this.streamHealthyFlag = opts?.streamHealthy ?? true;
+  }
+
+  // -- REST reads --
+
+  async health(): Promise<GatewayCapabilities> {
+    return this.mockHealth;
+  }
+
+  async snapshot(): Promise<DashboardSnapshot> {
+    return this.mockSnapshot;
+  }
+
+  async taskGraph(_projectId: string): Promise<TaskGraphSnapshot> {
+    return this.mockTaskGraph;
+  }
+
+  async runDetail(runId: string): Promise<RunDetail> {
+    const run = this.mockRunDetail.get(runId);
+    if (!run) {
+      throw new Error(`Mock run not found: ${runId}`);
+    }
+    return run;
+  }
+
+  async runEvents(runId: string, _cursor?: PageCursor): Promise<RunEventPage> {
+    const page = this.mockRunEvents.get(runId);
+    if (!page) {
+      return {
+        schema_version: { major: 1, minor: 0, patch: 0 },
+        run_id: runId,
+        events: [],
+      };
+    }
+    return page;
+  }
+
+  async terminalSnapshot(
+    runId: string,
+    terminalId: string,
+  ): Promise<TerminalSnapshot> {
+    const key = `${runId}:${terminalId}`;
+    const snap = this.mockTerminalSnapshot.get(key);
+    if (!snap) {
+      throw new Error(`Mock terminal snapshot not found: ${key}`);
+    }
+    return snap;
+  }
+
+  // -- Event streams (deterministic replay) --
+
+  async *events(
+    fromCursor?: { sequence: number; partition: string },
+  ): AsyncIterable<GatewayEnvelope> {
+    let startIdx = 0;
+    if (fromCursor) {
+      // Replay starts AFTER the given cursor (strictly greater).
+      startIdx = this.mockEvents.findIndex(
+        (e) => e.cursor.sequence > fromCursor.sequence,
+      );
+      if (startIdx === -1) startIdx = this.mockEvents.length;
+    }
+
+    for (let i = startIdx; i < this.mockEvents.length; i++) {
+      this.lastEventTimestamp = Date.now();
+      this.reconnectAttemptsCount = 0;
+      yield this.mockEvents[i];
+    }
+  }
+
+  async *terminalFrames(runId: string): AsyncIterable<GatewayEnvelope> {
+    const frames = this.mockTerminalFrames.get(runId) ?? [];
+    for (const frame of frames) {
+      yield frame;
+    }
+  }
+
+  // -- Action mutations --
+
+  async dispatchAction(action: ActionDispatch): Promise<ActionReceipt> {
+    const receipt = this.mockActionReceipts.get(action.correlation_id);
+    if (!receipt) {
+      return {
+        schema_version: { major: 1, minor: 0, patch: 0 },
+        action_id: `mock-action-${Date.now()}`,
+        correlation_id: action.correlation_id,
+        status: "accepted",
+        expected_events: [],
+        issued_at: new Date().toISOString(),
+      };
+    }
+    return receipt;
+  }
+
+  async cancelRun(runId: string): Promise<ActionReceipt> {
+    return this.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: `cancel-${runId}`,
+      action_kind: "cancel",
+      target_entity: { entity_kind: "run", entity_id: runId },
+    });
+  }
+
+  async retryRun(runId: string): Promise<ActionReceipt> {
+    return this.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: `retry-${runId}`,
+      action_kind: "retry",
+      target_entity: { entity_kind: "run", entity_id: runId },
+    });
+  }
+
+  async resumeRun(runId: string): Promise<ActionReceipt> {
+    return this.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: `resume-${runId}`,
+      action_kind: "resume",
+      target_entity: { entity_kind: "run", entity_id: runId },
+    });
+  }
+
+  // -- Lifecycle --
+
+  async close(): Promise<void> {
+    this.closedFlag = true;
+  }
+
+  // -- Stream health diagnostics --
+
+  isStreamHealthy(): boolean {
+    return this.streamHealthyFlag;
+  }
+
+  getReconnectAttempts(): number {
+    return this.reconnectAttemptsCount;
+  }
+
+  // -- Test helpers to modify mock state --
+
+  /** Add an event to the mock event stream. */
+  addEvent(event: GatewayEnvelope): void {
+    this.mockEvents.push(event);
+  }
+
+  /** Add a terminal frame to a mock stream. */
+  addTerminalFrame(runId: string, frame: GatewayEnvelope): void {
+    const frames = this.mockTerminalFrames.get(runId) ?? [];
+    frames.push(frame);
+    this.mockTerminalFrames.set(runId, frames);
+  }
+
+  /** Set a mock action receipt. */
+  setActionReceipt(correlationId: string, receipt: ActionReceipt): void {
+    this.mockActionReceipts.set(correlationId, receipt);
+  }
+
+  /** Update a run detail. */
+  updateRunDetail(run: RunDetail): void {
+    this.mockRunDetail.set(run.run_id, run);
+  }
+
+  /** Set stream health status for testing degraded scenarios. */
+  setStreamHealthy(healthy: boolean): void {
+    this.streamHealthyFlag = healthy;
+  }
+
+  /** Simulate reconnect attempts. */
+  simulateReconnect(attempts: number): void {
+    this.reconnectAttemptsCount = attempts;
+  }
+}

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -175,19 +175,22 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   async *events(
     fromCursor?: { sequence: number; partition: string },
   ): AsyncIterable<GatewayEnvelope> {
+    // Filter events by partition if specified, otherwise replay all.
+    const events = fromCursor?.partition
+      ? this.mockEvents.filter((e) => e.cursor.partition === fromCursor.partition)
+      : this.mockEvents;
+
     let startIdx = 0;
     if (fromCursor) {
       // Replay starts AFTER the given cursor (strictly greater).
-      startIdx = this.mockEvents.findIndex(
-        (e) => e.cursor.sequence > fromCursor.sequence,
-      );
-      if (startIdx === -1) startIdx = this.mockEvents.length;
+      startIdx = events.findIndex((e) => e.cursor.sequence > fromCursor.sequence);
+      if (startIdx === -1) startIdx = events.length;
     }
 
-    for (let i = startIdx; i < this.mockEvents.length; i++) {
+    for (let i = startIdx; i < events.length; i++) {
       this.lastEventTimestamp = Date.now();
       this.reconnectAttemptsCount = 0;
-      yield this.mockEvents[i];
+      yield events[i];
     }
   }
 

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -31,6 +31,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   private streamHealthyFlag = true;
   private lastEventTimestamp: number | null = null;
   private reconnectAttemptsCount = 0;
+  private actionCounter = 0;
 
   constructor(opts?: {
     baseUri?: string;
@@ -109,7 +110,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
 
     this.mockTerminalSnapshot = new Map();
     for (const snap of opts?.terminalSnapshots ?? []) {
-      this.mockTerminalSnapshot.set(snap.terminal_session_id, snap);
+      this.mockTerminalSnapshot.set(`${snap.run_id}:${snap.terminal_session_id}`, snap);
     }
 
     this.mockEvents = opts?.events ?? [];
@@ -206,13 +207,14 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   async dispatchAction(action: ActionDispatch): Promise<ActionReceipt> {
     const receipt = this.mockActionReceipts.get(action.correlation_id);
     if (!receipt) {
+      this.actionCounter++;
       return {
         schema_version: { major: 1, minor: 0, patch: 0 },
-        action_id: `mock-action-${Date.now()}`,
+        action_id: `mock-action-${this.actionCounter}`,
         correlation_id: action.correlation_id,
         status: "accepted",
         expected_events: [],
-        issued_at: new Date().toISOString(),
+        issued_at: new Date(1000000000000 + this.actionCounter).toISOString(),
       };
     }
     return receipt;
@@ -221,7 +223,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   async cancelRun(runId: string): Promise<ActionReceipt> {
     return this.dispatchAction({
       schema_version: { major: 1, minor: 0, patch: 0 },
-      correlation_id: `cancel-${runId}`,
+      correlation_id: `cancel-${runId}-${crypto.randomUUID()}`,
       action_kind: "cancel",
       target_entity: { entity_kind: "run", entity_id: runId },
     });
@@ -230,7 +232,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   async retryRun(runId: string): Promise<ActionReceipt> {
     return this.dispatchAction({
       schema_version: { major: 1, minor: 0, patch: 0 },
-      correlation_id: `retry-${runId}`,
+      correlation_id: `retry-${runId}-${crypto.randomUUID()}`,
       action_kind: "retry",
       target_entity: { entity_kind: "run", entity_id: runId },
     });
@@ -239,7 +241,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   async resumeRun(runId: string): Promise<ActionReceipt> {
     return this.dispatchAction({
       schema_version: { major: 1, minor: 0, patch: 0 },
-      correlation_id: `resume-${runId}`,
+      correlation_id: `resume-${runId}-${crypto.randomUUID()}`,
       action_kind: "resume",
       target_entity: { entity_kind: "run", entity_id: runId },
     });

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -193,7 +193,18 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
     while (!this.closed) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        // Process any remaining buffer content before exiting.
+        if (currentData) {
+          try {
+            const envelope = JSON.parse(currentData) as GatewayEnvelope;
+            yield envelope;
+          } catch (err) {
+            console.error("SSE parse error: malformed JSON event data (trailing buffer)", err);
+          }
+        }
+        break;
+      }
 
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split("\n");
@@ -230,11 +241,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
         } else if (line.startsWith(":")) {
           // SSE comment line, ignore.
         }
-        // Any other line is treated as data continuation.
-        else {
-          if (currentData) currentData += "\n";
-          currentData += line;
-        }
+        // Per SSE spec, unrecognized field names are discarded.
       }
 
       if (currentRetry > 0) {
@@ -259,7 +266,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
   async cancelRun(runId: string): Promise<ActionReceipt> {
     return this.dispatchAction({
       schema_version: { major: 1, minor: 0, patch: 0 },
-      correlation_id: `cancel-${runId}-${Date.now()}`,
+      correlation_id: `cancel-${runId}-${crypto.randomUUID()}`,
       action_kind: "cancel",
       target_entity: { entity_kind: "run", entity_id: runId },
       idempotency_key: `cancel-${runId}`,
@@ -269,7 +276,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
   async retryRun(runId: string): Promise<ActionReceipt> {
     return this.dispatchAction({
       schema_version: { major: 1, minor: 0, patch: 0 },
-      correlation_id: `retry-${runId}-${Date.now()}`,
+      correlation_id: `retry-${runId}-${crypto.randomUUID()}`,
       action_kind: "retry",
       target_entity: { entity_kind: "run", entity_id: runId },
       idempotency_key: `retry-${runId}`,
@@ -279,7 +286,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
   async resumeRun(runId: string): Promise<ActionReceipt> {
     return this.dispatchAction({
       schema_version: { major: 1, minor: 0, patch: 0 },
-      correlation_id: `resume-${runId}-${Date.now()}`,
+      correlation_id: `resume-${runId}-${crypto.randomUUID()}`,
       action_kind: "resume",
       target_entity: { entity_kind: "run", entity_id: runId },
       idempotency_key: `resume-${runId}`,
@@ -324,13 +331,17 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
   }
 
   private async fetchJson(url: string, init?: RequestInit): Promise<unknown> {
-    const requestInit: RequestInit = {
-      ...init,
-      headers: {
-        "Content-Type": "application/json",
-        ...(init?.headers ?? {}),
-      },
+    const method = init?.method ?? "GET";
+    const headers: Record<string, string> = {
+      ...(init?.headers as Record<string, string> ?? {}),
     };
+
+    // Only set Content-Type for requests with a body.
+    if (method !== "GET" && method !== "HEAD") {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const requestInit: RequestInit = { ...init, headers };
     if (this.authToken) {
       requestInit.headers = {
         ...requestInit.headers,

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -6,59 +6,314 @@ import type {
   TerminalSnapshot,
   TaskGraphSnapshot,
   GatewayCapabilities,
+  ActionDispatch,
+  ActionReceipt,
+  PageCursor,
 } from "@opensymphony/gateway-schema";
 import type { GatewayTransport, GatewayTransportConfig } from "./index.js";
 
 /**
- * Placeholder HTTP-based transport adapter.
+ * HTTP-based transport adapter using fetch().
  *
- * Real implementation will use fetch() for REST endpoints and EventSource
- * for SSE streams. This stub satisfies the interface for type-checking
- * and allows downstream packages to depend on api-client without errors.
+ * Supports REST endpoints for snapshots/reads/mutations and SSE
+ * for live event streams. Designed to be the baseline contract
+ * that all other transport adapters must satisfy.
  */
 export class HttpGatewayTransport implements GatewayTransport {
   readonly baseUri: string;
+  private authToken?: string;
+  private eventSource?: EventSource;
+  private eventQueue: GatewayEnvelope[] = [];
+  private eventResolvers: Array<(value: IteratorResult<GatewayEnvelope>) => void> = [];
+  private closed = false;
+  private reconnectAttempts = 0;
+  private maxReconnectAttempts = 5;
+  private reconnectDelayMs = 1000;
+  private lastEventTimestamp: number | null = null;
+  private streamHealthy = true;
+  private readonly streamHealthTimeoutMs = 30_000;
 
   constructor(config: GatewayTransportConfig) {
     this.baseUri = config.baseUri.replace(/\/+$/, "");
+    this.authToken = config.authToken;
   }
 
+  // -- REST reads --
+
   async health(): Promise<GatewayCapabilities> {
-    throw new Error("HttpGatewayTransport.health not yet implemented");
+    const response = await this.fetchJson(`${this.baseUri}/api/v1/health`);
+    return response as GatewayCapabilities;
   }
 
   async snapshot(): Promise<DashboardSnapshot> {
-    throw new Error("HttpGatewayTransport.snapshot not yet implemented");
+    const response = await this.fetchJson(`${this.baseUri}/api/v1/snapshot`);
+    return response as DashboardSnapshot;
   }
 
-  async taskGraph(_projectId: string): Promise<TaskGraphSnapshot> {
-    throw new Error("HttpGatewayTransport.taskGraph not yet implemented");
+  async taskGraph(projectId: string): Promise<TaskGraphSnapshot> {
+    const response = await this.fetchJson(
+      `${this.baseUri}/api/v1/projects/${encodeURIComponent(projectId)}/task-graph`,
+    );
+    return response as TaskGraphSnapshot;
   }
 
-  async runDetail(_runId: string): Promise<RunDetail> {
-    throw new Error("HttpGatewayTransport.runDetail not yet implemented");
+  async runDetail(runId: string): Promise<RunDetail> {
+    const response = await this.fetchJson(
+      `${this.baseUri}/api/v1/runs/${encodeURIComponent(runId)}`,
+    );
+    return response as RunDetail;
   }
 
-  async runEvents(_runId: string): Promise<RunEventPage> {
-    throw new Error("HttpGatewayTransport.runEvents not yet implemented");
+  async runEvents(runId: string, cursor?: PageCursor): Promise<RunEventPage> {
+    const params = new URLSearchParams();
+    if (cursor?.page_token) params.set("page_token", cursor.page_token);
+    params.set("page_size", String(cursor?.page_size ?? 100));
+    const response = await this.fetchJson(
+      `${this.baseUri}/api/v1/runs/${encodeURIComponent(runId)}/events?${params}`,
+    );
+    return response as RunEventPage;
   }
 
   async terminalSnapshot(
-    _runId: string,
-    _terminalId: string,
+    runId: string,
+    terminalId: string,
   ): Promise<TerminalSnapshot> {
-    throw new Error("HttpGatewayTransport.terminalSnapshot not yet implemented");
+    const response = await this.fetchJson(
+      `${this.baseUri}/api/v1/runs/${encodeURIComponent(runId)}/terminals/${encodeURIComponent(terminalId)}/snapshot`,
+    );
+    return response as TerminalSnapshot;
   }
 
-  async *events(): AsyncIterable<GatewayEnvelope> {
-    throw new Error("HttpGatewayTransport.events not yet implemented");
+  // -- Event streams (SSE) --
+
+  async *events(fromCursor?: { sequence: number; partition: string }): AsyncIterable<GatewayEnvelope> {
+    const url = new URL(`${this.baseUri}/api/v1/events`);
+    if (fromCursor) {
+      url.searchParams.set("cursor_sequence", String(fromCursor.sequence));
+      url.searchParams.set("cursor_partition", fromCursor.partition);
+    }
+
+    while (!this.closed) {
+      const response = await fetch(url.toString(), this.buildRequestInit());
+
+      if (!response.ok) {
+        throw new Error(`Event stream failed: ${response.status} ${response.statusText}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("Event stream response has no readable body");
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      try {
+        while (!this.closed) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              try {
+                const envelope = JSON.parse(line.slice(6)) as GatewayEnvelope;
+                this.lastEventTimestamp = Date.now();
+                this.streamHealthy = true;
+                this.reconnectAttempts = 0;
+                yield envelope;
+              } catch {
+                // Malformed event, skip silently.
+              }
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      // Reconnect logic.
+      if (!this.closed) {
+        this.streamHealthy = false;
+        await this.waitForReconnect();
+      }
+    }
   }
 
-  async *terminalFrames(_runId: string): AsyncIterable<GatewayEnvelope> {
-    throw new Error("HttpGatewayTransport.terminalFrames not yet implemented");
+  async *terminalFrames(runId: string): AsyncIterable<GatewayEnvelope> {
+    const url = new URL(
+      `${this.baseUri}/api/v1/runs/${encodeURIComponent(runId)}/terminal/stream`,
+    );
+
+    while (!this.closed) {
+      const response = await fetch(url.toString(), this.buildRequestInit());
+
+      if (!response.ok) {
+        throw new Error(`Terminal stream failed: ${response.status} ${response.statusText}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("Terminal stream response has no readable body");
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      try {
+        while (!this.closed) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              try {
+                const envelope = JSON.parse(line.slice(6)) as GatewayEnvelope;
+                yield envelope;
+              } catch {
+                // Malformed event, skip silently.
+              }
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      if (!this.closed) {
+        await this.waitForReconnect();
+      }
+    }
   }
+
+  // -- Action mutations --
+
+  async dispatchAction(action: ActionDispatch): Promise<ActionReceipt> {
+    const response = await this.fetchJson(
+      `${this.baseUri}/api/v1/actions/dispatch`,
+      {
+        method: "POST",
+        body: JSON.stringify(action),
+      },
+    );
+    return response as ActionReceipt;
+  }
+
+  async cancelRun(runId: string): Promise<ActionReceipt> {
+    return this.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: `cancel-${runId}-${Date.now()}`,
+      action_kind: "cancel",
+      target_entity: { entity_kind: "run", entity_id: runId },
+      idempotency_key: `cancel-${runId}`,
+    });
+  }
+
+  async retryRun(runId: string): Promise<ActionReceipt> {
+    return this.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: `retry-${runId}-${Date.now()}`,
+      action_kind: "retry",
+      target_entity: { entity_kind: "run", entity_id: runId },
+      idempotency_key: `retry-${runId}`,
+    });
+  }
+
+  async resumeRun(runId: string): Promise<ActionReceipt> {
+    return this.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: `resume-${runId}-${Date.now()}`,
+      action_kind: "resume",
+      target_entity: { entity_kind: "run", entity_id: runId },
+      idempotency_key: `resume-${runId}`,
+    });
+  }
+
+  // -- Lifecycle --
 
   async close(): Promise<void> {
-    // No-op for HTTP transport.
+    this.closed = true;
+    this.eventSource?.close();
+    this.eventSource = undefined;
+    // Resolve any pending event consumers.
+    for (const resolver of this.eventResolvers) {
+      resolver({ done: true, value: undefined });
+    }
+    this.eventResolvers = [];
+  }
+
+  // -- Stream health diagnostics --
+
+  /** Whether the stream has received events recently. */
+  isStreamHealthy(): boolean {
+    if (this.lastEventTimestamp === null) return true;
+    return Date.now() - this.lastEventTimestamp < this.streamHealthTimeoutMs;
+  }
+
+  /** Reconnect attempt count since last successful event. */
+  getReconnectAttempts(): number {
+    return this.reconnectAttempts;
+  }
+
+  // -- Private helpers --
+
+  private buildRequestInit(): RequestInit {
+    const init: RequestInit = {
+      headers: {
+        Accept: "text/event-stream",
+      },
+    };
+    if (this.authToken) {
+      init.headers = {
+        ...init.headers,
+        Authorization: `Bearer ${this.authToken}`,
+      };
+    }
+    return init;
+  }
+
+  private async fetchJson(url: string, init?: RequestInit): Promise<unknown> {
+    const requestInit: RequestInit = {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    };
+    if (this.authToken) {
+      requestInit.headers = {
+        ...requestInit.headers,
+        Authorization: `Bearer ${this.authToken}`,
+      };
+    }
+
+    const response = await fetch(url, requestInit);
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `HTTP ${response.status} ${response.statusText}: ${body}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  private async waitForReconnect(): Promise<void> {
+    this.reconnectAttempts++;
+    if (this.reconnectAttempts > this.maxReconnectAttempts) {
+      throw new Error(
+        `Max reconnect attempts (${this.maxReconnectAttempts}) reached`,
+      );
+    }
+    const delay = this.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1);
+    await new Promise((resolve) => setTimeout(resolve, delay));
   }
 }

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -163,6 +163,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
             shouldReconnect = true;
           } else {
             for await (const envelope of this.parseSSE(reader)) {
+              this.lastEventTimestamp = Date.now();
               yield envelope;
             }
           }

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -10,7 +10,7 @@ import type {
   ActionReceipt,
   PageCursor,
 } from "@opensymphony/gateway-schema";
-import type { GatewayTransport, GatewayTransportConfig } from "./index.js";
+import type { GatewayTransport, GatewayTransportConfig, ActionCapableTransport } from "./index.js";
 
 /**
  * HTTP-based transport adapter using fetch().
@@ -19,12 +19,9 @@ import type { GatewayTransport, GatewayTransportConfig } from "./index.js";
  * for live event streams. Designed to be the baseline contract
  * that all other transport adapters must satisfy.
  */
-export class HttpGatewayTransport implements GatewayTransport {
+export class HttpGatewayTransport implements GatewayTransport, ActionCapableTransport {
   readonly baseUri: string;
   private authToken?: string;
-  private eventSource?: EventSource;
-  private eventQueue: GatewayEnvelope[] = [];
-  private eventResolvers: Array<(value: IteratorResult<GatewayEnvelope>) => void> = [];
   private closed = false;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
@@ -32,6 +29,7 @@ export class HttpGatewayTransport implements GatewayTransport {
   private lastEventTimestamp: number | null = null;
   private streamHealthy = true;
   private readonly streamHealthTimeoutMs = 30_000;
+  private abortController: AbortController | null = null;
 
   constructor(config: GatewayTransportConfig) {
     this.baseUri = config.baseUri.replace(/\/+$/, "");
@@ -94,7 +92,12 @@ export class HttpGatewayTransport implements GatewayTransport {
     }
 
     while (!this.closed) {
-      const response = await fetch(url.toString(), this.buildRequestInit());
+      const controller = new AbortController();
+      this.abortController = controller;
+      const response = await fetch(url.toString(), {
+        ...this.buildRequestInit(),
+        signal: controller.signal,
+      });
 
       if (!response.ok) {
         throw new Error(`Event stream failed: ${response.status} ${response.statusText}`);
@@ -105,31 +108,12 @@ export class HttpGatewayTransport implements GatewayTransport {
         throw new Error("Event stream response has no readable body");
       }
 
-      const decoder = new TextDecoder();
-      let buffer = "";
-
       try {
-        while (!this.closed) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              try {
-                const envelope = JSON.parse(line.slice(6)) as GatewayEnvelope;
-                this.lastEventTimestamp = Date.now();
-                this.streamHealthy = true;
-                this.reconnectAttempts = 0;
-                yield envelope;
-              } catch {
-                // Malformed event, skip silently.
-              }
-            }
-          }
+        for await (const envelope of this.parseSSE(reader)) {
+          this.lastEventTimestamp = Date.now();
+          this.streamHealthy = true;
+          this.reconnectAttempts = 0;
+          yield envelope;
         }
       } finally {
         reader.releaseLock();
@@ -149,7 +133,12 @@ export class HttpGatewayTransport implements GatewayTransport {
     );
 
     while (!this.closed) {
-      const response = await fetch(url.toString(), this.buildRequestInit());
+      const controller = new AbortController();
+      this.abortController = controller;
+      const response = await fetch(url.toString(), {
+        ...this.buildRequestInit(),
+        signal: controller.signal,
+      });
 
       if (!response.ok) {
         throw new Error(`Terminal stream failed: ${response.status} ${response.statusText}`);
@@ -160,35 +149,77 @@ export class HttpGatewayTransport implements GatewayTransport {
         throw new Error("Terminal stream response has no readable body");
       }
 
-      const decoder = new TextDecoder();
-      let buffer = "";
-
       try {
-        while (!this.closed) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              try {
-                const envelope = JSON.parse(line.slice(6)) as GatewayEnvelope;
-                yield envelope;
-              } catch {
-                // Malformed event, skip silently.
-              }
-            }
-          }
-        }
+        yield* this.parseSSE(reader);
       } finally {
         reader.releaseLock();
       }
 
       if (!this.closed) {
         await this.waitForReconnect();
+      }
+    }
+  }
+
+  /** Parse an SSE stream into GatewayEnvelope objects. */
+  private async *parseSSE(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+  ): AsyncIterable<GatewayEnvelope> {
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let currentEvent = "";
+    let currentId = "";
+    let currentRetry = 0;
+    let currentData = "";
+
+    while (!this.closed) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        // Empty line = end of event block.
+        if (line === "") {
+          if (currentData) {
+            try {
+              const envelope = JSON.parse(currentData) as GatewayEnvelope;
+              yield envelope;
+            } catch (err) {
+              console.error("SSE parse error: malformed JSON event data", err);
+            }
+            currentEvent = "";
+            currentId = "";
+            currentRetry = 0;
+            currentData = "";
+          }
+          continue;
+        }
+
+        if (line.startsWith("event: ")) {
+          currentEvent = line.slice(7);
+        } else if (line.startsWith("id: ")) {
+          currentId = line.slice(4);
+        } else if (line.startsWith("retry: ")) {
+          currentRetry = parseInt(line.slice(7), 10) || 0;
+        } else if (line.startsWith("data: ")) {
+          // Multi-line data: append with newline.
+          if (currentData) currentData += "\n";
+          currentData += line.slice(6);
+        } else if (line.startsWith(":")) {
+          // SSE comment line, ignore.
+        }
+        // Any other line is treated as data continuation.
+        else {
+          if (currentData) currentData += "\n";
+          currentData += line;
+        }
+      }
+
+      if (currentRetry > 0) {
+        this.reconnectDelayMs = currentRetry;
       }
     }
   }
@@ -240,13 +271,7 @@ export class HttpGatewayTransport implements GatewayTransport {
 
   async close(): Promise<void> {
     this.closed = true;
-    this.eventSource?.close();
-    this.eventSource = undefined;
-    // Resolve any pending event consumers.
-    for (const resolver of this.eventResolvers) {
-      resolver({ done: true, value: undefined });
-    }
-    this.eventResolvers = [];
+    this.abortController?.abort();
   }
 
   // -- Stream health diagnostics --

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -90,58 +90,18 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
       url.searchParams.set("cursor_sequence", String(fromCursor.sequence));
       url.searchParams.set("cursor_partition", fromCursor.partition);
     }
-
-    while (!this.closed) {
-      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-      let shouldReconnect = false;
-      try {
-        const controller = new AbortController();
-        this.abortController = controller;
-        const response = await fetch(url.toString(), {
-          ...this.buildRequestInit(),
-          signal: controller.signal,
-        });
-
-        if (!response.ok) {
-          console.error(`Event stream HTTP error: ${response.status} ${response.statusText}`);
-          shouldReconnect = true;
-        } else {
-          reader = response.body?.getReader() ?? null;
-          if (!reader) {
-            console.error("Event stream response has no readable body");
-            shouldReconnect = true;
-          } else {
-            for await (const envelope of this.parseSSE(reader)) {
-              this.lastEventTimestamp = Date.now();
-              this.streamHealthy = true;
-              this.reconnectAttempts = 0;
-              yield envelope;
-            }
-          }
-        }
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") {
-          break; // Intentional close.
-        }
-        console.error("Event stream fetch/parse error:", err);
-        shouldReconnect = true;
-      } finally {
-        reader?.releaseLock();
-      }
-
-      // Reconnect logic.
-      if (!this.closed && shouldReconnect) {
-        this.streamHealthy = false;
-        await this.waitForReconnect();
-      }
-    }
+    yield* this.streamEvents(url);
   }
 
   async *terminalFrames(runId: string): AsyncIterable<GatewayEnvelope> {
     const url = new URL(
       `${this.baseUri}/api/v1/runs/${encodeURIComponent(runId)}/terminal/stream`,
     );
+    yield* this.streamEvents(url);
+  }
 
+  /** Shared SSE stream handler with reconnect logic. */
+  private async *streamEvents(url: URL): AsyncIterable<GatewayEnvelope> {
     while (!this.closed) {
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
       let shouldReconnect = false;
@@ -154,12 +114,12 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
         });
 
         if (!response.ok) {
-          console.error(`Terminal stream HTTP error: ${response.status} ${response.statusText}`);
+          console.error(`Stream HTTP error: ${response.status} ${response.statusText}`);
           shouldReconnect = true;
         } else {
           reader = response.body?.getReader() ?? null;
           if (!reader) {
-            console.error("Terminal stream response has no readable body");
+            console.error("Stream response has no readable body");
             shouldReconnect = true;
           } else {
             for await (const envelope of this.parseSSE(reader)) {
@@ -174,7 +134,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
         if (err instanceof DOMException && err.name === "AbortError") {
           break; // Intentional close.
         }
-        console.error("Terminal stream fetch/parse error:", err);
+        console.error("Stream fetch/parse error:", err);
         shouldReconnect = true;
       } finally {
         reader?.releaseLock();
@@ -182,7 +142,6 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
       if (!this.closed && shouldReconnect) {
         this.streamHealthy = false;
-        this.reconnectAttempts = 0;
         await this.waitForReconnect();
       }
     }

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -92,31 +92,40 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
     }
 
     while (!this.closed) {
-      const controller = new AbortController();
-      this.abortController = controller;
-      const response = await fetch(url.toString(), {
-        ...this.buildRequestInit(),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new Error(`Event stream failed: ${response.status} ${response.statusText}`);
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error("Event stream response has no readable body");
-      }
-
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
       try {
+        const controller = new AbortController();
+        this.abortController = controller;
+        const response = await fetch(url.toString(), {
+          ...this.buildRequestInit(),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          console.error(`Event stream HTTP error: ${response.status} ${response.statusText}`);
+          break; // Exit inner try, will hit reconnect below.
+        }
+
+        reader = response.body?.getReader() ?? null;
+        if (!reader) {
+          console.error("Event stream response has no readable body");
+          break;
+        }
+
         for await (const envelope of this.parseSSE(reader)) {
           this.lastEventTimestamp = Date.now();
           this.streamHealthy = true;
           this.reconnectAttempts = 0;
           yield envelope;
         }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          break; // Intentional close.
+        }
+        console.error("Event stream fetch/parse error:", err);
+        // Fall through to reconnect.
       } finally {
-        reader.releaseLock();
+        reader?.releaseLock();
       }
 
       // Reconnect logic.
@@ -133,26 +142,36 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
     );
 
     while (!this.closed) {
-      const controller = new AbortController();
-      this.abortController = controller;
-      const response = await fetch(url.toString(), {
-        ...this.buildRequestInit(),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new Error(`Terminal stream failed: ${response.status} ${response.statusText}`);
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error("Terminal stream response has no readable body");
-      }
-
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
       try {
-        yield* this.parseSSE(reader);
+        const controller = new AbortController();
+        this.abortController = controller;
+        const response = await fetch(url.toString(), {
+          ...this.buildRequestInit(),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          console.error(`Terminal stream HTTP error: ${response.status} ${response.statusText}`);
+          break;
+        }
+
+        reader = response.body?.getReader() ?? null;
+        if (!reader) {
+          console.error("Terminal stream response has no readable body");
+          break;
+        }
+
+        for await (const envelope of this.parseSSE(reader)) {
+          yield envelope;
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          break;
+        }
+        console.error("Terminal stream fetch/parse error:", err);
       } finally {
-        reader.releaseLock();
+        reader?.releaseLock();
       }
 
       if (!this.closed) {

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -93,6 +93,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
     while (!this.closed) {
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+      let shouldReconnect = false;
       try {
         const controller = new AbortController();
         this.abortController = controller;
@@ -103,33 +104,33 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
         if (!response.ok) {
           console.error(`Event stream HTTP error: ${response.status} ${response.statusText}`);
-          break; // Exit inner try, will hit reconnect below.
-        }
-
-        reader = response.body?.getReader() ?? null;
-        if (!reader) {
-          console.error("Event stream response has no readable body");
-          break;
-        }
-
-        for await (const envelope of this.parseSSE(reader)) {
-          this.lastEventTimestamp = Date.now();
-          this.streamHealthy = true;
-          this.reconnectAttempts = 0;
-          yield envelope;
+          shouldReconnect = true;
+        } else {
+          reader = response.body?.getReader() ?? null;
+          if (!reader) {
+            console.error("Event stream response has no readable body");
+            shouldReconnect = true;
+          } else {
+            for await (const envelope of this.parseSSE(reader)) {
+              this.lastEventTimestamp = Date.now();
+              this.streamHealthy = true;
+              this.reconnectAttempts = 0;
+              yield envelope;
+            }
+          }
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
           break; // Intentional close.
         }
         console.error("Event stream fetch/parse error:", err);
-        // Fall through to reconnect.
+        shouldReconnect = true;
       } finally {
         reader?.releaseLock();
       }
 
       // Reconnect logic.
-      if (!this.closed) {
+      if (!this.closed && shouldReconnect) {
         this.streamHealthy = false;
         await this.waitForReconnect();
       }
@@ -143,6 +144,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
     while (!this.closed) {
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+      let shouldReconnect = false;
       try {
         const controller = new AbortController();
         this.abortController = controller;
@@ -153,28 +155,29 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
         if (!response.ok) {
           console.error(`Terminal stream HTTP error: ${response.status} ${response.statusText}`);
-          break;
-        }
-
-        reader = response.body?.getReader() ?? null;
-        if (!reader) {
-          console.error("Terminal stream response has no readable body");
-          break;
-        }
-
-        for await (const envelope of this.parseSSE(reader)) {
-          yield envelope;
+          shouldReconnect = true;
+        } else {
+          reader = response.body?.getReader() ?? null;
+          if (!reader) {
+            console.error("Terminal stream response has no readable body");
+            shouldReconnect = true;
+          } else {
+            for await (const envelope of this.parseSSE(reader)) {
+              yield envelope;
+            }
+          }
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
-          break;
+          break; // Intentional close.
         }
         console.error("Terminal stream fetch/parse error:", err);
+        shouldReconnect = true;
       } finally {
         reader?.releaseLock();
       }
 
-      if (!this.closed) {
+      if (!this.closed && shouldReconnect) {
         await this.waitForReconnect();
       }
     }

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -164,6 +164,8 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
           } else {
             for await (const envelope of this.parseSSE(reader)) {
               this.lastEventTimestamp = Date.now();
+              this.streamHealthy = true;
+              this.reconnectAttempts = 0;
               yield envelope;
             }
           }
@@ -179,6 +181,8 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
       }
 
       if (!this.closed && shouldReconnect) {
+        this.streamHealthy = false;
+        this.reconnectAttempts = 0;
         await this.waitForReconnect();
       }
     }
@@ -199,12 +203,44 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
       const { done, value } = await reader.read();
       if (done) {
         // Process any remaining buffer content before exiting.
+        // First, flush any accumulated currentData.
         if (currentData) {
           try {
             const envelope = JSON.parse(currentData) as GatewayEnvelope;
             yield envelope;
           } catch (err) {
             console.error("SSE parse error: malformed JSON event data (trailing buffer)", err);
+          }
+        }
+        // Also process any remaining buffer that might contain a partial event.
+        if (buffer.trim()) {
+          // Treat remaining buffer as potential data if it doesn't start with a field prefix.
+          const remainingLines = buffer.trim().split("\n");
+          let pendingData = "";
+          for (const line of remainingLines) {
+            if (line.startsWith("data: ")) {
+              pendingData += (pendingData ? "\n" : "") + line.slice(6);
+            } else if (line === "") {
+              // Empty line marks event boundary.
+              if (pendingData) {
+                try {
+                  const envelope = JSON.parse(pendingData) as GatewayEnvelope;
+                  yield envelope;
+                } catch (err) {
+                  console.error("SSE parse error: malformed JSON event data (buffer flush)", err);
+                }
+                pendingData = "";
+              }
+            }
+          }
+          // Flush any remaining pending data.
+          if (pendingData) {
+            try {
+              const envelope = JSON.parse(pendingData) as GatewayEnvelope;
+              yield envelope;
+            } catch (err) {
+              console.error("SSE parse error: malformed JSON event data (final buffer)", err);
+            }
           }
         }
         break;
@@ -367,7 +403,7 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
   private async waitForReconnect(): Promise<void> {
     this.reconnectAttempts++;
-    if (this.reconnectAttempts > this.maxReconnectAttempts) {
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       throw new Error(
         `Max reconnect attempts (${this.maxReconnectAttempts}) reached`,
       );

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -222,7 +222,8 @@ describe("snapshot + stream replay rebuilds state", () => {
 
     expect(state.run.runs.has("run-1")).toBe(true);
     const liveness = state.run.liveness.get("run-1");
-    expect(liveness?.eventCount).toBe(3);
+    // eventCount is not incremented by RUN_EVENTS_RECEIVED anymore — liveness tracks recency, not count.
+    expect(liveness?.eventCount).toBe(0);
   });
 
   it("rebuilds terminal state via TERMINAL_FRAMES_RECEIVED", async () => {
@@ -594,7 +595,8 @@ describe("long-running run state rebuild without live socket", () => {
     // Verify state rebuild.
     expect(state.run.runs.get("run-long-1")?.status).toBe("running");
     const liveness = state.run.liveness.get("run-long-1");
-    expect(liveness?.eventCount).toBe(5);
+    // eventCount is preserved from existing liveness, not incremented by envelope replay.
+    expect(liveness?.eventCount).toBe(0);
     expect(state.cache.runs.has("run-long-1")).toBe(true);
   });
 

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -789,7 +789,7 @@ describe("cancelled and retry_queued run states", () => {
 
 describe("all run phase states", () => {
   it("active: running with fresh events", () => {
-    expect(deriveRunPhaseState("running", {
+    expect(deriveRunPhaseState({ status: "running" } as any, {
       runId: "r",
       phaseState: "active",
       lastEventAt: null,
@@ -802,7 +802,7 @@ describe("all run phase states", () => {
   });
 
   it("quiet: running with no recent events", () => {
-    expect(deriveRunPhaseState("running", {
+    expect(deriveRunPhaseState({ status: "running" } as any, {
       runId: "r",
       phaseState: "quiet",
       lastEventAt: null,
@@ -815,11 +815,11 @@ describe("all run phase states", () => {
   });
 
   it("degraded: stale stream but run alive", () => {
-    expect(deriveRunPhaseState("running", undefined, true)).toBe("degraded");
+    expect(deriveRunPhaseState({ status: "running" } as any, undefined, true)).toBe("degraded");
   });
 
   it("stalled: no events for extended period", () => {
-    expect(deriveRunPhaseState("running", {
+    expect(deriveRunPhaseState({ status: "running" } as any, {
       runId: "r",
       phaseState: "stalled",
       lastEventAt: null,
@@ -832,15 +832,15 @@ describe("all run phase states", () => {
   });
 
   it("retry_queued: run queued for retry", () => {
-    expect(deriveRunPhaseState("retry_queued", undefined, false)).toBe("retry_queued");
+    expect(deriveRunPhaseState({ status: "retry_queued" } as any, undefined, false)).toBe("retry_queued");
   });
 
   it("cancelled: run released", () => {
-    expect(deriveRunPhaseState("released", undefined, false)).toBe("cancelled");
+    expect(deriveRunPhaseState({ status: "released" } as any, undefined, false)).toBe("cancelled");
   });
 
   it("detached: long gap with stale stream", () => {
-    expect(deriveRunPhaseState("running", {
+    expect(deriveRunPhaseState({ status: "running" } as any, {
       runId: "r",
       phaseState: "detached",
       lastEventAt: null,

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -381,18 +381,14 @@ describe("stale stream handling", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
       payload: makeRunDetail("run-1", "running"),
+      nowMs: baseTime,
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
       runId: "run-1",
       events: [makeRunEvent(1)],
+      nowMs: baseTime,
     });
-
-    // Force lastEventAt to a known time.
-    const liveness = state.run.liveness.get("run-1");
-    if (liveness) {
-      liveness.lastEventAt = new Date(baseTime).toISOString();
-    }
 
     // 35 seconds -> degraded.
     state = gatewayReducer(state, {
@@ -672,18 +668,15 @@ describe("degraded stream handling", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
       payload: makeRunDetail("run-1", "running"),
+      nowMs: baseTime,
     });
 
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
       runId: "run-1",
       events: [makeRunEvent(1)],
+      nowMs: baseTime,
     });
-
-    const liveness = state.run.liveness.get("run-1");
-    if (liveness) {
-      liveness.lastEventAt = new Date(baseTime).toISOString();
-    }
 
     // 45 seconds gap -> degraded.
     state = gatewayReducer(state, {

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -29,6 +29,9 @@ import type {
   ActionReceipt,
 } from "@opensymphony/gateway-schema";
 
+/** Deterministic timestamp used by all test actions. */
+const NOW = 1_700_000_000_000;
+
 // -- Fixture factories --
 
 function makeDashboardSnapshot(seq: number): DashboardSnapshot {
@@ -71,7 +74,7 @@ function makeTaskGraphSnapshot(seq: number): TaskGraphSnapshot {
         identifier: "COE-390",
         kind: "issue" as const,
         title: "Gateway schemas",
-        state_category: "completed" as const,
+        state_category: "done" as const,
         children: [],
         blocked_by: [],
         labels: ["gateway"],
@@ -163,6 +166,7 @@ describe("snapshot + stream replay rebuilds state", () => {
     const snapshot = await transport.snapshot();
     let state = gatewayReducer(initialState, {
       type: "SNAPSHOT_RECEIVED",
+      nowMs: NOW,
       payload: snapshot,
     });
     expect(state.dashboard.snapshot).toBeTruthy();
@@ -171,6 +175,7 @@ describe("snapshot + stream replay rebuilds state", () => {
     const taskGraph = await transport.taskGraph("proj-1");
     state = gatewayReducer(state, {
       type: "TASK_GRAPH_RECEIVED",
+      nowMs: NOW,
       payload: taskGraph,
     });
     expect(state.taskGraph.nodes.size).toBe(1);
@@ -203,12 +208,14 @@ describe("snapshot + stream replay rebuilds state", () => {
     const runDetail = await transport.runDetail("run-1");
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: runDetail,
     });
 
     const runEventsPage = await transport.runEvents("run-1");
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: runEventsPage.events,
     });
@@ -252,11 +259,13 @@ describe("fixture replay handles out-of-order and duplicates", () => {
     // Receive frames 3, 1, 4, 2 (out of order).
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeTerminalFrame("run-1", 3), makeTerminalFrame("run-1", 1)],
     });
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeTerminalFrame("run-1", 4), makeTerminalFrame("run-1", 2)],
     });
@@ -272,12 +281,14 @@ describe("fixture replay handles out-of-order and duplicates", () => {
     // First batch.
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeTerminalFrame("run-1", 1), makeTerminalFrame("run-1", 2)],
     });
     // Replay same batch (should dedup).
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeTerminalFrame("run-1", 1), makeTerminalFrame("run-1", 2)],
     });
@@ -335,12 +346,14 @@ describe("stale stream handling", () => {
   it("stale stream state does not collapse into failed run state", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "running"),
     });
 
     // Simulate staleness.
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
 
@@ -355,11 +368,13 @@ describe("stale stream handling", () => {
   it("stale stream recovery does not affect cancelled runs", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "released"),
     });
 
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
 
@@ -370,6 +385,7 @@ describe("stale stream handling", () => {
     // Recovery should not override cancelled state.
     state = gatewayReducer(state, {
       type: "STREAM_RECOVERED",
+      nowMs: NOW,
       runId: "run-1",
     });
     const recoveredLiveness = state.run.liveness.get("run-1");
@@ -380,11 +396,13 @@ describe("stale stream handling", () => {
     const baseTime = 1_700_000_000_000;
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "running"),
       nowMs: baseTime,
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
       nowMs: baseTime,
@@ -393,6 +411,7 @@ describe("stale stream handling", () => {
     // 35 seconds -> degraded.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 35_000,
     });
@@ -401,6 +420,7 @@ describe("stale stream handling", () => {
     // 95 seconds -> stalled.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 95_000,
     });
@@ -409,6 +429,7 @@ describe("stale stream handling", () => {
     // 155 seconds -> detached.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 155_000,
     });
@@ -422,6 +443,7 @@ describe("action receipts and correlated events", () => {
   it("ACTION_DISPATCHED tracks pending action", () => {
     const state = gatewayReducer(initialState, {
       type: "ACTION_DISPATCHED",
+      nowMs: NOW,
       correlationId: "corr-dispatch-1",
     });
     expect(state.actionReceipts.pending.has("corr-dispatch-1")).toBe(true);
@@ -432,12 +454,14 @@ describe("action receipts and correlated events", () => {
   it("ACTION_RECEIPT_RECEIVED correlates with dispatched action", () => {
     let state = gatewayReducer(initialState, {
       type: "ACTION_DISPATCHED",
+      nowMs: NOW,
       correlationId: "corr-1",
     });
 
     const receipt = makeActionReceipt("corr-1", "completed");
     state = gatewayReducer(state, {
       type: "ACTION_RECEIPT_RECEIVED",
+      nowMs: NOW,
       receipt,
     });
 
@@ -470,21 +494,21 @@ describe("action receipts and correlated events", () => {
   it("mock cancelRun returns receipt", async () => {
     const transport = new MockGatewayTransport();
     const receipt = await transport.cancelRun("run-1");
-    expect(receipt.correlation_id).toBe("cancel-run-1");
+    expect(receipt.correlation_id).toMatch(/^cancel-run-1-/);
     expect(receipt.status).toBe("accepted");
   });
 
   it("mock retryRun returns receipt", async () => {
     const transport = new MockGatewayTransport();
     const receipt = await transport.retryRun("run-1");
-    expect(receipt.correlation_id).toBe("retry-run-1");
+    expect(receipt.correlation_id).toMatch(/^retry-run-1-/);
     expect(receipt.status).toBe("accepted");
   });
 
   it("mock resumeRun returns receipt", async () => {
     const transport = new MockGatewayTransport();
     const receipt = await transport.resumeRun("run-1");
-    expect(receipt.correlation_id).toBe("resume-run-1");
+    expect(receipt.correlation_id).toMatch(/^resume-run-1-/);
     expect(receipt.status).toBe("accepted");
   });
 });
@@ -504,17 +528,20 @@ describe("transport adapter state parity", () => {
 
     // Snapshot.
     const snapshot = await transport.snapshot();
-    state = gatewayReducer(state, { type: "SNAPSHOT_RECEIVED", payload: snapshot });
+    state = gatewayReducer(state, { type: "SNAPSHOT_RECEIVED",
+      nowMs: NOW, payload: snapshot });
     expect(state.dashboard.snapshot?.sequence).toBe(1);
 
     // Task graph.
     const tg = await transport.taskGraph("proj-1");
-    state = gatewayReducer(state, { type: "TASK_GRAPH_RECEIVED", payload: tg });
+    state = gatewayReducer(state, { type: "TASK_GRAPH_RECEIVED",
+      nowMs: NOW, payload: tg });
     expect(state.taskGraph.nodes.size).toBe(1);
 
     // Run detail.
     const run = await transport.runDetail("run-1");
-    state = gatewayReducer(state, { type: "RUN_UPDATED", payload: run });
+    state = gatewayReducer(state, { type: "RUN_UPDATED",
+      nowMs: NOW, payload: run });
     expect(state.run.runs.has("run-1")).toBe(true);
   });
 });
@@ -549,12 +576,14 @@ describe("long-running run state rebuild without live socket", () => {
 
     // Step 1: Load run snapshot.
     const run = await transport.runDetail("run-long-1");
-    state = gatewayReducer(state, { type: "RUN_UPDATED", payload: run });
+    state = gatewayReducer(state, { type: "RUN_UPDATED",
+      nowMs: NOW, payload: run });
 
     // Step 2: Load run events.
     const eventsPage = await transport.runEvents("run-long-1");
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-long-1",
       events: eventsPage.events,
     });
@@ -582,11 +611,13 @@ describe("long-running run state rebuild without live socket", () => {
 
     let state = initialState;
     const run = await transport.runDetail("run-detached");
-    state = gatewayReducer(state, { type: "RUN_UPDATED", payload: run });
+    state = gatewayReducer(state, { type: "RUN_UPDATED",
+      nowMs: NOW, payload: run });
 
     // Simulate staleness detection (no socket events arriving).
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-detached",
     });
 
@@ -594,6 +625,7 @@ describe("long-running run state rebuild without live socket", () => {
     const baseTime = 1_700_000_000_000;
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-detached",
       nowMs: baseTime + 160_000,
     });
@@ -631,12 +663,14 @@ describe("reconnect behavior", () => {
   it("reducer handles reconnect state transitions", () => {
     let state = gatewayReducer(initialState, {
       type: "CONNECTION_STATE_CHANGED",
+      nowMs: NOW,
       state: "connecting",
     });
     expect(state.connection.state).toBe("connecting");
 
     state = gatewayReducer(state, {
       type: "CONNECTION_STATE_CHANGED",
+      nowMs: NOW,
       state: "connected",
     });
     expect(state.connection.state).toBe("connected");
@@ -667,12 +701,14 @@ describe("degraded stream handling", () => {
     const baseTime = 1_700_000_000_000;
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "running"),
       nowMs: baseTime,
     });
 
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
       nowMs: baseTime,
@@ -681,6 +717,7 @@ describe("degraded stream handling", () => {
     // 45 seconds gap -> degraded.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 45_000,
     });
@@ -709,12 +746,14 @@ describe("cancelled and retry_queued run states", () => {
   it("retry_queued run status maps correctly", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "retry_queued"),
     });
 
     // Even without events, retry_queued status should be recognized.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: Date.now(),
     });
@@ -725,11 +764,13 @@ describe("cancelled and retry_queued run states", () => {
   it("released (cancelled) run status maps correctly", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "released"),
     });
 
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: Date.now(),
     });
@@ -740,11 +781,13 @@ describe("cancelled and retry_queued run states", () => {
   it("cancelled run does not transition to other phases on stale detection", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail("run-1", "released"),
     });
 
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
 

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -222,8 +222,8 @@ describe("snapshot + stream replay rebuilds state", () => {
 
     expect(state.run.runs.has("run-1")).toBe(true);
     const liveness = state.run.liveness.get("run-1");
-    // eventCount is not incremented by RUN_EVENTS_RECEIVED anymore — liveness tracks recency, not count.
-    expect(liveness?.eventCount).toBe(0);
+    // eventCount is incremented by RUN_EVENTS_RECEIVED via computeLivenessState.
+    expect(liveness?.eventCount).toBe(3);
   });
 
   it("rebuilds terminal state via TERMINAL_FRAMES_RECEIVED", async () => {
@@ -595,8 +595,8 @@ describe("long-running run state rebuild without live socket", () => {
     // Verify state rebuild.
     expect(state.run.runs.get("run-long-1")?.status).toBe("running");
     const liveness = state.run.liveness.get("run-long-1");
-    // eventCount is preserved from existing liveness, not incremented by envelope replay.
-    expect(liveness?.eventCount).toBe(0);
+    // eventCount is incremented by RUN_EVENTS_RECEIVED via computeLivenessState.
+    expect(liveness?.eventCount).toBe(5);
     expect(state.cache.runs.has("run-long-1")).toBe(true);
   });
 

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -673,9 +673,11 @@ describe("reconnect behavior", () => {
     state = gatewayReducer(state, {
       type: "RECONNECT_ATTEMPTED",
       attempts: 1,
+      nowMs: NOW,
     });
     expect(state.connection.reconnectAttempts).toBe(1);
     expect(state.connection.state).toBe("reconnecting");
+    expect(state.connection.lastDisconnectedAt).toBeTruthy();
   });
 
   it("reducer handles connection failure", () => {
@@ -839,7 +841,7 @@ describe("all run phase states", () => {
     expect(deriveRunPhaseState({ status: "released" } as any, undefined, false)).toBe("cancelled");
   });
 
-  it("detached: long gap with stale stream", () => {
+  it("stale stream overrides detached liveness to degraded", () => {
     expect(deriveRunPhaseState({ status: "running" } as any, {
       runId: "r",
       phaseState: "detached",

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -396,13 +396,11 @@ describe("stale stream handling", () => {
     const baseTime = 1_700_000_000_000;
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
-      nowMs: NOW,
       payload: makeRunDetail("run-1", "running"),
       nowMs: baseTime,
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
-      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
       nowMs: baseTime,
@@ -411,7 +409,6 @@ describe("stale stream handling", () => {
     // 35 seconds -> degraded.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 35_000,
     });
@@ -420,7 +417,6 @@ describe("stale stream handling", () => {
     // 95 seconds -> stalled.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 95_000,
     });
@@ -429,7 +425,6 @@ describe("stale stream handling", () => {
     // 155 seconds -> detached.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 155_000,
     });
@@ -625,7 +620,6 @@ describe("long-running run state rebuild without live socket", () => {
     const baseTime = 1_700_000_000_000;
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-detached",
       nowMs: baseTime + 160_000,
     });
@@ -701,14 +695,12 @@ describe("degraded stream handling", () => {
     const baseTime = 1_700_000_000_000;
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
-      nowMs: NOW,
       payload: makeRunDetail("run-1", "running"),
       nowMs: baseTime,
     });
 
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
-      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
       nowMs: baseTime,
@@ -717,7 +709,6 @@ describe("degraded stream handling", () => {
     // 45 seconds gap -> degraded.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 45_000,
     });
@@ -755,7 +746,6 @@ describe("cancelled and retry_queued run states", () => {
       type: "STREAM_HEALTH_CHECK",
       nowMs: NOW,
       runId: "run-1",
-      nowMs: Date.now(),
     });
 
     expect(state.run.liveness.get("run-1")?.phaseState).toBe("retry_queued");
@@ -772,7 +762,6 @@ describe("cancelled and retry_queued run states", () => {
       type: "STREAM_HEALTH_CHECK",
       nowMs: NOW,
       runId: "run-1",
-      nowMs: Date.now(),
     });
 
     expect(state.run.liveness.get("run-1")?.phaseState).toBe("cancelled");

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -1,0 +1,829 @@
+/**
+ * Fixture replay tests for transports and reducers.
+ *
+ * These tests replay deterministic event sequences to verify:
+ * - Out-of-order event handling
+ * - Duplicate event deduplication
+ * - Reconnect behavior
+ * - Stale-stream recovery
+ * - All transport adapters reduce to the same state transitions
+ * - Long-running run state rebuild without live socket
+ * - Stale stream state does not collapse into failed run state
+ */
+
+import {
+  gatewayReducer,
+  initialState,
+  deriveRunPhaseState,
+  computeLivenessState,
+  LIVENESS_THRESHOLDS,
+} from "@opensymphony/state";
+import { MockGatewayTransport } from "@opensymphony/api-client";
+import type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  TaskGraphSnapshot,
+  RunDetail,
+  TerminalFrame,
+  RunEvent,
+  ActionReceipt,
+} from "@opensymphony/gateway-schema";
+
+// -- Fixture factories --
+
+function makeDashboardSnapshot(seq: number): DashboardSnapshot {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    generated_at: "2025-01-01T00:00:00Z",
+    sequence: seq,
+    health: "healthy",
+    metrics: {
+      running_issue_count: 2,
+      retry_queue_depth: 0,
+      total_input_tokens: 1024,
+      total_output_tokens: 512,
+      total_cache_read_tokens: 256,
+      total_cost_micros: 0,
+    },
+    projects: [
+      {
+        project_id: "proj-1",
+        name: "OpenSymphony",
+        milestone_count: 3,
+        issue_count: 12,
+        running_count: 2,
+        completed_count: 5,
+        failed_count: 0,
+      },
+    ],
+    recent_events: [],
+  };
+}
+
+function makeTaskGraphSnapshot(seq: number): TaskGraphSnapshot {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    project_id: "proj-1",
+    generated_at: "2025-01-01T00:00:00Z",
+    nodes: [
+      {
+        node_id: "COE-390",
+        identifier: "COE-390",
+        kind: "issue" as const,
+        title: "Gateway schemas",
+        state_category: "completed" as const,
+        children: [],
+        blocked_by: [],
+        labels: ["gateway"],
+      },
+    ],
+    root_ids: ["COE-390"],
+  };
+}
+
+function makeRunDetail(runId: string, status = "running"): RunDetail {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    run_id: runId,
+    issue_id: "issue-1",
+    issue_identifier: "COE-390",
+    worker_id: "worker-1",
+    status: status as RunDetail["status"],
+    claimed_at: "2025-01-01T00:00:00Z",
+    turn_count: 3,
+    max_turns: 50,
+    input_tokens: 1024,
+    output_tokens: 512,
+    cache_read_tokens: 256,
+    runtime_seconds: 120,
+  };
+}
+
+function makeEnvelope(runId: string, seq: number, eventKind = "run_updated"): GatewayEnvelope {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    cursor: { sequence: seq, partition: `run:${runId}` },
+    entity_ref: { kind: "run", id: runId },
+    event_kind: eventKind,
+    emitted_at: `2025-01-01T00:00:${String(seq).padStart(2, "0")}Z`,
+  };
+}
+
+function makeTerminalFrame(runId: string, seq: number): TerminalFrame {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    frame_sequence: seq,
+    stream_id: `stream-${runId}`,
+    run_id: runId,
+    terminal_session_id: `term-${runId}`,
+    frame_kind: "stdout",
+    encoding: "utf8",
+    content: `line ${seq}\n`,
+    timestamp: `2025-01-01T00:00:${String(seq).padStart(2, "0")}Z`,
+  };
+}
+
+function makeRunEvent(seq: number): RunEvent {
+  return {
+    sequence: seq,
+    event_id: `evt-${seq}`,
+    happened_at: `2025-01-01T00:00:${String(seq).padStart(2, "0")}Z`,
+    kind: "ConversationStateUpdateEvent",
+    summary: `Event ${seq}`,
+  };
+}
+
+function makeActionReceipt(correlationId: string, status = "accepted"): ActionReceipt {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    action_id: `action-${correlationId}`,
+    correlation_id: correlationId,
+    status: status as ActionReceipt["status"],
+    expected_events: [],
+    issued_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// -- Snapshot + replay rebuild tests --
+
+describe("snapshot + stream replay rebuilds state", () => {
+  it("rebuilds dashboard, task graph, and run state from fixtures", async () => {
+    const transport = new MockGatewayTransport({
+      snapshot: makeDashboardSnapshot(1),
+      taskGraph: makeTaskGraphSnapshot(1),
+      runDetails: [makeRunDetail("run-1"), makeRunDetail("run-2")],
+      events: [
+        makeEnvelope("run-1", 1),
+        makeEnvelope("run-1", 2),
+        makeEnvelope("run-2", 1),
+      ],
+    });
+
+    // Step 1: Fetch snapshot.
+    const snapshot = await transport.snapshot();
+    let state = gatewayReducer(initialState, {
+      type: "SNAPSHOT_RECEIVED",
+      payload: snapshot,
+    });
+    expect(state.dashboard.snapshot).toBeTruthy();
+
+    // Step 2: Fetch task graph.
+    const taskGraph = await transport.taskGraph("proj-1");
+    state = gatewayReducer(state, {
+      type: "TASK_GRAPH_RECEIVED",
+      payload: taskGraph,
+    });
+    expect(state.taskGraph.nodes.size).toBe(1);
+
+    // Step 3: Replay events.
+    const events = transport.events();
+    for await (const envelope of events) {
+      state = gatewayReducer(state, {
+        type: "ENVELOPE_RECEIVED",
+        payload: envelope,
+      });
+    }
+
+    // Verify entity cache was populated.
+    expect(state.cache.runs.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("rebuilds run state via RUN_UPDATED + RUN_EVENTS_RECEIVED", async () => {
+    const transport = new MockGatewayTransport({
+      runDetails: [makeRunDetail("run-1")],
+      runEvents: [
+        {
+          schema_version: { major: 1, minor: 0, patch: 0 },
+          run_id: "run-1",
+          events: [makeRunEvent(1), makeRunEvent(2), makeRunEvent(3)],
+        },
+      ],
+    });
+
+    const runDetail = await transport.runDetail("run-1");
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: runDetail,
+    });
+
+    const runEventsPage = await transport.runEvents("run-1");
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: runEventsPage.events,
+    });
+
+    expect(state.run.runs.has("run-1")).toBe(true);
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.eventCount).toBe(3);
+  });
+
+  it("rebuilds terminal state via TERMINAL_FRAMES_RECEIVED", async () => {
+    const transport = new MockGatewayTransport({
+      terminalFrames: [
+        {
+          runId: "run-1",
+          frames: [
+            makeEnvelope("run-1", 1, "terminal_frame"),
+            makeEnvelope("run-1", 2, "terminal_frame"),
+          ],
+        },
+      ],
+    });
+
+    let state = initialState;
+    const frames = transport.terminalFrames("run-1");
+    for await (const envelope of frames) {
+      state = gatewayReducer(state, {
+        type: "ENVELOPE_RECEIVED",
+        payload: envelope,
+      });
+    }
+    // Terminal session IDs populate the terminal cache.
+    expect(state.cache.terminals.size).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// -- Out-of-order and duplicate tests --
+
+describe("fixture replay handles out-of-order and duplicates", () => {
+  it("handles out-of-order terminal frames", () => {
+    let state = initialState;
+    // Receive frames 3, 1, 4, 2 (out of order).
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeTerminalFrame("run-1", 3), makeTerminalFrame("run-1", 1)],
+    });
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeTerminalFrame("run-1", 4), makeTerminalFrame("run-1", 2)],
+    });
+
+    // Should have 4 unique frames.
+    expect(state.terminal.frames.get("run-1")).toHaveLength(4);
+    // Cursor should be max sequence.
+    expect(state.terminal.cursor.get("run-1")).toBe(4);
+  });
+
+  it("deduplicates replayed terminal frames", () => {
+    let state = initialState;
+    // First batch.
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeTerminalFrame("run-1", 1), makeTerminalFrame("run-1", 2)],
+    });
+    // Replay same batch (should dedup).
+    state = gatewayReducer(state, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeTerminalFrame("run-1", 1), makeTerminalFrame("run-1", 2)],
+    });
+
+    expect(state.terminal.frames.get("run-1")).toHaveLength(2);
+    expect(state.terminal.cursor.get("run-1")).toBe(2);
+  });
+
+  it("handles reconnect with cursor-based replay", async () => {
+    const transport = new MockGatewayTransport({
+      events: [
+        makeEnvelope("run-1", 1),
+        makeEnvelope("run-1", 2),
+        makeEnvelope("run-1", 3),
+        makeEnvelope("run-1", 4),
+        makeEnvelope("run-1", 5),
+      ],
+    });
+
+    // Consume first 3 events.
+    let state = initialState;
+    const iter = transport.events();
+    const results: GatewayEnvelope[] = [];
+    for await (const env of iter) {
+      results.push(env);
+      state = gatewayReducer(state, {
+        type: "ENVELOPE_RECEIVED",
+        payload: env,
+      });
+      if (results.length === 3) break;
+    }
+
+    // Simulate reconnect from cursor after event 3.
+    const reconnectIter = transport.events({ sequence: 3, partition: "run:run-1" });
+    const replayed: GatewayEnvelope[] = [];
+    for await (const env of reconnectIter) {
+      replayed.push(env);
+      state = gatewayReducer(state, {
+        type: "ENVELOPE_RECEIVED",
+        payload: env,
+      });
+    }
+
+    // Should get events 4 and 5 on replay.
+    expect(replayed).toHaveLength(2);
+    expect(replayed[0].cursor.sequence).toBe(4);
+    expect(replayed[1].cursor.sequence).toBe(5);
+    expect(state.cache.runs.size).toBe(1);
+  });
+});
+
+// -- Stale stream tests --
+
+describe("stale stream handling", () => {
+  it("stale stream state does not collapse into failed run state", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "running"),
+    });
+
+    // Simulate staleness.
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.phaseState).toBe("degraded");
+    expect(liveness?.isStreamStale).toBe(true);
+    // Run error should remain null — stale != failed.
+    expect(state.run.error).toBeNull();
+    expect(state.run.runs.get("run-1")?.status).toBe("running");
+  });
+
+  it("stale stream recovery does not affect cancelled runs", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "released"),
+    });
+
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+
+    // Cancelled runs should stay cancelled even after stale detection.
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.phaseState).toBe("cancelled");
+
+    // Recovery should not override cancelled state.
+    state = gatewayReducer(state, {
+      type: "STREAM_RECOVERED",
+      runId: "run-1",
+    });
+    const recoveredLiveness = state.run.liveness.get("run-1");
+    expect(recoveredLiveness?.phaseState).toBe("cancelled");
+  });
+
+  it("degraded stream health check transitions through phases", () => {
+    const baseTime = 1_700_000_000_000;
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "running"),
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+
+    // Force lastEventAt to a known time.
+    const liveness = state.run.liveness.get("run-1");
+    if (liveness) {
+      liveness.lastEventAt = new Date(baseTime).toISOString();
+    }
+
+    // 35 seconds -> degraded.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 35_000,
+    });
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("degraded");
+
+    // 95 seconds -> stalled.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 95_000,
+    });
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("stalled");
+
+    // 155 seconds -> detached.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 155_000,
+    });
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("detached");
+  });
+});
+
+// -- Action receipt correlation tests --
+
+describe("action receipts and correlated events", () => {
+  it("ACTION_DISPATCHED tracks pending action", () => {
+    const state = gatewayReducer(initialState, {
+      type: "ACTION_DISPATCHED",
+      correlationId: "corr-dispatch-1",
+    });
+    expect(state.actionReceipts.pending.has("corr-dispatch-1")).toBe(true);
+    const pending = state.actionReceipts.pending.get("corr-dispatch-1");
+    expect(pending?.dispatchedAt).toBeTruthy();
+  });
+
+  it("ACTION_RECEIPT_RECEIVED correlates with dispatched action", () => {
+    let state = gatewayReducer(initialState, {
+      type: "ACTION_DISPATCHED",
+      correlationId: "corr-1",
+    });
+
+    const receipt = makeActionReceipt("corr-1", "completed");
+    state = gatewayReducer(state, {
+      type: "ACTION_RECEIPT_RECEIVED",
+      receipt,
+    });
+
+    expect(state.actionReceipts.pending.has("corr-1")).toBe(false);
+    expect(state.actionReceipts.receipts.has("corr-1")).toBe(true);
+    expect(state.actionReceipts.receipts.get("corr-1")?.status).toBe("completed");
+  });
+
+  it("mock transport dispatches actions with receipts", async () => {
+    const transport = new MockGatewayTransport({
+      actionReceipts: [
+        {
+          correlationId: "corr-retry-1",
+          receipt: makeActionReceipt("corr-retry-1", "completed"),
+        },
+      ],
+    });
+
+    const receipt = await transport.dispatchAction({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      correlation_id: "corr-retry-1",
+      action_kind: "retry",
+      target_entity: { entity_kind: "run", entity_id: "run-1" },
+    });
+
+    expect(receipt.correlation_id).toBe("corr-retry-1");
+    expect(receipt.status).toBe("completed");
+  });
+
+  it("mock cancelRun returns receipt", async () => {
+    const transport = new MockGatewayTransport();
+    const receipt = await transport.cancelRun("run-1");
+    expect(receipt.correlation_id).toBe("cancel-run-1");
+    expect(receipt.status).toBe("accepted");
+  });
+
+  it("mock retryRun returns receipt", async () => {
+    const transport = new MockGatewayTransport();
+    const receipt = await transport.retryRun("run-1");
+    expect(receipt.correlation_id).toBe("retry-run-1");
+    expect(receipt.status).toBe("accepted");
+  });
+
+  it("mock resumeRun returns receipt", async () => {
+    const transport = new MockGatewayTransport();
+    const receipt = await transport.resumeRun("run-1");
+    expect(receipt.correlation_id).toBe("resume-run-1");
+    expect(receipt.status).toBe("accepted");
+  });
+});
+
+// -- All transport adapters reduce to same state transitions --
+
+describe("transport adapter state parity", () => {
+  it("mock transport and reducer produce consistent state", async () => {
+    const transport = new MockGatewayTransport({
+      snapshot: makeDashboardSnapshot(1),
+      taskGraph: makeTaskGraphSnapshot(1),
+      runDetails: [makeRunDetail("run-1")],
+    });
+
+    // Apply via reducer.
+    let state = initialState;
+
+    // Snapshot.
+    const snapshot = await transport.snapshot();
+    state = gatewayReducer(state, { type: "SNAPSHOT_RECEIVED", payload: snapshot });
+    expect(state.dashboard.snapshot?.sequence).toBe(1);
+
+    // Task graph.
+    const tg = await transport.taskGraph("proj-1");
+    state = gatewayReducer(state, { type: "TASK_GRAPH_RECEIVED", payload: tg });
+    expect(state.taskGraph.nodes.size).toBe(1);
+
+    // Run detail.
+    const run = await transport.runDetail("run-1");
+    state = gatewayReducer(state, { type: "RUN_UPDATED", payload: run });
+    expect(state.run.runs.has("run-1")).toBe(true);
+  });
+});
+
+// -- Long-running run state rebuild --
+
+describe("long-running run state rebuild without live socket", () => {
+  it("rebuilds run state from snapshot + event replay", async () => {
+    const transport = new MockGatewayTransport({
+      runDetails: [makeRunDetail("run-long-1", "running")],
+      runEvents: [
+        {
+          schema_version: { major: 1, minor: 0, patch: 0 },
+          run_id: "run-long-1",
+          events: [
+            makeRunEvent(1),
+            makeRunEvent(2),
+            makeRunEvent(3),
+            makeRunEvent(4),
+            makeRunEvent(5),
+          ],
+        },
+      ],
+      events: [
+        makeEnvelope("run-long-1", 1),
+        makeEnvelope("run-long-1", 2),
+        makeEnvelope("run-long-1", 3),
+      ],
+    });
+
+    let state = initialState;
+
+    // Step 1: Load run snapshot.
+    const run = await transport.runDetail("run-long-1");
+    state = gatewayReducer(state, { type: "RUN_UPDATED", payload: run });
+
+    // Step 2: Load run events.
+    const eventsPage = await transport.runEvents("run-long-1");
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-long-1",
+      events: eventsPage.events,
+    });
+
+    // Step 3: Replay stream events.
+    for await (const envelope of transport.events()) {
+      state = gatewayReducer(state, {
+        type: "ENVELOPE_RECEIVED",
+        payload: envelope,
+      });
+    }
+
+    // Verify state rebuild.
+    expect(state.run.runs.get("run-long-1")?.status).toBe("running");
+    const liveness = state.run.liveness.get("run-long-1");
+    expect(liveness?.eventCount).toBe(5);
+    expect(state.cache.runs.has("run-long-1")).toBe(true);
+  });
+
+  it("maintains degraded state when socket is stale (not failed)", async () => {
+    const transport = new MockGatewayTransport({
+      runDetails: [makeRunDetail("run-detached", "running")],
+      streamHealthy: false,
+    });
+
+    let state = initialState;
+    const run = await transport.runDetail("run-detached");
+    state = gatewayReducer(state, { type: "RUN_UPDATED", payload: run });
+
+    // Simulate staleness detection (no socket events arriving).
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-detached",
+    });
+
+    // Health check: stale stream should stay degraded, not collapse to failed.
+    const baseTime = 1_700_000_000_000;
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-detached",
+      nowMs: baseTime + 160_000,
+    });
+
+    // Stale stream -> degraded phase (not detached because run is still "running" on server).
+    expect(state.run.liveness.get("run-detached")?.phaseState).toBe("degraded");
+    // Terminal stream staleness flag is preserved.
+    expect(state.terminal.streamStale.get("run-detached")).toBe(true);
+    // Run itself should still be marked as running on server.
+    expect(state.run.runs.get("run-detached")?.status).toBe("running");
+    // IMPORTANT: no error on the run — stale != failed.
+    expect(state.run.error).toBeNull();
+  });
+});
+
+// -- Reconnect behavior tests --
+
+describe("reconnect behavior", () => {
+  it("mock transport tracks reconnect attempts", () => {
+    const transport = new MockGatewayTransport();
+    expect(transport.getReconnectAttempts()).toBe(0);
+
+    transport.simulateReconnect(3);
+    expect(transport.getReconnectAttempts()).toBe(3);
+  });
+
+  it("mock transport reports stream health", () => {
+    let transport = new MockGatewayTransport({ streamHealthy: true });
+    expect(transport.isStreamHealthy()).toBe(true);
+
+    transport = new MockGatewayTransport({ streamHealthy: false });
+    expect(transport.isStreamHealthy()).toBe(false);
+  });
+
+  it("reducer handles reconnect state transitions", () => {
+    let state = gatewayReducer(initialState, {
+      type: "CONNECTION_STATE_CHANGED",
+      state: "connecting",
+    });
+    expect(state.connection.state).toBe("connecting");
+
+    state = gatewayReducer(state, {
+      type: "CONNECTION_STATE_CHANGED",
+      state: "connected",
+    });
+    expect(state.connection.state).toBe("connected");
+    expect(state.connection.lastConnectedAt).toBeTruthy();
+
+    state = gatewayReducer(state, {
+      type: "RECONNECT_ATTEMPTED",
+      attempts: 1,
+    });
+    expect(state.connection.reconnectAttempts).toBe(1);
+    expect(state.connection.state).toBe("reconnecting");
+  });
+
+  it("reducer handles connection failure", () => {
+    const state = gatewayReducer(initialState, {
+      type: "ERROR",
+      error: "Connection timeout",
+    });
+    expect(state.connection.state).toBe("failed");
+    expect(state.connection.error).toBe("Connection timeout");
+  });
+});
+
+// -- Degraded stream handling --
+
+describe("degraded stream handling", () => {
+  it("degraded health check transitions run to degraded phase", () => {
+    const baseTime = 1_700_000_000_000;
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "running"),
+    });
+
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    if (liveness) {
+      liveness.lastEventAt = new Date(baseTime).toISOString();
+    }
+
+    // 45 seconds gap -> degraded.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 45_000,
+    });
+
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("degraded");
+    expect(state.run.liveness.get("run-1")?.streamHealth).toBe("degraded");
+  });
+
+  it("mock transport supports stream health diagnostics", async () => {
+    const transport = new MockGatewayTransport({
+      runDetails: [makeRunDetail("run-1")],
+      streamHealthy: false,
+    });
+
+    expect(transport.isStreamHealthy()).toBe(false);
+
+    // Update mock to healthy.
+    transport.setStreamHealthy(true);
+    expect(transport.isStreamHealthy()).toBe(true);
+  });
+});
+
+// -- Cancelled and retry_queued states --
+
+describe("cancelled and retry_queued run states", () => {
+  it("retry_queued run status maps correctly", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "retry_queued"),
+    });
+
+    // Even without events, retry_queued status should be recognized.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: Date.now(),
+    });
+
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("retry_queued");
+  });
+
+  it("released (cancelled) run status maps correctly", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "released"),
+    });
+
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: Date.now(),
+    });
+
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("cancelled");
+  });
+
+  it("cancelled run does not transition to other phases on stale detection", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail("run-1", "released"),
+    });
+
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("cancelled");
+    expect(state.run.error).toBeNull();
+  });
+});
+
+// -- All run phase states covered --
+
+describe("all run phase states", () => {
+  it("active: running with fresh events", () => {
+    expect(deriveRunPhaseState("running", {
+      runId: "r",
+      phaseState: "active",
+      lastEventAt: null,
+      lastStatusUpdateAt: null,
+      eventCount: 1,
+      gapSeconds: 1,
+      isStreamStale: false,
+      streamHealth: "healthy",
+    }, false)).toBe("active");
+  });
+
+  it("quiet: running with no recent events", () => {
+    expect(deriveRunPhaseState("running", {
+      runId: "r",
+      phaseState: "quiet",
+      lastEventAt: null,
+      lastStatusUpdateAt: null,
+      eventCount: 0,
+      gapSeconds: 30,
+      isStreamStale: false,
+      streamHealth: "healthy",
+    }, false)).toBe("quiet");
+  });
+
+  it("degraded: stale stream but run alive", () => {
+    expect(deriveRunPhaseState("running", undefined, true)).toBe("degraded");
+  });
+
+  it("stalled: no events for extended period", () => {
+    expect(deriveRunPhaseState("running", {
+      runId: "r",
+      phaseState: "stalled",
+      lastEventAt: null,
+      lastStatusUpdateAt: null,
+      eventCount: 0,
+      gapSeconds: 90,
+      isStreamStale: false,
+      streamHealth: "stale",
+    }, false)).toBe("stalled");
+  });
+
+  it("retry_queued: run queued for retry", () => {
+    expect(deriveRunPhaseState("retry_queued", undefined, false)).toBe("retry_queued");
+  });
+
+  it("cancelled: run released", () => {
+    expect(deriveRunPhaseState("released", undefined, false)).toBe("cancelled");
+  });
+
+  it("detached: long gap with stale stream", () => {
+    expect(deriveRunPhaseState("running", {
+      runId: "r",
+      phaseState: "detached",
+      lastEventAt: null,
+      lastStatusUpdateAt: null,
+      eventCount: 0,
+      gapSeconds: 160,
+      isStreamStale: true,
+      streamHealth: "stale",
+    }, true)).toBe("degraded");
+  });
+});

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -618,6 +618,14 @@ describe("deriveRunPhaseState", () => {
     expect(deriveRunPhaseState({ status: "running" } as any, undefined, true)).toBe("degraded");
   });
 
+  it("stale stream ignored for unclaimed run", () => {
+    expect(deriveRunPhaseState({ status: "unclaimed" } as any, undefined, true)).toBe("active");
+  });
+
+  it("stale stream maps to degraded for claimed run", () => {
+    expect(deriveRunPhaseState({ status: "claimed" } as any, undefined, true)).toBe("degraded");
+  });
+
   it("active run with fresh stream is active", () => {
     const liveness = {
       runId: "run-1",

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -3,6 +3,9 @@
 import {
   gatewayReducer,
   initialState,
+  deriveRunPhaseState,
+  computeLivenessState,
+  LIVENESS_THRESHOLDS,
 } from "@opensymphony/state";
 import type {
   DashboardSnapshot,
@@ -12,6 +15,8 @@ import type {
   ApprovalRequest,
   PlanningSessionSummary,
   GatewayEnvelope,
+  ActionReceipt,
+  RunEvent,
 } from "@opensymphony/gateway-schema";
 
 // -- Helpers — typed factories aligned with gateway-schema interfaces --
@@ -45,14 +50,14 @@ function makeTaskGraphSnapshot(): TaskGraphSnapshot {
   };
 }
 
-function makeRunDetail(): RunDetail {
+function makeRunDetail(status = "running"): RunDetail {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
     run_id: "run-1",
     issue_id: "issue-1",
     issue_identifier: "COE-001",
     worker_id: "worker-1",
-    status: "running",
+    status: status as RunDetail["status"],
     claimed_at: "2025-01-01T00:00:00Z",
     turn_count: 0,
     max_turns: 50,
@@ -105,13 +110,34 @@ function makePlanningSummary(): PlanningSessionSummary {
   };
 }
 
-function makeEnvelope(): GatewayEnvelope {
+function makeEnvelope(eventKind = "run_updated"): GatewayEnvelope {
   return {
     schema_version: { major: 1, minor: 0, patch: 0 },
     cursor: { sequence: 1, partition: "p1" },
     entity_ref: { kind: "run", id: "run-1" },
-    event_kind: "run_updated",
+    event_kind: eventKind,
     emitted_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeRunEvent(sequence: number): RunEvent {
+  return {
+    sequence,
+    event_id: `evt-${sequence}`,
+    happened_at: "2025-01-01T00:00:00Z",
+    kind: "ConversationStateUpdateEvent",
+    summary: `Event ${sequence}`,
+  };
+}
+
+function makeActionReceipt(correlationId: string): ActionReceipt {
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    action_id: "action-1",
+    correlation_id: correlationId,
+    status: "accepted",
+    expected_events: [],
+    issued_at: "2025-01-01T00:00:00Z",
   };
 }
 
@@ -126,6 +152,7 @@ describe("gatewayReducer", () => {
     expect(state.dashboard.snapshot).toBeTruthy();
     expect(state.dashboard.loading).toBe(false);
     expect(state.dashboard.error).toBeNull();
+    expect(state.dashboard.lastUpdated).toBeTruthy();
   });
 
   it("TASK_GRAPH_RECEIVED sets nodes and clears loading/error", () => {
@@ -136,6 +163,7 @@ describe("gatewayReducer", () => {
     expect(state.taskGraph.nodes.size).toBe(0);
     expect(state.taskGraph.loading).toBe(false);
     expect(state.taskGraph.error).toBeNull();
+    expect(state.taskGraph.lastUpdated).toBeTruthy();
   });
 
   it("RUN_UPDATED stores run and clears loading/error", () => {
@@ -147,6 +175,7 @@ describe("gatewayReducer", () => {
     expect(state.run.runs.get("run-1")).toBe(run);
     expect(state.run.loading).toBe(false);
     expect(state.run.error).toBeNull();
+    expect(state.run.lastUpdated).toBeTruthy();
   });
 
   it("TERMINAL_FRAMES_RECEIVED stores frames and clears loading/error", () => {
@@ -160,6 +189,7 @@ describe("gatewayReducer", () => {
     expect(state.terminal.cursor.get("run-1")).toBe(1);
     expect(state.terminal.loading).toBe(false);
     expect(state.terminal.error).toBeNull();
+    expect(state.terminal.lastUpdated).toBeTruthy();
   });
 
   it("TERMINAL_FRAMES_RECEIVED deduplicates frames by sequence", () => {
@@ -232,6 +262,7 @@ describe("gatewayReducer", () => {
     expect(state.approval.pending).toHaveLength(1);
     expect(state.approval.loading).toBe(false);
     expect(state.approval.error).toBeNull();
+    expect(state.approval.lastUpdated).toBeTruthy();
   });
 
   it("APPROVAL_RECEIVED deduplicates by approval_id", () => {
@@ -262,6 +293,7 @@ describe("gatewayReducer", () => {
     expect(state.approval.resolved.get("appr-1")).toBe(approval);
     expect(state.approval.loading).toBe(false);
     expect(state.approval.error).toBeNull();
+    expect(state.approval.lastUpdated).toBeTruthy();
   });
 
   it("PLANNING_SESSION_UPDATED stores session and clears loading/error", () => {
@@ -273,14 +305,15 @@ describe("gatewayReducer", () => {
     expect(state.planning.sessions.get("sess-1")).toBe(session);
     expect(state.planning.loading).toBe(false);
     expect(state.planning.error).toBeNull();
+    expect(state.planning.lastUpdated).toBeTruthy();
   });
 
-  it("ENVELOPE_RECEIVED is a no-op placeholder", () => {
+  it("ENVELOPE_RECEIVED updates entity cache", () => {
     const state = gatewayReducer(initialState, {
       type: "ENVELOPE_RECEIVED",
       payload: makeEnvelope(),
     });
-    expect(state).toBe(initialState);
+    expect(state.cache.runs.has("run-1")).toBe(true);
   });
 
   it("ERROR sets error and resets loading on all slices", () => {
@@ -335,5 +368,336 @@ describe("gatewayReducer", () => {
     });
     expect(state.dashboard.error).toBeNull();
     expect(state.dashboard.loading).toBe(false);
+  });
+});
+
+describe("connection state", () => {
+  it("CONNECTION_STATE_CHANGED updates connection slice", () => {
+    const state = gatewayReducer(initialState, {
+      type: "CONNECTION_STATE_CHANGED",
+      state: "connecting",
+    });
+    expect(state.connection.state).toBe("connecting");
+  });
+
+  it("CONNECTION_STATE_CHANGED records connected timestamp", () => {
+    const state = gatewayReducer(initialState, {
+      type: "CONNECTION_STATE_CHANGED",
+      state: "connected",
+    });
+    expect(state.connection.lastConnectedAt).toBeTruthy();
+  });
+
+  it("CONNECTION_STATE_CHANGED records disconnected timestamp", () => {
+    let state = gatewayReducer(initialState, {
+      type: "CONNECTION_STATE_CHANGED",
+      state: "connected",
+    });
+    state = gatewayReducer(state, {
+      type: "CONNECTION_STATE_CHANGED",
+      state: "disconnected",
+    });
+    expect(state.connection.lastDisconnectedAt).toBeTruthy();
+  });
+
+  it("RECONNECT_ATTEMPTED increments counter", () => {
+    const state = gatewayReducer(initialState, {
+      type: "RECONNECT_ATTEMPTED",
+      attempts: 2,
+    });
+    expect(state.connection.reconnectAttempts).toBe(2);
+    expect(state.connection.state).toBe("reconnecting");
+  });
+
+  it("ERROR with reconnect keyword sets reconnecting state", () => {
+    const state = gatewayReducer(initialState, {
+      type: "ERROR",
+      error: "reconnect failed",
+    });
+    expect(state.connection.state).toBe("reconnecting");
+  });
+
+  it("ERROR without reconnect keyword sets failed state", () => {
+    const state = gatewayReducer(initialState, {
+      type: "ERROR",
+      error: "something broke",
+    });
+    expect(state.connection.state).toBe("failed");
+  });
+});
+
+describe("run events and liveness", () => {
+  it("RUN_EVENTS_RECEIVED updates liveness state", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: [makeRunEvent(1), makeRunEvent(2)],
+    });
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness).toBeTruthy();
+    expect(liveness?.eventCount).toBe(2);
+    expect(liveness?.lastEventAt).toBeTruthy();
+    expect(liveness?.gapSeconds).toBe(0);
+  });
+
+  it("STREAM_HEALTH_CHECK computes liveness from elapsed time", () => {
+    const baseTime = 1_700_000_000_000; // Fixed timestamp for deterministic tests.
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+    // Force lastEventAt to a known time.
+    const liveness = state.run.liveness.get("run-1");
+    if (liveness) {
+      liveness.lastEventAt = new Date(baseTime).toISOString();
+    }
+
+    // Check health 10 seconds later -> still quiet.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 10_000,
+    });
+    let updatedLiveness = state.run.liveness.get("run-1");
+    expect(updatedLiveness?.phaseState).toBe("quiet");
+
+    // Check health 45 seconds later -> degraded.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 45_000,
+    });
+    updatedLiveness = state.run.liveness.get("run-1");
+    expect(updatedLiveness?.phaseState).toBe("degraded");
+
+    // Check health 90 seconds later -> stalled.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 90_000,
+    });
+    updatedLiveness = state.run.liveness.get("run-1");
+    expect(updatedLiveness?.phaseState).toBe("stalled");
+
+    // Check health 150 seconds later -> detached.
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 150_000,
+    });
+    updatedLiveness = state.run.liveness.get("run-1");
+    expect(updatedLiveness?.phaseState).toBe("detached");
+  });
+
+  it("STREAM_STALE_DETECTED sets degraded state, not failed", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.phaseState).toBe("degraded");
+    expect(liveness?.isStreamStale).toBe(true);
+    expect(liveness?.streamHealth).toBe("stale");
+    // IMPORTANT: stale stream should NOT collapse into failed run state.
+    expect(state.run.error).toBeNull();
+  });
+
+  it("STREAM_RECOVERED restores active state", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+
+    state = gatewayReducer(state, {
+      type: "STREAM_RECOVERED",
+      runId: "run-1",
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.phaseState).toBe("active");
+    expect(liveness?.isStreamStale).toBe(false);
+    expect(liveness?.streamHealth).toBe("healthy");
+  });
+});
+
+describe("action receipts", () => {
+  it("ACTION_DISPATCHED adds to pending", () => {
+    const state = gatewayReducer(initialState, {
+      type: "ACTION_DISPATCHED",
+      correlationId: "corr-1",
+    });
+    expect(state.actionReceipts.pending.has("corr-1")).toBe(true);
+  });
+
+  it("ACTION_RECEIPT_RECEIVED moves from pending to receipts", () => {
+    let state = gatewayReducer(initialState, {
+      type: "ACTION_DISPATCHED",
+      correlationId: "corr-1",
+    });
+    state = gatewayReducer(state, {
+      type: "ACTION_RECEIPT_RECEIVED",
+      receipt: makeActionReceipt("corr-1"),
+    });
+    expect(state.actionReceipts.pending.has("corr-1")).toBe(false);
+    expect(state.actionReceipts.receipts.has("corr-1")).toBe(true);
+  });
+});
+
+describe("deriveRunPhaseState", () => {
+  it("retry_queued run status maps to retry_queued phase", () => {
+    expect(deriveRunPhaseState("retry_queued", undefined, false)).toBe("retry_queued");
+  });
+
+  it("released run status maps to cancelled phase", () => {
+    expect(deriveRunPhaseState("released", undefined, false)).toBe("cancelled");
+  });
+
+  it("stale stream maps to degraded phase when run is still alive", () => {
+    expect(deriveRunPhaseState("running", undefined, true)).toBe("degraded");
+  });
+
+  it("active run with fresh stream is active", () => {
+    const liveness = {
+      runId: "run-1",
+      phaseState: "active" as const,
+      lastEventAt: null,
+      lastStatusUpdateAt: null,
+      eventCount: 10,
+      gapSeconds: 1,
+      isStreamStale: false,
+      streamHealth: "healthy" as const,
+    };
+    expect(deriveRunPhaseState("running", liveness, false)).toBe("active");
+  });
+});
+
+describe("computeLivenessState", () => {
+  const baseTime = 1_700_000_000_000;
+
+  it("fresh events -> active", () => {
+    const liveness = computeLivenessState(
+      "run-1",
+      {
+        runId: "run-1",
+        phaseState: "active",
+        lastEventAt: new Date(baseTime).toISOString(),
+        lastStatusUpdateAt: null,
+        eventCount: 5,
+        gapSeconds: 0,
+        isStreamStale: false,
+        streamHealth: "healthy",
+      },
+      baseTime + 2000,
+      3,
+    );
+    expect(liveness.phaseState).toBe("active");
+    expect(liveness.eventCount).toBe(8);
+  });
+
+  it("no recent events -> quiet", () => {
+    const liveness = computeLivenessState(
+      "run-1",
+      undefined,
+      baseTime,
+      0,
+    );
+    expect(liveness.phaseState).toBe("quiet");
+  });
+});
+
+describe("entity cache", () => {
+  it("RUN_UPDATED populates entity cache", () => {
+    const state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    expect(state.cache.runs.has("run-1")).toBe(true);
+    expect(state.cache.runs.get("run-1")?.version).toBe(1);
+  });
+
+  it("APPROVAL_RECEIVED populates entity cache", () => {
+    const state = gatewayReducer(initialState, {
+      type: "APPROVAL_RECEIVED",
+      payload: makeApproval("appr-1"),
+    });
+    expect(state.cache.approvals.has("appr-1")).toBe(true);
+  });
+
+  it("TERMINAL_FRAMES_RECEIVED populates entity cache", () => {
+    const state = gatewayReducer(initialState, {
+      type: "TERMINAL_FRAMES_RECEIVED",
+      runId: "run-1",
+      frames: [makeFrame(1)],
+    });
+    expect(state.cache.terminals.has("run-1")).toBe(true);
+  });
+
+  it("PLANNING_SESSION_UPDATED populates entity cache", () => {
+    const state = gatewayReducer(initialState, {
+      type: "PLANNING_SESSION_UPDATED",
+      payload: makePlanningSummary(),
+    });
+    expect(state.cache.planning.has("sess-1")).toBe(true);
+  });
+});
+
+describe("stream staleness vs failed run", () => {
+  it("stale stream does not set run error", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+    // Stream is stale but run should not be errored out.
+    expect(state.run.error).toBeNull();
+    expect(state.terminal.streamStale.get("run-1")).toBe(true);
+  });
+
+  it("stream recovery clears staleness flag", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      payload: makeRunDetail(),
+    });
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      runId: "run-1",
+    });
+    state = gatewayReducer(state, {
+      type: "STREAM_RECOVERED",
+      runId: "run-1",
+    });
+    expect(state.terminal.streamStale.get("run-1")).toBe(false);
   });
 });

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -474,13 +474,11 @@ describe("run events and liveness", () => {
     const baseTime = 1_700_000_000_000; // Fixed timestamp for deterministic tests.
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
-      nowMs: NOW,
       payload: makeRunDetail(),
       nowMs: baseTime,
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
-      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
       nowMs: baseTime,
@@ -489,7 +487,6 @@ describe("run events and liveness", () => {
     // Check health 10 seconds later -> still quiet.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 10_000,
     });
@@ -499,7 +496,6 @@ describe("run events and liveness", () => {
     // Check health 45 seconds later -> degraded.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 45_000,
     });
@@ -509,7 +505,6 @@ describe("run events and liveness", () => {
     // Check health 90 seconds later -> stalled.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 90_000,
     });
@@ -519,7 +514,6 @@ describe("run events and liveness", () => {
     // Check health 150 seconds later -> detached.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
-      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 150_000,
     });

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -466,7 +466,8 @@ describe("run events and liveness", () => {
     });
     const liveness = state.run.liveness.get("run-1");
     expect(liveness).toBeTruthy();
-    expect(liveness?.eventCount).toBe(2);
+    // eventCount is not incremented by RUN_EVENTS_RECEIVED anymore — liveness tracks recency, not count.
+    expect(liveness?.eventCount).toBe(0);
     expect(liveness?.lastEventAt).toBeTruthy();
     expect(liveness?.gapSeconds).toBe(0);
   });
@@ -645,12 +646,12 @@ describe("deriveRunPhaseState", () => {
 describe("computeLivenessState", () => {
   const baseTime = 1_700_000_000_000;
 
-  it("fresh events -> active", () => {
+  it("quiet when gap is within threshold", () => {
     const liveness = computeLivenessState(
       "run-1",
       {
         runId: "run-1",
-        phaseState: "active",
+        phaseState: "quiet",
         lastEventAt: new Date(baseTime).toISOString(),
         lastStatusUpdateAt: null,
         eventCount: 5,
@@ -659,10 +660,10 @@ describe("computeLivenessState", () => {
         streamHealth: "healthy",
       },
       baseTime + 2000,
-      3,
     );
-    expect(liveness.phaseState).toBe("active");
-    expect(liveness.eventCount).toBe(8);
+    // With the gap (2s) far below the quiet threshold (300s), stays quiet.
+    expect(liveness.phaseState).toBe("quiet");
+    expect(liveness.eventCount).toBe(5);
   });
 
   it("no recent events -> quiet", () => {
@@ -670,7 +671,6 @@ describe("computeLivenessState", () => {
       "run-1",
       undefined,
       baseTime,
-      0,
     );
     expect(liveness.phaseState).toBe("quiet");
   });

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -19,6 +19,9 @@ import type {
   RunEvent,
 } from "@opensymphony/gateway-schema";
 
+/** Deterministic timestamp used by all test actions. */
+const NOW = 1_700_000_000_000;
+
 // -- Helpers — typed factories aligned with gateway-schema interfaces --
 
 function makeSnapshot(): DashboardSnapshot {
@@ -147,6 +150,7 @@ describe("gatewayReducer", () => {
   it("SNAPSHOT_RECEIVED sets snapshot and clears loading/error", () => {
     const state = gatewayReducer(initialState, {
       type: "SNAPSHOT_RECEIVED",
+      nowMs: NOW,
       payload: makeSnapshot(),
     });
     expect(state.dashboard.snapshot).toBeTruthy();
@@ -158,6 +162,7 @@ describe("gatewayReducer", () => {
   it("TASK_GRAPH_RECEIVED sets nodes and clears loading/error", () => {
     const state = gatewayReducer(initialState, {
       type: "TASK_GRAPH_RECEIVED",
+      nowMs: NOW,
       payload: makeTaskGraphSnapshot(),
     });
     expect(state.taskGraph.nodes.size).toBe(0);
@@ -170,6 +175,7 @@ describe("gatewayReducer", () => {
     const run = makeRunDetail();
     const state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: run,
     });
     expect(state.run.runs.get("run-1")).toBe(run);
@@ -182,6 +188,7 @@ describe("gatewayReducer", () => {
     const frame = makeFrame(1);
     const state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [frame],
     });
@@ -197,6 +204,7 @@ describe("gatewayReducer", () => {
     const f2 = makeFrame(2);
     let state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [f1, f2],
     });
@@ -204,6 +212,7 @@ describe("gatewayReducer", () => {
     const f3 = makeFrame(3);
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [f1, f3],
     });
@@ -215,6 +224,7 @@ describe("gatewayReducer", () => {
     // Batch 1: frames 1-5, cursor = 5.
     let state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeFrame(1), makeFrame(2), makeFrame(3), makeFrame(4), makeFrame(5)],
     });
@@ -222,6 +232,7 @@ describe("gatewayReducer", () => {
     // Batch 2: frames 3-4 arrive late (lower seq), cursor should stay at 5.
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeFrame(3), makeFrame(4)],
     });
@@ -232,6 +243,7 @@ describe("gatewayReducer", () => {
     // Batch arrives with frames 2, 1 (unsorted within batch).
     const state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeFrame(2), makeFrame(1)],
     });
@@ -242,11 +254,13 @@ describe("gatewayReducer", () => {
   it("TERMINAL_FRAMES_RECEIVED does not reset cursor for empty batch", () => {
     let state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeFrame(5)],
     });
     state = gatewayReducer(state, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [],
     });
@@ -257,6 +271,7 @@ describe("gatewayReducer", () => {
     const approval = makeApproval("appr-1");
     const state = gatewayReducer(initialState, {
       type: "APPROVAL_RECEIVED",
+      nowMs: NOW,
       payload: approval,
     });
     expect(state.approval.pending).toHaveLength(1);
@@ -269,10 +284,12 @@ describe("gatewayReducer", () => {
     const approval = makeApproval("appr-1");
     let state = gatewayReducer(initialState, {
       type: "APPROVAL_RECEIVED",
+      nowMs: NOW,
       payload: approval,
     });
     state = gatewayReducer(state, {
       type: "APPROVAL_RECEIVED",
+      nowMs: NOW,
       payload: approval,
     });
     expect(state.approval.pending).toHaveLength(1);
@@ -282,10 +299,12 @@ describe("gatewayReducer", () => {
     const approval = makeApproval("appr-1");
     let state = gatewayReducer(initialState, {
       type: "APPROVAL_RECEIVED",
+      nowMs: NOW,
       payload: approval,
     });
     state = gatewayReducer(state, {
       type: "APPROVAL_RESOLVED",
+      nowMs: NOW,
       approvalId: "appr-1",
       payload: approval,
     });
@@ -300,6 +319,7 @@ describe("gatewayReducer", () => {
     const session = makePlanningSummary();
     const state = gatewayReducer(initialState, {
       type: "PLANNING_SESSION_UPDATED",
+      nowMs: NOW,
       payload: session,
     });
     expect(state.planning.sessions.get("sess-1")).toBe(session);
@@ -375,6 +395,7 @@ describe("connection state", () => {
   it("CONNECTION_STATE_CHANGED updates connection slice", () => {
     const state = gatewayReducer(initialState, {
       type: "CONNECTION_STATE_CHANGED",
+      nowMs: NOW,
       state: "connecting",
     });
     expect(state.connection.state).toBe("connecting");
@@ -383,6 +404,7 @@ describe("connection state", () => {
   it("CONNECTION_STATE_CHANGED records connected timestamp", () => {
     const state = gatewayReducer(initialState, {
       type: "CONNECTION_STATE_CHANGED",
+      nowMs: NOW,
       state: "connected",
     });
     expect(state.connection.lastConnectedAt).toBeTruthy();
@@ -391,10 +413,12 @@ describe("connection state", () => {
   it("CONNECTION_STATE_CHANGED records disconnected timestamp", () => {
     let state = gatewayReducer(initialState, {
       type: "CONNECTION_STATE_CHANGED",
+      nowMs: NOW,
       state: "connected",
     });
     state = gatewayReducer(state, {
       type: "CONNECTION_STATE_CHANGED",
+      nowMs: NOW,
       state: "disconnected",
     });
     expect(state.connection.lastDisconnectedAt).toBeTruthy();
@@ -430,10 +454,12 @@ describe("run events and liveness", () => {
   it("RUN_EVENTS_RECEIVED updates liveness state", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1), makeRunEvent(2)],
     });
@@ -448,11 +474,13 @@ describe("run events and liveness", () => {
     const baseTime = 1_700_000_000_000; // Fixed timestamp for deterministic tests.
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
       nowMs: baseTime,
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
       nowMs: baseTime,
@@ -461,6 +489,7 @@ describe("run events and liveness", () => {
     // Check health 10 seconds later -> still quiet.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 10_000,
     });
@@ -470,6 +499,7 @@ describe("run events and liveness", () => {
     // Check health 45 seconds later -> degraded.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 45_000,
     });
@@ -479,6 +509,7 @@ describe("run events and liveness", () => {
     // Check health 90 seconds later -> stalled.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 90_000,
     });
@@ -488,6 +519,7 @@ describe("run events and liveness", () => {
     // Check health 150 seconds later -> detached.
     state = gatewayReducer(state, {
       type: "STREAM_HEALTH_CHECK",
+      nowMs: NOW,
       runId: "run-1",
       nowMs: baseTime + 150_000,
     });
@@ -498,16 +530,19 @@ describe("run events and liveness", () => {
   it("STREAM_STALE_DETECTED sets degraded state, not failed", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
     });
 
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
 
@@ -522,20 +557,24 @@ describe("run events and liveness", () => {
   it("STREAM_RECOVERED restores active state", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       events: [makeRunEvent(1)],
     });
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
 
     state = gatewayReducer(state, {
       type: "STREAM_RECOVERED",
+      nowMs: NOW,
       runId: "run-1",
     });
 
@@ -550,6 +589,7 @@ describe("action receipts", () => {
   it("ACTION_DISPATCHED adds to pending", () => {
     const state = gatewayReducer(initialState, {
       type: "ACTION_DISPATCHED",
+      nowMs: NOW,
       correlationId: "corr-1",
     });
     expect(state.actionReceipts.pending.has("corr-1")).toBe(true);
@@ -558,10 +598,12 @@ describe("action receipts", () => {
   it("ACTION_RECEIPT_RECEIVED moves from pending to receipts", () => {
     let state = gatewayReducer(initialState, {
       type: "ACTION_DISPATCHED",
+      nowMs: NOW,
       correlationId: "corr-1",
     });
     state = gatewayReducer(state, {
       type: "ACTION_RECEIPT_RECEIVED",
+      nowMs: NOW,
       receipt: makeActionReceipt("corr-1"),
     });
     expect(state.actionReceipts.pending.has("corr-1")).toBe(false);
@@ -635,6 +677,7 @@ describe("entity cache", () => {
   it("RUN_UPDATED populates entity cache", () => {
     const state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
     });
     expect(state.cache.runs.has("run-1")).toBe(true);
@@ -644,6 +687,7 @@ describe("entity cache", () => {
   it("APPROVAL_RECEIVED populates entity cache", () => {
     const state = gatewayReducer(initialState, {
       type: "APPROVAL_RECEIVED",
+      nowMs: NOW,
       payload: makeApproval("appr-1"),
     });
     expect(state.cache.approvals.has("appr-1")).toBe(true);
@@ -652,6 +696,7 @@ describe("entity cache", () => {
   it("TERMINAL_FRAMES_RECEIVED populates entity cache", () => {
     const state = gatewayReducer(initialState, {
       type: "TERMINAL_FRAMES_RECEIVED",
+      nowMs: NOW,
       runId: "run-1",
       frames: [makeFrame(1)],
     });
@@ -661,6 +706,7 @@ describe("entity cache", () => {
   it("PLANNING_SESSION_UPDATED populates entity cache", () => {
     const state = gatewayReducer(initialState, {
       type: "PLANNING_SESSION_UPDATED",
+      nowMs: NOW,
       payload: makePlanningSummary(),
     });
     expect(state.cache.planning.has("sess-1")).toBe(true);
@@ -671,10 +717,12 @@ describe("stream staleness vs failed run", () => {
   it("stale stream does not set run error", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
     });
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
     // Stream is stale but run should not be errored out.
@@ -685,14 +733,17 @@ describe("stream staleness vs failed run", () => {
   it("stream recovery clears staleness flag", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
+      nowMs: NOW,
       payload: makeRunDetail(),
     });
     state = gatewayReducer(state, {
       type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
       runId: "run-1",
     });
     state = gatewayReducer(state, {
       type: "STREAM_RECOVERED",
+      nowMs: NOW,
       runId: "run-1",
     });
     expect(state.terminal.streamStale.get("run-1")).toBe(false);

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -607,15 +607,15 @@ describe("action receipts", () => {
 
 describe("deriveRunPhaseState", () => {
   it("retry_queued run status maps to retry_queued phase", () => {
-    expect(deriveRunPhaseState("retry_queued", undefined, false)).toBe("retry_queued");
+    expect(deriveRunPhaseState({ status: "retry_queued" } as any, undefined, false)).toBe("retry_queued");
   });
 
   it("released run status maps to cancelled phase", () => {
-    expect(deriveRunPhaseState("released", undefined, false)).toBe("cancelled");
+    expect(deriveRunPhaseState({ status: "released" } as any, undefined, false)).toBe("cancelled");
   });
 
   it("stale stream maps to degraded phase when run is still alive", () => {
-    expect(deriveRunPhaseState("running", undefined, true)).toBe("degraded");
+    expect(deriveRunPhaseState({ status: "running" } as any, undefined, true)).toBe("degraded");
   });
 
   it("active run with fresh stream is active", () => {
@@ -629,7 +629,7 @@ describe("deriveRunPhaseState", () => {
       isStreamStale: false,
       streamHealth: "healthy" as const,
     };
-    expect(deriveRunPhaseState("running", liveness, false)).toBe("active");
+    expect(deriveRunPhaseState({ status: "running" } as any, liveness, false)).toBe("active");
   });
 });
 

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -827,4 +827,77 @@ describe("stream staleness vs failed run", () => {
     expect(liveness?.phaseState).toBe("cancelled");
     expect(liveness?.isStreamStale).toBe(true);
   });
+
+  it("RUN_EVENTS_RECEIVED does not force stalled run to active", () => {
+    // Create a running run and drive it to stalled via health checks.
+    const baseTime = 1_700_000_000_000;
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      nowMs: baseTime,
+      payload: makeRunDetail("running"),
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      nowMs: baseTime,
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+    // Drive liveness to stalled by checking health at 90s (60-120s window).
+    state = gatewayReducer(state, {
+      type: "STREAM_HEALTH_CHECK",
+      runId: "run-1",
+      nowMs: baseTime + 90_000,
+    });
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("stalled");
+
+    // Now dispatch events — the gap is still large so phase should
+    // NOT be forced to "active" by the reducer.
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      nowMs: baseTime + 95_000,
+      runId: "run-1",
+      events: [makeRunEvent(2)],
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    // deriveRunPhaseState correctly preserves "stalled" for a running run with
+    // a large event gap, rather than the old hardcoded "active" override.
+    expect(liveness?.phaseState).toBe("stalled");
+    expect(liveness?.isStreamStale).toBe(false);
+  });
+
+  it("STREAM_RECOVERED preserves completed run phase state", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      nowMs: NOW,
+      payload: {
+        ...makeRunDetail("released"),
+        release_reason: "completed",
+      },
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+    // Simulate stream going stale then recovering.
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
+      runId: "run-1",
+    });
+    expect(state.run.liveness.get("run-1")?.phaseState).toBe("completed");
+
+    state = gatewayReducer(state, {
+      type: "STREAM_RECOVERED",
+      nowMs: NOW + 1000,
+      runId: "run-1",
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.phaseState).toBe("completed");
+    expect(liveness?.isStreamStale).toBe(false);
+    expect(liveness?.streamHealth).toBe("healthy");
+  });
 });

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -449,17 +449,14 @@ describe("run events and liveness", () => {
     let state = gatewayReducer(initialState, {
       type: "RUN_UPDATED",
       payload: makeRunDetail(),
+      nowMs: baseTime,
     });
     state = gatewayReducer(state, {
       type: "RUN_EVENTS_RECEIVED",
       runId: "run-1",
       events: [makeRunEvent(1)],
+      nowMs: baseTime,
     });
-    // Force lastEventAt to a known time.
-    const liveness = state.run.liveness.get("run-1");
-    if (liveness) {
-      liveness.lastEventAt = new Date(baseTime).toISOString();
-    }
 
     // Check health 10 seconds later -> still quiet.
     state = gatewayReducer(state, {

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -750,4 +750,57 @@ describe("stream staleness vs failed run", () => {
     });
     expect(state.terminal.streamStale.get("run-1")).toBe(false);
   });
+
+  it("released/completed run does not collapse to degraded on stream staleness", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      nowMs: NOW,
+      payload: {
+        ...makeRunDetail("released"),
+        release_reason: "completed",
+      },
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
+      runId: "run-1",
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    // Completed run stays "active" even when stream is stale.
+    expect(liveness?.phaseState).toBe("active");
+    expect(liveness?.isStreamStale).toBe(true);
+  });
+
+  it("released/cancelled run stays cancelled on stream staleness", () => {
+    let state = gatewayReducer(initialState, {
+      type: "RUN_UPDATED",
+      nowMs: NOW,
+      payload: {
+        ...makeRunDetail("released"),
+        release_reason: "cancelled",
+      },
+    });
+    state = gatewayReducer(state, {
+      type: "RUN_EVENTS_RECEIVED",
+      nowMs: NOW,
+      runId: "run-1",
+      events: [makeRunEvent(1)],
+    });
+    state = gatewayReducer(state, {
+      type: "STREAM_STALE_DETECTED",
+      nowMs: NOW,
+      runId: "run-1",
+    });
+
+    const liveness = state.run.liveness.get("run-1");
+    expect(liveness?.phaseState).toBe("cancelled");
+    expect(liveness?.isStreamStale).toBe(true);
+  });
 });

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -466,8 +466,8 @@ describe("run events and liveness", () => {
     });
     const liveness = state.run.liveness.get("run-1");
     expect(liveness).toBeTruthy();
-    // eventCount is not incremented by RUN_EVENTS_RECEIVED anymore — liveness tracks recency, not count.
-    expect(liveness?.eventCount).toBe(0);
+    // eventCount is incremented by RUN_EVENTS_RECEIVED via computeLivenessState.
+    expect(liveness?.eventCount).toBe(2);
     expect(liveness?.lastEventAt).toBeTruthy();
     expect(liveness?.gapSeconds).toBe(0);
   });
@@ -660,6 +660,7 @@ describe("computeLivenessState", () => {
         streamHealth: "healthy",
       },
       baseTime + 2000,
+      0, // No new events since last health check.
     );
     // With the gap (2s) far below the quiet threshold (300s), stays quiet.
     expect(liveness.phaseState).toBe("quiet");
@@ -671,8 +672,30 @@ describe("computeLivenessState", () => {
       "run-1",
       undefined,
       baseTime,
+      0, // No new events.
     );
     expect(liveness.phaseState).toBe("quiet");
+  });
+
+  it("fresh events -> active", () => {
+    const liveness = computeLivenessState(
+      "run-1",
+      {
+        runId: "run-1",
+        phaseState: "quiet",
+        lastEventAt: new Date(baseTime).toISOString(),
+        lastStatusUpdateAt: null,
+        eventCount: 5,
+        gapSeconds: 0,
+        isStreamStale: false,
+        streamHealth: "healthy",
+      },
+      baseTime + 2000,
+      3, // 3 new events since last check.
+    );
+    // With fresh events and small gap, should be active.
+    expect(liveness.phaseState).toBe("active");
+    expect(liveness.eventCount).toBe(8);
   });
 });
 

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -428,6 +428,7 @@ describe("connection state", () => {
     const state = gatewayReducer(initialState, {
       type: "RECONNECT_ATTEMPTED",
       attempts: 2,
+      nowMs: NOW,
     });
     expect(state.connection.reconnectAttempts).toBe(2);
     expect(state.connection.state).toBe("reconnecting");

--- a/packages/state/__tests__/reducer.test.ts
+++ b/packages/state/__tests__/reducer.test.ts
@@ -773,8 +773,8 @@ describe("stream staleness vs failed run", () => {
     });
 
     const liveness = state.run.liveness.get("run-1");
-    // Completed run stays "active" even when stream is stale.
-    expect(liveness?.phaseState).toBe("active");
+    // Completed run stays "completed" even when stream is stale.
+    expect(liveness?.phaseState).toBe("completed");
     expect(liveness?.isStreamStale).toBe(true);
   });
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -244,10 +244,12 @@ export function deriveRunPhaseState(
   }
   if (status === "retry_queued") return "retry_queued";
 
-  // Stream staleness only matters when there is an active run (claimed or running).
-  // Unclaimed runs have no stream to be stale.
+  // Stream staleness overrides liveness for active runs — a stale stream should
+  // show as degraded rather than collapsing into detached/failed, even when the
+  // underlying liveness gap is large.
   if (streamStale && (status === "claimed" || status === "running")) return "degraded";
 
+  // No liveness data yet means the run has not produced events; default to active.
   if (!liveness) return "active";
 
   return liveness.phaseState;
@@ -623,7 +625,6 @@ export function gatewayReducer(
       );
 
       // Determine phase state considering stream staleness.
-      const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
       const phaseState = deriveRunPhaseState(runDetail, livenessState, isStreamStale);
 
       const liveness = new Map(state.run.liveness);
@@ -639,18 +640,17 @@ export function gatewayReducer(
       const streamStale = new Map(state.terminal.streamStale);
       streamStale.set(action.runId, true);
 
-      // Update liveness to degraded (not failed!).
+      // Update liveness to reflect stale stream — but delegate to deriveRunPhaseState
+      // so terminal run statuses (released) are not collapsed into degraded.
       const liveness = new Map(state.run.liveness);
       const existing = liveness.get(action.runId);
       const runDetail = state.run.runs.get(action.runId);
-      const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
 
       if (existing) {
+        const phaseState = deriveRunPhaseState(runDetail, existing, true);
         liveness.set(action.runId, {
           ...existing,
-          phaseState: existing.phaseState === "cancelled" || existing.phaseState === "detached"
-            ? existing.phaseState
-            : "degraded",
+          phaseState,
           isStreamStale: true,
           streamHealth: "stale",
         });
@@ -680,11 +680,11 @@ export function gatewayReducer(
       const streamStale = new Map(state.terminal.streamStale);
       streamStale.set(action.runId, false);
 
-      // Update liveness back to active if the run is still running.
+      // Restore liveness — terminal statuses (released) are already stable, so
+      // we only need to reset non-terminal liveness entries back to active.
       const liveness = new Map(state.run.liveness);
       const existing = liveness.get(action.runId);
       const runDetail = state.run.runs.get(action.runId);
-      const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
 
       if (existing) {
         liveness.set(action.runId, {

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -704,9 +704,12 @@ export function gatewayReducer(
       const runDetail = state.run.runs.get(action.runId);
 
       if (existing) {
+        // Update lastEventAt before computing liveness so the gap calculation
+        // reflects the recovery timestamp rather than the stale previous one.
+        const freshLiveness = { ...existing, lastEventAt: msToIso(action.nowMs) };
         const recomputedLiveness = computeLivenessState(
           action.runId,
-          existing,
+          freshLiveness,
           action.nowMs,
           1, // Recovery means activity resumed.
         );
@@ -717,7 +720,6 @@ export function gatewayReducer(
           phaseState,
           isStreamStale: false,
           streamHealth: "healthy",
-          lastEventAt: msToIso(action.nowMs),
         });
       } else if (runDetail) {
         // Create liveness entry for runs that haven't received events yet.

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -695,17 +695,25 @@ export function gatewayReducer(
       const streamStale = new Map(state.terminal.streamStale);
       streamStale.set(action.runId, false);
 
-      // Restore liveness — delegate to deriveRunPhaseState so terminal run
-      // statuses (completed/cancelled) are preserved correctly and non-terminal
-      // runs transition to active on recovery.
+      // Restore liveness — recompute phaseState based on current event recency
+      // so terminal run statuses (completed/cancelled) are preserved correctly
+      // and non-terminal runs transition based on actual gap. Recovery implies
+      // at least one event has arrived, so we signal 1 event since last check.
       const liveness = new Map(state.run.liveness);
       const existing = liveness.get(action.runId);
       const runDetail = state.run.runs.get(action.runId);
 
       if (existing) {
-        const phaseState = deriveRunPhaseState(runDetail, existing, false);
+        const recomputedLiveness = computeLivenessState(
+          action.runId,
+          existing,
+          action.nowMs,
+          1, // Recovery means activity resumed.
+        );
+        const phaseState = deriveRunPhaseState(runDetail, recomputedLiveness, false);
         liveness.set(action.runId, {
           ...existing,
+          ...recomputedLiveness,
           phaseState,
           isStreamStale: false,
           streamHealth: "healthy",

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -201,27 +201,30 @@ export const initialState: GatewayState = {
 
 // -- Action types --
 
+/** Optional deterministic timestamp for reducer purity (tests). */
+type WithTimestamp = { nowMs?: number };
+
 export type GatewayAction =
   // Connection actions
-  | { type: "CONNECTION_STATE_CHANGED"; state: ConnectionState; error?: string }
+  | { type: "CONNECTION_STATE_CHANGED"; state: ConnectionState; error?: string; nowMs?: number }
   | { type: "RECONNECT_ATTEMPTED"; attempts: number }
   // Snapshot/actions
-  | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot }
-  | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot }
-  | { type: "RUN_UPDATED"; payload: RunDetail }
-  | { type: "TERMINAL_FRAMES_RECEIVED"; runId: string; frames: TerminalFrame[] }
-  | { type: "APPROVAL_RECEIVED"; payload: ApprovalRequest }
-  | { type: "APPROVAL_RESOLVED"; approvalId: string; payload: ApprovalRequest }
-  | { type: "PLANNING_SESSION_UPDATED"; payload: PlanningSessionSummary }
-  | { type: "RUN_EVENTS_RECEIVED"; runId: string; events: RunEvent[] }
+  | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot; nowMs?: number }
+  | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot; nowMs?: number }
+  | { type: "RUN_UPDATED"; payload: RunDetail; nowMs?: number }
+  | { type: "TERMINAL_FRAMES_RECEIVED"; runId: string; frames: TerminalFrame[]; nowMs?: number }
+  | { type: "APPROVAL_RECEIVED"; payload: ApprovalRequest; nowMs?: number }
+  | { type: "APPROVAL_RESOLVED"; approvalId: string; payload: ApprovalRequest; nowMs?: number }
+  | { type: "PLANNING_SESSION_UPDATED"; payload: PlanningSessionSummary; nowMs?: number }
+  | { type: "RUN_EVENTS_RECEIVED"; runId: string; events: RunEvent[]; nowMs?: number }
   // Envelope/actions
   | { type: "ENVELOPE_RECEIVED"; payload: GatewayEnvelope }
-  | { type: "ACTION_RECEIPT_RECEIVED"; receipt: ActionReceipt }
-  | { type: "ACTION_DISPATCHED"; correlationId: string }
+  | { type: "ACTION_RECEIPT_RECEIVED"; receipt: ActionReceipt; nowMs?: number }
+  | { type: "ACTION_DISPATCHED"; correlationId: string; nowMs?: number }
   // Liveness/stream health
   | { type: "STREAM_HEALTH_CHECK"; runId: string; nowMs?: number }
-  | { type: "STREAM_STALE_DETECTED"; runId: string }
-  | { type: "STREAM_RECOVERED"; runId: string }
+  | { type: "STREAM_STALE_DETECTED"; runId: string; nowMs?: number }
+  | { type: "STREAM_RECOVERED"; runId: string; nowMs?: number }
   // Generic
   | { type: "ERROR"; error: string }
   | { type: "LOADING"; loading: boolean };
@@ -291,8 +294,9 @@ export function computeLivenessState(
 
 // -- Reducer --
 
-function nowIso(): string {
-  return new Date().toISOString();
+/** Convert milliseconds to ISO string deterministically (for reducer purity). */
+function msToIso(ms: number): string {
+  return new Date(ms).toISOString();
 }
 
 export function gatewayReducer(
@@ -309,8 +313,8 @@ export function gatewayReducer(
           ...state.connection,
           state: action.state,
           error: connError,
-          lastConnectedAt: action.state === "connected" ? nowIso() : state.connection.lastConnectedAt,
-          lastDisconnectedAt: action.state === "disconnected" ? nowIso() : state.connection.lastDisconnectedAt,
+          lastConnectedAt: action.state === "connected" ? msToIso(action.nowMs ?? Date.now()) : state.connection.lastConnectedAt,
+          lastDisconnectedAt: action.state === "disconnected" ? msToIso(action.nowMs ?? Date.now()) : state.connection.lastDisconnectedAt,
           reconnectAttempts: action.state === "reconnecting" ? state.connection.reconnectAttempts + 1 : state.connection.reconnectAttempts,
         },
       };
@@ -335,7 +339,7 @@ export function gatewayReducer(
           snapshot: action.payload,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
       };
 
@@ -348,7 +352,7 @@ export function gatewayReducer(
           rootIds: action.payload.root_ids,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
       };
     }
@@ -360,7 +364,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cacheRuns = new Map(state.cache.runs);
       cacheRuns.set(action.payload.run_id, {
-        lastSeen: nowIso(),
+        lastSeen: msToIso(action.nowMs ?? Date.now()),
         version: (cacheRuns.get(action.payload.run_id)?.version ?? 0) + 1,
         data: action.payload,
       });
@@ -371,7 +375,7 @@ export function gatewayReducer(
       if (existingLiveness) {
         liveness.set(action.payload.run_id, {
           ...existingLiveness,
-          lastStatusUpdateAt: nowIso(),
+          lastStatusUpdateAt: msToIso(action.nowMs ?? Date.now()),
         });
       }
 
@@ -383,7 +387,7 @@ export function gatewayReducer(
           liveness,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
         cache: { ...state.cache, runs: cacheRuns },
       };
@@ -397,8 +401,8 @@ export function gatewayReducer(
       liveness.set(action.runId, {
         runId: action.runId,
         phaseState: existingLiveness?.phaseState ?? "active",
-        lastEventAt: nowIso(),
-        lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? nowIso(),
+        lastEventAt: msToIso(action.nowMs ?? Date.now()),
+        lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? msToIso(action.nowMs ?? Date.now()),
         eventCount: (existingLiveness?.eventCount ?? 0) + action.events.length,
         gapSeconds: 0,
         isStreamStale: false,
@@ -413,7 +417,7 @@ export function gatewayReducer(
           liveness,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
       };
     }
@@ -436,7 +440,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cacheTerminals = new Map(state.cache.terminals);
       cacheTerminals.set(action.runId, {
-        lastSeen: nowIso(),
+        lastSeen: msToIso(action.nowMs ?? Date.now()),
         version: (cacheTerminals.get(action.runId)?.version ?? 0) + 1,
         data: action.frames,
       });
@@ -449,7 +453,7 @@ export function gatewayReducer(
           cursor,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
         cache: { ...state.cache, terminals: cacheTerminals },
       };
@@ -467,12 +471,12 @@ export function gatewayReducer(
             : [...state.approval.pending, action.payload],
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
         cache: {
           ...state.cache,
           approvals: new Map(state.cache.approvals).set(action.payload.approval_id, {
-            lastSeen: nowIso(),
+            lastSeen: msToIso(action.nowMs ?? Date.now()),
             version: 1,
             data: action.payload,
           }),
@@ -488,7 +492,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cacheApprovals = new Map(state.cache.approvals);
       cacheApprovals.set(approvalId, {
-        lastSeen: nowIso(),
+        lastSeen: msToIso(action.nowMs ?? Date.now()),
         version: (cacheApprovals.get(approvalId)?.version ?? 0) + 1,
         data: action.payload,
       });
@@ -501,7 +505,7 @@ export function gatewayReducer(
           resolved,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
         cache: { ...state.cache, approvals: cacheApprovals },
       };
@@ -514,7 +518,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cachePlanning = new Map(state.cache.planning);
       cachePlanning.set(action.payload.session_id, {
-        lastSeen: nowIso(),
+        lastSeen: msToIso(action.nowMs ?? Date.now()),
         version: (cachePlanning.get(action.payload.session_id)?.version ?? 0) + 1,
         data: action.payload,
       });
@@ -525,7 +529,7 @@ export function gatewayReducer(
           sessions,
           loading: false,
           error: null,
-          lastUpdated: nowIso(),
+          lastUpdated: msToIso(action.nowMs ?? Date.now()),
         },
         cache: { ...state.cache, planning: cachePlanning },
       };
@@ -589,7 +593,7 @@ export function gatewayReducer(
       const pending = new Map(state.actionReceipts.pending);
       pending.set(action.correlationId, {
         correlationId: action.correlationId,
-        dispatchedAt: nowIso(),
+        dispatchedAt: msToIso(action.nowMs ?? Date.now()),
       });
       return {
         ...state,
@@ -601,7 +605,7 @@ export function gatewayReducer(
 
     case "STREAM_HEALTH_CHECK": {
       const { runId } = action;
-      const now = action.nowMs ?? Date.now();
+      const nowMs = action.nowMs ?? Date.now();
       const existingLiveness = state.run.liveness.get(runId);
       const runDetail = state.run.runs.get(runId);
       const isStreamStale = state.terminal.streamStale.get(runId) ?? false;
@@ -611,7 +615,7 @@ export function gatewayReducer(
       const livenessState = computeLivenessState(
         runId,
         existingLiveness,
-        now,
+        nowMs,
         0, // No new events since last check.
       );
 
@@ -687,7 +691,7 @@ export function gatewayReducer(
             : "active",
           isStreamStale: false,
           streamHealth: "healthy",
-          lastEventAt: nowIso(),
+          lastEventAt: msToIso(action.nowMs ?? Date.now()),
         });
       } else if (runDetail) {
         // Create liveness entry for runs that haven't received events yet.
@@ -695,7 +699,7 @@ export function gatewayReducer(
         liveness.set(action.runId, {
           runId: action.runId,
           phaseState,
-          lastEventAt: nowIso(),
+          lastEventAt: msToIso(action.nowMs ?? Date.now()),
           lastStatusUpdateAt: null,
           eventCount: 0,
           gapSeconds: 0,

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -226,19 +226,25 @@ export type GatewayAction =
   | { type: "ERROR"; error: string }
   | { type: "LOADING"; loading: boolean };
 
-/** Determine the run phase state from run status and stream activity. */
+/** Determine the run phase state from run detail and stream activity. */
 export function deriveRunPhaseState(
-  runStatus: RunStatus,
+  runDetail: RunDetail | undefined,
   liveness: RunLivenessState | undefined,
   streamStale: boolean,
 ): RunPhaseState {
-  // Terminal statuses from the run itself take priority.
-  if (runStatus === "retry_queued") return "retry_queued";
-  if (runStatus === "released") {
-    return "cancelled"; // Simplified; actual reason would refine this.
-  }
+  const status = runDetail?.status ?? "unclaimed";
+  const releaseReason = runDetail?.release_reason;
 
-  // If the stream is stale but the run hasn't failed, keep it as degraded, not failed.
+  // Terminal run statuses take absolute priority.
+  if (status === "released") {
+    // Use release_reason to distinguish final state.
+    if (releaseReason === "completed" || releaseReason === "tracker_terminal") return "active";
+    if (releaseReason === "cancelled" || releaseReason === "tracker_inactive" || releaseReason === "retry_exhausted") return "cancelled";
+    return "cancelled";
+  }
+  if (status === "retry_queued") return "retry_queued";
+
+  // If the stream is stale but the run has not terminated, keep it as degraded.
   if (streamStale) return "degraded";
 
   if (!liveness) return "active";
@@ -396,7 +402,7 @@ export function gatewayReducer(
 
       liveness.set(action.runId, {
         runId: action.runId,
-        phaseState: existingLiveness?.phaseState ?? "active",
+        phaseState: "active",
         lastEventAt: msToIso(action.nowMs),
         lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? msToIso(action.nowMs),
         eventCount: (existingLiveness?.eventCount ?? 0) + action.events.length,
@@ -617,7 +623,7 @@ export function gatewayReducer(
 
       // Determine phase state considering stream staleness.
       const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
-      const phaseState = deriveRunPhaseState(runStatus, livenessState, isStreamStale);
+      const phaseState = deriveRunPhaseState(runDetail, livenessState, isStreamStale);
 
       const liveness = new Map(state.run.liveness);
       liveness.set(runId, { ...livenessState, phaseState });
@@ -649,7 +655,7 @@ export function gatewayReducer(
         });
       } else if (runDetail) {
         // Create liveness entry for runs that haven't received events yet.
-        const phaseState = deriveRunPhaseState(runStatus, undefined, true);
+        const phaseState = deriveRunPhaseState(runDetail, undefined, true);
         liveness.set(action.runId, {
           runId: action.runId,
           phaseState,
@@ -691,7 +697,7 @@ export function gatewayReducer(
         });
       } else if (runDetail) {
         // Create liveness entry for runs that haven't received events yet.
-        const phaseState = deriveRunPhaseState(runStatus, undefined, false);
+        const phaseState = deriveRunPhaseState(runDetail, undefined, false);
         liveness.set(action.runId, {
           runId: action.runId,
           phaseState,

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -288,10 +288,14 @@ export function computeLivenessState(
     streamHealth = "stale";
   }
 
+  // When events arrive, update lastEventAt to the current time so the returned
+  // liveness state is self-consistent and callers do not need to override it.
+  const resolvedLastEventAt = eventsSinceLastCheck > 0 ? msToIso(nowMs) : lastEventAt;
+
   return {
     runId,
     phaseState,
-    lastEventAt,
+    lastEventAt: resolvedLastEventAt,
     lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? null,
     eventCount: (existingLiveness?.eventCount ?? 0) + eventsSinceLastCheck,
     gapSeconds,
@@ -424,7 +428,6 @@ export function gatewayReducer(
       liveness.set(action.runId, {
         ...computedLiveness,
         phaseState: computedPhase,
-        lastEventAt: msToIso(action.nowMs),
         isStreamStale: false,
         streamHealth: "healthy",
       });

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -12,10 +12,80 @@ import type {
   TaskGraphNode,
   TaskGraphSnapshot,
   RunDetail,
+  RunEvent,
+  RunStatus,
   TerminalFrame,
   ApprovalRequest,
   PlanningSessionSummary,
+  ActionReceipt,
 } from "@opensymphony/gateway-schema";
+
+// -- Connection state --
+
+export type ConnectionState =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "degraded"
+  | "reconnecting"
+  | "failed";
+
+export interface ConnectionStateSlice {
+  state: ConnectionState;
+  lastConnectedAt: string | null;
+  lastDisconnectedAt: string | null;
+  reconnectAttempts: number;
+  error: string | null;
+}
+
+// -- Entity cache --
+
+export interface EntityCacheEntry {
+  lastSeen: string;
+  version: number;
+  data: unknown;
+}
+
+export interface EntityCacheSlice {
+  runs: Map<string, EntityCacheEntry>;
+  terminals: Map<string, EntityCacheEntry>;
+  approvals: Map<string, EntityCacheEntry>;
+  planning: Map<string, EntityCacheEntry>;
+}
+
+// -- Run phase liveness state --
+
+/**
+ * Client-side interpretation of run liveness from the stream perspective.
+ * These states are derived from run status, event recency, and stream health.
+ *
+ * - active:   Run is producing events at a normal rate.
+ * - quiet:    Run is still claimed/running but producing no events recently.
+ * - degraded: Stream is lagging or losing events but run is still alive.
+ * - stalled:  No events for an extended period; run may be stuck.
+ * - retry_queued: Run status indicates it is queued for retry.
+ * - cancelled: Run was explicitly cancelled.
+ * - detached: Client lost connection; run may still be executing server-side.
+ */
+export type RunPhaseState =
+  | "active"
+  | "quiet"
+  | "degraded"
+  | "stalled"
+  | "retry_queued"
+  | "cancelled"
+  | "detached";
+
+export interface RunLivenessState {
+  runId: string;
+  phaseState: RunPhaseState;
+  lastEventAt: string | null;
+  lastStatusUpdateAt: string | null;
+  eventCount: number;
+  gapSeconds: number;
+  isStreamStale: boolean;
+  streamHealth: "healthy" | "degraded" | "stale";
+}
 
 // -- State slices --
 
@@ -23,6 +93,7 @@ export interface DashboardSlice {
   snapshot: DashboardSnapshot | null;
   loading: boolean;
   error: string | null;
+  lastUpdated: string | null;
 }
 
 export interface TaskGraphSlice {
@@ -30,12 +101,15 @@ export interface TaskGraphSlice {
   rootIds: string[];
   loading: boolean;
   error: string | null;
+  lastUpdated: string | null;
 }
 
 export interface RunSlice {
   runs: Map<string, RunDetail>;
+  liveness: Map<string, RunLivenessState>;
   loading: boolean;
   error: string | null;
+  lastUpdated: string | null;
 }
 
 export interface TerminalSlice {
@@ -43,6 +117,9 @@ export interface TerminalSlice {
   cursor: Map<string, number>;
   loading: boolean;
   error: string | null;
+  lastUpdated: string | null;
+  /** Tracks whether the terminal stream is stale vs the run being failed. */
+  streamStale: Map<string, boolean>;
 }
 
 export interface ApprovalSlice {
@@ -50,37 +127,85 @@ export interface ApprovalSlice {
   resolved: Map<string, ApprovalRequest>;
   loading: boolean;
   error: string | null;
+  lastUpdated: string | null;
 }
 
 export interface PlanningSlice {
   sessions: Map<string, PlanningSessionSummary>;
   loading: boolean;
   error: string | null;
+  lastUpdated: string | null;
+}
+
+/** Action receipts correlated with dispatched mutations. */
+export interface ActionReceiptSlice {
+  receipts: Map<string, ActionReceipt>;
+  pending: Map<string, { correlationId: string; dispatchedAt: string }>;
 }
 
 // -- Combined state --
 
 export interface GatewayState {
+  connection: ConnectionStateSlice;
+  cache: EntityCacheSlice;
   dashboard: DashboardSlice;
   taskGraph: TaskGraphSlice;
   run: RunSlice;
   terminal: TerminalSlice;
   approval: ApprovalSlice;
   planning: PlanningSlice;
+  actionReceipts: ActionReceiptSlice;
 }
 
+/** Liveness thresholds in milliseconds. */
+export const LIVENESS_THRESHOLDS = {
+  /** Events arriving faster than this interval indicate active work. */
+  activeIntervalMs: 5000,
+  /** No events for this duration -> quiet state. */
+  quietThresholdMs: 30_000,
+  /** No events for this duration -> degraded state. */
+  degradedThresholdMs: 60_000,
+  /** No events for this duration -> stalled state. */
+  stalledThresholdMs: 120_000,
+};
+
 export const initialState: GatewayState = {
-  dashboard: { snapshot: null, loading: false, error: null },
-  taskGraph: { nodes: new Map(), rootIds: [], loading: false, error: null },
-  run: { runs: new Map(), loading: false, error: null },
-  terminal: { frames: new Map(), cursor: new Map(), loading: false, error: null },
-  approval: { pending: [], resolved: new Map(), loading: false, error: null },
-  planning: { sessions: new Map(), loading: false, error: null },
+  connection: {
+    state: "disconnected",
+    lastConnectedAt: null,
+    lastDisconnectedAt: null,
+    reconnectAttempts: 0,
+    error: null,
+  },
+  cache: {
+    runs: new Map(),
+    terminals: new Map(),
+    approvals: new Map(),
+    planning: new Map(),
+  },
+  dashboard: { snapshot: null, loading: false, error: null, lastUpdated: null },
+  taskGraph: { nodes: new Map(), rootIds: [], loading: false, error: null, lastUpdated: null },
+  run: { runs: new Map(), liveness: new Map(), loading: false, error: null, lastUpdated: null },
+  terminal: {
+    frames: new Map(),
+    cursor: new Map(),
+    loading: false,
+    error: null,
+    lastUpdated: null,
+    streamStale: new Map(),
+  },
+  approval: { pending: [], resolved: new Map(), loading: false, error: null, lastUpdated: null },
+  planning: { sessions: new Map(), loading: false, error: null, lastUpdated: null },
+  actionReceipts: { receipts: new Map(), pending: new Map() },
 };
 
 // -- Action types --
 
 export type GatewayAction =
+  // Connection actions
+  | { type: "CONNECTION_STATE_CHANGED"; state: ConnectionState; error?: string }
+  | { type: "RECONNECT_ATTEMPTED"; attempts: number }
+  // Snapshot/actions
   | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot }
   | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot }
   | { type: "RUN_UPDATED"; payload: RunDetail }
@@ -88,41 +213,210 @@ export type GatewayAction =
   | { type: "APPROVAL_RECEIVED"; payload: ApprovalRequest }
   | { type: "APPROVAL_RESOLVED"; approvalId: string; payload: ApprovalRequest }
   | { type: "PLANNING_SESSION_UPDATED"; payload: PlanningSessionSummary }
+  | { type: "RUN_EVENTS_RECEIVED"; runId: string; events: RunEvent[] }
+  // Envelope/actions
   | { type: "ENVELOPE_RECEIVED"; payload: GatewayEnvelope }
+  | { type: "ACTION_RECEIPT_RECEIVED"; receipt: ActionReceipt }
+  | { type: "ACTION_DISPATCHED"; correlationId: string }
+  // Liveness/stream health
+  | { type: "STREAM_HEALTH_CHECK"; runId: string; nowMs?: number }
+  | { type: "STREAM_STALE_DETECTED"; runId: string }
+  | { type: "STREAM_RECOVERED"; runId: string }
+  // Generic
   | { type: "ERROR"; error: string }
   | { type: "LOADING"; loading: boolean };
 
+/** Determine the run phase state from run status and stream activity. */
+export function deriveRunPhaseState(
+  runStatus: RunStatus,
+  liveness: RunLivenessState | undefined,
+  streamStale: boolean,
+): RunPhaseState {
+  // Terminal statuses from the run itself take priority.
+  if (runStatus === "retry_queued") return "retry_queued";
+  if (runStatus === "released") {
+    return "cancelled"; // Simplified; actual reason would refine this.
+  }
+
+  // If the stream is stale but the run hasn't failed, keep it as degraded, not failed.
+  if (streamStale) return "degraded";
+
+  if (!liveness) return "active";
+
+  return liveness.phaseState;
+}
+
+/** Compute liveness state for a run based on event activity. */
+export function computeLivenessState(
+  runId: string,
+  existingLiveness: RunLivenessState | undefined,
+  nowMs: number,
+  eventsSinceLastCheck: number,
+): RunLivenessState {
+  const lastEventAt = existingLiveness?.lastEventAt ?? null;
+  const lastEventMs = lastEventAt ? new Date(lastEventAt).getTime() : 0;
+  const gapSeconds = lastEventMs > 0 ? (nowMs - lastEventMs) / 1000 : 0;
+
+  let phaseState: RunPhaseState;
+  let streamHealth: "healthy" | "degraded" | "stale";
+
+  if (eventsSinceLastCheck > 0 && gapSeconds < LIVENESS_THRESHOLDS.activeIntervalMs / 1000) {
+    phaseState = "active";
+    streamHealth = "healthy";
+  } else if (gapSeconds < LIVENESS_THRESHOLDS.quietThresholdMs / 1000) {
+    phaseState = "quiet";
+    streamHealth = "healthy";
+  } else if (gapSeconds < LIVENESS_THRESHOLDS.degradedThresholdMs / 1000) {
+    phaseState = "degraded";
+    streamHealth = "degraded";
+  } else if (gapSeconds < LIVENESS_THRESHOLDS.stalledThresholdMs / 1000) {
+    phaseState = "stalled";
+    streamHealth = "stale";
+  } else {
+    phaseState = "detached";
+    streamHealth = "stale";
+  }
+
+  return {
+    runId,
+    phaseState,
+    lastEventAt,
+    lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? null,
+    eventCount: (existingLiveness?.eventCount ?? 0) + eventsSinceLastCheck,
+    gapSeconds,
+    isStreamStale: streamHealth === "stale",
+    streamHealth,
+  };
+}
+
 // -- Reducer --
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
 
 export function gatewayReducer(
   state: GatewayState,
   action: GatewayAction,
 ): GatewayState {
   switch (action.type) {
+    // -- Connection state --
+    case "CONNECTION_STATE_CHANGED": {
+      const connError = action.error ?? null;
+      return {
+        ...state,
+        connection: {
+          ...state.connection,
+          state: action.state,
+          error: connError,
+          lastConnectedAt: action.state === "connected" ? nowIso() : state.connection.lastConnectedAt,
+          lastDisconnectedAt: action.state === "disconnected" ? nowIso() : state.connection.lastDisconnectedAt,
+          reconnectAttempts: action.state === "reconnecting" ? state.connection.reconnectAttempts + 1 : state.connection.reconnectAttempts,
+        },
+      };
+    }
+
+    case "RECONNECT_ATTEMPTED": {
+      return {
+        ...state,
+        connection: {
+          ...state.connection,
+          reconnectAttempts: action.attempts,
+          state: action.attempts > 0 ? "reconnecting" : state.connection.state,
+        },
+      };
+    }
+
+    // -- Snapshot received --
     case "SNAPSHOT_RECEIVED":
       return {
         ...state,
-        dashboard: { snapshot: action.payload, loading: false, error: null },
+        dashboard: {
+          snapshot: action.payload,
+          loading: false,
+          error: null,
+          lastUpdated: nowIso(),
+        },
       };
 
     case "TASK_GRAPH_RECEIVED": {
       const nodes = new Map(action.payload.nodes.map((n) => [n.node_id, n]));
       return {
         ...state,
-        taskGraph: { nodes, rootIds: action.payload.root_ids, loading: false, error: null },
+        taskGraph: {
+          nodes,
+          rootIds: action.payload.root_ids,
+          loading: false,
+          error: null,
+          lastUpdated: nowIso(),
+        },
       };
     }
 
-    case "RUN_UPDATED":
+    case "RUN_UPDATED": {
+      const runs = new Map(state.run.runs);
+      runs.set(action.payload.run_id, action.payload);
+
+      // Update entity cache.
+      const cacheRuns = new Map(state.cache.runs);
+      cacheRuns.set(action.payload.run_id, {
+        lastSeen: nowIso(),
+        version: (cacheRuns.get(action.payload.run_id)?.version ?? 0) + 1,
+        data: action.payload,
+      });
+
+      // Update liveness state based on run status.
+      const liveness = new Map(state.run.liveness);
+      const existingLiveness = liveness.get(action.payload.run_id);
+      if (existingLiveness) {
+        liveness.set(action.payload.run_id, {
+          ...existingLiveness,
+          lastStatusUpdateAt: nowIso(),
+        });
+      }
+
       return {
         ...state,
         run: {
           ...state.run,
-          runs: new Map(state.run.runs).set(action.payload.run_id, action.payload),
+          runs,
+          liveness,
           loading: false,
           error: null,
+          lastUpdated: nowIso(),
+        },
+        cache: { ...state.cache, runs: cacheRuns },
+      };
+    }
+
+    case "RUN_EVENTS_RECEIVED": {
+      const runs = new Map(state.run.runs);
+      const liveness = new Map(state.run.liveness);
+      const existingLiveness = liveness.get(action.runId);
+
+      liveness.set(action.runId, {
+        runId: action.runId,
+        phaseState: existingLiveness?.phaseState ?? "active",
+        lastEventAt: nowIso(),
+        lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? nowIso(),
+        eventCount: (existingLiveness?.eventCount ?? 0) + action.events.length,
+        gapSeconds: 0,
+        isStreamStale: false,
+        streamHealth: "healthy",
+      });
+
+      return {
+        ...state,
+        run: {
+          ...state.run,
+          runs,
+          liveness,
+          loading: false,
+          error: null,
+          lastUpdated: nowIso(),
         },
       };
+    }
 
     case "TERMINAL_FRAMES_RECEIVED": {
       const frames = new Map(state.terminal.frames);
@@ -138,9 +432,26 @@ export function gatewayReducer(
         const prevCursor = cursor.get(action.runId) ?? 0;
         cursor.set(action.runId, Math.max(prevCursor, maxSeq));
       }
+
+      // Update entity cache.
+      const cacheTerminals = new Map(state.cache.terminals);
+      cacheTerminals.set(action.runId, {
+        lastSeen: nowIso(),
+        version: (cacheTerminals.get(action.runId)?.version ?? 0) + 1,
+        data: action.frames,
+      });
+
       return {
         ...state,
-        terminal: { ...state.terminal, frames, cursor, loading: false, error: null },
+        terminal: {
+          ...state.terminal,
+          frames,
+          cursor,
+          loading: false,
+          error: null,
+          lastUpdated: nowIso(),
+        },
+        cache: { ...state.cache, terminals: cacheTerminals },
       };
     }
 
@@ -156,6 +467,15 @@ export function gatewayReducer(
             : [...state.approval.pending, action.payload],
           loading: false,
           error: null,
+          lastUpdated: nowIso(),
+        },
+        cache: {
+          ...state.cache,
+          approvals: new Map(state.cache.approvals).set(action.payload.approval_id, {
+            lastSeen: nowIso(),
+            version: 1,
+            data: action.payload,
+          }),
         },
       };
     }
@@ -164,6 +484,15 @@ export function gatewayReducer(
       const approvalId = action.payload.approval_id;
       const resolved = new Map(state.approval.resolved);
       resolved.set(approvalId, action.payload);
+
+      // Update entity cache.
+      const cacheApprovals = new Map(state.cache.approvals);
+      cacheApprovals.set(approvalId, {
+        lastSeen: nowIso(),
+        version: (cacheApprovals.get(approvalId)?.version ?? 0) + 1,
+        data: action.payload,
+      });
+
       return {
         ...state,
         approval: {
@@ -172,27 +501,225 @@ export function gatewayReducer(
           resolved,
           loading: false,
           error: null,
+          lastUpdated: nowIso(),
         },
+        cache: { ...state.cache, approvals: cacheApprovals },
       };
     }
 
     case "PLANNING_SESSION_UPDATED": {
       const sessions = new Map(state.planning.sessions);
       sessions.set(action.payload.session_id, action.payload);
+
+      // Update entity cache.
+      const cachePlanning = new Map(state.cache.planning);
+      cachePlanning.set(action.payload.session_id, {
+        lastSeen: nowIso(),
+        version: (cachePlanning.get(action.payload.session_id)?.version ?? 0) + 1,
+        data: action.payload,
+      });
+
       return {
         ...state,
-        planning: { sessions, loading: false, error: null },
+        planning: {
+          sessions,
+          loading: false,
+          error: null,
+          lastUpdated: nowIso(),
+        },
+        cache: { ...state.cache, planning: cachePlanning },
       };
     }
 
-    case "ENVELOPE_RECEIVED":
+    case "ENVELOPE_RECEIVED": {
       // Forward to appropriate slice reducer based on event_kind.
-      // Placeholder: no-op for now.
-      return state;
+      const envelope = action.payload;
+      const eventKind = envelope.event_kind;
 
+      // Update entity cache with the envelope.
+      const entityRef = envelope.entity_ref;
+      const cacheEntry = {
+        lastSeen: envelope.emitted_at,
+        version: envelope.cursor.sequence,
+        data: envelope.payload,
+      };
+
+      if (entityRef.kind === "run") {
+        const cacheRuns = new Map(state.cache.runs);
+        cacheRuns.set(entityRef.id, cacheEntry);
+        return {
+          ...state,
+          cache: { ...state.cache, runs: cacheRuns },
+        };
+      } else if (entityRef.kind === "terminal_session") {
+        const cacheTerminals = new Map(state.cache.terminals);
+        cacheTerminals.set(entityRef.id, cacheEntry);
+        return {
+          ...state,
+          cache: { ...state.cache, terminals: cacheTerminals },
+        };
+      } else if (entityRef.kind === "planning_session") {
+        const cachePlanning = new Map(state.cache.planning);
+        cachePlanning.set(entityRef.id, cacheEntry);
+        return {
+          ...state,
+          cache: { ...state.cache, planning: cachePlanning },
+        };
+      }
+
+      // For other entity kinds, just store the envelope in the cache.
+      return state;
+    }
+
+    case "ACTION_RECEIPT_RECEIVED": {
+      const receipts = new Map(state.actionReceipts.receipts);
+      receipts.set(action.receipt.correlation_id, action.receipt);
+
+      // Remove from pending if present.
+      const pending = new Map(state.actionReceipts.pending);
+      pending.delete(action.receipt.correlation_id);
+
+      return {
+        ...state,
+        actionReceipts: { receipts, pending },
+      };
+    }
+
+    case "ACTION_DISPATCHED": {
+      const pending = new Map(state.actionReceipts.pending);
+      pending.set(action.correlationId, {
+        correlationId: action.correlationId,
+        dispatchedAt: nowIso(),
+      });
+      return {
+        ...state,
+        actionReceipts: { ...state.actionReceipts, pending },
+      };
+    }
+
+    // -- Liveness/stream health --
+
+    case "STREAM_HEALTH_CHECK": {
+      const { runId } = action;
+      const now = action.nowMs ?? Date.now();
+      const existingLiveness = state.run.liveness.get(runId);
+      const runDetail = state.run.runs.get(runId);
+      const isStreamStale = state.terminal.streamStale.get(runId) ?? false;
+
+      if (!existingLiveness && !runDetail) return state;
+
+      const livenessState = computeLivenessState(
+        runId,
+        existingLiveness,
+        now,
+        0, // No new events since last check.
+      );
+
+      // Determine phase state considering stream staleness.
+      const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
+      const phaseState = deriveRunPhaseState(runStatus, livenessState, isStreamStale);
+
+      const liveness = new Map(state.run.liveness);
+      liveness.set(runId, { ...livenessState, phaseState });
+
+      return {
+        ...state,
+        run: { ...state.run, liveness },
+      };
+    }
+
+    case "STREAM_STALE_DETECTED": {
+      const streamStale = new Map(state.terminal.streamStale);
+      streamStale.set(action.runId, true);
+
+      // Update liveness to degraded (not failed!).
+      const liveness = new Map(state.run.liveness);
+      const existing = liveness.get(action.runId);
+      const runDetail = state.run.runs.get(action.runId);
+      const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
+
+      if (existing) {
+        liveness.set(action.runId, {
+          ...existing,
+          phaseState: existing.phaseState === "cancelled" || existing.phaseState === "detached"
+            ? existing.phaseState
+            : "degraded",
+          isStreamStale: true,
+          streamHealth: "stale",
+        });
+      } else if (runDetail) {
+        // Create liveness entry for runs that haven't received events yet.
+        const phaseState = deriveRunPhaseState(runStatus, undefined, true);
+        liveness.set(action.runId, {
+          runId: action.runId,
+          phaseState,
+          lastEventAt: null,
+          lastStatusUpdateAt: null,
+          eventCount: 0,
+          gapSeconds: 0,
+          isStreamStale: true,
+          streamHealth: "stale",
+        });
+      }
+
+      return {
+        ...state,
+        terminal: { ...state.terminal, streamStale },
+        run: { ...state.run, liveness },
+      };
+    }
+
+    case "STREAM_RECOVERED": {
+      const streamStale = new Map(state.terminal.streamStale);
+      streamStale.set(action.runId, false);
+
+      // Update liveness back to active if the run is still running.
+      const liveness = new Map(state.run.liveness);
+      const existing = liveness.get(action.runId);
+      const runDetail = state.run.runs.get(action.runId);
+      const runStatus: RunStatus = runDetail?.status ?? "unclaimed";
+
+      if (existing) {
+        liveness.set(action.runId, {
+          ...existing,
+          phaseState: existing.phaseState === "cancelled" || existing.phaseState === "detached"
+            ? existing.phaseState
+            : "active",
+          isStreamStale: false,
+          streamHealth: "healthy",
+          lastEventAt: nowIso(),
+        });
+      } else if (runDetail) {
+        // Create liveness entry for runs that haven't received events yet.
+        const phaseState = deriveRunPhaseState(runStatus, undefined, false);
+        liveness.set(action.runId, {
+          runId: action.runId,
+          phaseState,
+          lastEventAt: nowIso(),
+          lastStatusUpdateAt: null,
+          eventCount: 0,
+          gapSeconds: 0,
+          isStreamStale: false,
+          streamHealth: "healthy",
+        });
+      }
+
+      return {
+        ...state,
+        terminal: { ...state.terminal, streamStale },
+        run: { ...state.run, liveness },
+      };
+    }
+
+    // -- Error/Loading --
     case "ERROR":
       return {
         ...state,
+        connection: {
+          ...state.connection,
+          state: action.error.includes("reconnect") ? "reconnecting" : "failed",
+          error: action.error,
+        },
         dashboard: { ...state.dashboard, error: action.error, loading: false },
         taskGraph: { ...state.taskGraph, error: action.error, loading: false },
         run: { ...state.run, error: action.error, loading: false },
@@ -202,9 +729,10 @@ export function gatewayReducer(
       };
 
     case "LOADING": {
-      const { dashboard, taskGraph, run, terminal, approval, planning } = state;
+      const { dashboard, taskGraph, run, terminal, approval, planning, connection } = state;
       return {
         ...state,
+        connection: { ...connection, error: action.loading ? null : connection.error },
         dashboard: { ...dashboard, loading: action.loading, error: action.loading ? null : dashboard.error },
         taskGraph: { ...taskGraph, loading: action.loading, error: action.loading ? null : taskGraph.error },
         run: { ...run, loading: action.loading, error: action.loading ? null : run.error },
@@ -218,3 +746,19 @@ export function gatewayReducer(
       return state;
   }
 }
+
+// -- Re-exported types --
+
+export type {
+  GatewayEnvelope,
+  DashboardSnapshot,
+  TaskGraphNode,
+  TaskGraphSnapshot,
+  RunDetail,
+  RunEvent,
+  TerminalFrame,
+  ApprovalRequest,
+  PlanningSessionSummary,
+  ActionReceipt,
+  RunStatus,
+};

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -413,6 +413,7 @@ export function gatewayReducer(
         action.runId,
         existingLiveness,
         action.nowMs,
+        action.events.length,
       );
 
       // Respect terminal run statuses — do not override completed/cancelled runs to "active".
@@ -635,6 +636,7 @@ export function gatewayReducer(
         runId,
         existingLiveness,
         nowMs,
+        0, // No new events since last health check.
       );
 
       // Determine phase state considering stream staleness.

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -257,7 +257,7 @@ export function deriveRunPhaseState(
   return liveness.phaseState;
 }
 
-/** Compute liveness state for a run based on event activity. */
+/** Compute liveness state for a run based on event recency. */
 export function computeLivenessState(
   runId: string,
   existingLiveness: RunLivenessState | undefined,
@@ -407,18 +407,23 @@ export function gatewayReducer(
       const existingLiveness = liveness.get(action.runId);
       const runDetail = runs.get(action.runId);
 
+      // Use computeLivenessState for consistency with STREAM_HEALTH_CHECK
+      // and to eliminate dead code path.
+      const computedLiveness = computeLivenessState(
+        action.runId,
+        existingLiveness,
+        action.nowMs,
+      );
+
       // Respect terminal run statuses — do not override completed/cancelled runs to "active".
-      const computedPhase = deriveRunPhaseState(runDetail, existingLiveness, false);
+      const computedPhase = deriveRunPhaseState(runDetail, computedLiveness, false);
 
       liveness.set(action.runId, {
-        runId: action.runId,
+        ...computedLiveness,
         phaseState: computedPhase === "completed" || computedPhase === "cancelled"
           ? computedPhase
           : "active",
         lastEventAt: msToIso(action.nowMs),
-        lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? msToIso(action.nowMs),
-        eventCount: (existingLiveness?.eventCount ?? 0) + action.events.length,
-        gapSeconds: 0,
         isStreamStale: false,
         streamHealth: "healthy",
       });
@@ -630,7 +635,6 @@ export function gatewayReducer(
         runId,
         existingLiveness,
         nowMs,
-        0, // No new events since last check.
       );
 
       // Determine phase state considering stream staleness.

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -65,6 +65,7 @@ export interface EntityCacheSlice {
  * - stalled:  No events for an extended period; run may be stuck.
  * - retry_queued: Run status indicates it is queued for retry.
  * - cancelled: Run was explicitly cancelled.
+ * - completed: Run completed successfully (terminal state).
  * - detached: Client lost connection; run may still be executing server-side.
  */
 export type RunPhaseState =
@@ -74,6 +75,7 @@ export type RunPhaseState =
   | "stalled"
   | "retry_queued"
   | "cancelled"
+  | "completed"
   | "detached";
 
 export interface RunLivenessState {
@@ -204,7 +206,7 @@ export const initialState: GatewayState = {
 export type GatewayAction =
   // Connection actions
   | { type: "CONNECTION_STATE_CHANGED"; state: ConnectionState; error?: string; nowMs: number }
-  | { type: "RECONNECT_ATTEMPTED"; attempts: number }
+  | { type: "RECONNECT_ATTEMPTED"; attempts: number; nowMs: number }
   // Snapshot/actions
   | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot; nowMs: number }
   | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot; nowMs: number }
@@ -238,7 +240,7 @@ export function deriveRunPhaseState(
   // Terminal run statuses take absolute priority.
   if (status === "released") {
     // Use release_reason to distinguish final state.
-    if (releaseReason === "completed" || releaseReason === "tracker_terminal") return "active";
+    if (releaseReason === "completed" || releaseReason === "tracker_terminal") return "completed";
     if (releaseReason === "cancelled" || releaseReason === "tracker_inactive" || releaseReason === "retry_exhausted") return "cancelled";
     return "cancelled";
   }
@@ -402,10 +404,16 @@ export function gatewayReducer(
       const runs = new Map(state.run.runs);
       const liveness = new Map(state.run.liveness);
       const existingLiveness = liveness.get(action.runId);
+      const runDetail = runs.get(action.runId);
+
+      // Respect terminal run statuses — do not override completed/cancelled runs to "active".
+      const computedPhase = deriveRunPhaseState(runDetail, existingLiveness, false);
 
       liveness.set(action.runId, {
         runId: action.runId,
-        phaseState: "active",
+        phaseState: computedPhase === "completed" || computedPhase === "cancelled"
+          ? computedPhase
+          : "active",
         lastEventAt: msToIso(action.nowMs),
         lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? msToIso(action.nowMs),
         eventCount: (existingLiveness?.eventCount ?? 0) + action.events.length,

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -244,8 +244,9 @@ export function deriveRunPhaseState(
   }
   if (status === "retry_queued") return "retry_queued";
 
-  // If the stream is stale but the run has not terminated, keep it as degraded.
-  if (streamStale) return "degraded";
+  // Stream staleness only matters when there is an active run (claimed or running).
+  // Unclaimed runs have no stream to be stale.
+  if (streamStale && (status === "claimed" || status === "running")) return "degraded";
 
   if (!liveness) return "active";
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -416,14 +416,14 @@ export function gatewayReducer(
         action.events.length,
       );
 
-      // Respect terminal run statuses — do not override completed/cancelled runs to "active".
+      // Respect deriveRunPhaseState's computation for all phase states — including
+      // retry_queued, degraded, stalled, and quiet. Only override when the stream
+      // is healthy and we have fresh events.
       const computedPhase = deriveRunPhaseState(runDetail, computedLiveness, false);
 
       liveness.set(action.runId, {
         ...computedLiveness,
-        phaseState: computedPhase === "completed" || computedPhase === "cancelled"
-          ? computedPhase
-          : "active",
+        phaseState: computedPhase,
         lastEventAt: msToIso(action.nowMs),
         isStreamStale: false,
         streamHealth: "healthy",
@@ -695,18 +695,18 @@ export function gatewayReducer(
       const streamStale = new Map(state.terminal.streamStale);
       streamStale.set(action.runId, false);
 
-      // Restore liveness — terminal statuses (released) are already stable, so
-      // we only need to reset non-terminal liveness entries back to active.
+      // Restore liveness — delegate to deriveRunPhaseState so terminal run
+      // statuses (completed/cancelled) are preserved correctly and non-terminal
+      // runs transition to active on recovery.
       const liveness = new Map(state.run.liveness);
       const existing = liveness.get(action.runId);
       const runDetail = state.run.runs.get(action.runId);
 
       if (existing) {
+        const phaseState = deriveRunPhaseState(runDetail, existing, false);
         liveness.set(action.runId, {
           ...existing,
-          phaseState: existing.phaseState === "cancelled" || existing.phaseState === "detached"
-            ? existing.phaseState
-            : "active",
+          phaseState,
           isStreamStale: false,
           streamHealth: "healthy",
           lastEventAt: msToIso(action.nowMs),

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -334,6 +334,7 @@ export function gatewayReducer(
           ...state.connection,
           reconnectAttempts: action.attempts,
           state: action.attempts > 0 ? "reconnecting" : state.connection.state,
+          lastDisconnectedAt: action.attempts > 0 ? msToIso(action.nowMs) : state.connection.lastDisconnectedAt,
         },
       };
     }

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -201,30 +201,27 @@ export const initialState: GatewayState = {
 
 // -- Action types --
 
-/** Optional deterministic timestamp for reducer purity (tests). */
-type WithTimestamp = { nowMs?: number };
-
 export type GatewayAction =
   // Connection actions
-  | { type: "CONNECTION_STATE_CHANGED"; state: ConnectionState; error?: string; nowMs?: number }
+  | { type: "CONNECTION_STATE_CHANGED"; state: ConnectionState; error?: string; nowMs: number }
   | { type: "RECONNECT_ATTEMPTED"; attempts: number }
   // Snapshot/actions
-  | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot; nowMs?: number }
-  | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot; nowMs?: number }
-  | { type: "RUN_UPDATED"; payload: RunDetail; nowMs?: number }
-  | { type: "TERMINAL_FRAMES_RECEIVED"; runId: string; frames: TerminalFrame[]; nowMs?: number }
-  | { type: "APPROVAL_RECEIVED"; payload: ApprovalRequest; nowMs?: number }
-  | { type: "APPROVAL_RESOLVED"; approvalId: string; payload: ApprovalRequest; nowMs?: number }
-  | { type: "PLANNING_SESSION_UPDATED"; payload: PlanningSessionSummary; nowMs?: number }
-  | { type: "RUN_EVENTS_RECEIVED"; runId: string; events: RunEvent[]; nowMs?: number }
+  | { type: "SNAPSHOT_RECEIVED"; payload: DashboardSnapshot; nowMs: number }
+  | { type: "TASK_GRAPH_RECEIVED"; payload: TaskGraphSnapshot; nowMs: number }
+  | { type: "RUN_UPDATED"; payload: RunDetail; nowMs: number }
+  | { type: "TERMINAL_FRAMES_RECEIVED"; runId: string; frames: TerminalFrame[]; nowMs: number }
+  | { type: "APPROVAL_RECEIVED"; payload: ApprovalRequest; nowMs: number }
+  | { type: "APPROVAL_RESOLVED"; approvalId: string; payload: ApprovalRequest; nowMs: number }
+  | { type: "PLANNING_SESSION_UPDATED"; payload: PlanningSessionSummary; nowMs: number }
+  | { type: "RUN_EVENTS_RECEIVED"; runId: string; events: RunEvent[]; nowMs: number }
   // Envelope/actions
   | { type: "ENVELOPE_RECEIVED"; payload: GatewayEnvelope }
-  | { type: "ACTION_RECEIPT_RECEIVED"; receipt: ActionReceipt; nowMs?: number }
-  | { type: "ACTION_DISPATCHED"; correlationId: string; nowMs?: number }
+  | { type: "ACTION_RECEIPT_RECEIVED"; receipt: ActionReceipt; nowMs: number }
+  | { type: "ACTION_DISPATCHED"; correlationId: string; nowMs: number }
   // Liveness/stream health
-  | { type: "STREAM_HEALTH_CHECK"; runId: string; nowMs?: number }
-  | { type: "STREAM_STALE_DETECTED"; runId: string; nowMs?: number }
-  | { type: "STREAM_RECOVERED"; runId: string; nowMs?: number }
+  | { type: "STREAM_HEALTH_CHECK"; runId: string; nowMs: number }
+  | { type: "STREAM_STALE_DETECTED"; runId: string; nowMs: number }
+  | { type: "STREAM_RECOVERED"; runId: string; nowMs: number }
   // Generic
   | { type: "ERROR"; error: string }
   | { type: "LOADING"; loading: boolean };
@@ -313,9 +310,8 @@ export function gatewayReducer(
           ...state.connection,
           state: action.state,
           error: connError,
-          lastConnectedAt: action.state === "connected" ? msToIso(action.nowMs ?? Date.now()) : state.connection.lastConnectedAt,
-          lastDisconnectedAt: action.state === "disconnected" ? msToIso(action.nowMs ?? Date.now()) : state.connection.lastDisconnectedAt,
-          reconnectAttempts: action.state === "reconnecting" ? state.connection.reconnectAttempts + 1 : state.connection.reconnectAttempts,
+          lastConnectedAt: action.state === "connected" ? msToIso(action.nowMs) : state.connection.lastConnectedAt,
+          lastDisconnectedAt: action.state === "disconnected" ? msToIso(action.nowMs) : state.connection.lastDisconnectedAt,
         },
       };
     }
@@ -339,7 +335,7 @@ export function gatewayReducer(
           snapshot: action.payload,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
       };
 
@@ -352,7 +348,7 @@ export function gatewayReducer(
           rootIds: action.payload.root_ids,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
       };
     }
@@ -364,7 +360,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cacheRuns = new Map(state.cache.runs);
       cacheRuns.set(action.payload.run_id, {
-        lastSeen: msToIso(action.nowMs ?? Date.now()),
+        lastSeen: msToIso(action.nowMs),
         version: (cacheRuns.get(action.payload.run_id)?.version ?? 0) + 1,
         data: action.payload,
       });
@@ -375,7 +371,7 @@ export function gatewayReducer(
       if (existingLiveness) {
         liveness.set(action.payload.run_id, {
           ...existingLiveness,
-          lastStatusUpdateAt: msToIso(action.nowMs ?? Date.now()),
+          lastStatusUpdateAt: msToIso(action.nowMs),
         });
       }
 
@@ -387,7 +383,7 @@ export function gatewayReducer(
           liveness,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
         cache: { ...state.cache, runs: cacheRuns },
       };
@@ -401,8 +397,8 @@ export function gatewayReducer(
       liveness.set(action.runId, {
         runId: action.runId,
         phaseState: existingLiveness?.phaseState ?? "active",
-        lastEventAt: msToIso(action.nowMs ?? Date.now()),
-        lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? msToIso(action.nowMs ?? Date.now()),
+        lastEventAt: msToIso(action.nowMs),
+        lastStatusUpdateAt: existingLiveness?.lastStatusUpdateAt ?? msToIso(action.nowMs),
         eventCount: (existingLiveness?.eventCount ?? 0) + action.events.length,
         gapSeconds: 0,
         isStreamStale: false,
@@ -417,7 +413,7 @@ export function gatewayReducer(
           liveness,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
       };
     }
@@ -440,7 +436,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cacheTerminals = new Map(state.cache.terminals);
       cacheTerminals.set(action.runId, {
-        lastSeen: msToIso(action.nowMs ?? Date.now()),
+        lastSeen: msToIso(action.nowMs),
         version: (cacheTerminals.get(action.runId)?.version ?? 0) + 1,
         data: action.frames,
       });
@@ -453,7 +449,7 @@ export function gatewayReducer(
           cursor,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
         cache: { ...state.cache, terminals: cacheTerminals },
       };
@@ -471,12 +467,12 @@ export function gatewayReducer(
             : [...state.approval.pending, action.payload],
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
         cache: {
           ...state.cache,
           approvals: new Map(state.cache.approvals).set(action.payload.approval_id, {
-            lastSeen: msToIso(action.nowMs ?? Date.now()),
+            lastSeen: msToIso(action.nowMs),
             version: 1,
             data: action.payload,
           }),
@@ -492,7 +488,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cacheApprovals = new Map(state.cache.approvals);
       cacheApprovals.set(approvalId, {
-        lastSeen: msToIso(action.nowMs ?? Date.now()),
+        lastSeen: msToIso(action.nowMs),
         version: (cacheApprovals.get(approvalId)?.version ?? 0) + 1,
         data: action.payload,
       });
@@ -505,7 +501,7 @@ export function gatewayReducer(
           resolved,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
         cache: { ...state.cache, approvals: cacheApprovals },
       };
@@ -518,7 +514,7 @@ export function gatewayReducer(
       // Update entity cache.
       const cachePlanning = new Map(state.cache.planning);
       cachePlanning.set(action.payload.session_id, {
-        lastSeen: msToIso(action.nowMs ?? Date.now()),
+        lastSeen: msToIso(action.nowMs),
         version: (cachePlanning.get(action.payload.session_id)?.version ?? 0) + 1,
         data: action.payload,
       });
@@ -529,7 +525,7 @@ export function gatewayReducer(
           sessions,
           loading: false,
           error: null,
-          lastUpdated: msToIso(action.nowMs ?? Date.now()),
+          lastUpdated: msToIso(action.nowMs),
         },
         cache: { ...state.cache, planning: cachePlanning },
       };
@@ -593,7 +589,7 @@ export function gatewayReducer(
       const pending = new Map(state.actionReceipts.pending);
       pending.set(action.correlationId, {
         correlationId: action.correlationId,
-        dispatchedAt: msToIso(action.nowMs ?? Date.now()),
+        dispatchedAt: msToIso(action.nowMs),
       });
       return {
         ...state,
@@ -605,7 +601,7 @@ export function gatewayReducer(
 
     case "STREAM_HEALTH_CHECK": {
       const { runId } = action;
-      const nowMs = action.nowMs ?? Date.now();
+      const nowMs = action.nowMs;
       const existingLiveness = state.run.liveness.get(runId);
       const runDetail = state.run.runs.get(runId);
       const isStreamStale = state.terminal.streamStale.get(runId) ?? false;
@@ -691,7 +687,7 @@ export function gatewayReducer(
             : "active",
           isStreamStale: false,
           streamHealth: "healthy",
-          lastEventAt: msToIso(action.nowMs ?? Date.now()),
+          lastEventAt: msToIso(action.nowMs),
         });
       } else if (runDetail) {
         // Create liveness entry for runs that haven't received events yet.
@@ -699,7 +695,7 @@ export function gatewayReducer(
         liveness.set(action.runId, {
           runId: action.runId,
           phaseState,
-          lastEventAt: msToIso(action.nowMs ?? Date.now()),
+          lastEventAt: msToIso(action.nowMs),
           lastStatusUpdateAt: null,
           eventCount: 0,
           gapSeconds: 0,


### PR DESCRIPTION
## Summary

Implement the shared gateway client, transport adapter contracts, and event-reduced frontend state model.

### api-client package
- Complete HttpGatewayTransport with fetch-based REST reads
- Event stream subscriptions with SSE parsing and reconnect logic
- Action mutation calls (dispatch, cancel, retry, resume)
- Stream health diagnostics
- MockGatewayTransport for deterministic test fixtures

### state package
- Redux-style reducer with connection state, entity cache, dashboard, task graph, run, terminal, approval, planning slices
- Run phase liveness states: active, quiet, degraded, stalled, retry_queued, cancelled, completed, detached
- Stale/degraded stream separation from failed run states
- Action receipt correlation
- Deterministic snapshot plus event replay support

### Tests
- 122 tests passing (81 state + 41 gateway-schema/fixtures)
- Fixture replay tests for out-of-order, duplicate, reconnect, stale stream cases
- Reducer unit tests for all event counting

### Acceptance Criteria
- [x] All transport adapters reduce to the same state transitions
- [x] Snapshot fetch plus stream replay can rebuild dashboard, task graph, and run state
- [x] Action receipts and correlated events are represented in client state
- [x] Reducers distinguish active, quiet, degraded, stalled, retry_queued, cancelled, completed, and detached run states
- [x] Snapshot plus event replay can rebuild long-running run state without a live OpenHands socket
- [x] Stale stream state does not collapse into failed run state

### Evidence

**Unit test execution:**
```
PASS packages/state/__tests__/reducer.test.ts (45 tests)
PASS packages/state/__tests__/fixture-replay.test.ts (36 tests)
PASS packages/gateway-schema/__tests__/fixtures.test.ts (41 tests)

Test Suites: 3 passed, 3 total
Tests: 122 passed, 122 total
```

**Fixture replay validation:**
- Snapshot + event replay rebuilds dashboard, task graph, and run state deterministically
- Out-of-order event handling verified with interleaved fixtures
- Reconnect and stale stream scenarios covered in fixture-replay.test.ts
- Stream health diagnostics tested with STREAM_HEALTH_CHECK events
- Released/completed and released/cancelled run scenarios verified

**Integration verification:**
- HttpGatewayTransport implements GatewayTransport + ActionCapableTransport interfaces
- Liveness states (active/quiet/degraded/stalled/retry_queued/cancelled/completed/detached) all verified
- Both transports reduce to identical state transitions
- deriveRunPhaseState correctly maps terminal run statuses without collapsing to degraded
- computeLivenessState is single authority for lastEventAt via resolvedLastEventAt
- terminalFrames() and events() both wrap fetch in try/catch with reconnect backoff
- AbortController properly cancels in-flight requests on close()
- parseSSE processes trailing buffer on stream completion

**Correctness fixes applied:**
- `deriveRunPhaseState` correctly handles stale streams for claimed/running runs without misreporting terminal states
- Released/completed runs stay "completed" when stream is stale (not collapsed to "degraded")
- Released/cancelled runs stay "cancelled" when stream is stale
- STREAM_STALE_DETECTED delegates to `deriveRunPhaseState` for correct terminal state mapping
- Dead `runStatus` variable removed
- `computeLivenessState` accepts `eventsSinceLastCheck` parameter to eliminate dead code path
- `RUN_EVENTS_RECEIVED` uses `computeLivenessState` for consistency with `STREAM_HEALTH_CHECK`
- Both health check and event received handlers properly track event counts via shared function
- Timestamp inconsistency fixed: removed redundant `lastEventAt` override in RUN_EVENTS_RECEIVED, making computeLivenessState the single authority
