### PR TITLE
feat: desktop connection profiles, gateway discovery, and daemon supervision (COE-404)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1866,7 +1866,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2791,7 +2791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2914,7 +2914,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -214,6 +214,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -454,6 +478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +493,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -529,7 +568,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1010,21 +1049,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1040,12 +1070,6 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
@@ -1058,6 +1082,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1259,8 +1289,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1270,9 +1302,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1586,22 +1620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1924,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac-notification-sys"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,23 +2159,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2440,54 +2457,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "opensymphony-desktop"
 version = "1.6.0"
 dependencies = [
  "libc",
- "reqwest 0.12.28",
+ "reqwest",
  "security-framework 2.11.1",
  "serde",
  "serde_json",
@@ -2845,6 +2825,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,67 +3007,36 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3115,6 +3120,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -3123,13 +3129,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3137,6 +3183,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3147,12 +3194,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3387,18 +3428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3820,7 +3849,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4259,16 +4288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4653,12 +4672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4846,6 +4859,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4899,6 +4922,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -214,28 +214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,8 +417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -478,12 +454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,15 +463,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1084,12 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,10 +1244,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1302,11 +1255,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1471,25 +1422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,7 +1525,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1602,21 +1533,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -1637,11 +1553,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1924,16 +1838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,12 +1972,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
@@ -2457,18 +2355,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "opensymphony-desktop"
 version = "1.6.0"
 dependencies = [
  "libc",
  "reqwest",
- "security-framework 2.11.1",
+ "security-framework",
  "serde",
  "serde_json",
  "tauri",
@@ -2825,62 +2717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,30 +2849,21 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3073,20 +2900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,81 +2928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
-dependencies = [
- "aws-lc-rs",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
-dependencies = [
- "web-time",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.7.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,15 +2940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3278,19 +3007,6 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3671,12 +3387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,27 +3436,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4288,16 +3977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4617,12 +4296,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,16 +4532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,15 +4585,6 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -5119,17 +4773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5172,15 +4815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5737,12 +5371,6 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1010,12 +1010,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1028,6 +1037,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1422,6 +1437,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1559,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1533,6 +1568,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1553,9 +1619,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2060,6 +2128,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,10 +2440,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opensymphony-desktop"
 version = "1.6.0"
 dependencies = [
- "security-framework",
+ "libc",
+ "reqwest 0.12.28",
+ "security-framework 2.11.1",
  "serde",
  "serde_json",
  "tauri",
@@ -2367,7 +2497,10 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2838,6 +2971,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2895,6 +3068,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,10 +3110,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2935,6 +3161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3002,6 +3237,19 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3139,6 +3387,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3382,6 +3642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +3697,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3533,7 +3820,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3956,7 +4243,39 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4279,6 +4598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,6 +4651,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4756,6 +5087,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,6 +5140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5354,6 +5705,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 tracing = "0.1"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13", features = ["json"] }
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 tracing = "0.1"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,9 +21,18 @@ tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1", features = ["sync", "time", "macros"] }
+tracing = "0.1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2"
+
+[dev-dependencies]
+tempfile = "3"
 
 [workspace]
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -13,6 +13,49 @@ use tauri::command;
 use tauri::State;
 use thiserror::Error;
 use tokio::sync::Mutex;
+use tracing::warn;
+
+// ─── Executable validation ─────────────────────────────────────────────────
+
+/// Validate that a daemon executable path is safe to run.
+///
+/// Rejects paths that don't exist, aren't regular files, or lack execute
+/// permission on Unix systems.
+///
+/// In production deployments, this should be restricted to bundled
+/// executables within the app's resource directory.
+fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
+    if !path.exists() {
+        return Err(DaemonPathError::NotFound);
+    }
+
+    let metadata = std::fs::metadata(path).map_err(|e| DaemonPathError::AccessDenied { detail: e.to_string() })?;
+    if !metadata.is_file() {
+        return Err(DaemonPathError::NotAFile);
+    }
+
+    // On Unix, verify execute permission
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = metadata.permissions();
+        if perms.mode() & 0o111 == 0 {
+            return Err(DaemonPathError::NotExecutable);
+        }
+    }
+
+    Ok(())
+}
+
+/// Error returned when a daemon executable path fails validation.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case", tag = "error")]
+enum DaemonPathError {
+    NotFound,
+    NotAFile,
+    NotExecutable,
+    AccessDenied { detail: String },
+}
 
 // ─── Error type ─────────────────────────────────────────────────────────────
 
@@ -355,19 +398,34 @@ pub struct StartDaemonRequest {
 }
 
 /// Start and supervise a local daemon.
+///
+/// Acquires the daemon mutex for the entire start sequence to prevent
+/// concurrent starts that could orphan processes.
 #[command]
 pub async fn start_daemon(
     state: State<'_, DesktopState>,
     req: StartDaemonRequest,
 ) -> CommandResult<StartupResult> {
-    if state.daemon_supervised.load(Ordering::SeqCst) {
+    // Atomically check-and-start by holding the mutex for the entire operation
+    let mut handle_guard = state.daemon_handle.lock().await;
+
+    if handle_guard.is_some() {
+        warn!("daemon already supervised, rejecting start request");
         return Err(DesktopError::Internal {
             message: "Daemon already supervised by this instance".to_string(),
         });
     }
 
+    let exec_path = PathBuf::from(&req.executable);
+
+    // Validate executable path for safety
+    if let Err(err) = validate_executable_path(&exec_path) {
+        warn!(?err, path = ?exec_path, "daemon executable path validation failed");
+        return Err(DesktopError::PermissionDenied);
+    }
+
     let config = DaemonConfig {
-        executable: PathBuf::from(&req.executable),
+        executable: exec_path,
         args: req.args.unwrap_or_default(),
         env: req.env.unwrap_or_default(),
         startup_timeout: Duration::from_secs(req.startup_timeout_secs.unwrap_or(30)),
@@ -380,7 +438,9 @@ pub async fn start_daemon(
 
     if result.success {
         state.daemon_supervised.store(true, Ordering::SeqCst);
-        *state.daemon_handle.lock().await = Some(handle);
+        *handle_guard = Some(handle);
+    } else {
+        warn!(error = ?result.error, "daemon startup failed");
     }
 
     Ok(result)

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -475,6 +475,7 @@ pub async fn start_daemon(
         startup_timeout: Duration::from_secs(req.startup_timeout_secs.unwrap_or(30)),
         auto_restart: req.auto_restart.unwrap_or(true),
         gateway_url: req.gateway_url.unwrap_or_else(|| "http://127.0.0.1:8080".to_string()),
+        skip_health_check: false,
     };
 
     let mut handle = DaemonHandle::new(config);

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -20,7 +20,8 @@ use tracing::warn;
 /// Validate that a daemon executable path is safe to run.
 ///
 /// Rejects paths that don't exist, aren't regular files, or lack execute
-/// permission on Unix systems.
+/// permission on Unix systems. Also rejects world-writable and group-writable
+/// paths to prevent tampering by other local users.
 ///
 /// In production deployments, this should be restricted to bundled
 /// executables within the app's resource directory.
@@ -34,12 +35,24 @@ fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
         return Err(DaemonPathError::NotAFile);
     }
 
-    // On Unix, verify execute permission
+    // On Unix, verify execute permission and reject writable-by-others paths
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = metadata.permissions();
-        if perms.mode() & 0o111 == 0 {
+        let mode = perms.mode();
+
+        // Reject world-writable paths (prevents tampering by any local user)
+        if mode & 0o002 != 0 {
+            return Err(DaemonPathError::WorldWritable);
+        }
+
+        // Reject group-writable paths (prevents tampering by group members)
+        if mode & 0o020 != 0 {
+            return Err(DaemonPathError::GroupWritable);
+        }
+
+        if mode & 0o111 == 0 {
             return Err(DaemonPathError::NotExecutable);
         }
     }
@@ -54,6 +67,8 @@ enum DaemonPathError {
     NotFound,
     NotAFile,
     NotExecutable,
+    WorldWritable,
+    GroupWritable,
     AccessDenied { detail: String },
 }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -256,8 +256,10 @@ pub struct ProfileResponse {
 /// Store a connection profile.
 #[command]
 pub async fn store_profile(_req: ProfileRequest) -> CommandResult<ProfileResponse> {
-    // Real implementation persists to local storage
-    // Use serde_json for consistent snake_case serialization
+    // Stub implementation - real persistence will be added in COE-409
+    // with proper UUID generation to prevent ID collisions.
+    // Current behavior: returns "new-profile" only when no ID is provided,
+    // which is acceptable for this alpha-stage stub.
     let kind_str = serde_json::to_string(&_req.kind).unwrap_or_else(|_| "\"unknown\"".to_string());
     Ok(ProfileResponse {
         id: _req.id.unwrap_or_else(|| "new-profile".to_string()),

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -530,8 +530,8 @@ pub async fn stop_daemon(state: State<'_, DesktopState>) -> CommandResult<serde_
 /// Query the status of the supervised daemon.
 #[command]
 pub async fn daemon_status(state: State<'_, DesktopState>) -> CommandResult<ProcessStatus> {
-    let handle_guard = state.daemon_handle.lock().await;
-    if let Some(ref handle) = *handle_guard {
+    let mut handle_guard = state.daemon_handle.lock().await;
+    if let Some(ref mut handle) = *handle_guard {
         let is_running = handle.is_running();
         // Derive state string from actual liveness check to avoid stale
         // enum values when the daemon crashes or is killed externally.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -62,8 +62,7 @@ fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
 }
 
 /// Error returned when a daemon executable path fails validation.
-#[derive(Error, Debug, Serialize)]
-#[serde(rename_all = "snake_case", tag = "error")]
+#[derive(Error, Debug)]
 enum DaemonPathError {
     #[error("daemon executable path does not exist")]
     NotFound,
@@ -75,6 +74,18 @@ enum DaemonPathError {
     WorldWritable,
     #[error("daemon executable path cannot be inspected: {detail}")]
     AccessDenied { detail: String },
+}
+
+impl DaemonPathError {
+    fn kind(&self) -> &'static str {
+        match self {
+            DaemonPathError::NotFound => "not_found",
+            DaemonPathError::NotAFile => "not_a_file",
+            DaemonPathError::NotExecutable => "not_executable",
+            DaemonPathError::WorldWritable => "world_writable",
+            DaemonPathError::AccessDenied { .. } => "access_denied",
+        }
+    }
 }
 
 // ─── Error type ─────────────────────────────────────────────────────────────
@@ -101,8 +112,8 @@ pub enum DesktopError {
     #[error("daemon unavailable")]
     DaemonUnavailable,
     /// Daemon executable path validation failed with a specific reason.
-    #[error("daemon path error: {detail}")]
-    DaemonPath { detail: String },
+    #[error("daemon path error ({kind}): {detail}")]
+    DaemonPath { kind: String, detail: String },
     /// Generic internal error with a human-readable message.
     #[error("internal error: {message}")]
     Internal { message: String },
@@ -482,6 +493,7 @@ pub async fn start_daemon(
     if let Err(err) = validate_executable_path(&exec_path) {
         warn!(?err, path = ?exec_path, "daemon executable path validation failed");
         return Err(DesktopError::DaemonPath {
+            kind: err.kind().to_string(),
             detail: err.to_string(),
         });
     }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -531,10 +531,18 @@ pub async fn stop_daemon(state: State<'_, DesktopState>) -> CommandResult<serde_
 pub async fn daemon_status(state: State<'_, DesktopState>) -> CommandResult<ProcessStatus> {
     let handle_guard = state.daemon_handle.lock().await;
     if let Some(ref handle) = *handle_guard {
+        let is_running = handle.is_running();
+        // Derive state string from actual liveness check to avoid stale
+        // enum values when the daemon crashes or is killed externally.
+        let state_str = if is_running {
+            handle.state().as_str().to_string()
+        } else {
+            "stopped".to_string()
+        };
         Ok(ProcessStatus {
             pid: handle.pid(),
-            running: handle.is_running(),
-            state: handle.state().as_str().to_string(),
+            running: is_running,
+            state: state_str,
             supervised: state.daemon_supervised.load(Ordering::SeqCst),
         })
     } else {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -93,6 +93,9 @@ pub enum DesktopError {
     /// The local daemon is not running.
     #[error("daemon unavailable")]
     DaemonUnavailable,
+    /// Daemon executable path validation failed with a specific reason.
+    #[error("daemon path error: {detail}")]
+    DaemonPath { detail: String },
     /// Generic internal error with a human-readable message.
     #[error("internal error: {message}")]
     Internal { message: String },
@@ -462,7 +465,9 @@ pub async fn start_daemon(
     // Validate executable path for safety
     if let Err(err) = validate_executable_path(&exec_path) {
         warn!(?err, path = ?exec_path, "daemon executable path validation failed");
-        return Err(DesktopError::PermissionDenied);
+        return Err(DesktopError::DaemonPath {
+            detail: format!("path validation failed: {:?}", err),
+        });
     }
 
     let config = DaemonConfig {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -229,6 +229,18 @@ pub enum ProfileKind {
     HostedGateway,
 }
 
+impl ProfileKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ProfileKind::LocalDaemon => "local_daemon",
+            ProfileKind::SupervisedLocalDaemon => "supervised_local_daemon",
+            ProfileKind::EmbeddedHost => "embedded_host",
+            ProfileKind::ExternalGateway => "external_gateway",
+            ProfileKind::HostedGateway => "hosted_gateway",
+        }
+    }
+}
+
 /// Request to create or update a connection profile.
 #[derive(Debug, Deserialize)]
 pub struct ProfileRequest {
@@ -266,11 +278,10 @@ pub async fn store_profile(_req: ProfileRequest) -> CommandResult<ProfileRespons
             .unwrap_or(0);
         format!("profile-{}", ts)
     });
-    let kind_str = serde_json::to_string(&_req.kind).unwrap_or_else(|_| "\"unknown\"".to_string());
     Ok(ProfileResponse {
         id: profile_id,
         label: _req.label,
-        kind: kind_str.trim_matches('"').to_string(),
+        kind: _req.kind.as_str().to_string(),
         gateway_url: _req.gateway_url,
         managed: matches!(_req.kind, ProfileKind::SupervisedLocalDaemon | ProfileKind::EmbeddedHost),
         daemon_path: _req.daemon_path,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -2,13 +2,17 @@
 //!
 //! Every command uses narrow, strongly-typed request and response structs so
 //! that the capability matrix stays auditable and the attack surface is small.
-//!
-//! Fields are stubbed and unused until COE-404/COE-409 implement real backends.
-#![allow(dead_code)]
 
+use crate::daemon::{DaemonConfig, DaemonHandle, StartupResult};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use tauri::command;
+use tauri::State;
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 // ─── Error type ─────────────────────────────────────────────────────────────
 
@@ -40,6 +44,25 @@ pub enum DesktopError {
 
 /// Alias for ergonomic command return types.
 type CommandResult<T> = Result<T, DesktopError>;
+
+// ─── Shared desktop state ───────────────────────────────────────────────────
+
+/// Shared application state managed by Tauri.
+pub struct DesktopState {
+    /// The supervised daemon handle, if any.
+    pub daemon_handle: Arc<Mutex<Option<DaemonHandle>>>,
+    /// Whether the daemon is currently supervised by this app instance.
+    pub daemon_supervised: Arc<AtomicBool>,
+}
+
+impl DesktopState {
+    pub fn new() -> Self {
+        Self {
+            daemon_handle: Arc::new(Mutex::new(None)),
+            daemon_supervised: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
 
 // ─── File / Folder Selection ────────────────────────────────────────────────
 
@@ -150,27 +173,281 @@ pub async fn set_setting(_req: SetSettingRequest) -> CommandResult<SetSettingRes
     Ok(SetSettingResponse { persisted: false })
 }
 
-// ─── Local Process Supervision (stencil only) ───────────────────────────────
+// ─── Connection Profiles ───────────────────────────────────────────────────
 
-/// The shell plugin is loaded at minimal baseline (`shell:default`) to allow
-/// future process supervision without requiring a capability redesign.
-/// `shell:default` grants only the `open` helper (launch default app for a URL/path).
-/// No `shell:execute` or `shell:kill` permissions are active.
-/// COE-404 will implement whitelisted executable paths, PID tracking, and
-/// input sanitization before any execute/kill permissions are added.
+/// Connection profile kind discriminant.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileKind {
+    LocalDaemon,
+    SupervisedLocalDaemon,
+    EmbeddedHost,
+    ExternalGateway,
+    HostedGateway,
+}
 
+/// Request to create or update a connection profile.
+#[derive(Debug, Deserialize)]
+pub struct ProfileRequest {
+    pub id: Option<String>,
+    pub label: String,
+    pub kind: ProfileKind,
+    pub gateway_url: String,
+    pub daemon_path: Option<String>,
+    pub daemon_args: Option<Vec<String>>,
+    pub auto_restart: Option<bool>,
+    pub startup_timeout_secs: Option<u64>,
+}
+
+/// Response with profile details.
+#[derive(Debug, Serialize)]
+pub struct ProfileResponse {
+    pub id: String,
+    pub label: String,
+    pub kind: String,
+    pub gateway_url: String,
+    pub managed: bool,
+    pub daemon_path: Option<String>,
+}
+
+/// Store a connection profile.
+#[command]
+pub async fn store_profile(_req: ProfileRequest) -> CommandResult<ProfileResponse> {
+    // Real implementation persists to local storage
+    Ok(ProfileResponse {
+        id: _req.id.unwrap_or_else(|| "new-profile".to_string()),
+        label: _req.label,
+        kind: format!("{:?}", _req.kind),
+        gateway_url: _req.gateway_url,
+        managed: matches!(_req.kind, ProfileKind::SupervisedLocalDaemon | ProfileKind::EmbeddedHost),
+        daemon_path: _req.daemon_path,
+    })
+}
+
+/// List all stored connection profiles.
+#[command]
+pub async fn list_profiles() -> CommandResult<Vec<ProfileResponse>> {
+    // Real implementation reads from local storage
+    Ok(vec![])
+}
+
+/// Set the active connection profile.
+#[command]
+pub async fn set_active_profile(_profile_id: String) -> CommandResult<ProfileResponse> {
+    // Real implementation updates active profile in storage
+    Err(DesktopError::NotFound)
+}
+
+// ─── Gateway Discovery ──────────────────────────────────────────────────────
+
+/// Result of a gateway discovery probe.
+#[derive(Debug, Serialize)]
+pub struct DiscoveryResult {
+    pub healthy: bool,
+    pub compatible: bool,
+    pub gateway_url: String,
+    pub latency_ms: u64,
+    pub error: Option<String>,
+    pub capabilities: Option<serde_json::Value>,
+}
+
+/// Probe a gateway URL for health and capabilities.
+#[command]
+pub async fn probe_gateway(gateway_url: String) -> CommandResult<DiscoveryResult> {
+    let start = std::time::Instant::now();
+    let health_url = format!("{}/healthz", gateway_url.trim_end_matches('/'));
+    let capabilities_url = format!("{}/api/v1/capabilities", gateway_url.trim_end_matches('/'));
+
+    // Probe health
+    match reqwest::get(&health_url).await {
+        Ok(response) if response.status().is_success() => {
+            let _health_latency = start.elapsed().as_millis() as u64;
+            
+            // Probe capabilities
+            match reqwest::get(&capabilities_url).await {
+                Ok(cap_response) if cap_response.status().is_success() => {
+                    let capabilities: Option<serde_json::Value> = cap_response.json().await.ok();
+                    let total_latency = start.elapsed().as_millis() as u64;
+                    
+                    Ok(DiscoveryResult {
+                        healthy: true,
+                        compatible: true,
+                        gateway_url,
+                        latency_ms: total_latency,
+                        error: None,
+                        capabilities,
+                    })
+                }
+                Ok(cap_response) => Ok(DiscoveryResult {
+                    healthy: true,
+                    compatible: false,
+                    gateway_url,
+                    latency_ms: start.elapsed().as_millis() as u64,
+                    error: Some(format!("Capabilities endpoint returned {}", cap_response.status())),
+                    capabilities: None,
+                }),
+                Err(e) => Ok(DiscoveryResult {
+                    healthy: true,
+                    compatible: false,
+                    gateway_url,
+                    latency_ms: start.elapsed().as_millis() as u64,
+                    error: Some(format!("Capabilities probe failed: {}", e)),
+                    capabilities: None,
+                }),
+            }
+        }
+        Ok(response) => Ok(DiscoveryResult {
+            healthy: false,
+            compatible: false,
+            gateway_url,
+            latency_ms: start.elapsed().as_millis() as u64,
+            error: Some(format!("Health check returned {}", response.status())),
+            capabilities: None,
+        }),
+        Err(e) => Ok(DiscoveryResult {
+            healthy: false,
+            compatible: false,
+            gateway_url,
+            latency_ms: start.elapsed().as_millis() as u64,
+            error: Some(format!("Health probe failed: {}", e)),
+            capabilities: None,
+        }),
+    }
+}
+
+/// Discover gateway on default loopback address.
+#[command]
+pub async fn discover_default_gateway() -> CommandResult<DiscoveryResult> {
+    let default_urls = [
+        "http://127.0.0.1:8080",
+        "http://localhost:8080",
+        "http://0.0.0.0:8080",
+    ];
+
+    for url in &default_urls {
+        let result = probe_gateway(url.to_string()).await?;
+        if result.healthy && result.compatible {
+            return Ok(result);
+        }
+    }
+
+    // Return last result if none succeeded
+    probe_gateway(default_urls[0].to_string()).await
+}
+
+// ─── Daemon Supervision ─────────────────────────────────────────────────────
+
+/// Request to start a supervised daemon.
+#[derive(Debug, Deserialize)]
+pub struct StartDaemonRequest {
+    /// Path to the daemon executable.
+    pub executable: String,
+    /// Arguments to pass to the daemon.
+    pub args: Option<Vec<String>>,
+    /// Environment variables for the daemon.
+    pub env: Option<Vec<(String, String)>>,
+    /// Gateway URL where the daemon listens.
+    pub gateway_url: Option<String>,
+    /// Startup timeout in seconds.
+    pub startup_timeout_secs: Option<u64>,
+    /// Whether to auto-restart on failure.
+    pub auto_restart: Option<bool>,
+}
+
+/// Start and supervise a local daemon.
+#[command]
+pub async fn start_daemon(
+    state: State<'_, DesktopState>,
+    req: StartDaemonRequest,
+) -> CommandResult<StartupResult> {
+    if state.daemon_supervised.load(Ordering::SeqCst) {
+        return Err(DesktopError::Internal {
+            message: "Daemon already supervised by this instance".to_string(),
+        });
+    }
+
+    let config = DaemonConfig {
+        executable: PathBuf::from(&req.executable),
+        args: req.args.unwrap_or_default(),
+        env: req.env.unwrap_or_default(),
+        startup_timeout: Duration::from_secs(req.startup_timeout_secs.unwrap_or(30)),
+        auto_restart: req.auto_restart.unwrap_or(true),
+        gateway_url: req.gateway_url.unwrap_or_else(|| "http://127.0.0.1:8080".to_string()),
+    };
+
+    let mut handle = DaemonHandle::new(config);
+    let result = handle.start().await;
+
+    if result.success {
+        state.daemon_supervised.store(true, Ordering::SeqCst);
+        *state.daemon_handle.lock().await = Some(handle);
+    }
+
+    Ok(result)
+}
+
+/// Stop the supervised daemon.
+///
+/// Only stops if this app instance owns the process.
+#[command]
+pub async fn stop_daemon(state: State<'_, DesktopState>) -> CommandResult<serde_json::Value> {
+    if !state.daemon_supervised.load(Ordering::SeqCst) {
+        return Ok(serde_json::json!({
+            "stopped": false,
+            "reason": "no daemon supervised"
+        }));
+    }
+
+    let mut handle_guard = state.daemon_handle.lock().await;
+    if let Some(ref mut handle) = *handle_guard {
+        match handle.stop() {
+            Ok(()) => {
+                state.daemon_supervised.store(false, Ordering::SeqCst);
+                *handle_guard = None;
+                Ok(serde_json::json!({
+                    "stopped": true,
+                    "reason": null
+                }))
+            }
+            Err(e) => Ok(serde_json::json!({
+                "stopped": false,
+                "reason": e.to_string()
+            })),
+        }
+    } else {
+        Ok(serde_json::json!({
+            "stopped": false,
+            "reason": "no daemon handle"
+        }))
+    }
+}
+
+/// Query the status of the supervised daemon.
+#[command]
+pub async fn daemon_status(state: State<'_, DesktopState>) -> CommandResult<ProcessStatus> {
+    let handle_guard = state.daemon_handle.lock().await;
+    if let Some(ref handle) = *handle_guard {
+        Ok(ProcessStatus {
+            pid: handle.pid(),
+            running: handle.is_running(),
+            state: format!("{:?}", handle.state()),
+            supervised: state.daemon_supervised.load(Ordering::SeqCst),
+        })
+    } else {
+        Ok(ProcessStatus {
+            pid: None,
+            running: false,
+            state: "stopped".to_string(),
+            supervised: false,
+        })
+    }
+}
+
+/// Response for daemon process status.
 #[derive(Debug, Serialize)]
 pub struct ProcessStatus {
     pub pid: Option<u32>,
     pub running: bool,
-}
-
-/// Stub: query whether the locally-supervised daemon process is running.
-#[command]
-pub async fn daemon_status() -> CommandResult<ProcessStatus> {
-    // COE-404 will implement actual discovery + supervision.
-    Ok(ProcessStatus {
-        pid: None,
-        running: false,
-    })
+    pub state: String,
+    pub supervised: bool,
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -257,10 +257,12 @@ pub struct ProfileResponse {
 #[command]
 pub async fn store_profile(_req: ProfileRequest) -> CommandResult<ProfileResponse> {
     // Real implementation persists to local storage
+    // Use serde_json for consistent snake_case serialization
+    let kind_str = serde_json::to_string(&_req.kind).unwrap_or_else(|_| "\"unknown\"".to_string());
     Ok(ProfileResponse {
         id: _req.id.unwrap_or_else(|| "new-profile".to_string()),
         label: _req.label,
-        kind: format!("{:?}", _req.kind),
+        kind: kind_str.trim_matches('"').to_string(),
         gateway_url: _req.gateway_url,
         managed: matches!(_req.kind, ProfileKind::SupervisedLocalDaemon | ProfileKind::EmbeddedHost),
         daemon_path: _req.daemon_path,
@@ -301,13 +303,21 @@ pub async fn probe_gateway(gateway_url: String) -> CommandResult<DiscoveryResult
     let health_url = format!("{}/healthz", gateway_url.trim_end_matches('/'));
     let capabilities_url = format!("{}/api/v1/capabilities", gateway_url.trim_end_matches('/'));
 
+    // Use a client with a timeout to avoid blocking the async runtime
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| DesktopError::Internal {
+            message: format!("Failed to build HTTP client: {}", e),
+        })?;
+
     // Probe health
-    match reqwest::get(&health_url).await {
+    match client.get(&health_url).send().await {
         Ok(response) if response.status().is_success() => {
             let _health_latency = start.elapsed().as_millis() as u64;
             
             // Probe capabilities
-            match reqwest::get(&capabilities_url).await {
+            match client.get(&capabilities_url).send().await {
                 Ok(cap_response) if cap_response.status().is_success() => {
                     let capabilities: Option<serde_json::Value> = cap_response.json().await.ok();
                     let total_latency = start.elapsed().as_millis() as u64;
@@ -487,10 +497,12 @@ pub async fn stop_daemon(state: State<'_, DesktopState>) -> CommandResult<serde_
 pub async fn daemon_status(state: State<'_, DesktopState>) -> CommandResult<ProcessStatus> {
     let handle_guard = state.daemon_handle.lock().await;
     if let Some(ref handle) = *handle_guard {
+        // Use serde_json serialization for consistent snake_case format
+        let state_str = serde_json::to_string(handle.state()).unwrap_or_else(|_| "unknown".to_string());
         Ok(ProcessStatus {
             pid: handle.pid(),
             running: handle.is_running(),
-            state: format!("{:?}", handle.state()),
+            state: state_str.trim_matches('"').to_string(),
             supervised: state.daemon_supervised.load(Ordering::SeqCst),
         })
     } else {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -256,13 +256,19 @@ pub struct ProfileResponse {
 /// Store a connection profile.
 #[command]
 pub async fn store_profile(_req: ProfileRequest) -> CommandResult<ProfileResponse> {
-    // Stub implementation - real persistence will be added in COE-409
-    // with proper UUID generation to prevent ID collisions.
-    // Current behavior: returns "new-profile" only when no ID is provided,
-    // which is acceptable for this alpha-stage stub.
+    // Stub implementation - real persistence will be added in COE-409.
+    // Generate a timestamp-based unique ID to prevent collisions when
+    // multiple profiles are stored without explicit IDs.
+    let profile_id = _req.id.unwrap_or_else(|| {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        format!("profile-{}", ts)
+    });
     let kind_str = serde_json::to_string(&_req.kind).unwrap_or_else(|_| "\"unknown\"".to_string());
     Ok(ProfileResponse {
-        id: _req.id.unwrap_or_else(|| "new-profile".to_string()),
+        id: profile_id,
         label: _req.label,
         kind: kind_str.trim_matches('"').to_string(),
         gateway_url: _req.gateway_url,
@@ -472,7 +478,7 @@ pub async fn stop_daemon(state: State<'_, DesktopState>) -> CommandResult<serde_
 
     let mut handle_guard = state.daemon_handle.lock().await;
     if let Some(ref mut handle) = *handle_guard {
-        match handle.stop() {
+        match handle.stop().await {
             Ok(()) => {
                 state.daemon_supervised.store(false, Ordering::SeqCst);
                 *handle_guard = None;

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -20,8 +20,12 @@ use tracing::warn;
 /// Validate that a daemon executable path is safe to run.
 ///
 /// Rejects paths that don't exist, aren't regular files, or lack execute
-/// permission on Unix systems. Also rejects world-writable and group-writable
-/// paths to prevent tampering by other local users.
+/// permission on Unix systems. Also rejects world-writable paths to prevent
+/// tampering by other local users.
+///
+/// Note: Group-writable paths are NOT rejected because in a desktop environment,
+/// the user's primary group typically contains only that user, so rejecting
+/// group-writable paths would break legitimate executables (e.g., `~/bin/`).
 ///
 /// In production deployments, this should be restricted to bundled
 /// executables within the app's resource directory.
@@ -35,7 +39,7 @@ fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
         return Err(DaemonPathError::NotAFile);
     }
 
-    // On Unix, verify execute permission and reject writable-by-others paths
+    // On Unix, verify execute permission and reject world-writable paths
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -45,11 +49,6 @@ fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
         // Reject world-writable paths (prevents tampering by any local user)
         if mode & 0o002 != 0 {
             return Err(DaemonPathError::WorldWritable);
-        }
-
-        // Reject group-writable paths (prevents tampering by group members)
-        if mode & 0o020 != 0 {
-            return Err(DaemonPathError::GroupWritable);
         }
 
         if mode & 0o111 == 0 {
@@ -68,7 +67,6 @@ enum DaemonPathError {
     NotAFile,
     NotExecutable,
     WorldWritable,
-    GroupWritable,
     AccessDenied { detail: String },
 }
 
@@ -408,7 +406,6 @@ pub async fn discover_default_gateway() -> CommandResult<DiscoveryResult> {
     let default_urls = [
         "http://127.0.0.1:8080",
         "http://localhost:8080",
-        "http://0.0.0.0:8080",
     ];
 
     for url in &default_urls {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -505,12 +505,10 @@ pub async fn stop_daemon(state: State<'_, DesktopState>) -> CommandResult<serde_
 pub async fn daemon_status(state: State<'_, DesktopState>) -> CommandResult<ProcessStatus> {
     let handle_guard = state.daemon_handle.lock().await;
     if let Some(ref handle) = *handle_guard {
-        // Use serde_json serialization for consistent snake_case format
-        let state_str = serde_json::to_string(handle.state()).unwrap_or_else(|_| "unknown".to_string());
         Ok(ProcessStatus {
             pid: handle.pid(),
             running: handle.is_running(),
-            state: state_str.trim_matches('"').to_string(),
+            state: handle.state().as_str().to_string(),
             supervised: state.daemon_supervised.load(Ordering::SeqCst),
         })
     } else {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -6,11 +6,11 @@
 use crate::daemon::{DaemonConfig, DaemonHandle, StartupResult};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
-use tauri::command;
 use tauri::State;
+use tauri::command;
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -34,7 +34,9 @@ fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
         return Err(DaemonPathError::NotFound);
     }
 
-    let metadata = std::fs::metadata(path).map_err(|e| DaemonPathError::AccessDenied { detail: e.to_string() })?;
+    let metadata = std::fs::metadata(path).map_err(|e| DaemonPathError::AccessDenied {
+        detail: e.to_string(),
+    })?;
     if !metadata.is_file() {
         return Err(DaemonPathError::NotAFile);
     }
@@ -60,13 +62,18 @@ fn validate_executable_path(path: &PathBuf) -> Result<(), DaemonPathError> {
 }
 
 /// Error returned when a daemon executable path fails validation.
-#[derive(Debug, Serialize)]
+#[derive(Error, Debug, Serialize)]
 #[serde(rename_all = "snake_case", tag = "error")]
 enum DaemonPathError {
+    #[error("daemon executable path does not exist")]
     NotFound,
+    #[error("daemon executable path is not a regular file")]
     NotAFile,
+    #[error("daemon executable path is not executable")]
     NotExecutable,
+    #[error("daemon executable path is world-writable")]
     WorldWritable,
+    #[error("daemon executable path cannot be inspected: {detail}")]
     AccessDenied { detail: String },
 }
 
@@ -120,6 +127,12 @@ impl DesktopState {
             daemon_handle: Arc::new(Mutex::new(None)),
             daemon_supervised: Arc::new(AtomicBool::new(false)),
         }
+    }
+}
+
+impl Default for DesktopState {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -299,7 +312,10 @@ pub async fn store_profile(_req: ProfileRequest) -> CommandResult<ProfileRespons
         label: _req.label,
         kind: _req.kind.as_str().to_string(),
         gateway_url: _req.gateway_url,
-        managed: matches!(_req.kind, ProfileKind::SupervisedLocalDaemon | ProfileKind::EmbeddedHost),
+        managed: matches!(
+            _req.kind,
+            ProfileKind::SupervisedLocalDaemon | ProfileKind::EmbeddedHost
+        ),
         daemon_path: _req.daemon_path,
     })
 }
@@ -350,13 +366,13 @@ pub async fn probe_gateway(gateway_url: String) -> CommandResult<DiscoveryResult
     match client.get(&health_url).send().await {
         Ok(response) if response.status().is_success() => {
             let _health_latency = start.elapsed().as_millis() as u64;
-            
+
             // Probe capabilities
             match client.get(&capabilities_url).send().await {
                 Ok(cap_response) if cap_response.status().is_success() => {
                     let capabilities: Option<serde_json::Value> = cap_response.json().await.ok();
                     let total_latency = start.elapsed().as_millis() as u64;
-                    
+
                     Ok(DiscoveryResult {
                         healthy: true,
                         compatible: true,
@@ -371,7 +387,10 @@ pub async fn probe_gateway(gateway_url: String) -> CommandResult<DiscoveryResult
                     compatible: false,
                     gateway_url,
                     latency_ms: start.elapsed().as_millis() as u64,
-                    error: Some(format!("Capabilities endpoint returned {}", cap_response.status())),
+                    error: Some(format!(
+                        "Capabilities endpoint returned {}",
+                        cap_response.status()
+                    )),
                     capabilities: None,
                 }),
                 Err(e) => Ok(DiscoveryResult {
@@ -406,10 +425,7 @@ pub async fn probe_gateway(gateway_url: String) -> CommandResult<DiscoveryResult
 /// Discover gateway on default loopback address.
 #[command]
 pub async fn discover_default_gateway() -> CommandResult<DiscoveryResult> {
-    let default_urls = [
-        "http://127.0.0.1:8080",
-        "http://localhost:8080",
-    ];
+    let default_urls = ["http://127.0.0.1:8080", "http://localhost:8080"];
 
     for url in &default_urls {
         let result = probe_gateway(url.to_string()).await?;
@@ -466,7 +482,7 @@ pub async fn start_daemon(
     if let Err(err) = validate_executable_path(&exec_path) {
         warn!(?err, path = ?exec_path, "daemon executable path validation failed");
         return Err(DesktopError::DaemonPath {
-            detail: format!("path validation failed: {:?}", err),
+            detail: err.to_string(),
         });
     }
 
@@ -476,7 +492,9 @@ pub async fn start_daemon(
         env: req.env.unwrap_or_default(),
         startup_timeout: Duration::from_secs(req.startup_timeout_secs.unwrap_or(30)),
         auto_restart: req.auto_restart.unwrap_or(true),
-        gateway_url: req.gateway_url.unwrap_or_else(|| "http://127.0.0.1:8080".to_string()),
+        gateway_url: req
+            .gateway_url
+            .unwrap_or_else(|| "http://127.0.0.1:8080".to_string()),
         skip_health_check: false,
     };
 

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -236,12 +236,37 @@ impl DaemonHandle {
     }
 
     /// Check if the daemon is currently running.
+    ///
+    /// Verifies both internal state and OS-level process liveness to detect
+    /// crashes or external kills.
     pub fn is_running(&self) -> bool {
-        self.pid.is_some()
-            && matches!(
+        if self.pid.is_none()
+            || !matches!(
                 self.state,
                 DaemonState::Running | DaemonState::Starting | DaemonState::Unhealthy
             )
+        {
+            return false;
+        }
+        self.is_process_alive()
+    }
+
+    /// Check if the OS process is still alive.
+    #[cfg(unix)]
+    fn is_process_alive(&self) -> bool {
+        if let Some(pid) = self.pid {
+            // kill(pid, 0) checks process existence without sending a signal
+            let result = unsafe { libc::kill(pid as i32, 0) };
+            result == 0
+        } else {
+            false
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn is_process_alive(&self) -> bool {
+        // Windows would use OpenProcess/GetExitCodeProcess
+        self.pid.is_some()
     }
 
     /// Get the current state of the daemon.

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -146,8 +146,8 @@ impl DaemonHandle {
         let mut cmd = Command::new(&self.config.executable);
         cmd.args(&self.config.args)
             .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
 
         for (key, value) in &self.config.env {
             cmd.env(key, value);
@@ -366,9 +366,9 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and calls `wait()` to reap the zombie. After SIGKILL
-    /// the process is already dead, so `wait()` returns immediately rather
-    /// than blocking. This ensures the PID is fully released for reuse.
+    /// Sends SIGKILL and calls `try_wait()` to reap the zombie.
+    /// Uses a short retry loop (up to 500ms) to ensure the zombie is actually
+    /// reaped, which is needed for proper process cleanup on all platforms.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -384,9 +384,28 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Wait to reap the zombie. After SIGKILL the process is guaranteed
-            // to be dead, so this returns immediately without blocking.
-            let _ = child.wait();
+            // Reap the zombie with a short non-blocking retry loop.
+            // try_wait() returns immediately; the loop ensures we catch
+            // the window between SIGKILL delivery and OS process table update.
+            let deadline = std::time::Instant::now() + Duration::from_millis(500);
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,     // Process exited and was reaped
+                    Ok(None) => {             // Process still running
+                        if std::time::Instant::now() >= deadline {
+                            warn!(
+                                "try_wait() timed out after 500ms, zombie may linger briefly",
+                            );
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "failed to check child process status");
+                        break;
+                    }
+                }
+            }
         }
         self.child = None;
     }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -367,8 +367,8 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Reap the zombie so the PID becomes truly invalid
-            let _ = child.try_wait();
+            // Block to reap the zombie so the PID becomes truly invalid
+            let _ = child.wait();
         }
     }
 

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -407,8 +407,13 @@ impl Drop for DaemonHandle {
                 pid = ?self.pid,
                 "daemon handle dropped, cleaning up owned process",
             );
-            // Non-blocking cleanup: just kill, never wait
-            let _ = self.kill();
+            // Non-blocking cleanup: kill without waiting to avoid blocking
+            // the thread during drop, especially in async contexts.
+            self.kill_process_only();
+            self.child = None;
+            self.pid = None;
+            self.state = DaemonState::Stopped;
+            self.owns_process = false;
         }
     }
 }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -258,7 +258,8 @@ impl DaemonHandle {
     ///
     /// Only stops if this handle owns the process. Sends SIGTERM first,
     /// waits up to 5 seconds for exit, then escalates to SIGKILL if needed.
-    pub fn stop(&mut self) -> Result<(), DaemonError> {
+    /// Uses async sleep to avoid blocking the tokio worker thread.
+    pub async fn stop(&mut self) -> Result<(), DaemonError> {
         if !self.owns_process {
             warn!("attempted to stop daemon that we don't own");
             return Ok(());
@@ -282,8 +283,7 @@ impl DaemonHandle {
                     .output();
             }
 
-            // Non-blocking wait: poll for exit with a short timeout to avoid
-            // blocking the tokio runtime indefinitely.
+            // Async wait loop: poll for exit without blocking the tokio worker thread.
             // If the process doesn't exit within 5 seconds, escalate to SIGKILL.
             let deadline = Instant::now() + Duration::from_secs(5);
             let mut exited = false;
@@ -296,9 +296,9 @@ impl DaemonHandle {
                             break;
                         }
                         Ok(None) => {
-                            // Process still running, use spawn_blocking to avoid
-                            // blocking the tokio worker thread
-                            std::thread::sleep(Duration::from_millis(100));
+                            // Process still running; use async sleep so we
+                            // don't block the tokio worker thread.
+                            tokio::time::sleep(Duration::from_millis(100)).await;
                         }
                         Err(e) => {
                             warn!(pid = ?self.pid, error = %e, "error checking daemon status");
@@ -436,7 +436,7 @@ mod tests {
         assert!(!result.success || result.pid.is_some());
 
         // Clean up
-        let _ = handle.stop();
+        let _ = handle.stop().await;
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 use thiserror::Error;
-use tokio::sync::watch;
 use tracing::{error, info, warn};
 
 /// Configuration for a supervised daemon process.
@@ -78,6 +77,7 @@ pub enum DaemonError {
 /// Handle to a supervised daemon process.
 ///
 /// Tracks process ownership and provides lifecycle management.
+/// Only stops processes that this handle explicitly owns.
 pub struct DaemonHandle {
     /// The child process.
     child: Option<Child>,
@@ -89,8 +89,6 @@ pub struct DaemonHandle {
     owns_process: bool,
     /// Configuration used to start this daemon.
     config: DaemonConfig,
-    /// Shutdown signal sender.
-    shutdown_tx: Option<watch::Sender<bool>>,
 }
 
 impl DaemonHandle {
@@ -102,7 +100,6 @@ impl DaemonHandle {
             state: DaemonState::Stopped,
             owns_process: false,
             config,
-            shutdown_tx: None,
         }
     }
 
@@ -330,62 +327,6 @@ impl Drop for DaemonHandle {
             // Non-blocking cleanup: just kill, never wait
             let _ = self.kill();
         }
-    }
-}
-
-/// Supervisor that manages a daemon's lifecycle.
-///
-/// Monitors the daemon process and optionally restarts it on failure.
-pub struct DaemonSupervisor {
-    /// The daemon handle being supervised.
-    handle: DaemonHandle,
-    /// Whether auto-restart is enabled.
-    auto_restart: bool,
-    /// Shutdown signal receiver.
-    shutdown_rx: watch::Receiver<bool>,
-}
-
-impl DaemonSupervisor {
-    /// Create a new supervisor for the given daemon configuration.
-    pub fn new(config: DaemonConfig) -> (Self, watch::Sender<bool>) {
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let auto_restart = config.auto_restart;
-        let handle = DaemonHandle::new(config);
-        let supervisor = Self {
-            handle,
-            auto_restart,
-            shutdown_rx,
-        };
-        (supervisor, shutdown_tx)
-    }
-
-    /// Start supervising the daemon.
-    ///
-    /// Returns immediately after starting the daemon. The supervisor will
-    /// monitor and optionally restart the daemon in the background.
-    pub async fn start(&mut self) -> StartupResult {
-        self.handle.start().await
-    }
-
-    /// Get a reference to the daemon handle.
-    pub fn handle(&self) -> &DaemonHandle {
-        &self.handle
-    }
-
-    /// Get a mutable reference to the daemon handle.
-    pub fn handle_mut(&mut self) -> &mut DaemonHandle {
-        &mut self.handle
-    }
-
-    /// Check if the daemon is currently running.
-    pub fn is_running(&self) -> bool {
-        self.handle.is_running()
-    }
-
-    /// Stop the supervised daemon.
-    pub fn stop(&mut self) -> Result<(), DaemonError> {
-        self.auto_restart = false;
-        self.handle.stop()
     }
 }
 

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -1,0 +1,452 @@
+//! Local daemon supervisor for OpenSymphony desktop.
+//!
+//! Manages the lifecycle of a local OpenSymphony daemon process,
+//! including startup, health checking, monitoring, and graceful shutdown.
+//! Only stops processes that it explicitly owns.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use thiserror::Error;
+use tokio::sync::watch;
+use tracing::{error, info, warn};
+
+/// Configuration for a supervised daemon process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonConfig {
+    /// Path to the daemon executable.
+    pub executable: PathBuf,
+    /// Arguments to pass to the daemon.
+    pub args: Vec<String>,
+    /// Environment variables to set for the daemon process.
+    pub env: Vec<(String, String)>,
+    /// Maximum time to wait for the daemon to become healthy.
+    pub startup_timeout: Duration,
+    /// Whether to automatically restart the daemon if it exits.
+    pub auto_restart: bool,
+    /// Gateway URL where the daemon listens.
+    pub gateway_url: String,
+}
+
+/// Current state of the supervised daemon.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum DaemonState {
+    /// Daemon is not running.
+    Stopped,
+    /// Daemon is starting up.
+    Starting,
+    /// Daemon is running and healthy.
+    Running,
+    /// Daemon is running but unhealthy.
+    Unhealthy,
+    /// Daemon is shutting down.
+    Stopping,
+    /// Daemon has crashed or failed to start.
+    Failed(String),
+}
+
+/// Result of a daemon startup attempt.
+#[derive(Debug, Serialize)]
+pub struct StartupResult {
+    /// Whether startup succeeded.
+    pub success: bool,
+    /// Process ID if started successfully.
+    pub pid: Option<u32>,
+    /// Error message if startup failed.
+    pub error: Option<String>,
+    /// Time taken to start up in milliseconds.
+    pub elapsed_ms: u64,
+}
+
+/// Error type for daemon operations.
+#[derive(Error, Debug)]
+pub enum DaemonError {
+    #[error("daemon failed to start: {0}")]
+    StartFailed(String),
+    #[error("daemon is not running")]
+    NotRunning,
+    #[error("daemon health check failed: {0}")]
+    HealthCheckFailed(String),
+    #[error("timeout waiting for daemon to start")]
+    StartupTimeout,
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Handle to a supervised daemon process.
+///
+/// Tracks process ownership and provides lifecycle management.
+pub struct DaemonHandle {
+    /// The child process.
+    child: Option<Child>,
+    /// Process ID of the daemon.
+    pid: Option<u32>,
+    /// Current state of the daemon.
+    state: DaemonState,
+    /// Whether this handle owns the process (and should stop it on drop).
+    owns_process: bool,
+    /// Configuration used to start this daemon.
+    config: DaemonConfig,
+    /// Shutdown signal sender.
+    shutdown_tx: Option<watch::Sender<bool>>,
+}
+
+impl DaemonHandle {
+    /// Create a new daemon handle with the given configuration.
+    pub fn new(config: DaemonConfig) -> Self {
+        Self {
+            child: None,
+            pid: None,
+            state: DaemonState::Stopped,
+            owns_process: false,
+            config,
+            shutdown_tx: None,
+        }
+    }
+
+    /// Start the daemon process.
+    ///
+    /// Only starts if not already running. Returns a StartupResult with
+    /// the outcome and timing information.
+    pub async fn start(&mut self) -> StartupResult {
+        if self.is_running() {
+            warn!("daemon already running, pid={:?}", self.pid);
+            return StartupResult {
+                success: true,
+                pid: self.pid,
+                error: None,
+                elapsed_ms: 0,
+            };
+        }
+
+        let start_time = Instant::now();
+        info!(
+            executable = ?self.config.executable,
+            args = ?self.config.args,
+            "starting supervised daemon",
+        );
+
+        self.state = DaemonState::Starting;
+
+        let mut cmd = Command::new(&self.config.executable);
+        cmd.args(&self.config.args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        for (key, value) in &self.config.env {
+            cmd.env(key, value);
+        }
+
+        match cmd.spawn() {
+            Ok(child) => {
+                let pid = child.id();
+                self.child = Some(child);
+                self.pid = Some(pid);
+                self.owns_process = true;
+
+                info!(pid, "daemon process started");
+
+                // Wait for health check
+                let health_result = self.wait_for_health().await;
+
+                let elapsed = start_time.elapsed().as_millis() as u64;
+
+                match health_result {
+                    Ok(()) => {
+                        self.state = DaemonState::Running;
+                        info!(pid, elapsed_ms = elapsed, "daemon healthy");
+                        StartupResult {
+                            success: true,
+                            pid: Some(pid),
+                            error: None,
+                            elapsed_ms: elapsed,
+                        }
+                    }
+                    Err(e) => {
+                        self.state = DaemonState::Failed(e.to_string());
+                        error!(pid, error = %e, "daemon failed health check");
+                        StartupResult {
+                            success: false,
+                            pid: Some(pid),
+                            error: Some(e.to_string()),
+                            elapsed_ms: elapsed,
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                self.state = DaemonState::Failed(e.to_string());
+                error!(error = %e, "failed to spawn daemon process");
+                StartupResult {
+                    success: false,
+                    pid: None,
+                    error: Some(e.to_string()),
+                    elapsed_ms: start_time.elapsed().as_millis() as u64,
+                }
+            }
+        }
+    }
+
+    /// Wait for the daemon to become healthy.
+    ///
+    /// Polls the health endpoint until it responds or the timeout is reached.
+    async fn wait_for_health(&self) -> Result<(), DaemonError> {
+        let deadline = Instant::now() + self.config.startup_timeout;
+        let health_url = format!("{}/healthz", self.config.gateway_url.trim_end_matches('/'));
+
+        info!(url = %health_url, "waiting for daemon health check");
+
+        while Instant::now() < deadline {
+            match reqwest::get(&health_url).await {
+                Ok(response) if response.status().is_success() => {
+                    return Ok(());
+                }
+                Ok(response) => {
+                    warn!(status = %response.status(), "daemon not yet ready");
+                }
+                Err(e) => {
+                    warn!(error = %e, "health check failed, retrying");
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        Err(DaemonError::StartupTimeout)
+    }
+
+    /// Check if the daemon is currently running.
+    pub fn is_running(&self) -> bool {
+        self.pid.is_some()
+            && matches!(
+                self.state,
+                DaemonState::Running | DaemonState::Starting | DaemonState::Unhealthy
+            )
+    }
+
+    /// Get the current state of the daemon.
+    pub fn state(&self) -> &DaemonState {
+        &self.state
+    }
+
+    /// Get the process ID of the daemon.
+    pub fn pid(&self) -> Option<u32> {
+        self.pid
+    }
+
+    /// Get the gateway URL for this daemon.
+    pub fn gateway_url(&self) -> &str {
+        &self.config.gateway_url
+    }
+
+    /// Stop the daemon process gracefully.
+    ///
+    /// Only stops if this handle owns the process.
+    pub fn stop(&mut self) -> Result<(), DaemonError> {
+        if !self.owns_process {
+            warn!("attempted to stop daemon that we don't own");
+            return Ok(());
+        }
+
+        if let Some(ref mut child) = self.child {
+            info!(pid = ?self.pid, "stopping daemon process");
+            self.state = DaemonState::Stopping;
+
+            #[cfg(unix)]
+            {
+                // Send SIGTERM for graceful shutdown on Unix
+                let _ = unsafe { libc::kill(self.pid.unwrap_or(0) as i32, libc::SIGTERM) };
+            }
+
+            #[cfg(windows)]
+            {
+                // Use taskkill on Windows
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
+                    .output();
+            }
+
+            // Wait for process to exit
+            match child.wait() {
+                Ok(status) => {
+                    info!(pid = ?self.pid, status = ?status, "daemon stopped");
+                }
+                Err(e) => {
+                    warn!(pid = ?self.pid, error = %e, "error waiting for daemon to stop");
+                }
+            }
+
+            self.child = None;
+            self.pid = None;
+            self.state = DaemonState::Stopped;
+            self.owns_process = false;
+        }
+
+        Ok(())
+    }
+
+    /// Force-kill the daemon process.
+    pub fn kill(&mut self) -> Result<(), DaemonError> {
+        if let Some(ref mut child) = self.child {
+            info!(pid = ?self.pid, "force-killing daemon");
+            let _ = child.kill();
+            self.child = None;
+            self.pid = None;
+            self.state = DaemonState::Stopped;
+            self.owns_process = false;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        if self.owns_process {
+            info!(
+                pid = ?self.pid,
+                "daemon handle dropped, cleaning up owned process",
+            );
+            let _ = self.stop();
+        }
+    }
+}
+
+/// Supervisor that manages a daemon's lifecycle.
+///
+/// Monitors the daemon process and optionally restarts it on failure.
+pub struct DaemonSupervisor {
+    /// The daemon handle being supervised.
+    handle: DaemonHandle,
+    /// Whether auto-restart is enabled.
+    auto_restart: bool,
+    /// Shutdown signal receiver.
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl DaemonSupervisor {
+    /// Create a new supervisor for the given daemon configuration.
+    pub fn new(config: DaemonConfig) -> (Self, watch::Sender<bool>) {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let auto_restart = config.auto_restart;
+        let handle = DaemonHandle::new(config);
+        let supervisor = Self {
+            handle,
+            auto_restart,
+            shutdown_rx,
+        };
+        (supervisor, shutdown_tx)
+    }
+
+    /// Start supervising the daemon.
+    ///
+    /// Returns immediately after starting the daemon. The supervisor will
+    /// monitor and optionally restart the daemon in the background.
+    pub async fn start(&mut self) -> StartupResult {
+        self.handle.start().await
+    }
+
+    /// Get a reference to the daemon handle.
+    pub fn handle(&self) -> &DaemonHandle {
+        &self.handle
+    }
+
+    /// Get a mutable reference to the daemon handle.
+    pub fn handle_mut(&mut self) -> &mut DaemonHandle {
+        &mut self.handle
+    }
+
+    /// Check if the daemon is currently running.
+    pub fn is_running(&self) -> bool {
+        self.handle.is_running()
+    }
+
+    /// Stop the supervised daemon.
+    pub fn stop(&mut self) -> Result<(), DaemonError> {
+        self.auto_restart = false;
+        self.handle.stop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn test_config() -> DaemonConfig {
+        DaemonConfig {
+            executable: PathBuf::from("/bin/sleep"),
+            args: vec!["300".to_string()],
+            env: vec![("TEST_VAR".to_string(), "test_value".to_string())],
+            startup_timeout: Duration::from_secs(5),
+            auto_restart: true,
+            gateway_url: "http://127.0.0.1:8080".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_daemon_handle_creation() {
+        let config = test_config();
+        let handle = DaemonHandle::new(config);
+        assert_eq!(handle.state(), &DaemonState::Stopped);
+        assert!(handle.pid().is_none());
+        assert!(!handle.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_daemon_start_stop_with_fake_command() {
+        // Create a simple script that exits immediately
+        let dir = tempdir().unwrap();
+        let script_path = dir.path().join("fake_daemon.sh");
+        fs::write(
+            &script_path,
+            "#!/bin/bash\nsleep 0.1\necho 'daemon started'\nwhile true; do sleep 1; done\n",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).unwrap();
+        }
+
+        let mut config = test_config();
+        config.executable = script_path.clone();
+        config.args = vec![];
+        config.startup_timeout = Duration::from_secs(2);
+        config.gateway_url = format!("file://{}", dir.path().display());
+
+        let mut handle = DaemonHandle::new(config);
+
+        // Start the daemon
+        let result = handle.start().await;
+        // The fake daemon won't have a health endpoint, so it should fail
+        assert!(!result.success || result.pid.is_some());
+
+        // Clean up
+        let _ = handle.stop();
+    }
+
+    #[test]
+    fn test_daemon_ownership_tracking() {
+        let config = test_config();
+        let handle = DaemonHandle::new(config);
+        assert!(!handle.owns_process);
+
+        // After start, owns_process would be true
+        // After stop, owns_process would be false
+    }
+
+    #[test]
+    fn test_daemon_config_serialization() {
+        let config = test_config();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: DaemonConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.executable, config.executable);
+        assert_eq!(deserialized.args, config.args);
+        assert_eq!(deserialized.gateway_url, config.gateway_url);
+    }
+}

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -384,8 +384,8 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Reap the zombie immediately after SIGKILL. Since the process
-            // is already dead, wait() returns without blocking.
+            // Wait to reap the zombie. After SIGKILL the process is guaranteed
+            // to be dead, so this returns immediately without blocking.
             let _ = child.wait();
         }
         self.child = None;

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -149,6 +149,19 @@ impl DaemonHandle {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
 
+        // Create a new process group so we can kill the entire group on cleanup.
+        // This prevents orphaned child processes when the parent is killed.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            unsafe {
+                cmd.pre_exec(|| {
+                    libc::setsid();
+                    Ok(())
+                });
+            }
+        }
+
         for (key, value) in &self.config.env {
             cmd.env(key, value);
         }
@@ -290,10 +303,15 @@ impl DaemonHandle {
         }
     }
 
-    #[cfg(not(unix))]
-    fn is_process_alive(&self) -> bool {
-        // Windows would use OpenProcess/GetExitCodeProcess
-        self.pid.is_some()
+    #[cfg(windows)]
+    fn is_process_alive(&mut self) -> bool {
+        // Use try_wait() on the actual Child handle to check if the process
+        // has exited. Returns Ok(Some(status)) if exited, Ok(None) if still running.
+        if let Some(ref mut child) = self.child {
+            matches!(child.try_wait(), Ok(None))
+        } else {
+            false
+        }
     }
 
     /// Get the current state of the daemon.
@@ -334,10 +352,11 @@ impl DaemonHandle {
 
             #[cfg(windows)]
             {
-                // Use taskkill on Windows
+                // Use spawn() to avoid blocking the async worker thread.
+                // The OS reaps the taskkill process asynchronously.
                 let _ = std::process::Command::new("taskkill")
                     .args(["/PID", &self.pid.unwrap_or(0).to_string()])
-                    .output();
+                    .spawn();
             }
 
             // Async wait loop: poll for exit without blocking the tokio worker thread.
@@ -382,9 +401,10 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and polls with `try_wait()` to verify the process exits.
-    /// Uses a short retry loop (max 100 ms) so it remains safe for `Drop` and
-    /// async contexts while ensuring the process is actually reaped.
+    /// Sends SIGKILL and waits for the process to exit to ensure it is fully
+    /// reaped. This avoids zombies and is safe for `Drop` context because
+    /// SIGKILL termination is immediate. The wait is bounded by the OS
+    /// scheduler — typically under 1 ms after signal delivery.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -395,22 +415,17 @@ impl DaemonHandle {
             }
             #[cfg(windows)]
             {
+                // Use spawn() instead of output() to avoid blocking the thread.
+                // The OS will reap the taskkill process asynchronously.
                 let _ = std::process::Command::new("taskkill")
                     .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
-                    .output();
+                    .spawn();
             }
             let _ = child.kill();
 
-            // Poll briefly so SIGKILL propagates and the child is reaped.
-            // 100 ms max keeps this safe for Drop and async callers.
-            let deadline = Instant::now() + Duration::from_millis(100);
-            while Instant::now() < deadline {
-                match child.try_wait() {
-                    Ok(Some(_)) => break, // Process reaped.
-                    Ok(None) => std::thread::sleep(Duration::from_millis(5)),
-                    Err(_) => break,
-                }
-            }
+            // Wait for the process to fully exit so it is reaped from the
+            // process table. SIGKILL is immediate, so this returns quickly.
+            let _ = child.wait();
         }
         self.child = None;
     }
@@ -427,7 +442,7 @@ impl DaemonHandle {
             {
                 let _ = std::process::Command::new("taskkill")
                     .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
-                    .output();
+                    .spawn();
             }
             let _ = child.kill();
         }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -354,6 +354,10 @@ impl DaemonHandle {
     }
 
     /// Internal helper to kill just the process without updating state fields.
+    ///
+    /// Sends SIGKILL and does a blocking wait() to reap the zombie, ensuring
+    /// the PID becomes fully invalid. This is used by Drop where blocking is
+    /// acceptable since we're already in a synchronous cleanup context.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -367,7 +371,7 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Block to reap the zombie so the PID becomes truly invalid
+            // Reap the zombie synchronously
             let _ = child.wait();
         }
     }
@@ -388,9 +392,9 @@ impl DaemonHandle {
             }
             let _ = child.kill();
         }
-        // Reap the zombie process by waiting for it to exit
+        // Non-blocking reap: try_wait() returns immediately even if process hasn't exited yet
         if let Some(ref mut child) = self.child {
-            let _ = child.wait();
+            let _ = child.try_wait();
         }
         self.child = None;
         self.pid = None;

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 use thiserror::Error;
-use tokio::time::timeout;
 use tracing::{error, info, warn};
 
 /// Configuration for a supervised daemon process.
@@ -27,6 +26,8 @@ pub struct DaemonConfig {
     pub auto_restart: bool,
     /// Gateway URL where the daemon listens.
     pub gateway_url: String,
+    /// Skip health check after startup (for testing or daemons without HTTP).
+    pub skip_health_check: bool,
 }
 
 /// Current state of the supervised daemon.
@@ -161,8 +162,12 @@ impl DaemonHandle {
 
                 info!(pid, "daemon process started");
 
-                // Wait for health check
-                let health_result = self.wait_for_health().await;
+                // Wait for health check unless explicitly skipped
+                let health_result = if self.config.skip_health_check {
+                    Ok(())
+                } else {
+                    self.wait_for_health().await
+                };
 
                 let elapsed = start_time.elapsed().as_millis() as u64;
 
@@ -180,9 +185,15 @@ impl DaemonHandle {
                     Err(e) => {
                         self.state = DaemonState::Failed(e.to_string());
                         error!(pid, error = %e, "daemon failed health check");
+                        // Kill the spawned process since startup failed.
+                        // This prevents orphaned daemon processes.
+                        self.kill_process_only();
+                        self.child = None;
+                        self.pid = None;
+                        self.owns_process = false;
                         StartupResult {
                             success: false,
-                            pid: Some(pid),
+                            pid: None,
                             error: Some(e.to_string()),
                             elapsed_ms: elapsed,
                         }
@@ -355,15 +366,16 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and spins briefly to reap the zombie. This is used by
-    /// Drop where blocking wait() is undesirable. Since SIGKILL cannot be
-    /// caught or ignored, the process dies almost instantly and the spin
-    /// loop typically reaps the zombie within a few iterations.
+    /// Sends SIGKILL and calls `wait()` to reap the zombie. After SIGKILL
+    /// the process is already dead, so `wait()` returns immediately rather
+    /// than blocking. This ensures the PID is fully released for reuse.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
             {
-                let _ = unsafe { libc::kill(self.pid.unwrap_or(0) as i32, libc::SIGKILL) };
+                if let Some(pid) = self.pid {
+                    let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+                }
             }
             #[cfg(windows)]
             {
@@ -372,20 +384,11 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Spin briefly to reap the zombie without blocking indefinitely.
-            // After SIGKILL the process is already dead, so try_wait() should
-            // succeed quickly to reap the zombie.
-            for _ in 0..50 {
-                match child.try_wait() {
-                    Ok(Some(_)) => return, // Zombie reaped successfully
-                    Ok(None) => std::thread::sleep(std::time::Duration::from_millis(5)),
-                    Err(_) => return, // Process already reaped or error
-                }
-            }
-            // Final attempt: if the process hasn't been reaped yet, it may
-            // still be in the process of dying. Give up gracefully rather
-            // than blocking the Drop handler indefinitely.
+            // Reap the zombie immediately after SIGKILL. Since the process
+            // is already dead, wait() returns without blocking.
+            let _ = child.wait();
         }
+        self.child = None;
     }
 
     /// Force-kill the daemon process.
@@ -448,6 +451,7 @@ mod tests {
             startup_timeout: Duration::from_secs(5),
             auto_restart: true,
             gateway_url: "http://127.0.0.1:8080".to_string(),
+            skip_health_check: false,
         }
     }
 
@@ -484,14 +488,15 @@ mod tests {
         config.args = vec![];
         config.startup_timeout = Duration::from_secs(2);
         config.gateway_url = format!("file://{}", dir.path().display());
+        config.skip_health_check = true;
 
         let mut handle = DaemonHandle::new(config);
 
         // Start the daemon
         let result = handle.start().await;
-        // The fake daemon won't have a health endpoint, so it should fail health check
-        assert!(!result.success);
-        // But the process was spawned before health check failure
+        // With skip_health_check = true, startup succeeds without waiting for health check.
+        assert!(result.success);
+        // The spawned process is not killed since health check was skipped
         assert!(result.pid.is_some());
 
         // Clean up

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -255,15 +255,18 @@ impl DaemonHandle {
         if self.pid.is_none()
             || !matches!(
                 self.state,
-                DaemonState::Running | DaemonState::Starting | DaemonState::Unhealthy
+                DaemonState::Running
+                    | DaemonState::Starting
+                    | DaemonState::Unhealthy
+                    | DaemonState::Stopping
             )
         {
             return false;
         }
         if !self.is_process_alive() {
-            // OS process died but state still says running - update to reflect reality.
+            // OS process died but state still says running/stopping - update to reflect reality.
             // This prevents stale-state hazards where is_running() returns false
-            // but daemon_status() still reports state as "running".
+            // but daemon_status() still reports state as "running" or "stopping".
             warn!(pid = ?self.pid, "daemon process detected dead, updating state");
             self.state = DaemonState::Stopped;
             self.pid = None;
@@ -379,11 +382,9 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and calls `wait()` to reap the zombie. This is safe
-    /// because SIGKILL is uncatchable: the process is guaranteed to exit
-    /// within milliseconds, so `wait()` returns immediately rather than
-    /// blocking indefinitely. Use this instead of `try_wait()` when you
-    /// need to guarantee the zombie is reaped (e.g., before PID reuse).
+    /// Sends SIGKILL and polls with `try_wait()` to verify the process exits.
+    /// Uses a short retry loop (max 100 ms) so it remains safe for `Drop` and
+    /// async contexts while ensuring the process is actually reaped.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -399,9 +400,17 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Block briefly to reap the zombie. This returns almost immediately
-            // because SIGKILL is uncatchable — the process cannot ignore it.
-            let _ = child.wait();
+
+            // Poll briefly so SIGKILL propagates and the child is reaped.
+            // 100 ms max keeps this safe for Drop and async callers.
+            let deadline = Instant::now() + Duration::from_millis(100);
+            while Instant::now() < deadline {
+                match child.try_wait() {
+                    Ok(Some(_)) => break, // Process reaped.
+                    Ok(None) => std::thread::sleep(Duration::from_millis(5)),
+                    Err(_) => break,
+                }
+            }
         }
         self.child = None;
     }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -367,6 +367,8 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
+            // Reap the zombie so the PID becomes truly invalid
+            let _ = child.try_wait();
         }
     }
 
@@ -385,6 +387,10 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
+        }
+        // Reap the zombie process by waiting for it to exit
+        if let Some(ref mut child) = self.child {
+            let _ = child.wait();
         }
         self.child = None;
         self.pid = None;

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -44,16 +44,21 @@ pub enum DaemonState {
     /// Daemon is shutting down.
     Stopping,
     /// Daemon has crashed or failed to start.
-    #[serde(serialize_with = "serialize_failed_state")]
     Failed(String),
 }
 
-/// Serialize the Failed variant as a snake_case string for consistency.
-fn serialize_failed_state<S>(error: &str, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&format!("failed: {}", error))
+impl DaemonState {
+    /// Return a simple snake_case string representation for API responses.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DaemonState::Stopped => "stopped",
+            DaemonState::Starting => "starting",
+            DaemonState::Running => "running",
+            DaemonState::Unhealthy => "unhealthy",
+            DaemonState::Stopping => "stopping",
+            DaemonState::Failed(_) => "failed",
+        }
+    }
 }
 
 /// Result of a daemon startup attempt.

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -304,8 +304,13 @@ impl DaemonHandle {
                     false
                 }
                 Err(e) => {
-                    warn!(pid = ?self.pid, error = %e, "failed to check daemon process status");
-                    false
+                    if Self::is_child_already_reaped_error(&e) {
+                        info!(pid = ?self.pid, error = %e, "daemon process was already reaped");
+                        false
+                    } else {
+                        warn!(pid = ?self.pid, error = %e, "failed to check daemon process status");
+                        true
+                    }
                 }
             }
         } else {
@@ -466,21 +471,33 @@ impl DaemonHandle {
         }
     }
 
+    fn is_child_already_reaped_error(error: &std::io::Error) -> bool {
+        #[cfg(unix)]
+        {
+            error.raw_os_error() == Some(libc::ECHILD)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = error;
+            false
+        }
+    }
+
     fn reap_child_in_background(mut child: Child, pid: Option<u32>) {
-        let name = pid
-            .map(|pid| format!("opensymphony-daemon-reaper-{pid}"))
-            .unwrap_or_else(|| "opensymphony-daemon-reaper".to_string());
-        if let Err(e) = std::thread::Builder::new().name(name).spawn(move || {
-            let status = child.wait();
-            match status {
-                Ok(status) => {
-                    info!(pid = ?pid, status = ?status, "daemon process reaped in background");
+        if let Err(e) = std::thread::Builder::new()
+            .name("os-reaper".to_string())
+            .spawn(move || {
+                let status = child.wait();
+                match status {
+                    Ok(status) => {
+                        info!(pid = ?pid, status = ?status, "daemon process reaped in background");
+                    }
+                    Err(e) => {
+                        warn!(pid = ?pid, error = %e, "background daemon reap failed");
+                    }
                 }
-                Err(e) => {
-                    warn!(pid = ?pid, error = %e, "background daemon reap failed");
-                }
-            }
-        }) {
+            })
+        {
             warn!(pid = ?pid, error = %e, "failed to spawn daemon reaper thread");
         }
     }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -249,8 +249,9 @@ impl DaemonHandle {
     /// Check if the daemon is currently running.
     ///
     /// Verifies both internal state and OS-level process liveness to detect
-    /// crashes or external kills.
-    pub fn is_running(&self) -> bool {
+    /// crashes or external kills. Updates internal state if the OS process
+    /// has died but our state still says running.
+    pub fn is_running(&mut self) -> bool {
         if self.pid.is_none()
             || !matches!(
                 self.state,
@@ -259,7 +260,19 @@ impl DaemonHandle {
         {
             return false;
         }
-        self.is_process_alive()
+        if !self.is_process_alive() {
+            // OS process died but state still says running - update to reflect reality.
+            // This prevents stale-state hazards where is_running() returns false
+            // but daemon_status() still reports state as "running".
+            warn!(pid = ?self.pid, "daemon process detected dead, updating state");
+            self.state = DaemonState::Stopped;
+            self.pid = None;
+            self.child = None;
+            self.owns_process = false;
+            false
+        } else {
+            true
+        }
     }
 
     /// Check if the OS process is still alive.
@@ -366,9 +379,11 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and polls with `try_wait()` to verify the process exits.
-    /// Uses a short retry loop (max 100 ms) so it remains safe for `Drop` and
-    /// async contexts while ensuring the process is actually reaped.
+    /// Sends SIGKILL and calls `wait()` to reap the zombie. This is safe
+    /// because SIGKILL is uncatchable: the process is guaranteed to exit
+    /// within milliseconds, so `wait()` returns immediately rather than
+    /// blocking indefinitely. Use this instead of `try_wait()` when you
+    /// need to guarantee the zombie is reaped (e.g., before PID reuse).
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -384,17 +399,9 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-
-            // Poll briefly so SIGKILL propagates and the child is reaped.
-            // 100 ms max keeps this safe for Drop and async callers.
-            let deadline = Instant::now() + Duration::from_millis(100);
-            while Instant::now() < deadline {
-                match child.try_wait() {
-                    Ok(Some(_)) => break, // Process reaped.
-                    Ok(None) => std::thread::sleep(Duration::from_millis(5)),
-                    Err(_) => break,
-                }
-            }
+            // Block briefly to reap the zombie. This returns almost immediately
+            // because SIGKILL is uncatchable — the process cannot ignore it.
+            let _ = child.wait();
         }
         self.child = None;
     }
@@ -466,7 +473,7 @@ mod tests {
     #[test]
     fn test_daemon_handle_creation() {
         let config = test_config();
-        let handle = DaemonHandle::new(config);
+        let mut handle = DaemonHandle::new(config);
         assert_eq!(handle.state(), &DaemonState::Stopped);
         assert!(handle.pid().is_none());
         assert!(!handle.is_running());

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -462,8 +462,10 @@ mod tests {
 
         // Start the daemon
         let result = handle.start().await;
-        // The fake daemon won't have a health endpoint, so it should fail
-        assert!(!result.success || result.pid.is_some());
+        // The fake daemon won't have a health endpoint, so it should fail health check
+        assert!(!result.success);
+        // But the process was spawned before health check failure
+        assert!(result.pid.is_some());
 
         // Clean up
         let _ = handle.stop().await;

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -355,9 +355,10 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and does a blocking wait() to reap the zombie, ensuring
-    /// the PID becomes fully invalid. This is used by Drop where blocking is
-    /// acceptable since we're already in a synchronous cleanup context.
+    /// Sends SIGKILL and spins briefly to reap the zombie. This is used by
+    /// Drop where blocking wait() is undesirable. Since SIGKILL cannot be
+    /// caught or ignored, the process dies almost instantly and the spin
+    /// loop typically reaps the zombie within a few iterations.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -371,8 +372,19 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Reap the zombie synchronously
-            let _ = child.wait();
+            // Spin briefly to reap the zombie without blocking indefinitely.
+            // After SIGKILL the process is already dead, so try_wait() should
+            // succeed quickly to reap the zombie.
+            for _ in 0..50 {
+                match child.try_wait() {
+                    Ok(Some(_)) => return, // Zombie reaped successfully
+                    Ok(None) => std::thread::sleep(std::time::Duration::from_millis(5)),
+                    Err(_) => return, // Process already reaped or error
+                }
+            }
+            // Final attempt: if the process hasn't been reaped yet, it may
+            // still be in the process of dying. Give up gracefully rather
+            // than blocking the Drop handler indefinitely.
         }
     }
 

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::time::timeout;
 use tracing::{error, info, warn};
 
 /// Configuration for a supervised daemon process.
@@ -43,7 +44,16 @@ pub enum DaemonState {
     /// Daemon is shutting down.
     Stopping,
     /// Daemon has crashed or failed to start.
+    #[serde(serialize_with = "serialize_failed_state")]
     Failed(String),
+}
+
+/// Serialize the Failed variant as a snake_case string for consistency.
+fn serialize_failed_state<S>(error: &str, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&format!("failed: {}", error))
 }
 
 /// Result of a daemon startup attempt.
@@ -196,8 +206,14 @@ impl DaemonHandle {
 
         info!(url = %health_url, "waiting for daemon health check");
 
+        // Use a client with per-request timeout to avoid blocking indefinitely
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|e| DaemonError::StartFailed(format!("Failed to build HTTP client: {}", e)))?;
+
         while Instant::now() < deadline {
-            match reqwest::get(&health_url).await {
+            match client.get(&health_url).send().await {
                 Ok(response) if response.status().is_success() => {
                     return Ok(());
                 }
@@ -240,14 +256,15 @@ impl DaemonHandle {
 
     /// Stop the daemon process gracefully.
     ///
-    /// Only stops if this handle owns the process.
+    /// Only stops if this handle owns the process. Sends SIGTERM first,
+    /// waits up to 5 seconds for exit, then escalates to SIGKILL if needed.
     pub fn stop(&mut self) -> Result<(), DaemonError> {
         if !self.owns_process {
             warn!("attempted to stop daemon that we don't own");
             return Ok(());
         }
 
-        if let Some(ref mut child) = self.child {
+        if self.child.is_some() {
             info!(pid = ?self.pid, "stopping daemon process");
             self.state = DaemonState::Stopping;
 
@@ -261,27 +278,40 @@ impl DaemonHandle {
             {
                 // Use taskkill on Windows
                 let _ = std::process::Command::new("taskkill")
-                    .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
+                    .args(["/PID", &self.pid.unwrap_or(0).to_string()])
                     .output();
             }
 
             // Non-blocking wait: poll for exit with a short timeout to avoid
             // blocking the tokio runtime indefinitely.
+            // If the process doesn't exit within 5 seconds, escalate to SIGKILL.
             let deadline = Instant::now() + Duration::from_secs(5);
+            let mut exited = false;
             while Instant::now() < deadline {
-                match child.try_wait() {
-                    Ok(Some(status)) => {
-                        info!(pid = ?self.pid, status = ?status, "daemon stopped");
-                        break;
-                    }
-                    Ok(None) => {
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-                    Err(e) => {
-                        warn!(pid = ?self.pid, error = %e, "error checking daemon status");
-                        break;
+                if let Some(ref mut child) = self.child {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            info!(pid = ?self.pid, status = ?status, "daemon stopped gracefully");
+                            exited = true;
+                            break;
+                        }
+                        Ok(None) => {
+                            // Process still running, use spawn_blocking to avoid
+                            // blocking the tokio worker thread
+                            std::thread::sleep(Duration::from_millis(100));
+                        }
+                        Err(e) => {
+                            warn!(pid = ?self.pid, error = %e, "error checking daemon status");
+                            break;
+                        }
                     }
                 }
+            }
+
+            // Escalate to SIGKILL if process didn't exit within timeout
+            if !exited {
+                warn!(pid = ?self.pid, "daemon did not exit within 5s, force-killing");
+                self.kill_process_only();
             }
         }
 
@@ -291,6 +321,23 @@ impl DaemonHandle {
         self.owns_process = false;
 
         Ok(())
+    }
+
+    /// Internal helper to kill just the process without updating state fields.
+    fn kill_process_only(&mut self) {
+        if let Some(ref mut child) = self.child {
+            #[cfg(unix)]
+            {
+                let _ = unsafe { libc::kill(self.pid.unwrap_or(0) as i32, libc::SIGKILL) };
+            }
+            #[cfg(windows)]
+            {
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
+                    .output();
+            }
+            let _ = child.kill();
+        }
     }
 
     /// Force-kill the daemon process.

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -346,8 +346,11 @@ impl DaemonHandle {
 
             #[cfg(unix)]
             {
-                // Send SIGTERM for graceful shutdown on Unix
-                let _ = unsafe { libc::kill(self.pid.unwrap_or(0) as i32, libc::SIGTERM) };
+                if let Some(pid) = self.pid {
+                    // Send SIGTERM to the entire process group for graceful shutdown.
+                    // Since we use setsid(), all child processes are in the same group.
+                    let _ = unsafe { libc::kill(-(pid as i32), libc::SIGTERM) };
+                }
             }
 
             #[cfg(windows)]
@@ -410,7 +413,10 @@ impl DaemonHandle {
             #[cfg(unix)]
             {
                 if let Some(pid) = self.pid {
-                    let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+                    // Kill the entire process group (negative PID means process group ID).
+                    // This ensures all child processes are also terminated, preventing
+                    // orphaned processes when the parent is killed.
+                    let _ = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
                 }
             }
             #[cfg(windows)]
@@ -436,7 +442,10 @@ impl DaemonHandle {
             info!(pid = ?self.pid, "force-killing daemon");
             #[cfg(unix)]
             {
-                let _ = unsafe { libc::kill(self.pid.unwrap_or(0) as i32, libc::SIGKILL) };
+                if let Some(pid) = self.pid {
+                    // Kill the entire process group to ensure all children are also terminated.
+                    let _ = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+                }
             }
             #[cfg(windows)]
             {

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -366,9 +366,9 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and calls `wait()` to reap the zombie.
-    /// `wait()` returns immediately after SIGKILL (which is uncatchable),
-    /// so this is effectively non-blocking while still ensuring zombie reaping.
+    /// Sends SIGKILL and polls with `try_wait()` to verify the process exits.
+    /// Uses a short retry loop (max 100 ms) so it remains safe for `Drop` and
+    /// async contexts while ensuring the process is actually reaped.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -384,9 +384,17 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // wait() after SIGKILL is effectively non-blocking since SIGKILL
-            // cannot be caught or ignored - the process exits immediately.
-            let _ = child.wait();
+
+            // Poll briefly so SIGKILL propagates and the child is reaped.
+            // 100 ms max keeps this safe for Drop and async callers.
+            let deadline = Instant::now() + Duration::from_millis(100);
+            while Instant::now() < deadline {
+                match child.try_wait() {
+                    Ok(Some(_)) => break, // Process reaped.
+                    Ok(None) => std::thread::sleep(Duration::from_millis(5)),
+                    Err(_) => break,
+                }
+            }
         }
         self.child = None;
     }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -366,9 +366,9 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and calls `try_wait()` to reap the zombie.
-    /// Uses a short retry loop (up to 500ms) to ensure the zombie is actually
-    /// reaped, which is needed for proper process cleanup on all platforms.
+    /// Sends SIGKILL and calls `wait()` to reap the zombie.
+    /// `wait()` returns immediately after SIGKILL (which is uncatchable),
+    /// so this is effectively non-blocking while still ensuring zombie reaping.
     fn kill_process_only(&mut self) {
         if let Some(ref mut child) = self.child {
             #[cfg(unix)]
@@ -384,28 +384,9 @@ impl DaemonHandle {
                     .output();
             }
             let _ = child.kill();
-            // Reap the zombie with a short non-blocking retry loop.
-            // try_wait() returns immediately; the loop ensures we catch
-            // the window between SIGKILL delivery and OS process table update.
-            let deadline = std::time::Instant::now() + Duration::from_millis(500);
-            loop {
-                match child.try_wait() {
-                    Ok(Some(_)) => break,     // Process exited and was reaped
-                    Ok(None) => {             // Process still running
-                        if std::time::Instant::now() >= deadline {
-                            warn!(
-                                "try_wait() timed out after 500ms, zombie may linger briefly",
-                            );
-                            break;
-                        }
-                        std::thread::sleep(Duration::from_millis(10));
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "failed to check child process status");
-                        break;
-                    }
-                }
-            }
+            // wait() after SIGKILL is effectively non-blocking since SIGKILL
+            // cannot be caught or ignored - the process exits immediately.
+            let _ = child.wait();
         }
         self.child = None;
     }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -31,6 +31,7 @@ pub struct DaemonConfig {
 
 /// Current state of the supervised daemon.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DaemonState {
     /// Daemon is not running.
     Stopped,

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -267,21 +267,30 @@ impl DaemonHandle {
                     .output();
             }
 
-            // Wait for process to exit
-            match child.wait() {
-                Ok(status) => {
-                    info!(pid = ?self.pid, status = ?status, "daemon stopped");
-                }
-                Err(e) => {
-                    warn!(pid = ?self.pid, error = %e, "error waiting for daemon to stop");
+            // Non-blocking wait: poll for exit with a short timeout to avoid
+            // blocking the tokio runtime indefinitely.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        info!(pid = ?self.pid, status = ?status, "daemon stopped");
+                        break;
+                    }
+                    Ok(None) => {
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                    Err(e) => {
+                        warn!(pid = ?self.pid, error = %e, "error checking daemon status");
+                        break;
+                    }
                 }
             }
-
-            self.child = None;
-            self.pid = None;
-            self.state = DaemonState::Stopped;
-            self.owns_process = false;
         }
+
+        self.child = None;
+        self.pid = None;
+        self.state = DaemonState::Stopped;
+        self.owns_process = false;
 
         Ok(())
     }
@@ -290,12 +299,22 @@ impl DaemonHandle {
     pub fn kill(&mut self) -> Result<(), DaemonError> {
         if let Some(ref mut child) = self.child {
             info!(pid = ?self.pid, "force-killing daemon");
+            #[cfg(unix)]
+            {
+                let _ = unsafe { libc::kill(self.pid.unwrap_or(0) as i32, libc::SIGKILL) };
+            }
+            #[cfg(windows)]
+            {
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
+                    .output();
+            }
             let _ = child.kill();
-            self.child = None;
-            self.pid = None;
-            self.state = DaemonState::Stopped;
-            self.owns_process = false;
         }
+        self.child = None;
+        self.pid = None;
+        self.state = DaemonState::Stopped;
+        self.owns_process = false;
         Ok(())
     }
 }
@@ -307,7 +326,8 @@ impl Drop for DaemonHandle {
                 pid = ?self.pid,
                 "daemon handle dropped, cleaning up owned process",
             );
-            let _ = self.stop();
+            // Non-blocking cleanup: just kill, never wait
+            let _ = self.kill();
         }
     }
 }

--- a/apps/desktop/src-tauri/src/daemon.rs
+++ b/apps/desktop/src-tauri/src/daemon.rs
@@ -291,24 +291,23 @@ impl DaemonHandle {
         }
     }
 
-    /// Check if the OS process is still alive.
-    #[cfg(unix)]
-    fn is_process_alive(&self) -> bool {
-        if let Some(pid) = self.pid {
-            // kill(pid, 0) checks process existence without sending a signal
-            let result = unsafe { libc::kill(pid as i32, 0) };
-            result == 0
-        } else {
-            false
-        }
-    }
-
-    #[cfg(windows)]
+    /// Check if the child process is still alive.
+    ///
+    /// `try_wait()` is non-blocking and reaps the child if it has already
+    /// exited, which keeps liveness checks accurate on every platform.
     fn is_process_alive(&mut self) -> bool {
-        // Use try_wait() on the actual Child handle to check if the process
-        // has exited. Returns Ok(Some(status)) if exited, Ok(None) if still running.
         if let Some(ref mut child) = self.child {
-            matches!(child.try_wait(), Ok(None))
+            match child.try_wait() {
+                Ok(None) => true,
+                Ok(Some(status)) => {
+                    info!(pid = ?self.pid, status = ?status, "daemon process exited");
+                    false
+                }
+                Err(e) => {
+                    warn!(pid = ?self.pid, error = %e, "failed to check daemon process status");
+                    false
+                }
+            }
         } else {
             false
         }
@@ -355,11 +354,9 @@ impl DaemonHandle {
 
             #[cfg(windows)]
             {
-                // Use spawn() to avoid blocking the async worker thread.
-                // The OS reaps the taskkill process asynchronously.
-                let _ = std::process::Command::new("taskkill")
-                    .args(["/PID", &self.pid.unwrap_or(0).to_string()])
-                    .spawn();
+                if let Some(pid) = self.pid {
+                    Self::spawn_taskkill(pid, false);
+                }
             }
 
             // Async wait loop: poll for exit without blocking the tokio worker thread.
@@ -404,66 +401,88 @@ impl DaemonHandle {
 
     /// Internal helper to kill just the process without updating state fields.
     ///
-    /// Sends SIGKILL and waits for the process to exit to ensure it is fully
-    /// reaped. This avoids zombies and is safe for `Drop` context because
-    /// SIGKILL termination is immediate. The wait is bounded by the OS
-    /// scheduler — typically under 1 ms after signal delivery.
+    /// Sends a force-kill signal and performs only an immediate `try_wait()` on
+    /// the caller's thread. If the child has not exited yet, a background thread
+    /// owns the final blocking wait so `Drop` and async callers never stall.
     fn kill_process_only(&mut self) {
-        if let Some(ref mut child) = self.child {
-            #[cfg(unix)]
-            {
-                if let Some(pid) = self.pid {
-                    // Kill the entire process group (negative PID means process group ID).
-                    // This ensures all child processes are also terminated, preventing
-                    // orphaned processes when the parent is killed.
-                    let _ = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+        if let Some(mut child) = self.child.take() {
+            let pid = self.pid;
+            Self::force_kill_child(pid, &mut child);
+
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    info!(pid = ?pid, status = ?status, "daemon process reaped after force kill");
+                }
+                Ok(None) => {
+                    Self::reap_child_in_background(child, pid);
+                }
+                Err(e) => {
+                    warn!(pid = ?pid, error = %e, "failed to reap daemon after force kill");
+                    Self::reap_child_in_background(child, pid);
                 }
             }
-            #[cfg(windows)]
-            {
-                // Use spawn() instead of output() to avoid blocking the thread.
-                // The OS will reap the taskkill process asynchronously.
-                let _ = std::process::Command::new("taskkill")
-                    .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
-                    .spawn();
-            }
-            let _ = child.kill();
-
-            // Wait for the process to fully exit so it is reaped from the
-            // process table. SIGKILL is immediate, so this returns quickly.
-            let _ = child.wait();
         }
-        self.child = None;
     }
 
     /// Force-kill the daemon process.
     pub fn kill(&mut self) -> Result<(), DaemonError> {
-        if let Some(ref mut child) = self.child {
-            info!(pid = ?self.pid, "force-killing daemon");
-            #[cfg(unix)]
-            {
-                if let Some(pid) = self.pid {
-                    // Kill the entire process group to ensure all children are also terminated.
-                    let _ = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
-                }
-            }
-            #[cfg(windows)]
-            {
-                let _ = std::process::Command::new("taskkill")
-                    .args(["/PID", &self.pid.unwrap_or(0).to_string(), "/F"])
-                    .spawn();
-            }
-            let _ = child.kill();
-        }
-        // Non-blocking reap: try_wait() returns immediately even if process hasn't exited yet
-        if let Some(ref mut child) = self.child {
-            let _ = child.try_wait();
-        }
-        self.child = None;
+        info!(pid = ?self.pid, "force-killing daemon");
+        self.kill_process_only();
         self.pid = None;
         self.state = DaemonState::Stopped;
         self.owns_process = false;
         Ok(())
+    }
+
+    fn force_kill_child(pid: Option<u32>, child: &mut Child) {
+        #[cfg(unix)]
+        {
+            if let Some(pid) = pid {
+                // Kill the entire process group (negative PID means process group ID).
+                // This ensures all child processes are also terminated, preventing
+                // orphaned processes when the parent is killed.
+                let _ = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+            }
+        }
+        #[cfg(windows)]
+        {
+            if let Some(pid) = pid {
+                Self::spawn_taskkill(pid, true);
+            }
+        }
+        let _ = child.kill();
+    }
+
+    #[cfg(windows)]
+    fn spawn_taskkill(pid: u32, force: bool) {
+        let pid_arg = pid.to_string();
+        let mut command = Command::new("taskkill");
+        command.args(["/PID", pid_arg.as_str(), "/T"]);
+        if force {
+            command.arg("/F");
+        }
+        if let Err(e) = command.spawn() {
+            warn!(pid, error = %e, "failed to spawn taskkill");
+        }
+    }
+
+    fn reap_child_in_background(mut child: Child, pid: Option<u32>) {
+        let name = pid
+            .map(|pid| format!("opensymphony-daemon-reaper-{pid}"))
+            .unwrap_or_else(|| "opensymphony-daemon-reaper".to_string());
+        if let Err(e) = std::thread::Builder::new().name(name).spawn(move || {
+            let status = child.wait();
+            match status {
+                Ok(status) => {
+                    info!(pid = ?pid, status = ?status, "daemon process reaped in background");
+                }
+                Err(e) => {
+                    warn!(pid = ?pid, error = %e, "background daemon reap failed");
+                }
+            }
+        }) {
+            warn!(pid = ?pid, error = %e, "failed to spawn daemon reaper thread");
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,3 +4,4 @@
 //! Each command uses narrow request and response types to limit attack surface.
 
 pub mod commands;
+pub mod daemon;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,16 +4,23 @@
 //! Custom commands are gated by capability files in `src-tauri/capabilities/`.
 
 use std::process;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use tauri::Manager;
+use tokio::sync::Mutex;
 
 mod commands;
+mod daemon;
 
 fn main() {
+    let desktop_state = commands::DesktopState::new();
+
     if let Err(e) = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        .manage(desktop_state)
         .setup(|app| {
             if let Some(_window) = app.get_webview_window("main") {
                 // Window exists; future setup hooks can attach here.
@@ -27,6 +34,13 @@ fn main() {
             commands::get_setting,
             commands::set_setting,
             commands::daemon_status,
+            commands::store_profile,
+            commands::list_profiles,
+            commands::set_active_profile,
+            commands::probe_gateway,
+            commands::discover_default_gateway,
+            commands::start_daemon,
+            commands::stop_daemon,
         ])
         .run(tauri::generate_context!())
     {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,10 +4,7 @@
 //! Custom commands are gated by capability files in `src-tauri/capabilities/`.
 
 use std::process;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use tauri::Manager;
-use tokio::sync::Mutex;
 
 mod commands;
 mod daemon;

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -125,14 +125,22 @@ while true; do sleep 1; done
             pid
         };
 
-        // Give the OS a moment to clean up after drop
-        std::thread::sleep(Duration::from_millis(200));
-
-        // Verify the process was actually killed
+        // Give the OS a moment to clean up after drop.
+        // Retry for up to 2 seconds to allow SIGKILL propagation and zombie reaping.
         #[cfg(unix)]
         {
-            let result = unsafe { libc::kill(pid as i32, 0) };
-            assert!(result != 0, "process {} should no longer exist after drop", pid);
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            loop {
+                let result = unsafe { libc::kill(pid as i32, 0) };
+                if result != 0 {
+                    // Process no longer exists - cleanup successful
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    panic!("process {} still exists after drop and 2s grace period", pid);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
         }
     }
 

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -137,7 +137,10 @@ while true; do sleep 1; done
                     break;
                 }
                 if std::time::Instant::now() >= deadline {
-                    panic!("process {} still exists after drop and 2s grace period", pid);
+                    panic!(
+                        "process {} still exists after drop and 2s grace period",
+                        pid
+                    );
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
@@ -185,8 +188,14 @@ while true; do sleep 1; done
         let result2 = handle2.start().await;
 
         // Verify both processes were spawned and have PIDs
-        assert!(result1.pid.is_some(), "daemon 1 should have a PID after spawn");
-        assert!(result2.pid.is_some(), "daemon 2 should have a PID after spawn");
+        assert!(
+            result1.pid.is_some(),
+            "daemon 1 should have a PID after spawn"
+        );
+        assert!(
+            result2.pid.is_some(),
+            "daemon 2 should have a PID after spawn"
+        );
 
         // Verify PIDs are unique - each daemon tracks its own process
         assert_ne!(
@@ -199,8 +208,14 @@ while true; do sleep 1; done
         assert!(handle1.pid().is_some(), "handle 1 should track its PID");
         assert!(handle2.pid().is_some(), "handle 2 should track its PID");
         // With health check skipped, daemons should be in Running state
-        assert!(matches!(handle1.state(), DaemonState::Running), "handle 1 should be Running");
-        assert!(matches!(handle2.state(), DaemonState::Running), "handle 2 should be Running");
+        assert!(
+            matches!(handle1.state(), DaemonState::Running),
+            "handle 1 should be Running"
+        );
+        assert!(
+            matches!(handle2.state(), DaemonState::Running),
+            "handle 2 should be Running"
+        );
 
         // Verify stop only affects the targeted daemon
         handle1.stop().await.unwrap();

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -76,6 +76,7 @@ while true; do sleep 1; done
             startup_timeout: Duration::from_secs(1),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8080".to_string(),
+            skip_health_check: true,
         };
         let handle = DaemonHandle::new(config);
         assert!(handle.pid().is_none());
@@ -92,6 +93,7 @@ while true; do sleep 1; done
             startup_timeout: Duration::from_secs(1),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8080".to_string(),
+            skip_health_check: true,
         };
         let mut handle = DaemonHandle::new(config);
         // Calling stop on an unstarted handle should succeed without error
@@ -111,6 +113,7 @@ while true; do sleep 1; done
             startup_timeout: Duration::from_secs(2),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8080".to_string(),
+            skip_health_check: true,
         };
 
         let pid = {
@@ -149,6 +152,7 @@ while true; do sleep 1; done
             startup_timeout: Duration::from_secs(2),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8081".to_string(),
+            skip_health_check: true,
         };
 
         let config2 = DaemonConfig {
@@ -158,6 +162,7 @@ while true; do sleep 1; done
             startup_timeout: Duration::from_secs(2),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8082".to_string(),
+            skip_health_check: true,
         };
 
         let mut handle1 = DaemonHandle::new(config1);
@@ -185,14 +190,14 @@ while true; do sleep 1; done
         // Verify each handle tracks its own PID independently
         assert!(handle1.pid().is_some(), "handle 1 should track its PID");
         assert!(handle2.pid().is_some(), "handle 2 should track its PID");
-        // Health check fails for fake daemons, so state is Failed
-        assert!(matches!(handle1.state(), DaemonState::Failed(_)), "handle 1 should be Failed");
-        assert!(matches!(handle2.state(), DaemonState::Failed(_)), "handle 2 should be Failed");
+        // With health check skipped, daemons should be in Running state
+        assert!(matches!(handle1.state(), DaemonState::Running), "handle 1 should be Running");
+        assert!(matches!(handle2.state(), DaemonState::Running), "handle 2 should be Running");
 
         // Verify stop only affects the targeted daemon
         handle1.stop().await.unwrap();
         assert!(!handle1.is_running(), "handle 1 should be stopped");
-        assert!(!handle2.is_running(), "handle 2 should be stopped after its health check fails");
+        assert!(handle2.is_running(), "handle 2 should still be running");
 
         // Clean up second daemon
         handle2.stop().await.unwrap();

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -105,7 +105,7 @@ while true; do sleep 1; done
         let script = fake.script_path();
 
         let config = DaemonConfig {
-            executable: script,
+            executable: script.clone(),
             args: vec![],
             env: vec![],
             startup_timeout: Duration::from_secs(2),
@@ -113,44 +113,89 @@ while true; do sleep 1; done
             gateway_url: "http://127.0.0.1:8080".to_string(),
         };
 
-        {
+        let pid = {
             let mut handle = DaemonHandle::new(config);
-            let _result = handle.start().await;
+            let result = handle.start().await;
+            let pid = result.pid.expect("process should have been spawned");
+            assert!(result.pid.is_some(), "daemon should have a PID after spawn");
             // Handle will be dropped here, triggering cleanup
-        }
+            pid
+        };
 
-        // Give the OS a moment to clean up
-        std::thread::sleep(Duration::from_millis(100));
+        // Give the OS a moment to clean up after drop
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Verify the process was actually killed
+        #[cfg(unix)]
+        {
+            let result = unsafe { libc::kill(pid as i32, 0) };
+            assert!(result != 0, "process {} should no longer exist after drop", pid);
+        }
     }
 
-    #[test]
-    fn test_process_ownership_tracks_multiple_daemons() {
-        // Verify that ownership tracking works correctly for multiple daemon instances
+    #[tokio::test]
+    async fn test_process_ownership_tracks_multiple_daemons() {
         use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
 
+        let fake1 = FakeDaemon::new();
+        let fake2 = FakeDaemon::new();
+        let script1 = fake1.script_path();
+        let script2 = fake2.script_path();
+
         let config1 = DaemonConfig {
-            executable: PathBuf::from("/bin/true"),
-            args: vec!["1".to_string()],
+            executable: script1.clone(),
+            args: vec![],
             env: vec![],
-            startup_timeout: Duration::from_secs(1),
+            startup_timeout: Duration::from_secs(2),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8081".to_string(),
         };
 
         let config2 = DaemonConfig {
-            executable: PathBuf::from("/bin/true"),
-            args: vec!["2".to_string()],
+            executable: script2.clone(),
+            args: vec![],
             env: vec![],
-            startup_timeout: Duration::from_secs(1),
+            startup_timeout: Duration::from_secs(2),
             auto_restart: false,
             gateway_url: "http://127.0.0.1:8082".to_string(),
         };
 
-        let handle1 = DaemonHandle::new(config1);
-        let handle2 = DaemonHandle::new(config2);
+        let mut handle1 = DaemonHandle::new(config1);
+        let mut handle2 = DaemonHandle::new(config2);
 
         // Both handles start unowned
         assert!(handle1.pid().is_none());
         assert!(handle2.pid().is_none());
+
+        // Start both daemons
+        let result1 = handle1.start().await;
+        let result2 = handle2.start().await;
+
+        // Verify both processes were spawned and have PIDs
+        assert!(result1.pid.is_some(), "daemon 1 should have a PID after spawn");
+        assert!(result2.pid.is_some(), "daemon 2 should have a PID after spawn");
+
+        // Verify PIDs are unique - each daemon tracks its own process
+        assert_ne!(
+            result1.pid.unwrap(),
+            result2.pid.unwrap(),
+            "each daemon should have a unique PID"
+        );
+
+        // Verify each handle tracks its own PID independently
+        assert!(handle1.pid().is_some(), "handle 1 should track its PID");
+        assert!(handle2.pid().is_some(), "handle 2 should track its PID");
+        assert!(handle1.is_running(), "handle 1 should be running");
+        assert!(handle2.is_running(), "handle 2 should be running");
+
+        // Verify stop only affects the targeted daemon
+        handle1.stop().await.unwrap();
+        assert!(!handle1.is_running(), "handle 1 should be stopped");
+        assert!(handle2.is_running(), "handle 2 should still be running");
+
+        // Clean up second daemon
+        handle2.stop().await.unwrap();
+        assert!(!handle1.is_running(), "handle 1 should still be stopped");
+        assert!(!handle2.is_running(), "handle 2 should be stopped");
     }
 }

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -1,0 +1,156 @@
+//! Process ownership tests for daemon supervision.
+//!
+//! Verifies that the desktop app:
+//! - Only starts configured supervised daemons
+//! - Only stops processes it owns
+//! - Tracks process ownership correctly
+//! - Does not interfere with externally-managed daemons
+
+#[cfg(test)]
+mod process_ownership_tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    /// Fake daemon command that simulates a daemon process.
+    /// Creates a PID file and sleeps to stay alive.
+    struct FakeDaemon {
+        dir: tempfile::TempDir,
+        pid_path: PathBuf,
+    }
+
+    impl FakeDaemon {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let pid_path = dir.path().join("daemon.pid");
+            Self { dir, pid_path }
+        }
+
+        /// Create a fake daemon script that writes its PID and sleeps.
+        fn script_path(&self) -> PathBuf {
+            let script = self.dir.path().join("fake_daemon.sh");
+            let pid_path = &self.pid_path;
+            fs::write(
+                &script,
+                format!(
+                    r#"#!/bin/bash
+echo $$ > "{}"
+while true; do sleep 1; done
+"#,
+                    pid_path.display()
+                ),
+            )
+            .unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = fs::metadata(&script).unwrap().permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(&script, perms).unwrap();
+            }
+            script
+        }
+    }
+
+    #[test]
+    fn test_fake_daemon_creates_pid_file() {
+        let daemon = FakeDaemon::new();
+        let script = daemon.script_path();
+        assert!(script.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::metadata(&script).unwrap().permissions();
+            assert!(perms.mode() & 0o111 != 0);
+        }
+    }
+
+    #[test]
+    fn test_process_ownership_starts_unowned() {
+        // A fresh daemon handle should not own any process
+        use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
+        let config = DaemonConfig {
+            executable: PathBuf::from("/bin/true"),
+            args: vec![],
+            env: vec![],
+            startup_timeout: Duration::from_secs(1),
+            auto_restart: false,
+            gateway_url: "http://127.0.0.1:8080".to_string(),
+        };
+        let handle = DaemonHandle::new(config);
+        assert!(handle.pid().is_none());
+    }
+
+    #[test]
+    fn test_unsupervised_daemon_not_stopped_by_app() {
+        // Verify that the app does not attempt to stop processes it doesn't own
+        use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
+        let config = DaemonConfig {
+            executable: PathBuf::from("/bin/true"),
+            args: vec![],
+            env: vec![],
+            startup_timeout: Duration::from_secs(1),
+            auto_restart: false,
+            gateway_url: "http://127.0.0.1:8080".to_string(),
+        };
+        let mut handle = DaemonHandle::new(config);
+        // Calling stop on an unstarted handle should succeed without error
+        assert!(handle.stop().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_daemon_handle_cleans_up_on_drop() {
+        use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
+        let fake = FakeDaemon::new();
+        let script = fake.script_path();
+
+        let config = DaemonConfig {
+            executable: script,
+            args: vec![],
+            env: vec![],
+            startup_timeout: Duration::from_secs(2),
+            auto_restart: false,
+            gateway_url: "http://127.0.0.1:8080".to_string(),
+        };
+
+        {
+            let mut handle = DaemonHandle::new(config);
+            let _result = handle.start().await;
+            // Handle will be dropped here, triggering cleanup
+        }
+
+        // Give the OS a moment to clean up
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_process_ownership_tracks_multiple_daemons() {
+        // Verify that ownership tracking works correctly for multiple daemon instances
+        use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
+
+        let config1 = DaemonConfig {
+            executable: PathBuf::from("/bin/true"),
+            args: vec!["1".to_string()],
+            env: vec![],
+            startup_timeout: Duration::from_secs(1),
+            auto_restart: false,
+            gateway_url: "http://127.0.0.1:8081".to_string(),
+        };
+
+        let config2 = DaemonConfig {
+            executable: PathBuf::from("/bin/true"),
+            args: vec!["2".to_string()],
+            env: vec![],
+            startup_timeout: Duration::from_secs(1),
+            auto_restart: false,
+            gateway_url: "http://127.0.0.1:8082".to_string(),
+        };
+
+        let handle1 = DaemonHandle::new(config1);
+        let handle2 = DaemonHandle::new(config2);
+
+        // Both handles start unowned
+        assert!(handle1.pid().is_none());
+        assert!(handle2.pid().is_none());
+    }
+}

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -81,8 +81,8 @@ while true; do sleep 1; done
         assert!(handle.pid().is_none());
     }
 
-    #[test]
-    fn test_unsupervised_daemon_not_stopped_by_app() {
+    #[tokio::test]
+    async fn test_unsupervised_daemon_not_stopped_by_app() {
         // Verify that the app does not attempt to stop processes it doesn't own
         use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
         let config = DaemonConfig {
@@ -95,7 +95,7 @@ while true; do sleep 1; done
         };
         let mut handle = DaemonHandle::new(config);
         // Calling stop on an unstarted handle should succeed without error
-        assert!(handle.stop().is_ok());
+        assert!(handle.stop().await.is_ok());
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/tests/process_ownership.rs
+++ b/apps/desktop/src-tauri/tests/process_ownership.rs
@@ -135,7 +135,7 @@ while true; do sleep 1; done
 
     #[tokio::test]
     async fn test_process_ownership_tracks_multiple_daemons() {
-        use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle};
+        use opensymphony_desktop::daemon::{DaemonConfig, DaemonHandle, DaemonState};
 
         let fake1 = FakeDaemon::new();
         let fake2 = FakeDaemon::new();
@@ -185,13 +185,14 @@ while true; do sleep 1; done
         // Verify each handle tracks its own PID independently
         assert!(handle1.pid().is_some(), "handle 1 should track its PID");
         assert!(handle2.pid().is_some(), "handle 2 should track its PID");
-        assert!(handle1.is_running(), "handle 1 should be running");
-        assert!(handle2.is_running(), "handle 2 should be running");
+        // Health check fails for fake daemons, so state is Failed
+        assert!(matches!(handle1.state(), DaemonState::Failed(_)), "handle 1 should be Failed");
+        assert!(matches!(handle2.state(), DaemonState::Failed(_)), "handle 2 should be Failed");
 
         // Verify stop only affects the targeted daemon
         handle1.stop().await.unwrap();
         assert!(!handle1.is_running(), "handle 1 should be stopped");
-        assert!(handle2.is_running(), "handle 2 should still be running");
+        assert!(!handle2.is_running(), "handle 2 should be stopped after its health check fails");
 
         // Clean up second daemon
         handle2.stop().await.unwrap();

--- a/packages/api-client/__tests__/discovery.test.ts
+++ b/packages/api-client/__tests__/discovery.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Gateway discovery tests.
+ *
+ * Tests discovery logic against healthy, missing, and incompatible gateway fixtures.
+ * Uses mock fetch to simulate gateway responses without requiring a real server.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+// Mock fetch globally
+const originalFetch = global.fetch;
+
+function mockFetch(responses: Map<string, { ok: boolean; status: number; json?: () => Promise<any> }>) {
+  global.fetch = jest.fn(async (url: string) => {
+    const response = responses.get(url);
+    if (!response) {
+      throw new Error(`No mock for URL: ${url}`);
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      json: response.json || (async () => ({})),
+    } as Response;
+  }) as jest.MockedFunction<typeof global.fetch>;
+}
+
+function restoreFetch() {
+  global.fetch = originalFetch;
+}
+
+describe("gateway discovery", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    jest.useRealTimers();
+  });
+
+  describe("probeHealth", () => {
+    it("returns healthy when /healthz returns 200 with ok status", async () => {
+      const { probeHealth } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({ status: "ok" }),
+            },
+          ],
+        ]),
+      );
+      const result = await probeHealth("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("returns unhealthy when /healthz returns non-200", async () => {
+      const { probeHealth } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            { ok: false, status: 503 },
+          ],
+        ]),
+      );
+      const result = await probeHealth("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain("503");
+    });
+
+    it("returns unhealthy when /healthz returns unexpected status", async () => {
+      const { probeHealth } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({ status: "degraded" }),
+            },
+          ],
+        ]),
+      );
+      const result = await probeHealth("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain("degraded");
+    });
+
+    it("returns unhealthy when /healthz is unreachable", async () => {
+      const { probeHealth } = await import("../src/discovery");
+      global.fetch = jest.fn(async () => {
+        throw new Error("Connection refused");
+      }) as jest.MockedFunction<typeof global.fetch>;
+      const result = await probeHealth("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain("Connection refused");
+    });
+  });
+
+  describe("probeCapabilities", () => {
+    it("returns capabilities when /api/v1/capabilities returns 200", async () => {
+      const { probeCapabilities } = await import("../src/discovery");
+      const mockCaps = {
+        schema_version: "v1",
+        gateway_version: "1.0.0",
+        supported_api_versions: ["v1"],
+        transports: [],
+        features: [],
+        auth_modes: ["none"],
+        max_event_page_size: 100,
+        max_terminal_frame_batch: 50,
+      };
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/api/v1/capabilities",
+            {
+              ok: true,
+              status: 200,
+              json: async () => mockCaps,
+            },
+          ],
+        ]),
+      );
+      const result = await probeCapabilities("http://127.0.0.1:8080");
+      expect(result).toEqual(mockCaps);
+    });
+
+    it("returns null when /api/v1/capabilities returns 404", async () => {
+      const { probeCapabilities } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/api/v1/capabilities",
+            { ok: false, status: 404 },
+          ],
+        ]),
+      );
+      const result = await probeCapabilities("http://127.0.0.1:8080");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when /api/v1/capabilities is unreachable", async () => {
+      const { probeCapabilities } = await import("../src/discovery");
+      global.fetch = jest.fn(async () => {
+        throw new Error("Network error");
+      }) as jest.MockedFunction<typeof global.fetch>;
+      const result = await probeCapabilities("http://127.0.0.1:8080");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("discoverGateway", () => {
+    it("returns compatible when both health and capabilities succeed", async () => {
+      const { discoverGateway } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({ status: "ok" }),
+            },
+          ],
+          [
+            "http://127.0.0.1:8080/api/v1/capabilities",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                schema_version: "v1",
+                gateway_version: "1.0.0",
+                supported_api_versions: ["v1"],
+                transports: [],
+                features: [],
+                auth_modes: ["none"],
+                max_event_page_size: 100,
+                max_terminal_frame_batch: 50,
+              }),
+            },
+          ],
+        ]),
+      );
+      const result = await discoverGateway("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(true);
+      expect(result.compatible).toBe(true);
+      expect(result.error).toBeNull();
+      expect(result.capabilities).not.toBeNull();
+    });
+
+    it("returns incompatible when capabilities endpoint is missing", async () => {
+      const { discoverGateway } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({ status: "ok" }),
+            },
+          ],
+          [
+            "http://127.0.0.1:8080/api/v1/capabilities",
+            { ok: false, status: 404 },
+          ],
+        ]),
+      );
+      const result = await discoverGateway("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(true);
+      expect(result.compatible).toBe(false);
+      expect(result.error).toContain("unreachable");
+    });
+
+    it("returns unhealthy when health check fails", async () => {
+      const { discoverGateway } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            { ok: false, status: 503 },
+          ],
+        ]),
+      );
+      const result = await discoverGateway("http://127.0.0.1:8080");
+      expect(result.healthy).toBe(false);
+      expect(result.compatible).toBe(false);
+      expect(result.capabilities).toBeNull();
+    });
+  });
+
+  describe("validateGateway", () => {
+    it("returns true for healthy compatible gateway", async () => {
+      const { validateGateway } = await import("../src/discovery");
+      mockFetch(
+        new Map([
+          [
+            "http://127.0.0.1:8080/healthz",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({ status: "ok" }),
+            },
+          ],
+          [
+            "http://127.0.0.1:8080/api/v1/capabilities",
+            {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                schema_version: "v1",
+                gateway_version: "1.0.0",
+                supported_api_versions: ["v1"],
+                transports: [],
+                features: [],
+                auth_modes: ["none"],
+                max_event_page_size: 100,
+                max_terminal_frame_batch: 50,
+              }),
+            },
+          ],
+        ]),
+      );
+      const result = await validateGateway("http://127.0.0.1:8080");
+      expect(result).toBe(true);
+    });
+
+    it("returns false for unhealthy gateway", async () => {
+      const { validateGateway } = await import("../src/discovery");
+      global.fetch = jest.fn(async () => {
+        throw new Error("Connection refused");
+      }) as jest.MockedFunction<typeof global.fetch>;
+      const result = await validateGateway("http://127.0.0.1:8080");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("discoverGatewayWithFallback", () => {
+    it("tries fallback URLs until one succeeds", async () => {
+      const { discoverGatewayWithFallback } = await import("../src/discovery");
+      let callCount = 0;
+      global.fetch = jest.fn(async (url: string) => {
+        callCount++;
+        if (url.includes("127.0.0.1:8080")) {
+          throw new Error("Connection refused");
+        }
+        if (url.includes("localhost:8080")) {
+          if (url.includes("capabilities")) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                schema_version: "v1",
+                gateway_version: "1.0.0",
+                supported_api_versions: ["v1"],
+                transports: [],
+                features: [],
+                auth_modes: ["none"],
+                max_event_page_size: 100,
+                max_terminal_frame_batch: 50,
+              }),
+            } as Response;
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ status: "ok" }),
+          } as Response;
+        }
+        return { ok: false, status: 404 } as Response;
+      }) as jest.MockedFunction<typeof global.fetch>;
+      const result = await discoverGatewayWithFallback();
+      expect(callCount).toBeGreaterThanOrEqual(2);
+      expect(result.healthy).toBe(true);
+      expect(result.compatible).toBe(true);
+    });
+  });
+});

--- a/packages/api-client/__tests__/discovery.test.ts
+++ b/packages/api-client/__tests__/discovery.test.ts
@@ -283,6 +283,20 @@ describe("gateway discovery", () => {
   });
 
   describe("discoverGatewayWithFallback", () => {
+    it("does not probe 0.0.0.0 in the default fallback list", async () => {
+      const { discoverGatewayWithFallback } = await import("../src/discovery");
+      const probedUrls: string[] = [];
+      global.fetch = jest.fn(async (url: string) => {
+        probedUrls.push(url);
+        throw new Error("Connection refused");
+      }) as jest.MockedFunction<typeof global.fetch>;
+
+      const result = await discoverGatewayWithFallback();
+
+      expect(result.healthy).toBe(false);
+      expect(probedUrls.some((url) => url.includes("0.0.0.0"))).toBe(false);
+    });
+
     it("tries fallback URLs until one succeeds", async () => {
       const { discoverGatewayWithFallback } = await import("../src/discovery");
       let callCount = 0;

--- a/packages/api-client/src/discovery.ts
+++ b/packages/api-client/src/discovery.ts
@@ -1,0 +1,161 @@
+/**
+ * Gateway discovery and health probing.
+ *
+ * Provides functions to probe default loopback gateway endpoints
+ * and validate gateway capabilities.
+ */
+
+import type { GatewayCapabilities } from "@opensymphony/gateway-schema";
+
+/** Result of a gateway discovery probe. */
+export interface DiscoveryResult {
+  /** Whether the gateway responded to the health check. */
+  healthy: boolean;
+  /** Gateway capabilities if the probe succeeded. */
+  capabilities: GatewayCapabilities | null;
+  /** URL that was probed. */
+  probedUrl: string;
+  /** Error message if the probe failed. */
+  error: string | null;
+  /** Time taken for the probe in milliseconds. */
+  latencyMs: number;
+  /** Whether the gateway API version is compatible. */
+  compatible: boolean;
+}
+
+/** Default gateway URL to probe for local discovery. */
+export const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8080";
+
+/** Minimum compatible API version. */
+export const MIN_COMPATIBLE_API_VERSION = "v1";
+
+/**
+ * Probe the gateway health endpoint.
+ *
+ * Calls GET /healthz and returns whether the gateway is responsive.
+ */
+export async function probeHealth(baseUrl: string): Promise<{ healthy: boolean; error: string | null }> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/healthz`;
+  const start = Date.now();
+  try {
+    const response = await fetch(url, { method: "GET", signal: AbortSignal.timeout(5000) });
+    const latencyMs = Date.now() - start;
+    if (!response.ok) {
+      return { healthy: false, error: `HTTP ${response.status} after ${latencyMs}ms` };
+    }
+    const body = await response.json();
+    if (body.status !== "ok" && body.status !== "healthy") {
+      return { healthy: false, error: `Unexpected health status: ${body.status}` };
+    }
+    return { healthy: true, error: null };
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    return {
+      healthy: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Probe the gateway capabilities endpoint.
+ *
+ * Calls GET /api/v1/capabilities and returns the gateway capabilities
+ * or an error if the endpoint is unreachable or returns an data.
+ */
+export async function probeCapabilities(baseUrl: string): Promise<GatewayCapabilities | null> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/api/v1/capabilities`;
+  try {
+    const response = await fetch(url, { method: "GET", signal: AbortSignal.timeout(5000) });
+    if (!response.ok) {
+      return null;
+    }
+    const body = await response.json();
+    return body as GatewayCapabilities;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Discover and validate a gateway at the given URL.
+ *
+ * Probes /healthz and /api/v1/capabilities, then returns a structured
+ * result with health status, capabilities, and compatibility info.
+ */
+export async function discoverGateway(baseUrl: string = DEFAULT_GATEWAY_URL): Promise<DiscoveryResult> {
+  const start = Date.now();
+  
+  // Probe health
+  const healthResult = await probeHealth(baseUrl);
+  const healthLatency = Date.now() - start;
+  
+  if (!healthResult.healthy) {
+    return {
+      healthy: false,
+      capabilities: null,
+      probedUrl: baseUrl,
+      error: healthResult.error,
+      latencyMs: healthLatency,
+      compatible: false,
+    };
+  }
+  
+  // Probe capabilities
+  const capabilities = await probeCapabilities(baseUrl);
+  const totalLatency = Date.now() - start;
+  
+  if (!capabilities) {
+    return {
+      healthy: true,
+      capabilities: null,
+      probedUrl: baseUrl,
+      error: "Capabilities endpoint unreachable",
+      latencyMs: totalLatency,
+      compatible: false,
+    };
+  }
+  
+  // Check API version compatibility
+  const compatible = (capabilities.supported_api_versions ?? []).some(
+    (version) => version === MIN_COMPATIBLE_API_VERSION || version.startsWith(`${MIN_COMPATIBLE_API_VERSION}.`),
+  );
+  
+  return {
+    healthy: true,
+    capabilities,
+    probedUrl: baseUrl,
+    error: null,
+    latencyMs: totalLatency,
+    compatible,
+  };
+}
+
+/**
+ * Validate that a gateway URL is reachable and returns a compatible API version.
+ *
+ * Returns true if the gateway is healthy and compatible, false otherwise.
+ */
+export async function validateGateway(baseUrl: string): Promise<boolean> {
+  const result = await discoverGateway(baseUrl);
+  return result.healthy && result.compatible;
+}
+
+/**
+ * Discover gateway with fallback URLs.
+ *
+ * Tries each URL in order until one responds with a healthy, compatible gateway.
+ */
+export async function discoverGatewayWithFallback(
+  urls: string[] = [DEFAULT_GATEWAY_URL, "http://localhost:8080", "http://0.0.0.0:8080"],
+): Promise<DiscoveryResult> {
+  for (const url of urls) {
+    const result = await discoverGateway(url);
+    if (result.healthy && result.compatible) {
+      return result;
+    }
+  }
+  
+  // Return the last result if none succeeded
+  return discoverGateway(urls[urls.length - 1]);
+}

--- a/packages/api-client/src/discovery.ts
+++ b/packages/api-client/src/discovery.ts
@@ -147,7 +147,7 @@ export async function validateGateway(baseUrl: string): Promise<boolean> {
  * Tries each URL in order until one responds with a healthy, compatible gateway.
  */
 export async function discoverGatewayWithFallback(
-  urls: string[] = [DEFAULT_GATEWAY_URL, "http://localhost:8080", "http://0.0.0.0:8080"],
+  urls: string[] = [DEFAULT_GATEWAY_URL, "http://localhost:8080"],
 ): Promise<DiscoveryResult> {
   for (const url of urls) {
     const result = await discoverGateway(url);

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -10,6 +10,16 @@ import type {
 } from "@opensymphony/gateway-schema";
 
 export { HttpGatewayTransport } from "./transports.js";
+export {
+  discoverGateway,
+  discoverGatewayWithFallback,
+  probeHealth,
+  probeCapabilities,
+  validateGateway,
+  DEFAULT_GATEWAY_URL,
+  MIN_COMPATIBLE_API_VERSION,
+} from "./discovery.js";
+export type { DiscoveryResult } from "./discovery.js";
 
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {

--- a/packages/gateway-schema/__tests__/profile.test.ts
+++ b/packages/gateway-schema/__tests__/profile.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for connection profile types.
+ *
+ * Tests default profiles, profile creation, serialization, and kind-based logic.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  defaultProfiles,
+  createProfile,
+  type ConnectionProfile,
+  type ConnectionProfileKind,
+  type LocalDaemonProfile,
+  type SupervisedLocalDaemonProfile,
+  type EmbeddedHostProfile,
+  type ExternalGatewayProfile,
+  type HostedGatewayProfile,
+} from "@opensymphony/gateway-schema";
+
+describe("defaultProfiles", () => {
+  it("returns exactly five profile kinds", () => {
+    const profiles = defaultProfiles();
+    expect(profiles).toHaveLength(5);
+  });
+
+  it("includes a local_daemon profile with loopback_http transport", () => {
+    const profiles = defaultProfiles();
+    const localDaemon = profiles.find((p) => p.kind === "local_daemon");
+    expect(localDaemon).toBeDefined();
+    expect(localDaemon!.transport).toBe("loopback_http");
+    expect(localDaemon!.managed).toBe(false);
+    expect(localDaemon!.gatewayUrl).toBe("http://127.0.0.1:8080");
+  });
+
+  it("includes a supervised_local_daemon profile with auto-restart", () => {
+    const profiles = defaultProfiles();
+    const supervised = profiles.find(
+      (p) => p.kind === "supervised_local_daemon",
+    ) as SupervisedLocalDaemonProfile | undefined;
+    expect(supervised).toBeDefined();
+    expect(supervised!.managed).toBe(true);
+    expect(supervised!.autoRestart).toBe(true);
+    expect(supervised!.startupTimeoutSecs).toBe(30);
+  });
+
+  it("includes an embedded_host profile with in_process_channel transport", () => {
+    const profiles = defaultProfiles();
+    const embedded = profiles.find(
+      (p) => p.kind === "embedded_host",
+    ) as EmbeddedHostProfile | undefined;
+    expect(embedded).toBeDefined();
+    expect(embedded!.managed).toBe(true);
+    expect(embedded!.transport).toBe("in_process_channel");
+  });
+
+  it("includes an external_gateway profile with probeOnConnect", () => {
+    const profiles = defaultProfiles();
+    const external = profiles.find(
+      (p) => p.kind === "external_gateway",
+    ) as ExternalGatewayProfile | undefined;
+    expect(external).toBeDefined();
+    expect(external!.managed).toBe(false);
+    expect(external!.probeOnConnect).toBe(true);
+  });
+
+  it("includes a hosted_gateway profile with websocket transport", () => {
+    const profiles = defaultProfiles();
+    const hosted = profiles.find(
+      (p) => p.kind === "hosted_gateway",
+    ) as HostedGatewayProfile | undefined;
+    expect(hosted).toBeDefined();
+    expect(hosted!.managed).toBe(false);
+    expect(hosted!.transport).toBe("websocket");
+  });
+
+  it("all profiles start inactive", () => {
+    const profiles = defaultProfiles();
+    profiles.forEach((p) => expect(p.active).toBe(false));
+  });
+});
+
+describe("createProfile", () => {
+  it("creates a local_daemon profile with defaults", () => {
+    const profile = createProfile("local_daemon") as LocalDaemonProfile;
+    expect(profile.kind).toBe("local_daemon");
+    expect(profile.managed).toBe(false);
+    expect(profile.id).toMatch(/^local_daemon-\d+-\d+$/);
+    expect(profile.active).toBe(false);
+  });
+
+  it("creates a supervised_local_daemon profile with defaults", () => {
+    const profile = createProfile(
+      "supervised_local_daemon",
+    ) as SupervisedLocalDaemonProfile;
+    expect(profile.kind).toBe("supervised_local_daemon");
+    expect(profile.managed).toBe(true);
+    expect(profile.daemonPath).toBe("");
+    expect(profile.daemonArgs).toEqual([]);
+    expect(profile.daemonEnv).toEqual({});
+  });
+
+  it("creates an embedded_host profile with defaults", () => {
+    const profile = createProfile("embedded_host") as EmbeddedHostProfile;
+    expect(profile.kind).toBe("embedded_host");
+    expect(profile.managed).toBe(true);
+    expect(profile.transport).toBe("in_process_channel");
+  });
+
+  it("creates an external_gateway profile with defaults", () => {
+    const profile = createProfile(
+      "external_gateway",
+    ) as ExternalGatewayProfile;
+    expect(profile.kind).toBe("external_gateway");
+    expect(profile.managed).toBe(false);
+    expect(profile.probeOnConnect).toBe(true);
+  });
+
+  it("creates a hosted_gateway profile with defaults", () => {
+    const profile = createProfile("hosted_gateway") as HostedGatewayProfile;
+    expect(profile.kind).toBe("hosted_gateway");
+    expect(profile.managed).toBe(false);
+    expect(profile.gatewayUrl).toBe("");
+    expect(profile.probeOnConnect).toBe(true);
+  });
+
+  it("throws for unknown profile kind", () => {
+    expect(() => createProfile("unknown" as ConnectionProfileKind)).toThrow(
+      "Unknown connection profile kind: unknown",
+    );
+  });
+
+  it("generates unique IDs based on timestamp", () => {
+    const profile1 = createProfile("local_daemon");
+    const profile2 = createProfile("local_daemon");
+    expect(profile1.id).not.toBe(profile2.id);
+  });
+});
+
+describe("profile serialization", () => {
+  it("serializes and deserializes a local_daemon profile", () => {
+    const profile: ConnectionProfile = {
+      id: "test-1",
+      label: "Test Local",
+      kind: "local_daemon",
+      active: true,
+      gatewayUrl: "http://127.0.0.1:9090",
+      transport: "loopback_http",
+      managed: false,
+    };
+
+    const serialized = JSON.stringify(profile);
+    const deserialized: ConnectionProfile = JSON.parse(serialized);
+
+    expect(deserialized.kind).toBe("local_daemon");
+    expect(deserialized.gatewayUrl).toBe("http://127.0.0.1:9090");
+    expect(deserialized.active).toBe(true);
+  });
+
+  it("serializes and deserializes a supervised_local_daemon profile", () => {
+    const profile: ConnectionProfile = {
+      id: "test-2",
+      label: "Test Supervised",
+      kind: "supervised_local_daemon",
+      active: false,
+      gatewayUrl: "http://127.0.0.1:8080",
+      transport: "loopback_http",
+      managed: true,
+      daemonPath: "/usr/local/bin/opensymphony-daemon",
+      daemonArgs: ["--verbose"],
+      daemonEnv: { LOG_LEVEL: "debug" },
+      startupTimeoutSecs: 60,
+      autoRestart: false,
+    };
+
+    const serialized = JSON.stringify(profile);
+    const deserialized: ConnectionProfile = JSON.parse(serialized);
+
+    expect(deserialized.kind).toBe("supervised_local_daemon");
+    expect(deserialized.managed).toBe(true);
+    expect(deserialized.daemonPath).toBe("/usr/local/bin/opensymphony-daemon");
+  });
+});

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -37,6 +37,22 @@ export type { ActionKind, ActionTarget, ActionDispatch } from "./action.js";
 // transport
 export type { TransportProfile, TransportRecommendation } from "./transport.js";
 
+// profile
+export type {
+  ConnectionProfile,
+  ConnectionProfileBase,
+  ConnectionProfileKind,
+  LocalDaemonProfile,
+  SupervisedLocalDaemonProfile,
+  EmbeddedHostProfile,
+  ExternalGatewayProfile,
+  HostedGatewayProfile,
+} from "./profile.js";
+export {
+  defaultProfiles,
+  createProfile,
+} from "./profile.js";
+
 // validation
 export {
   isValidSchemaVersion,

--- a/packages/gateway-schema/src/profile.ts
+++ b/packages/gateway-schema/src/profile.ts
@@ -1,0 +1,179 @@
+/**
+ * Connection profiles define how the desktop client connects to an OpenSymphony gateway.
+ *
+ * Profiles determine the transport, discovery behavior, and daemon supervision settings.
+ */
+
+import type { TransportProfile } from "./transport.js";
+
+/** Profile type discriminator. */
+export type ConnectionProfileKind =
+  | "local_daemon"
+  | "supervised_local_daemon"
+  | "embedded_host"
+  | "external_gateway"
+  | "hosted_gateway";
+
+/** Base connection profile fields shared by all profile kinds. */
+export interface ConnectionProfileBase {
+  /** Unique identifier for this profile instance. */
+  id: string;
+  /** Human-readable label shown in UI. */
+  label: string;
+  /** Discriminates the profile kind. */
+  kind: ConnectionProfileKind;
+  /** Whether this profile is currently active. */
+  active: boolean;
+}
+
+/** Local daemon: connects to a separately-started daemon on loopback. */
+export interface LocalDaemonProfile extends ConnectionProfileBase {
+  kind: "local_daemon";
+  /** Gateway base URL, defaults to http://127.0.0.1:8080. */
+  gatewayUrl: string;
+  /** Preferred transport for local communication. */
+  transport: TransportProfile;
+  /** Do not start/stop the daemon; connect to an externally-managed process. */
+  managed: false;
+}
+
+/** Supervised local daemon: desktop app owns the daemon lifecycle. */
+export interface SupervisedLocalDaemonProfile extends ConnectionProfileBase {
+  kind: "supervised_local_daemon";
+  /** Gateway base URL, defaults to http://127.0.0.1:8080. */
+  gatewayUrl: string;
+  /** Preferred transport for local communication. */
+  transport: TransportProfile;
+  /** Desktop app supervises the daemon process. */
+  managed: true;
+  /** Path to the daemon executable. */
+  daemonPath: string;
+  /** Optional arguments passed to the daemon. */
+  daemonArgs: string[];
+  /** Environment overrides for the daemon process. */
+  daemonEnv: Record<string, string>;
+  /** Maximum seconds to wait for the daemon to become healthy. */
+  startupTimeoutSecs: number;
+  /** Whether to restart the daemon if it exits unexpectedly. */
+  autoRestart: boolean;
+}
+
+/** Embedded/direct host: OpenSymphony runs in-process with the desktop shell. */
+export interface EmbeddedHostProfile extends ConnectionProfileBase {
+  kind: "embedded_host";
+  /** Gateway base URL (loopback for embedded HTTP fallback). */
+  gatewayUrl: string;
+  /** Preferred in-process transport. */
+  transport: TransportProfile;
+  /** Desktop app owns the host lifecycle. */
+  managed: true;
+}
+
+/** External gateway: connects to a local server on loopback or trusted network. */
+export interface ExternalGatewayProfile extends ConnectionProfileBase {
+  kind: "external_gateway";
+  /** Gateway base URL, user-configurable. */
+  gatewayUrl: string;
+  /** Loopback HTTP/WebSocket transport. */
+  transport: TransportProfile;
+  /** No daemon management. */
+  managed: false;
+  /** Whether to probe /healthz on startup. */
+  probeOnConnect: boolean;
+}
+
+/** Hosted gateway: connects to a remote hosted OpenSymphony server. */
+export interface HostedGatewayProfile extends ConnectionProfileBase {
+  kind: "hosted_gateway";
+  /** Gateway base URL for the hosted server. */
+  gatewayUrl: string;
+  /** Authenticated HTTPS/WSS transport. */
+  transport: TransportProfile;
+  /** No daemon management. */
+  managed: false;
+  /** Whether to probe /healthz on startup. */
+  probeOnConnect: boolean;
+}
+
+/** Union of all connection profile variants. */
+export type ConnectionProfile =
+  | LocalDaemonProfile
+  | SupervisedLocalDaemonProfile
+  | EmbeddedHostProfile
+  | ExternalGatewayProfile
+  | HostedGatewayProfile;
+
+/** Default connection profiles shipped with the desktop app. */
+export function defaultProfiles(): ConnectionProfile[] {
+  return [
+    {
+      id: "local-daemon",
+      label: "Local Daemon",
+      kind: "local_daemon",
+      active: false,
+      gatewayUrl: "http://127.0.0.1:8080",
+      transport: "loopback_http",
+      managed: false,
+    },
+    {
+      id: "supervised-local-daemon",
+      label: "Supervised Local Daemon",
+      kind: "supervised_local_daemon",
+      active: false,
+      gatewayUrl: "http://127.0.0.1:8080",
+      transport: "loopback_http",
+      managed: true,
+      daemonPath: "",
+      daemonArgs: [],
+      daemonEnv: {},
+      startupTimeoutSecs: 30,
+      autoRestart: true,
+    },
+    {
+      id: "embedded-host",
+      label: "Embedded Host",
+      kind: "embedded_host",
+      active: false,
+      gatewayUrl: "http://127.0.0.1:8080",
+      transport: "in_process_channel",
+      managed: true,
+    },
+    {
+      id: "external-gateway",
+      label: "External Gateway",
+      kind: "external_gateway",
+      active: false,
+      gatewayUrl: "http://127.0.0.1:8080",
+      transport: "loopback_http",
+      managed: false,
+      probeOnConnect: true,
+    },
+    {
+      id: "hosted-gateway",
+      label: "Hosted Gateway",
+      kind: "hosted_gateway",
+      active: false,
+      gatewayUrl: "",
+      transport: "websocket",
+      managed: false,
+      probeOnConnect: true,
+    },
+  ];
+}
+
+/** Monotonic counter to ensure unique IDs even within the same millisecond. */
+let _profileIdCounter = 0;
+
+/** Create a blank profile of the given kind with sensible defaults. */
+export function createProfile(kind: ConnectionProfileKind): ConnectionProfile {
+  const defaults = defaultProfiles().find((p) => p.kind === kind);
+  if (!defaults) {
+    throw new Error(`Unknown connection profile kind: ${kind}`);
+  }
+  _profileIdCounter++;
+  return {
+    ...defaults,
+    id: `${kind}-${Date.now()}-${_profileIdCounter}`,
+    active: false,
+  };
+}

--- a/packages/state/__tests__/fixture-replay.test.ts
+++ b/packages/state/__tests__/fixture-replay.test.ts
@@ -70,10 +70,12 @@ function makeTaskGraphSnapshot(seq: number): TaskGraphSnapshot {
     generated_at: "2025-01-01T00:00:00Z",
     nodes: [
       {
+        schema_version: { major: 1, minor: 0, patch: 0 },
         node_id: "COE-390",
         identifier: "COE-390",
         kind: "issue" as const,
         title: "Gateway schemas",
+        state: "Done",
         state_category: "done" as const,
         children: [],
         blocked_by: [],

--- a/packages/state/__tests__/profile.test.ts
+++ b/packages/state/__tests__/profile.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Unit tests for connection profile state management.
+ *
+ * Tests profile reducer actions, state transitions, and selector functions.
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  profileReducer,
+  initialProfileState,
+  getEffectiveGatewayUrl,
+  getActiveProfile,
+  isManagedProfile,
+  isLocalProfile,
+  type ProfileState,
+  type ProfileAction,
+} from "../src/profiles";
+import {
+  createProfile,
+  type ConnectionProfile,
+  type LocalDaemonProfile,
+  type SupervisedLocalDaemonProfile,
+  type ExternalGatewayProfile,
+} from "@opensymphony/gateway-schema";
+
+function testProfile(overrides?: Partial<LocalDaemonProfile>): LocalDaemonProfile {
+  const base = createProfile("local_daemon") as LocalDaemonProfile;
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+describe("profileReducer", () => {
+  let state: ProfileState;
+
+  beforeEach(() => {
+    state = { ...initialProfileState };
+  });
+
+  it("returns initial state for unknown action", () => {
+    const newState = profileReducer(state, { type: "UNKNOWN" } as any);
+    expect(newState).toEqual(state);
+  });
+
+  describe("PROFILE_ADD", () => {
+    it("adds a new profile to the list", () => {
+      const profile = testProfile({ id: "test-1", label: "Test Profile" });
+      const newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      expect(newState.profiles).toHaveLength(1);
+      expect(newState.profiles[0].id).toBe("test-1");
+    });
+
+    it("appends profiles without replacing existing ones", () => {
+      const profile1 = testProfile({ id: "p1" });
+      const profile2 = testProfile({ id: "p2" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile: profile1,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_ADD",
+        profile: profile2,
+      });
+      expect(newState.profiles).toHaveLength(2);
+      expect(newState.profiles.map((p) => p.id)).toEqual(["p1", "p2"]);
+    });
+  });
+
+  describe("PROFILE_UPDATE", () => {
+    it("updates an existing profile", () => {
+      const profile = testProfile({ id: "test-1", label: "Old Label" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      const updatedProfile = { ...profile, label: "New Label" };
+      newState = profileReducer(newState, {
+        type: "PROFILE_UPDATE",
+        profile: updatedProfile,
+      });
+      expect(newState.profiles[0].label).toBe("New Label");
+    });
+
+    it("leaves other profiles unchanged", () => {
+      const p1 = testProfile({ id: "p1", label: "P1" });
+      const p2 = testProfile({ id: "p2", label: "P2" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile: p1,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_ADD",
+        profile: p2,
+      });
+      const updatedP1 = { ...p1, label: "Updated P1" };
+      newState = profileReducer(newState, {
+        type: "PROFILE_UPDATE",
+        profile: updatedP1,
+      });
+      expect(newState.profiles.find((p) => p.id === "p1")?.label).toBe(
+        "Updated P1",
+      );
+      expect(newState.profiles.find((p) => p.id === "p2")?.label).toBe("P2");
+    });
+  });
+
+  describe("PROFILE_REMOVE", () => {
+    it("removes a profile by ID", () => {
+      const profile = testProfile({ id: "to-remove" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_REMOVE",
+        profileId: "to-remove",
+      });
+      expect(newState.profiles).toHaveLength(0);
+    });
+
+    it("clears activeProfileId if the removed profile was active", () => {
+      const profile = testProfile({ id: "active-profile", active: true });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "active-profile",
+      });
+      expect(newState.activeProfileId).toBe("active-profile");
+      newState = profileReducer(newState, {
+        type: "PROFILE_REMOVE",
+        profileId: "active-profile",
+      });
+      expect(newState.activeProfileId).toBeNull();
+    });
+  });
+
+  describe("PROFILE_SET_ACTIVE", () => {
+    it("sets the active profile ID", () => {
+      const p1 = testProfile({ id: "p1" });
+      const p2 = testProfile({ id: "p2" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile: p1,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_ADD",
+        profile: p2,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "p2",
+      });
+      expect(newState.activeProfileId).toBe("p2");
+    });
+
+    it("updates the active flag on profiles", () => {
+      const p1 = testProfile({ id: "p1" });
+      const p2 = testProfile({ id: "p2" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile: p1,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_ADD",
+        profile: p2,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "p2",
+      });
+      expect(newState.profiles.find((p) => p.id === "p1")?.active).toBe(false);
+      expect(newState.profiles.find((p) => p.id === "p2")?.active).toBe(true);
+    });
+
+    it("does nothing for non-existent profile ID", () => {
+      const newState = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "nonexistent",
+      });
+      expect(newState).toEqual(state);
+    });
+  });
+
+  describe("PROFILES_LOAD", () => {
+    it("replaces all profiles", () => {
+      const profiles: ConnectionProfile[] = [
+        testProfile({ id: "p1" }),
+        testProfile({ id: "p2" }),
+      ];
+      const newState = profileReducer(state, {
+        type: "PROFILES_LOAD",
+        profiles,
+      });
+      expect(newState.profiles).toHaveLength(2);
+    });
+
+    it("sets activeProfileId if a loaded profile is active", () => {
+      const profiles: ConnectionProfile[] = [
+        testProfile({ id: "p1" }),
+        testProfile({ id: "p2", active: true }),
+      ];
+      const newState = profileReducer(state, {
+        type: "PROFILES_LOAD",
+        profiles,
+      });
+      expect(newState.activeProfileId).toBe("p2");
+    });
+  });
+
+  describe("GATEWAY_URL_OVERRIDE", () => {
+    it("sets the override URL", () => {
+      const newState = profileReducer(state, {
+        type: "GATEWAY_URL_OVERRIDE",
+        url: "http://custom-server:9999",
+      });
+      expect(newState.gatewayUrlOverride).toBe("http://custom-server:9999");
+    });
+
+    it("clears the override URL when null", () => {
+      let newState = profileReducer(state, {
+        type: "GATEWAY_URL_OVERRIDE",
+        url: "http://custom-server:9999",
+      });
+      newState = profileReducer(newState, {
+        type: "GATEWAY_URL_OVERRIDE",
+        url: null,
+      });
+      expect(newState.gatewayUrlOverride).toBeNull();
+    });
+  });
+
+  describe("DISCOVERY_START/SUCCESS/FAILURE", () => {
+    it("marks discovery as in progress", () => {
+      const newState = profileReducer(state, {
+        type: "DISCOVERY_START",
+      });
+      expect(newState.discovering).toBe(true);
+      expect(newState.discoveryError).toBeNull();
+    });
+
+    it("marks discovery as successful with timestamp", () => {
+      let newState = profileReducer(state, {
+        type: "DISCOVERY_START",
+      });
+      const timestamp = Date.now();
+      newState = profileReducer(newState, {
+        type: "DISCOVERY_SUCCESS",
+        timestamp,
+      });
+      expect(newState.discovering).toBe(false);
+      expect(newState.discoveryError).toBeNull();
+      expect(newState.lastDiscoveryAt).toBe(timestamp);
+    });
+
+    it("marks discovery as failed with error", () => {
+      let newState = profileReducer(state, {
+        type: "DISCOVERY_START",
+      });
+      newState = profileReducer(newState, {
+        type: "DISCOVERY_FAILURE",
+        error: "Connection refused",
+      });
+      expect(newState.discovering).toBe(false);
+      expect(newState.discoveryError).toBe("Connection refused");
+    });
+  });
+
+  describe("PROFILE_RESET", () => {
+    it("returns to initial state", () => {
+      const profile = testProfile({ id: "p1" });
+      let newState = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "p1",
+      });
+      newState = profileReducer(newState, {
+        type: "PROFILE_RESET",
+      });
+      expect(newState).toEqual(initialProfileState);
+    });
+  });
+});
+
+describe("selectors", () => {
+  let state: ProfileState;
+
+  beforeEach(() => {
+    state = { ...initialProfileState };
+  });
+
+  describe("getEffectiveGatewayUrl", () => {
+    it("returns override URL when set", () => {
+      state = profileReducer(state, {
+        type: "GATEWAY_URL_OVERRIDE",
+        url: "http://override:8888",
+      });
+      expect(getEffectiveGatewayUrl(state)).toBe("http://override:8888");
+    });
+
+    it("returns active profile URL when no override", () => {
+      const profile = testProfile({
+        id: "active",
+        gatewayUrl: "http://active:7777",
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "active",
+      });
+      expect(getEffectiveGatewayUrl(state)).toBe("http://active:7777");
+    });
+
+    it("returns null when no active profile and no override", () => {
+      expect(getEffectiveGatewayUrl(state)).toBeNull();
+    });
+  });
+
+  describe("getActiveProfile", () => {
+    it("returns the active profile", () => {
+      const profile = testProfile({ id: "active" });
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "active",
+      });
+      const active = getActiveProfile(state);
+      expect(active?.id).toBe("active");
+    });
+
+    it("returns null when no profile is active", () => {
+      expect(getActiveProfile(state)).toBeNull();
+    });
+  });
+
+  describe("isManagedProfile", () => {
+    it("returns true for supervised_local_daemon", () => {
+      const profile = createProfile("supervised_local_daemon") as SupervisedLocalDaemonProfile;
+      profile.id = "supervised";
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "supervised",
+      });
+      expect(isManagedProfile(state)).toBe(true);
+    });
+
+    it("returns false for local_daemon", () => {
+      const profile = createProfile("local_daemon") as LocalDaemonProfile;
+      profile.id = "local";
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "local",
+      });
+      expect(isManagedProfile(state)).toBe(false);
+    });
+
+    it("returns false when no profile is active", () => {
+      expect(isManagedProfile(state)).toBe(false);
+    });
+  });
+
+  describe("isLocalProfile", () => {
+    it("returns true for local_daemon", () => {
+      const profile = createProfile("local_daemon");
+      profile.id = "local";
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "local",
+      });
+      expect(isLocalProfile(state)).toBe(true);
+    });
+
+    it("returns true for external_gateway", () => {
+      const profile = createProfile("external_gateway") as ExternalGatewayProfile;
+      profile.id = "external";
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "external",
+      });
+      expect(isLocalProfile(state)).toBe(true);
+    });
+
+    it("returns false for hosted_gateway", () => {
+      const profile = createProfile("hosted_gateway");
+      profile.id = "hosted";
+      state = profileReducer(state, {
+        type: "PROFILE_ADD",
+        profile,
+      });
+      state = profileReducer(state, {
+        type: "PROFILE_SET_ACTIVE",
+        profileId: "hosted",
+      });
+      expect(isLocalProfile(state)).toBe(false);
+    });
+
+    it("returns false when no profile is active", () => {
+      expect(isLocalProfile(state)).toBe(false);
+    });
+  });
+});

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -15,7 +15,23 @@ import type {
   TerminalFrame,
   ApprovalRequest,
   PlanningSessionSummary,
+  ConnectionProfile,
+  ConnectionProfileKind,
 } from "@opensymphony/gateway-schema";
+
+// Profile state management
+export type {
+  ProfileState,
+  ProfileAction,
+} from "./profiles.js";
+export {
+  initialProfileState,
+  profileReducer,
+  getEffectiveGatewayUrl,
+  getActiveProfile,
+  isManagedProfile,
+  isLocalProfile,
+} from "./profiles.js";
 
 // -- State slices --
 

--- a/packages/state/src/profiles.ts
+++ b/packages/state/src/profiles.ts
@@ -1,0 +1,186 @@
+/**
+ * Connection profile state management.
+ *
+ * Manages profile selection, storage, and gateway URL override.
+ */
+
+import type { ConnectionProfile, ConnectionProfileKind } from "@opensymphony/gateway-schema";
+
+/** Profile state slice. */
+export interface ProfileState {
+  /** Available connection profiles. */
+  profiles: ConnectionProfile[];
+  /** ID of the currently active profile. */
+  activeProfileId: string | null;
+  /** Manual gateway URL override. */
+  gatewayUrlOverride: string | null;
+  /** Whether discovery is in progress. */
+  discovering: boolean;
+  /** Discovery error message. */
+  discoveryError: string | null;
+  /** Last successful discovery timestamp. */
+  lastDiscoveryAt: number | null;
+}
+
+/** Initial profile state with default profiles. */
+export const initialProfileState: ProfileState = {
+  profiles: [],
+  activeProfileId: null,
+  gatewayUrlOverride: null,
+  discovering: false,
+  discoveryError: null,
+  lastDiscoveryAt: null,
+};
+
+/** Profile-related action types. */
+export type ProfileAction =
+  | { type: "PROFILE_ADD"; profile: ConnectionProfile }
+  | { type: "PROFILE_UPDATE"; profile: ConnectionProfile }
+  | { type: "PROFILE_REMOVE"; profileId: string }
+  | { type: "PROFILE_SET_ACTIVE"; profileId: string }
+  | { type: "PROFILES_LOAD"; profiles: ConnectionProfile[] }
+  | { type: "GATEWAY_URL_OVERRIDE"; url: string | null }
+  | { type: "DISCOVERY_START" }
+  | { type: "DISCOVERY_SUCCESS"; timestamp: number }
+  | { type: "DISCOVERY_FAILURE"; error: string }
+  | { type: "PROFILE_RESET" };
+
+/** Profile reducer. */
+export function profileReducer(
+  state: ProfileState,
+  action: ProfileAction,
+): ProfileState {
+  switch (action.type) {
+    case "PROFILE_ADD":
+      return {
+        ...state,
+        profiles: [...state.profiles, action.profile],
+      };
+
+    case "PROFILE_UPDATE":
+      return {
+        ...state,
+        profiles: state.profiles.map((p) =>
+          p.id === action.profile.id ? action.profile : p,
+        ),
+      };
+
+    case "PROFILE_REMOVE":
+      return {
+        ...state,
+        profiles: state.profiles.filter((p) => p.id !== action.profileId),
+        activeProfileId:
+          state.activeProfileId === action.profileId
+            ? null
+            : state.activeProfileId,
+      };
+
+    case "PROFILE_SET_ACTIVE": {
+      const profile = state.profiles.find((p) => p.id === action.profileId);
+      if (!profile) {
+        return state;
+      }
+      return {
+        ...state,
+        activeProfileId: action.profileId,
+        profiles: state.profiles.map((p) => ({
+          ...p,
+          active: p.id === action.profileId,
+        })),
+      };
+    }
+
+    case "PROFILES_LOAD":
+      return {
+        ...state,
+        profiles: action.profiles,
+        activeProfileId:
+          action.profiles.find((p) => p.active)?.id ?? state.activeProfileId,
+      };
+
+    case "GATEWAY_URL_OVERRIDE":
+      return {
+        ...state,
+        gatewayUrlOverride: action.url,
+      };
+
+    case "DISCOVERY_START":
+      return {
+        ...state,
+        discovering: true,
+        discoveryError: null,
+      };
+
+    case "DISCOVERY_SUCCESS":
+      return {
+        ...state,
+        discovering: false,
+        discoveryError: null,
+        lastDiscoveryAt: action.timestamp,
+      };
+
+    case "DISCOVERY_FAILURE":
+      return {
+        ...state,
+        discovering: false,
+        discoveryError: action.error,
+      };
+
+    case "PROFILE_RESET":
+      return initialProfileState;
+
+    default:
+      return state;
+  }
+}
+
+/**
+ * Get the effective gateway URL for the active profile.
+ *
+ * Returns the override URL if set, otherwise the active profile's URL.
+ */
+export function getEffectiveGatewayUrl(state: ProfileState): string | null {
+  if (state.gatewayUrlOverride) {
+    return state.gatewayUrlOverride;
+  }
+  const activeProfile = state.profiles.find(
+    (p) => p.id === state.activeProfileId,
+  );
+  return activeProfile?.gatewayUrl ?? null;
+}
+
+/**
+ * Get the active profile.
+ */
+export function getActiveProfile(
+  state: ProfileState,
+): ConnectionProfile | null {
+  return (
+    state.profiles.find((p) => p.id === state.activeProfileId) ?? null
+  );
+}
+
+/**
+ * Check if the active profile is managed (daemon supervision enabled).
+ */
+export function isManagedProfile(state: ProfileState): boolean {
+  const activeProfile = getActiveProfile(state);
+  return activeProfile?.managed ?? false;
+}
+
+/**
+ * Check if the active profile uses local daemon transport.
+ */
+export function isLocalProfile(state: ProfileState): boolean {
+  const activeProfile = getActiveProfile(state);
+  if (!activeProfile) {
+    return false;
+  }
+  const localKinds: ConnectionProfileKind[] = [
+    "local_daemon",
+    "supervised_local_daemon",
+    "embedded_host",
+    "external_gateway",
+  ];
+  return localKinds.includes(activeProfile.kind);
+}

--- a/packages/state/src/profiles.ts
+++ b/packages/state/src/profiles.ts
@@ -169,7 +169,16 @@ export function isManagedProfile(state: ProfileState): boolean {
 }
 
 /**
- * Check if the active profile uses local daemon transport.
+ * Check if the active profile uses local transport (daemon or embedded).
+ *
+ * Heuristic: local profiles include daemon-managed modes and local gateways.
+ * - local_daemon: unmanaged local daemon (user started externally)
+ * - supervised_local_daemon: app-managed daemon lifecycle
+ * - embedded_host: daemon runs in-process with the desktop app
+ * - external_gateway: local gateway on loopback or LAN (not hosted cloud)
+ *
+ * hosted_gateway is excluded because it uses a remote cloud endpoint that
+ * requires authentication and different connection handling.
  */
 export function isLocalProfile(state: ProfileState): boolean {
   const activeProfile = getActiveProfile(state);


### PR DESCRIPTION
## Summary

Implement desktop connection profiles, gateway discovery, and supervised local daemon lifecycle management for COE-404. This update also addresses the latest review feedback around daemon cleanup, process liveness, Windows behavior, fallback URLs, and executable validation errors.

## Changes

- Added strongly typed connection profile request/response models and Tauri command stubs for profile storage, listing, activation, gateway probing, discovery, daemon start, daemon stop, and daemon status.
- Added gateway discovery through `/healthz` and `/api/v1/capabilities` with bounded `reqwest::Client` timeouts and loopback-only default fallback URLs.
- Added daemon supervision with process ownership tracking, async graceful stop, SIGKILL/taskkill escalation, process-group cleanup on Unix, process-tree cleanup on Windows, and non-blocking drop/async cleanup paths.
- Hardened executable validation with regular-file, execute-bit, and world-writable checks; validation failures now return a structured `DaemonPath` kind and readable detail.
- Added and refreshed daemon/process ownership tests, gateway discovery regression coverage, and task graph fixture compatibility.

## Evidence

### Test output

```
cargo fmt --check
# pass

cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check
# pass

cargo clippy --workspace --all-targets -- -D warnings
# pass

cargo test --workspace
# pass: 375 unit tests plus integration suites and doc-tests

cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml -- --nocapture
# pass: 4 lib tests, 4 bin tests, 5 process ownership tests, doc-tests

cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets
# pass with existing alpha stub dead-code warnings only

npm run type-check
# pass

npx jest --config jest.config.js --runTestsByPath packages/api-client/__tests__/discovery.test.ts packages/state/__tests__/fixture-replay.test.ts
# pass: 2 suites, 48 tests
```

### Verification

- Verified the PR branch at `56cfac0278f9c57f1dfaf1f7169135bb16203cc5`.
- GitHub `ci/rust` passed on the latest head.
- GitHub `ai-pr-review/openhands-review` passed on the latest head and did not add new review threads after the final cleanup commit.
- Confirmed `discoverGatewayWithFallback()` does not probe `0.0.0.0` by default.
- Confirmed daemon drop cleanup still kills the spawned fake daemon in the process ownership integration test.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- COE-404

## Additional notes

The desktop Tauri crate is currently its own Cargo workspace, separate from the root OpenSymphony crate workspace. Root CI covers the orchestrator crate; the desktop commands were also validated directly with their manifest.

