### PR TITLE
feat(desktop-alpha): mount real OpenSymphony app shell in Tauri wrapper (COE-449)

### DIFF
--- a/apps/desktop/__tests__/app-shell-render.test.ts
+++ b/apps/desktop/__tests__/app-shell-render.test.ts
@@ -1,0 +1,78 @@
+/**
+ * App-shell render smoke test for the desktop alpha.
+ *
+ * The Tauri desktop entrypoint should mount the real shared OpenSymphony
+ * app shell -- not a generated stub page. This test renders the shared
+ * `renderOpenSymphonyApp()` entry into a JSDOM mount and asserts the
+ * expected top-level viewport is produced, against a fake gateway reader
+ * that always rejects.
+ *
+ * The contract is intentionally different from the dist/bundle smoke
+ * test in `build-smoke.test.ts`: the bundle test catches "I shipped the
+ * stub instead of the app shell" at build time; this render test
+ * exercises the published mount-point code path so a regression that
+ * drops the actual `os-app` markup fails here even if the artifact
+ * bundle still emits the data attribute by accident.
+ *
+ * @jest-environment jsdom
+ */
+
+import { renderOpenSymphonyApp } from "@opensymphony/ui-core";
+import type {
+  GatewayReader,
+  OpenSymphonyAppHandle,
+} from "@opensymphony/ui-core";
+
+describe("desktop app shell render", () => {
+  it("mounts the shared OpenSymphony app shell with the expected viewport markup", async () => {
+    document.body.innerHTML = `<div id="root"></div>`;
+    const root = document.getElementById("root") as HTMLElement;
+
+    // Fake reader that always rejects so the app shell falls back to its
+    // built-in alpha-fixture flow. We are intentionally exercising the
+    // fallback render path because that's what users will see when the
+    // gateway daemon is offline during cold launch.
+    const reader: GatewayReader = {
+      baseUri: "http://127.0.0.1:8000",
+      async health() {
+        throw new Error("gateway unreachable for smoke test");
+      },
+      async snapshot() {
+        throw new Error("gateway unreachable for smoke test");
+      },
+      async taskGraph() {
+        throw new Error("gateway unreachable for smoke test");
+      },
+      async runDetail() {
+        throw new Error("gateway unreachable for smoke test");
+      },
+      async close() {
+        return undefined;
+      },
+    };
+
+    const handle: OpenSymphonyAppHandle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      title: "OpenSymphony Desktop",
+      transport: reader,
+      initialProfiles: [],
+    });
+
+    // The initial render is scheduled synchronously via refresh(); allow
+    // its inner await chain to finish before asserting on innerHTML.
+    await handle.refresh();
+
+    const shell = root.querySelector('[data-opensymphony-app-shell="mounted"]');
+    expect(shell).not.toBeNull();
+    expect(shell?.getAttribute("data-mode")).toBe("desktop");
+    expect(root.querySelector(".os-topbar")).not.toBeNull();
+    expect(root.querySelector(".os-grid")).not.toBeNull();
+    expect(root.querySelector(".os-profile-panel")).not.toBeNull();
+    expect(root.querySelector("[data-profile-select]")).not.toBeNull();
+    expect(root.querySelector("[data-profile-gateway]")).not.toBeNull();
+    expect(root.querySelector("[data-save-profile]")).not.toBeNull();
+
+    await handle.destroy();
+  });
+});

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -198,7 +198,8 @@ pub async fn store_profile(
             .active_profile_id
             .as_ref()
             .is_some_and(|active_id| active_id == &profile_id);
-        let make_active = was_active || store.active_profile_id.is_none() || store.profiles.is_empty();
+        let make_active =
+            was_active || store.active_profile_id.is_none() || store.profiles.is_empty();
         let response = profile_response_from_request(req, profile_id.clone(), make_active);
 
         store.profiles.retain(|profile| profile.id != profile_id);

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,6 +54,66 @@ Key choices:
   `opensymphony init`
 - FrankenTUI is optional and must not affect correctness
 
+## Desktop alpha (COE-449)
+
+The Tauri desktop wrapper now mounts the same shared `OpenSymphonyApp`
+shell as the web bundle, instead of the historical stub renderer. Both
+entry points live under `apps/`:
+
+- `apps/desktop` — Tauri wrapper; frontend ships from `apps/desktop/dist`.
+- `apps/web` — browser bundle served by the gateway or deployed as a
+  static site.
+
+### Running the desktop alpha locally
+
+```bash
+# 1. Build the shared frontend first (workspace root).
+npm install
+npm run build --workspace=@opensymphony/gateway-schema
+npm run build --workspace=@opensymphony/ui-core
+npm run build --workspace=@opensymphony/desktop
+
+# 2. Run the desktop frontend against a loopback gateway.
+#    The bundle auto-attaches via HttpGatewayTransport if the
+#    Rust gateway isn't reachable.
+(cd apps/desktop && npm run dev)            # vite dev server on 127.0.0.1:1420
+# 3. (optional) Launch the Tauri shell once dependencies are installed.
+cargo install --path apps/desktop/src-tauri --locked
+(cd apps/desktop/src-tauri && cargo run)
+```
+
+The desktop entry detects the Tauri runtime via
+`globalThis.__TAURI__` and uses the native `list_profiles`,
+`store_profile`, and `set_active_profile` commands for connection
+profile persistence. Outside Tauri (vite dev, `npm run build` preview)
+the entry falls back to a loopback HTTP transport against
+`http://127.0.0.1:8000` and renders the same `OpenSymphony Desktop`
+shell.
+
+### Verification artifacts
+
+Every release-blocking check below is wired to a single command and is
+expected to pass on every pull request:
+
+| Check | Command | Verifies |
+|---|---|---|
+| TypeScript types | `npm run type-check` | Shared frontend compiles end-to-end |
+| Frontend tests | `npx jest --config jest.config.js` (or `npm test`) | Includes the route contract, app-shell render, transport contract, reducer, profile, and discovery suites |
+| Desktop bundle | `npm run build --workspace=@opensymphony/desktop` | `dist/index.html` + `dist/assets/main-*.js` contain the real app shell markup (no stub placeholder text) |
+| Desktop smoke | `npx jest --config jest.config.js --testPathPattern apps/desktop` | `build-smoke.test.ts` and `app-shell-render.test.ts` both pass |
+| Rust desktop | `cd apps/desktop/src-tauri && cargo test` | 36 unit tests + 5 process-ownership integration tests |
+| Rust Lint | `cd apps/desktop/src-tauri && cargo fmt --check && cargo clippy --all-targets -- -D warnings` | Formatting + clippy on the desktop crate |
+
+### Acceptance reminders
+
+- Capability discovery (`alphaCapabilities()` in `packages/ui-core/src/app-shell.ts`) only advertises `loopback_http` and explicitly marks `terminal_stream` as `available: false`. No stub native transport is marked as ready.
+- Connection profiles persist via the `settings` capability and the
+  `fs:allow-read-text-file` / `fs:allow-write-text-file` permission set,
+  scoped to `$HOME/.config/opensymphony` by fs-plugin config.
+- The frontend's `routes-contract.test.ts` keeps the TS API client in
+  lock-step with the Rust axum router declared in
+  `crates/opensymphony-gateway/src/lib.rs` (`pub fn router(&self) -> Router`).
+
 ## Milestones
 
 ### M1 Foundation and contracts

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/ws": "^8.18.0",
     "eslint": "^9.0.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.2.0",
     "typescript": "^5.8.0",
     "ws": "^8.21.0"

--- a/packages/api-client/__tests__/routes-contract.test.ts
+++ b/packages/api-client/__tests__/routes-contract.test.ts
@@ -88,6 +88,13 @@ const EXPECTED_PATHS: ReadonlyArray<{
  * is the only authoritative list of routable endpoints. We extract just
  * that block so unrelated `.route(...)` calls inside helper functions
  * don't accidentally satisfy the contract check.
+ *
+ * The scan tracks brace depth while skipping characters that appear
+ * inside line comments, Rust block comments, regular strings, byte
+ * strings, char literals, and raw strings. Without these skips a
+ * router that contains a format! macro or a comment with an opening
+ * brace would terminate the block at the wrong brace and silently
+ * turn legitimate routes into `missing`.
  */
 function extractRouterBlock(source: string): string {
   const startMarker = "pub fn router(&self) -> Router";
@@ -97,12 +104,77 @@ function extractRouterBlock(source: string): string {
       "Could not locate `pub fn router(&self) -> Router` in gateway lib.rs",
     );
   }
-  // The router block ends when the function's brace matching closes.
+
   let depth = 0;
   let started = false;
   let endIdx = -1;
-  for (let i = startIdx; i < source.length; i++) {
+  let i = startIdx;
+  while (i < source.length) {
     const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === "/" && next === "/") {
+      // Line comment: skip to next newline.
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      // Block comment: skip until closing `*/`.
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    if (ch === '"') {
+      // Plain string: skip until matching unescaped `"`.
+      i++;
+      while (i < source.length && source[i] !== '"') {
+        if (source[i] === "\\") i += 2;
+        else i++;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "b" && next === '"') {
+      // Byte string: same as plain string but with the `b` prefix.
+      i += 2;
+      while (i < source.length && source[i] !== '"') {
+        if (source[i] === "\\") i += 2;
+        else i++;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "'") {
+      // Char literal: take the next character, accounting for `\` escapes.
+      i++;
+      if (source[i] === "\\") i += 2;
+      else i++;
+      if (source[i] === "'") i++;
+      continue;
+    }
+    if (ch === "r") {
+      // Raw string: r"...", r#"..."#, r##"..."## up to 255 hashes.
+      let j = i + 1;
+      let hashCount = 0;
+      while (j < source.length && source[j] === "#") {
+        hashCount++;
+        j++;
+      }
+      if (source[j] === '"') {
+        const close = '"' + "#".repeat(hashCount);
+        i = j + 1;
+        const closeIdx = source.indexOf(close, i);
+        if (closeIdx === -1) {
+          throw new Error("Unterminated raw string in gateway lib.rs");
+        }
+        i = closeIdx + close.length;
+        continue;
+      }
+    }
+
     if (ch === "{") {
       depth++;
       started = true;
@@ -113,7 +185,9 @@ function extractRouterBlock(source: string): string {
         break;
       }
     }
+    i++;
   }
+
   if (endIdx < 0) {
     throw new Error("Could not find end of router block in gateway lib.rs");
   }
@@ -184,5 +258,39 @@ describe("api-client -> Rust gateway route contract", () => {
     }
 
     expect(unrouted).toEqual([]);
+  });
+
+  it("skips Rust strings, comments, char literals, and raw strings when extracting the router block", () => {
+    // Adversarial fixtures to prove the brace tracker does not terminate
+    // early on characters that appear inside Rust string / comment
+    // literals. Regression coverage for the comment that originally used
+    // a naive character-level extractor.
+    const adversarialSnippets = [
+      `.route("/api/v1/${"{run_id}"}/logs", get(logs))`,
+      `.route("/api/v1/runs/{id}", get(run)) // see also {nested}`,
+      `.route("/api/v1/proof", get(proof)) /* keep {this_brace} */`,
+      `.route(b"/api/v1/binary", get(bytes))`,
+      `.route("/api/v1/single", get(charlie)) // char "'" lives in a string`,
+      `.route(r##"/api/v1/raw/{still_a_route}"##, get(raw_path))`,
+    ];
+
+    for (const snippet of adversarialSnippets) {
+      const source = [
+        "impl GatewayRouter {",
+        "    pub fn router(&self) -> Router {",
+        snippet,
+        "    }",
+        "}",
+      ].join("\n");
+      const block = extractRouterBlock(source);
+      // All braces inside the snippet body belong to the array + map
+      // literals, none to the router function body. Therefore the
+      // extracted block must terminate at the actual function closing
+      // brace, not at any `}` introduced by a string literal above.
+      expect(block).toContain("Router {");
+      expect(block.trim().endsWith("}")).toBe(true);
+      // Make sure every adversarial route snippet survived extraction.
+      expect(block).toContain(snippet.replace(/\\/g, ""));
+    }
   });
 });

--- a/packages/api-client/__tests__/routes-contract.test.ts
+++ b/packages/api-client/__tests__/routes-contract.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Verifies that every HTTP endpoint used by the api-client transports
+ * has a matching route in the Rust gateway router.
+ *
+ * Drift here means the frontend would call an endpoint that the gateway
+ * 404s on, which breaks the desktop alpha flow before it ever renders
+ * OpenSymphony state.
+ *
+ * The contract lives in two places:
+ *   - `packages/api-client/src/transports.ts` (TypeScript clients)
+ *   - `crates/opensymphony-gateway/src/lib.rs`  (Rust axum router)
+ *
+ * This test reads both, then asserts that every documented transport
+ * path template appears in the Rust router's route table.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const TRANSPORTS_SRC = path.join(
+  REPO_ROOT,
+  "packages/api-client/src/transports.ts",
+);
+const GATEWAY_SRC = path.join(
+  REPO_ROOT,
+  "crates/opensymphony-gateway/src/lib.rs",
+);
+
+/**
+ * The HTTP and WebSocket paths the api-client transports call. The
+ * template uses {param} placeholders that get url-encoded at runtime;
+ * the contract checks against the equivalent Rust router path which
+ * uses {param} syntax inside axum's `.route(...)`.
+ *
+ * When changes are made to `transports.ts` with a new REST/SSE/WS path,
+ * this list must be updated in lockstep.
+ */
+const EXPECTED_PATHS: ReadonlyArray<{
+  description: string;
+  tsSource: string; // substring that must appear in transports.ts
+  rustPath: string; // exact route in the Rust router
+}> = [
+  {
+    description: "Gateway capabilities",
+    tsSource: "/api/v1/capabilities",
+    rustPath: "/api/v1/capabilities",
+  },
+  {
+    description: "Dashboard snapshot",
+    tsSource: "/api/v1/dashboard/snapshot",
+    rustPath: "/api/v1/dashboard/snapshot",
+  },
+  {
+    description: "Project task graph",
+    tsSource: "/api/v1/projects/${encodeURIComponent(projectId)}/taskgraph",
+    rustPath: "/api/v1/projects/{project_id}/taskgraph",
+  },
+  {
+    description: "Run detail",
+    tsSource: "/api/v1/runs/${encodeURIComponent(runId)}",
+    rustPath: "/api/v1/runs/{run_id}",
+  },
+  {
+    description: "Run events",
+    tsSource: "/api/v1/runs/${encodeURIComponent(runId)}/events?",
+    rustPath: "/api/v1/runs/{run_id}/events",
+  },
+  {
+    description: "Action dispatch",
+    tsSource: "/api/v1/actions/dispatch",
+    rustPath: "/api/v1/actions/dispatch",
+  },
+  {
+    description: "Gateway SSE event journal stream",
+    tsSource: "/api/v1/events",
+    rustPath: "/api/v1/events",
+  },
+  {
+    description: "Gateway WebSocket event stream",
+    tsSource: "/api/v1/streams/events",
+    rustPath: "/api/v1/streams/events",
+  },
+];
+
+/**
+ * The Rust router block lives in `pub fn router(&self) -> Router` and
+ * is the only authoritative list of routable endpoints. We extract just
+ * that block so unrelated `.route(...)` calls inside helper functions
+ * don't accidentally satisfy the contract check.
+ */
+function extractRouterBlock(source: string): string {
+  const startMarker = "pub fn router(&self) -> Router";
+  const startIdx = source.indexOf(startMarker);
+  if (startIdx < 0) {
+    throw new Error(
+      "Could not locate `pub fn router(&self) -> Router` in gateway lib.rs",
+    );
+  }
+  // The router block ends when the function's brace matching closes.
+  let depth = 0;
+  let started = false;
+  let endIdx = -1;
+  for (let i = startIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") {
+      depth++;
+      started = true;
+    } else if (ch === "}") {
+      depth--;
+      if (started && depth === 0) {
+        endIdx = i;
+        break;
+      }
+    }
+  }
+  if (endIdx < 0) {
+    throw new Error("Could not find end of router block in gateway lib.rs");
+  }
+  return source.slice(startIdx, endIdx + 1);
+}
+
+describe("api-client -> Rust gateway route contract", () => {
+  let transportsSource: string;
+  let routerBlock: string;
+
+  beforeAll(() => {
+    transportsSource = fs.readFileSync(TRANSPORTS_SRC, "utf-8");
+    const gatewaySource = fs.readFileSync(GATEWAY_SRC, "utf-8");
+    routerBlock = extractRouterBlock(gatewaySource);
+  });
+
+  it("keeps transports.ts and the Rust router in sync for every REST/SSE/WS path", () => {
+    const missing: Array<{ description: string; rustPath: string }> = [];
+
+    for (const entry of EXPECTED_PATHS) {
+      // 1. Confirm the path still lives in the TS transports file.
+      if (!transportsSource.includes(entry.tsSource)) {
+        throw new Error(
+          `Frontend transport no longer calls ${entry.description} (expected substring "${entry.tsSource}" in transports.ts). ` +
+            "If the call site moved, update EXPECTED_PATHS.",
+        );
+      }
+      // 2. Confirm the matching Rust route is still registered.
+      if (!routerBlock.includes(`"${entry.rustPath}"`)) {
+        missing.push({ description: entry.description, rustPath: entry.rustPath });
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it("does not advertise stub-only or unrouted HTTP paths in HttpGatewayTransport", () => {
+    // Guardrail: any new `/api/v1/` literal added to HttpGatewayTransport
+    // must be acknowledged here. The exact substring scan below makes a
+    // forgotten entry loud during code review instead of silently breaking
+    // the desktop alpha flow at runtime.
+    const unrouted: string[] = [];
+    const pathRegex = /\/api\/v1\/[a-zA-Z0-9_\-/{}:.]+/g;
+    const documented = new Set(
+      EXPECTED_PATHS.map((entry) => entry.tsSource.split("$")[0]),
+    );
+
+    const seen = new Set<string>();
+    for (const match of transportsSource.match(pathRegex) ?? []) {
+      const normalized = match.split("?")[0];
+      if (seen.has(normalized)) continue;
+      seen.add(normalized);
+      const documentedHit = Array.from(documented).some((doc) =>
+        normalized.startsWith(doc.replace(/\$\{[^}]+\}/g, "")),
+      );
+      // Only entries prefixed with /api/v1/ should be tracked. Subpath
+      // hits like /api/v1/actions are covered by the documented list.
+      if (
+        !documentedHit &&
+        normalized !== "/api/v1/capabilities" &&
+        normalized !== "/api/v1/dashboard/snapshot" &&
+        normalized !== "/api/v1/events" &&
+        normalized !== "/api/v1/actions/dispatch" &&
+        normalized !== "/api/v1/streams/events"
+      ) {
+        unrouted.push(normalized);
+      }
+    }
+
+    expect(unrouted).toEqual([]);
+  });
+});

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -186,9 +186,21 @@ async function flushUntil(
     if (predicate()) return;
     await flushAsync();
   }
+  throw new Error(
+    `flushUntil timed out after ${maxIterations} iterations waiting for predicate`,
+  );
 }
 
 describe("OpenSymphonyApp mount", () => {
+  it("flushUntil rejects with a clear timeout message instead of returning silently", async () => {
+    // Regression coverage for the reviewer finding that exhausted
+    // flushUntil iterations used to resolve silently, which masked the
+    // real failure inside a later null assertion.
+    await expect(flushUntil(() => false, 4)).rejects.toThrow(
+      /timed out after 4 iterations/,
+    );
+  });
+
   it("mounts the shared app shell with the marker attribute", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
@@ -259,7 +271,7 @@ describe("OpenSymphonyApp mount", () => {
     expect(root.querySelector(".os-run-head strong")?.textContent).toBe("COE-449");
     expect(root.querySelector(".os-pill")?.textContent).toBe("running");
 
-    handle.destroy();
+    await handle.destroy();
   });
 
   it("enables loopback fallback fixtures when the gateway health probe fails", async () => {
@@ -285,7 +297,7 @@ describe("OpenSymphonyApp mount", () => {
     expect(root.textContent).toContain("Fixture");
     expect(root.textContent).toContain("desktop-alpha");
 
-    handle.destroy();
+    await handle.destroy();
   });
 
   it("disables profile save when no profile controller is provided", async () => {
@@ -302,7 +314,7 @@ describe("OpenSymphonyApp mount", () => {
     expect(save).not.toBeNull();
     expect(save.disabled).toBe(true);
 
-    handle.destroy();
+    await handle.destroy();
   });
 
   it("routes a saved profile through ProfileController and refreshes the active gateway URL", async () => {
@@ -368,7 +380,7 @@ describe("OpenSymphonyApp mount", () => {
     expect(lastConnect).toBe(newUrl);
     expect(save.disabled).toBe(false);
 
-    handle.destroy();
+    await handle.destroy();
   });
 
   it("renders the profile panel and provided initial profile when no controller is set", async () => {
@@ -387,6 +399,6 @@ describe("OpenSymphonyApp mount", () => {
     expect(select).not.toBeNull();
     // Without a profile controller the shell uses the default UI profile.
     expect(select.options.length).toBeGreaterThan(0);
-    handle.destroy();
+    await handle.destroy();
   });
 });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1,0 +1,392 @@
+/**
+ * @jest-environment jsdom
+ *
+ * App-shell mount smoke tests for COE-449 desktop alpha recovery.
+ */
+
+import { renderOpenSymphonyApp } from "../src/app-shell.js";
+import { MockGatewayTransport } from "@opensymphony/api-client";
+import { schemaVersionV1 } from "@opensymphony/gateway-schema";
+import type {
+  EditableProfileInput,
+  ProfileController,
+} from "../src/app-shell.js";
+import type {
+  ConnectionProfile,
+  DashboardSnapshot,
+  GatewayCapabilities,
+  RunDetail,
+  TaskGraphSnapshot,
+} from "@opensymphony/gateway-schema";
+
+const capabilities: GatewayCapabilities = {
+  schema_version: schemaVersionV1(),
+  gateway_version: "alpha-test",
+  supported_api_versions: ["1.0.0"],
+  transports: [
+    {
+      transport: "loopback_http",
+      modes: ["json"],
+      supported_encodings: ["utf-8"],
+      bidirectional: false,
+    },
+  ],
+  features: [
+    { feature: "task_graph", available: true, requires_auth: false },
+    { feature: "terminal_stream", available: false, requires_auth: false },
+  ],
+  auth_modes: ["none"],
+  max_event_page_size: 1000,
+  max_terminal_frame_batch: 500,
+};
+
+const dashboard: DashboardSnapshot = {
+  schema_version: schemaVersionV1(),
+  generated_at: "2025-09-01T00:00:00Z",
+  sequence: 7,
+  health: "healthy",
+  metrics: {
+    running_issue_count: 2,
+    retry_queue_depth: 1,
+    total_input_tokens: 4500,
+    total_output_tokens: 1100,
+    total_cache_read_tokens: 600,
+    total_cost_micros: 250,
+  },
+  projects: [
+    {
+      project_id: "proj-alpha",
+      name: "Alpha Recovery",
+      milestone_count: 2,
+      issue_count: 4,
+      running_count: 1,
+      completed_count: 2,
+      failed_count: 1,
+    },
+  ],
+  recent_events: [
+    {
+      happened_at: "2025-09-01T00:00:00Z",
+      kind: "client_attached",
+      issue_identifier: "COE-449",
+      summary: "App shell mounted under test",
+    },
+  ],
+};
+
+const taskGraph: TaskGraphSnapshot = {
+  schema_version: schemaVersionV1(),
+  project_id: "proj-alpha",
+  generated_at: "2025-09-01T00:00:00Z",
+  root_ids: ["m7-milestone"],
+  nodes: [
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "m7-milestone",
+      kind: "milestone",
+      identifier: "M7",
+      title: "Shared Client and Desktop Alpha",
+      state: "In Progress",
+      state_category: "in_progress",
+      children: ["app-shell", "desktop-alpha"],
+      blocked_by: [],
+      labels: ["desktop"],
+    },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "app-shell",
+      kind: "issue",
+      identifier: "DESKTOP-ALPHA",
+      title: "Desktop alpha recovery",
+      state: "Backlog",
+      state_category: "backlog",
+      parent_id: "m7-milestone",
+      children: [],
+      blocked_by: [],
+      labels: ["desktop", "recovery"],
+    },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "desktop-alpha",
+      kind: "issue",
+      identifier: "COE-449",
+      title: "Replace stubs with functional app",
+      state: "Done",
+      state_category: "done",
+      parent_id: "m7-milestone",
+      children: [],
+      blocked_by: [],
+      labels: ["transport"],
+    },
+  ],
+};
+
+const runDetail: RunDetail = {
+  schema_version: schemaVersionV1(),
+  run_id: "COE-449",
+  issue_id: "issue-coe-449",
+  issue_identifier: "COE-449",
+  worker_id: "worker-alpha",
+  status: "running",
+  claimed_at: "2025-09-01T00:00:00Z",
+  started_at: "2025-09-01T00:00:30Z",
+  turn_count: 3,
+  max_turns: 8,
+  input_tokens: 4500,
+  output_tokens: 1100,
+  cache_read_tokens: 600,
+  runtime_seconds: 90,
+  workspace_path: "/tmp/opensymphony/projects/COE-449",
+  safe_actions: {
+    retry: false,
+    cancel: true,
+    rehydrate: true,
+    detach: false,
+  },
+};
+
+function buildTransport(opts?: { failHealth?: boolean }): MockGatewayTransport {
+  if (opts?.failHealth) {
+    class AlwaysFailHealthTransport extends MockGatewayTransport {
+      override async health(): Promise<never> {
+        throw new Error("simulated health probe failure");
+      }
+    }
+    return new AlwaysFailHealthTransport({
+      baseUri: "http://127.0.0.1:8000",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph,
+      runDetails: [runDetail],
+    });
+  }
+  return new MockGatewayTransport({
+    baseUri: "http://127.0.0.1:8000",
+    health: capabilities,
+    snapshot: dashboard,
+    taskGraph,
+    // Map the desktop-alpha task graph node to the COE-449 run detail so
+    // the actual mock gateway response drives the run detail panel.
+    runDetails: [
+      runDetail,
+      { ...runDetail, run_id: "desktop-alpha", issue_id: "desktop-alpha" },
+    ],
+  });
+}
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushUntil(
+  predicate: () => boolean,
+  maxIterations = 40,
+): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    if (predicate()) return;
+    await flushAsync();
+  }
+}
+
+describe("OpenSymphonyApp mount", () => {
+  it("mounts the shared app shell with the marker attribute", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      title: "OpenSymphony Desktop",
+      transport: buildTransport(),
+    });
+    await flushUntil(
+      () =>
+        root.querySelector(".os-app[data-opensymphony-app-shell='mounted']") !==
+        null,
+    );
+
+    expect(
+      root.querySelector(".os-app[data-opensymphony-app-shell='mounted']"),
+    ).not.toBeNull();
+    expect(root.querySelector(".os-app[data-mode='desktop']")).not.toBeNull();
+    expect(root.textContent).toContain("OpenSymphony Desktop");
+
+    await handle.destroy();
+    expect(root.children.length).toBe(0);
+  });
+
+  it("wires dashboard to task graph to run detail navigation against the mock gateway", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+    });
+
+    await flushUntil(
+      () => root.querySelector("[data-project-id='proj-alpha']") !== null,
+    );
+
+    const projectButton = root.querySelector(
+      "[data-project-id='proj-alpha']",
+    ) as HTMLButtonElement;
+    expect(projectButton).not.toBeNull();
+    expect(root.querySelector(".os-metrics")).not.toBeNull();
+
+    taskGraph.root_ids.forEach((rootId) => {
+      expect(root.querySelector(`[data-node-id='${rootId}']`)).not.toBeNull();
+    });
+
+    const targetNode = root.querySelector(
+      "[data-node-id='desktop-alpha']",
+    ) as HTMLButtonElement;
+    expect(targetNode).not.toBeNull();
+    targetNode.click();
+    await flushAsync();
+
+    const openRunButton = root.querySelector(
+      "[data-open-run='desktop-alpha']",
+    ) as HTMLButtonElement;
+    expect(openRunButton).not.toBeNull();
+    openRunButton.click();
+    await flushUntil(() => root.querySelector(".os-run-grid") !== null);
+
+    const runSection = root.querySelector(".os-run-grid");
+    expect(runSection).not.toBeNull();
+    // The issue identifier is rendered in the .os-run-head strip, not
+    // inside the .os-run-grid metrics block. Verify the run detail
+    // panel reflects the navigation event with the mocked fixture.
+    expect(root.querySelector(".os-run-head strong")?.textContent).toBe("COE-449");
+    expect(root.querySelector(".os-pill")?.textContent).toBe("running");
+
+    handle.destroy();
+  });
+
+  it("enables loopback fallback fixtures when the gateway health probe fails", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ failHealth: true }),
+    });
+
+    await flushUntil(
+      () =>
+        root.querySelector("[data-opensymphony-app-shell='mounted']") !== null,
+    );
+
+    // The first render happens before loadGatewayState resolves with the
+    // connection state. Wait for the catch path to flip the connection
+    // mode to "fixture" and re-render.
+    await flushUntil(() => root.querySelector(".os-status-fixture") !== null);
+
+    expect(root.querySelector(".os-status-fixture")).not.toBeNull();
+    expect(root.textContent).toContain("Fixture");
+    expect(root.textContent).toContain("desktop-alpha");
+
+    handle.destroy();
+  });
+
+  it("disables profile save when no profile controller is provided", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+    });
+
+    await flushUntil(() => root.querySelector("[data-save-profile]") !== null);
+    const save = root.querySelector("[data-save-profile]") as HTMLButtonElement;
+    expect(save).not.toBeNull();
+    expect(save.disabled).toBe(true);
+
+    handle.destroy();
+  });
+
+  it("routes a saved profile through ProfileController and refreshes the active gateway URL", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    const newUrl = "http://127.0.0.1:9001";
+    let lastConnect: string | null = null;
+    const controller: ProfileController = {
+      async listProfiles(): Promise<ConnectionProfile[]> {
+        return [];
+      },
+      async storeProfile(profile: EditableProfileInput): Promise<ConnectionProfile> {
+        return {
+          id: "profile-saved",
+          label: profile.label,
+          kind: profile.kind,
+          active: true,
+          gatewayUrl: profile.gatewayUrl,
+          transport: "loopback_http",
+          managed: false,
+        };
+      },
+      async setActiveProfile(profileId: string): Promise<ConnectionProfile> {
+        return {
+          id: profileId,
+          label: "Saved profile",
+          kind: "external_gateway",
+          active: true,
+          gatewayUrl: newUrl,
+          transport: "loopback_http",
+          managed: false,
+        };
+      },
+    };
+
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+      profileController: controller,
+      onGatewayUrlChanged: async (url) => {
+        lastConnect = url;
+        return buildTransport();
+      },
+    });
+
+    await flushUntil(() => root.querySelector("[data-save-profile]") !== null);
+
+    const labelInput = root.querySelector(
+      "[data-profile-label]",
+    ) as HTMLInputElement;
+    const gatewayInput = root.querySelector(
+      "[data-profile-gateway]",
+    ) as HTMLInputElement;
+    const save = root.querySelector("[data-save-profile]") as HTMLButtonElement;
+
+    labelInput.value = "Saved Gateway";
+    gatewayInput.value = newUrl;
+    save.click();
+
+    await flushUntil(() => lastConnect === newUrl);
+    expect(lastConnect).toBe(newUrl);
+    expect(save.disabled).toBe(false);
+
+    handle.destroy();
+  });
+
+  it("renders the profile panel and provided initial profile when no controller is set", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+    });
+
+    await flushUntil(() => root.querySelector(".os-profile-panel") !== null);
+    const select = root.querySelector(
+      "[data-profile-select]",
+    ) as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    // Without a profile controller the shell uses the default UI profile.
+    expect(select.options.length).toBeGreaterThan(0);
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

This PR closes the COE-449 post-mortem gap by replacing the historical stub renderer in `apps/desktop` with a real mount of the shared `OpenSymphonyApp` shell from `packages/ui-core`. Both the desktop and web entrypoints now go through the same `renderOpenSymphonyApp` runtime, the desktop transport falls back to loopback HTTP when no Tauri runtime is present, connection profiles persist across restarts, and the frontend and Rust gateway endpoint lists are pinned by a contract test.

## Changes

- `apps/desktop/src/index.ts` already mounts the shared app shell via `renderOpenSymphonyApp` with `createDesktopProfileController` and falls back to `HttpGatewayTransport` when `globalThis.__TAURI__` is undefined. No code changes were required here; the new regression-detector tests now prove it stays that way.
- `apps/desktop/__tests__/app-shell-render.test.ts` (new): jsdom render smoke test that imports `renderOpenSymphonyApp` from `@opensymphony/ui-core` and asserts the `data-opensymphony-app-shell="mounted"` marker, `.os-topbar`, `.os-grid`, `.os-profile-panel`, and the profile form fields are present immediately after `handle.refresh()`.
- `packages/api-client/__tests__/routes-contract.test.ts` (new): mirrors the endpoint paths from the Rust axum router in `crates/opensymphony-gateway/src/lib.rs`. Future drift between frontend and backend routes fails loud.
- `packages/ui-core/__tests__/app-shell.test.ts` (new + repaired): proves the mount marker, dashboard -> task graph -> run-detail navigation against `MockGatewayTransport`, loopback fallback when `health()` throws, and that profile save is disabled when no profile controller is supplied. Two prior assertions referenced the wrong DOM region or polled too early -- both repaired here.
- `apps/desktop/src-tauri/src/commands.rs`: `cargo fmt` cleanup so the Test Plan's `cargo fmt --check` gate passes for the desktop subcrate.
- `package.json`: add `jest-environment-jsdom` as a workspace dev dependency so the jsdom render smoke has a deterministic environment.
- `docs/DEVELOPMENT.md`: new "Desktop alpha (COE-449)" section with a one-command local run path, a verification artifact table, and acceptance reminders for capability advertising, profile persistence scope, and routes-contract invariants.

## Evidence

### Test output (frontend)

```
PASS packages/api-client/__tests__/routes-contract.test.ts
PASS packages/state/__tests__/reducer.test.ts
PASS packages/api-client/__tests__/transport-contract.test.ts
PASS apps/desktop/__tests__/build-smoke.test.ts
PASS packages/state/__tests__/profile.test.ts
PASS packages/state/__tests__/fixture-replay.test.ts
PASS apps/web/__tests__/build-smoke.test.ts
PASS packages/gateway-schema/__tests__/profile.test.ts
PASS packages/api-client/__tests__/discovery.test.ts
PASS packages/gateway-schema/__tests__/fixtures.test.ts
PASS apps/desktop/__tests__/app-shell-render.test.ts
PASS packages/ui-core/__tests__/app-shell.test.ts
PASS packages/ui-core/__tests__/terminal-renderer.test.ts

Test Suites: 13 passed, 13 total
Tests:       305 passed, 305 total
```

### TypeScript and desktop bundle

```
$ npm run type-check
> tsc --build tsconfig.projects.json
(exit 0)

$ npm run build --workspace=@opensymphony/desktop
dist/index.html                0.33 kB | gzip:  0.24 kB
dist/assets/main-CK1L1OMZ.js  37.85 kB | gzip: 10.70 kB
✓ built in 87ms
```

### Rust desktop tests / lint

```
$ cd apps/desktop/src-tauri && cargo test
test result: ok. 36 passed; 0 failed; ...
Doc-tests opensymphony_desktop: 0 passed
5 passed (process_ownership integration tests)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s

$ cargo fmt --check           # workspace and desktop subcrate both clean
```

### git diff --check

```
(no whitespace / line-ending diffs reported)
```

### Regression detection proof

To prove the new tests actually catch the regression this PR exists to prevent, I temporarily edited `packages/ui-core/src/app-shell.ts` to replace `data-opensymphony-app-shell="mounted"` with `stub-marker` and rebuilt the desktop bundle: both `apps/desktop/__tests__/app-shell-render.test.ts` and `apps/desktop/__tests__/build-smoke.test.ts` failed loud. After restoring the real marker (the temporary edit was reverted), both tests passed. That edit was NOT committed.

## Checklist

- [x] Tests pass (`npx jest --config jest.config.js` and `cargo test -p opensymphony-desktop`)
- [x] Code is formatted (`cargo fmt --check` workspace + desktop subcrate)
- [x] Clippy is clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (new "Desktop alpha (COE-449)" section in `docs/DEVELOPMENT.md`)
- [x] Evidence section filled out above

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactoring

## Breaking changes

None.

## Related issues

Closes COE-449 (Desktop alpha recovery: replace stubs with functional app).

## Additional notes

The prior M7 PRs (COE-398 / COE-402 / COE-404 / COE-410) had already shipped the desktop entrypoint's real mount path and the app-shell markers; this PR adds the regression detectors, the routes contract test, and the CI gates that lock that state in before COE-430 / COE-431 pick up the desktop work.

---
This PR description was prepared by an AI agent (OpenHands) on behalf of the assignee.
