### PR TITLE
COE-452: Add DuckDB prebuilt developer build mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,7 @@
 [build]
 target-dir = "target"
 
-[env]
-DUCKDB_DOWNLOAD_LIB = "1"
-
 [alias]
-check-dev = "check --no-default-features --features duckdb-prebuilt"
-test-dev = "test --no-default-features --features duckdb-prebuilt"
-clippy-dev = "clippy --no-default-features --features duckdb-prebuilt --all-targets -- -D warnings"
+check-dev = "--config env.DUCKDB_DOWNLOAD_LIB='1' check --no-default-features --features duckdb-prebuilt"
+test-dev = "--config env.DUCKDB_DOWNLOAD_LIB='1' test --no-default-features --features duckdb-prebuilt"
+clippy-dev = "--config env.DUCKDB_DOWNLOAD_LIB='1' clippy --no-default-features --features duckdb-prebuilt --all-targets -- -D warnings"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,10 @@
 [build]
 target-dir = "target"
+
+[env]
+DUCKDB_DOWNLOAD_LIB = "1"
+
+[alias]
+check-dev = "check --no-default-features --features duckdb-prebuilt"
+test-dev = "test --no-default-features --features duckdb-prebuilt"
+clippy-dev = "clippy --no-default-features --features duckdb-prebuilt --all-targets -- -D warnings"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,8 @@ When changing the pinned OpenHands assumptions, update `docs/sources.md`.
 - `docs/ui-frankentui.md`: operator UI design
 - `docs/repository-layout.md`: crate ownership
 - `docs/deployment-modes.md`: local MVP and hosted follow-on
+- `docs/installer-and-distribution.md`: future signed installer, component
+  selection, update, and DuckDB runtime packaging strategy
 - `docs/configuration.md`: target repo bootstrap and runtime config
 - `docs/operations.md`: doctor, rehydration, diagnostics, packaging, and local ops
 - `docs/testing-and-operations.md`: test strategy and validation layers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,27 @@ The local MVP is a trusted-environment mode.
 - integration code isolated inside `opensymphony-openhands`
 - no direct OpenHands protocol types leaking into orchestrator core types
 
+### Developer build acceleration
+
+DuckDB is bundled by default so `cargo install opensymphony`, release builds,
+and normal user builds do not require a separate system DuckDB installation.
+For iterative OpenSymphony development, prefer the repo cargo aliases that link
+against a downloaded prebuilt libduckdb instead of recompiling bundled DuckDB:
+
+```bash
+cargo check-dev
+cargo test-dev
+cargo test-dev --test memory
+cargo clippy-dev
+```
+
+Repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and these aliases
+run Cargo with `--no-default-features --features duckdb-prebuilt`. `cargo fmt`
+is unaffected because it does not compile dependencies. Before
+release-sensitive, packaging, or dependency changes, also run the default
+bundled-mode validation commands such as
+`cargo clippy --all-targets -- -D warnings` and `cargo test`.
+
 ## Required tests by subsystem
 
 ### Workflow and config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,11 +170,11 @@ cargo test-dev --test memory
 cargo clippy-dev
 ```
 
-Repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and these aliases
-run Cargo with `--no-default-features --features duckdb-prebuilt`. `cargo fmt`
-is unaffected because it does not compile dependencies. Before
-release-sensitive, packaging, or dependency changes, also run the default
-bundled-mode validation commands such as
+The aliases set `DUCKDB_DOWNLOAD_LIB=1` only for the aliased command and run
+Cargo with `--no-default-features --features duckdb-prebuilt`. `cargo fmt` is
+unaffected because it does not compile dependencies. Before release-sensitive,
+packaging, or dependency changes, also run the default bundled-mode validation
+commands such as
 `cargo clippy --all-targets -- -D warnings` and `cargo test`.
 
 ## Required tests by subsystem

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ workspace = true
 members = ["."]
 resolver = "2"
 
+[features]
+default = ["duckdb-bundled"]
+duckdb-bundled = ["duckdb/bundled"]
+duckdb-prebuilt = []
+
 [dependencies]
 async-stream.workspace = true
 async-trait.workspace = true
@@ -81,7 +86,7 @@ axum = { version = "0.8", features = ["macros", "ws"] }
 chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 crossterm = "0.29"
-duckdb = { version = "1.10502.0", features = ["bundled"] }
+duckdb = { version = "1.10502.0", default-features = false }
 ftui = { version = "0.2.1", features = ["crossterm"] }
 lru = "0.16"
 futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ need a separate DuckDB system package. That choice adds compile time and binary
 size, but keeps the memory database portable for local-first operator workflows.
 Repository developers can use `cargo check-dev`, `cargo test-dev`, and
 `cargo clippy-dev` to build with `--no-default-features --features
-duckdb-prebuilt`; repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`
-so those aliases reuse a downloaded prebuilt libduckdb during iterative
+duckdb-prebuilt`; those aliases set `DUCKDB_DOWNLOAD_LIB=1` for the aliased
+command so they reuse a downloaded prebuilt libduckdb during iterative
 development. Power users can also build against a manually installed system
 DuckDB by setting `DUCKDB_LIB_DIR`, `DUCKDB_INCLUDE_DIR`, and the platform
 runtime loader path before installing with `--no-default-features --features

--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ Repository developers can use `cargo check-dev`, `cargo test-dev`, and
 `cargo clippy-dev` to build with `--no-default-features --features
 duckdb-prebuilt`; repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`
 so those aliases reuse a downloaded prebuilt libduckdb during iterative
-development.
+development. Power users can also build against a manually installed system
+DuckDB by setting `DUCKDB_LIB_DIR`, `DUCKDB_INCLUDE_DIR`, and the platform
+runtime loader path before installing with `--no-default-features --features
+duckdb-prebuilt`; see [Installer and Distribution Strategy](docs/installer-and-distribution.md).
 
 ## Architecture
 
@@ -381,6 +384,7 @@ OPENSYMPHONY_LIVE_OPENHANDS=1 ./scripts/live_e2e.sh
 - [Architecture](docs/architecture.md) - High-level design and component interactions
 - [Configuration](docs/configuration.md) - Target repo bootstrap and runtime config
 - [Deployment Modes](docs/deployment-modes.md) - Local vs hosted deployment
+- [Installer and Distribution Strategy](docs/installer-and-distribution.md) - Future signed installer shape and DuckDB packaging boundaries
 - [Operations](docs/operations.md) - Doctor, rehydration, diagnostics, and local ops
 - [Testing](docs/testing-and-operations.md) - Test strategy and validation layers
 - [Migration Guide](docs/migration-1.0.0.md) - Breaking changes and upgrade steps for 1.0.0

--- a/README.md
+++ b/README.md
@@ -181,9 +181,14 @@ See [Project Memory](docs/memory.md) for archive guards, YAML import/backfill,
 source schema, automation flags, and the distinction between CLI commands and
 template-managed agent skills.
 
-The memory index uses DuckDB's bundled build so local installs do not need a
-separate DuckDB system package. That choice adds compile time and binary size,
-but keeps the memory database portable for local-first operator workflows.
+The memory index uses DuckDB's bundled build by default so local installs do not
+need a separate DuckDB system package. That choice adds compile time and binary
+size, but keeps the memory database portable for local-first operator workflows.
+Repository developers can use `cargo check-dev`, `cargo test-dev`, and
+`cargo clippy-dev` to build with `--no-default-features --features
+duckdb-prebuilt`; repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`
+so those aliases reuse a downloaded prebuilt libduckdb during iterative
+development.
 
 ## Architecture
 
@@ -354,6 +359,9 @@ contains the requested conversation.
 ```bash
 # Unit tests
 cargo test
+
+# Faster iterative development mode with prebuilt libduckdb
+cargo test-dev
 
 # Static validation
 opensymphony doctor

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -149,6 +149,11 @@ cargo test-dev
 cargo clippy-dev
 ```
 
+These aliases download and reuse a prebuilt DuckDB library inside the checkout's
+Cargo target directory. They do not require a system DuckDB install. Use a
+system-linked DuckDB only when intentionally testing the power-user install path
+documented in [Operations](operations.md).
+
 Before release-sensitive, packaging, or dependency changes, also run the default
 bundled-mode checks:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -138,6 +138,20 @@ Fake server, live tests, doctor command, packaging.
 
 ## Required checks
 
+Fast iterative checks can use the developer aliases. Repo-local Cargo
+configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and the aliases build with
+`--no-default-features --features duckdb-prebuilt`:
+
+```bash
+cargo fmt --check
+cargo check-dev
+cargo test-dev
+cargo clippy-dev
+```
+
+Before release-sensitive, packaging, or dependency changes, also run the default
+bundled-mode checks:
+
 ```bash
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
@@ -150,9 +164,11 @@ cargo test
 # Format and lint
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
+cargo clippy-dev
 
 # Full tests
 cargo test
+cargo test-dev
 
 # CLI-focused checks
 cargo test --test init

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -138,8 +138,8 @@ Fake server, live tests, doctor command, packaging.
 
 ## Required checks
 
-Fast iterative checks can use the developer aliases. Repo-local Cargo
-configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and the aliases build with
+Fast iterative checks can use the developer aliases. The aliases set
+`DUCKDB_DOWNLOAD_LIB=1` only for the aliased command and build with
 `--no-default-features --features duckdb-prebuilt`:
 
 ```bash

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -18,6 +18,12 @@ Stable contract:
 
 The runtime adapter should not need a redesign when moving from local development to hosted execution.
 
+Distribution is a separate concern from deployment topology. The current Cargo
+install path is the CLI/operator path. A future signed installer may install the
+desktop client, web app server, orchestrator host, memory server, and native
+runtime assets as selectable components. That future shape is specified in
+[Installer and Distribution Strategy](installer-and-distribution.md).
+
 ## 2. Mode A: local supervised mode
 
 This is the MVP target.

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -1,0 +1,191 @@
+# Installer and Distribution Strategy
+
+This document defines a future installer and update shape for OpenSymphony. It
+is a planning spec, not the current installation path.
+
+## Audience and outcome
+
+Reader: an OpenSymphony implementation agent or maintainer planning packaging,
+desktop, web, hosted, or memory-server distribution work.
+
+After reading this document, the reader should be able to decide whether a
+change belongs in the current Cargo install path, the developer build
+acceleration path, or a future managed installer/update path.
+
+## Current decision
+
+Keep `cargo install opensymphony` turnkey for normal users. The CLI package uses
+bundled DuckDB by default so first-time users do not need to install a native
+DuckDB library or configure dynamic loader paths.
+
+Keep downloaded or system-linked DuckDB as an optimization path:
+
+- OpenSymphony contributors use the repository aliases documented in
+  [Development Guide](DEVELOPMENT.md).
+- Power users may opt into system-linked DuckDB when they are willing to manage
+  the native library and runtime loader path themselves.
+- Release-sensitive validation still includes the default bundled path.
+
+Do not make downloaded prebuilt DuckDB the default `cargo install` path until a
+managed installer or equivalent runtime-library strategy owns native library
+placement, loader configuration, health checks, and rollback.
+
+## Why a managed installer exists
+
+The downloaded prebuilt DuckDB mode reduces compile time, but it introduces a
+runtime packaging concern. Cargo can compile against a downloaded native
+library, yet a binary installed by Cargo is only the executable. It does not
+also install `libduckdb` into a stable application-owned runtime location, and
+it does not by itself guarantee that the OS dynamic loader can find the
+library.
+
+That makes raw `cargo install` a poor place to own native runtime distribution.
+A managed installer can make the dependency graph explicit and can install,
+verify, update, and remove native runtime assets alongside OpenSymphony
+components.
+
+## Future product shape
+
+The future installer should be a signed, platform-native installer or installer
+bootstrapper for macOS, Windows, and Linux. It may start as a script for early
+testing, but the target experience should be a signed app or package.
+
+The installer should let the user select components:
+
+| Component | Purpose | Native dependencies |
+|---|---|---|
+| Desktop client | Tauri shell and shared frontend for local or hosted profiles | Desktop webview/runtime requirements |
+| Web app server | Gateway-served browser client or local static web server | None beyond the OpenSymphony host if bundled there |
+| Orchestrator host | `opensymphony run`, gateway, workspace manager, OpenHands supervisor | Rust executable, OpenHands tooling, optional managed Python/uv |
+| Memory server | Local memory MCP server and DuckDB-backed index | DuckDB native runtime |
+| OpenHands tooling | Pinned local agent-server bundle | Python/uv and pinned OpenHands server assets |
+
+The desktop and web clients must remain clients. They can start or connect to a
+local host profile, and they can connect to hosted mode, but they must not
+become the authority for scheduling state.
+
+## Component boundaries
+
+The installer should preserve the same boundaries used by the runtime
+architecture:
+
+- `opensymphony run` remains the local execution-plane entrypoint.
+- GUI launcher behavior belongs to a separate desktop/web command or app flow.
+- The desktop client may supervise a local host, attach to an existing local
+  host, or connect to hosted mode through profiles.
+- The web client connects to a configured gateway URL.
+- The memory server is part of the host/runtime component, not the UI-only
+  components.
+- DuckDB is a memory-server dependency and should be absent from UI-only
+  installs unless the selected profile also installs a local host.
+
+## DuckDB distribution requirements
+
+A managed installer that chooses non-bundled DuckDB must own all of the
+following:
+
+- Select the exact DuckDB runtime version compatible with the OpenSymphony
+  build.
+- Install the native library into an application-owned location.
+- Configure the executable so the OS dynamic loader can find that library.
+- Verify the memory database can be opened before reporting success.
+- Detect a missing or incompatible DuckDB runtime during `doctor`.
+- Update DuckDB and OpenSymphony together or refuse an unsafe partial update.
+- Roll back both executable and native runtime assets after a failed update.
+- Avoid exposing the memory database or admin token through client-only
+  components.
+
+The installer may use different platform mechanisms:
+
+- macOS: signed `.app`, `.pkg`, or command-line package with notarization,
+  stable library placement, and rpath or loader-path configuration.
+- Windows: signed installer or MSIX with `duckdb.dll` placed beside the
+  executable or in an application-owned runtime directory.
+- Linux: signed archive, AppImage, `.deb`, `.rpm`, or tarball with an explicit
+  library directory and wrapper or rpath strategy.
+
+## Update strategy
+
+The current `opensymphony update` command refreshes the CLI through Cargo and
+then updates template-managed agent assets in target repositories. That remains
+appropriate for the bundled default.
+
+A future managed update path should be staged:
+
+1. Ship a safe version that still installs through the bundled default but adds
+   managed-installer awareness to `opensymphony update`.
+2. Teach `opensymphony update` to detect whether the current install is
+   Cargo-managed, installer-managed, Homebrew-managed, or otherwise externally
+   managed.
+3. For installer-managed installs, update the selected components and their
+   native dependencies together.
+4. For Cargo-managed installs, keep using the bundled default unless the user
+   explicitly selected a power-user system-linked build.
+5. Only after the managed path is proven should non-bundled DuckDB become a
+   default for normal user installs.
+
+This staging matters because existing users run the updater from the version
+they already have. They cannot rely on new updater behavior until they first
+receive a version that installs and launches safely.
+
+## Relation to the roadmap
+
+This work is complementary to, not a replacement for, current roadmap stories:
+
+- M9.5 developer build acceleration keeps source checkouts fast without
+  changing normal user installation behavior.
+- M10 web client and external gateway work defines the browser and remote
+  gateway profiles that an installer can configure.
+- M11 hosted alpha reduces the need for local memory-server installation when a
+  user selects hosted mode only.
+- M13 hardening and release quality is the natural place to convert this spec
+  into signed installers, update tests, platform smoke tests, and support docs.
+
+The installer should not be used to blur local and hosted mode. Hosted mode is a
+server-side topology with centralized auth, isolation, secrets, runtime pools,
+and memory storage. A local installer may configure hosted client profiles, but
+it should not pretend that local process execution has hosted isolation.
+
+## Current landing guidance
+
+For normal users:
+
+- Keep the default bundled DuckDB path.
+- Install with `cargo install opensymphony`.
+- Update with `opensymphony update`.
+- Do not require a system DuckDB package.
+
+For power users who want faster native builds and accept manual setup:
+
+- Install DuckDB through the platform package manager or from DuckDB release
+  artifacts.
+- Build OpenSymphony with `--no-default-features --features duckdb-prebuilt`.
+- Set `DUCKDB_LIB_DIR` and `DUCKDB_INCLUDE_DIR` at build time.
+- Keep the matching library directory on the OS runtime loader path when
+  running the installed binary.
+- Update by repeating the same Cargo install command before running
+  `opensymphony update` for target-repo template refresh.
+- Verify `opensymphony memory status` or a focused memory command before using
+  the build for real work.
+
+For OpenSymphony contributors:
+
+- Use the repository aliases for iterative checks.
+- Let repository Cargo configuration set `DUCKDB_DOWNLOAD_LIB=1`.
+- Run default bundled validation before release-sensitive or packaging changes.
+- Do not use a shared target directory across independent agent workspaces
+  unless the task explicitly accepts that isolation tradeoff.
+
+## Open questions
+
+- Which platform packaging format should be first: macOS package, Homebrew
+  formula, signed shell bootstrapper, Windows installer, Linux tarball, or
+  AppImage?
+- Should the desktop installer embed the local host by default or install it as
+  an optional component selected during first run?
+- Should `opensymphony update` become a dispatcher that delegates to the package
+  manager that originally installed OpenSymphony?
+- Should the memory server eventually ship as a separately versioned local
+  service when hosted mode is not selected?
+- Which health check should be the release gate for managed DuckDB runtime
+  compatibility?

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -171,7 +171,7 @@ For power users who want faster native builds and accept manual setup:
 For OpenSymphony contributors:
 
 - Use the repository aliases for iterative checks.
-- Let repository Cargo configuration set `DUCKDB_DOWNLOAD_LIB=1`.
+- Let the repository aliases set `DUCKDB_DOWNLOAD_LIB=1`.
 - Run default bundled validation before release-sensitive or packaging changes.
 - Do not use a shared target directory across independent agent workspaces
   unless the task explicitly accepts that isolation tradeoff.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,6 +63,23 @@ maintenance path:
 
 ## 3. Recommended validation commands
 
+For fast iterative development inside this repository, use the developer aliases
+that download and reuse a prebuilt libduckdb instead of compiling bundled
+DuckDB:
+
+```bash
+cargo fmt --check
+cargo check-dev
+cargo test-dev
+cargo test-dev --test memory
+cargo clippy-dev
+```
+
+Repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and the aliases
+use `--no-default-features --features duckdb-prebuilt`. Release-sensitive,
+packaging, and dependency work should still include the default bundled-mode
+checks so `cargo install opensymphony` remains turnkey for users:
+
 ```bash
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
@@ -171,11 +188,15 @@ GitHub access should be fixed before live capture is retried.
 
 `memory capture` creates or refreshes issue capsules, updates
 `.opensymphony/memory/memory.duckdb`, and refreshes markdown indexes when
-enabled. The index is built with DuckDB's bundled native library so operators
-do not need to install DuckDB separately, at the cost of heavier Rust compile
-time and a larger binary. Treat that native dependency as part of the hosted
-deployment threat model before enabling memory in a multi-tenant service. It
-does not archive Linear issues.
+enabled. Normal builds use DuckDB's bundled native library so operators do not
+need to install DuckDB separately, at the cost of heavier Rust compile time and
+a larger binary. Repository development can opt into the `duckdb-prebuilt`
+feature through `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev`;
+repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1` so
+`libduckdb-sys` downloads and reuses a prebuilt native library in
+`target/duckdb-download`. Treat that native dependency as part of the hosted
+deployment threat model before enabling memory in a multi-tenant service.
+Memory capture does not archive Linear issues.
 
 Read commands such as `memory status`, `memory brief`, `memory related`, and
 `memory context` open the DuckDB index in read-only mode and do not run schema

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -71,7 +71,6 @@ DuckDB development package and build without default features:
 ```bash
 # macOS with Homebrew
 brew install duckdb
-export DUCKDB_DOWNLOAD_LIB=0
 export DUCKDB_LIB_DIR="$(brew --prefix duckdb)/lib"
 export DUCKDB_INCLUDE_DIR="$(brew --prefix duckdb)/include"
 export DYLD_LIBRARY_PATH="$DUCKDB_LIB_DIR${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
@@ -105,8 +104,8 @@ cargo test-dev --test memory
 cargo clippy-dev
 ```
 
-Repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and the aliases
-use `--no-default-features --features duckdb-prebuilt`. Release-sensitive,
+The aliases set `DUCKDB_DOWNLOAD_LIB=1` only for the aliased command and use
+`--no-default-features --features duckdb-prebuilt`. Release-sensitive,
 packaging, and dependency work should still include the default bundled-mode
 checks so `cargo install opensymphony` remains turnkey for users:
 
@@ -222,7 +221,7 @@ enabled. Normal builds use DuckDB's bundled native library so operators do not
 need to install DuckDB separately, at the cost of heavier Rust compile time and
 a larger binary. Repository development can opt into the `duckdb-prebuilt`
 feature through `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev`;
-repo-local Cargo configuration sets `DUCKDB_DOWNLOAD_LIB=1` so
+those aliases set `DUCKDB_DOWNLOAD_LIB=1` so
 `libduckdb-sys` downloads and reuses a prebuilt native library in
 `target/duckdb-download`. Treat that native dependency as part of the hosted
 deployment threat model before enabling memory in a multi-tenant service.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,6 +61,36 @@ maintenance path:
 - leaves `WORKFLOW.md`, `AGENTS.md`, `.github/*`, and repo-local extra skills
   alone
 
+Normal user installs use bundled DuckDB. This keeps `cargo install
+opensymphony` and `opensymphony update` turnkey even when the memory database is
+enabled.
+
+Power users who want to avoid compiling bundled DuckDB may install a system
+DuckDB development package and build without default features:
+
+```bash
+# macOS with Homebrew
+brew install duckdb
+export DUCKDB_DOWNLOAD_LIB=0
+export DUCKDB_LIB_DIR="$(brew --prefix duckdb)/lib"
+export DUCKDB_INCLUDE_DIR="$(brew --prefix duckdb)/include"
+export DYLD_LIBRARY_PATH="$DUCKDB_LIB_DIR${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+cargo install opensymphony --no-default-features --features duckdb-prebuilt
+```
+
+On Linux, set `DUCKDB_LIB_DIR`, `DUCKDB_INCLUDE_DIR`, and `LD_LIBRARY_PATH` to
+the matching DuckDB installation. On Windows, set `DUCKDB_LIB_DIR`,
+`DUCKDB_INCLUDE_DIR`, and add the DuckDB DLL directory to `PATH` before running
+the same Cargo install command. This is a manual optimization path: verify a
+memory command after installation, and expect to keep the runtime library
+available anywhere the installed binary runs.
+
+To update a power-user system-linked install, run the same Cargo install command
+with the same environment first. Then run `opensymphony update` from a target
+repository only to refresh template-managed agent assets. Starting with
+`opensymphony update` may reinstall the default bundled build when a newer
+release exists.
+
 ## 3. Recommended validation commands
 
 For fast iterative development inside this repository, use the developer aliases

--- a/docs/tasks/linear-publish.yaml
+++ b/docs/tasks/linear-publish.yaml
@@ -1,6 +1,6 @@
 planningWave: rich-client-hosted-mode
 linearProject: e7b957855cb7
-publishedAt: '2026-05-17T00:20:01.508972+00:00'
+publishedAt: '2026-06-14T20:18:00Z'
 milestones:
   'M6: Gateway And Stream Contract':
     milestoneId: c32b5191-7349-4f30-bd46-6340af6da3e5
@@ -14,6 +14,9 @@ milestones:
   'M9: Collaborative Planning Alpha':
     milestoneId: 806afecc-4a9f-4862-8330-6ce70d606058
     name: 'M9: Collaborative Planning Alpha'
+  'M9.5: Developer Build Acceleration':
+    milestoneId: 7e66f03b-c3f1-4adf-b534-fbf07f18627c
+    name: 'M9.5: Developer Build Acceleration'
   'M10: Web Client And External Gateway':
     milestoneId: 58d8ef29-ea13-4cd2-b7a5-3768070e8a01
     name: 'M10: Web Client And External Gateway'
@@ -182,6 +185,11 @@ tasks:
     issueId: b360641b-ba85-407e-99ba-48e7b2caa795
     url: https://linear.app/trilogy-ai-coe/issue/COE-418/linear-draft-preview-and-publish-flow
     file: docs/tasks/osym-736-linear-draft-preview-and-publish-flow.md
+  OSYM-737:
+    issue: COE-452
+    issueId: 43a507cc-a292-4d5e-9d16-2c518d9e559c
+    url: https://linear.app/trilogy-ai-coe/issue/COE-452/duckdb-prebuilt-developer-build-mode
+    file: docs/tasks/osym-737-duckdb-prebuilt-developer-build-mode.md
   OSYM-742:
     issue: COE-419
     issueId: d4170095-6d55-4c36-bdc6-2e3f9d434dbe

--- a/docs/tasks/milestones.md
+++ b/docs/tasks/milestones.md
@@ -63,6 +63,14 @@ Tasks:
 - OSYM-735 Planning Workspace UI
 - OSYM-736 Linear Draft Preview And Publish Flow
 
+## M9.5: Developer Build Acceleration
+
+Goal: Reduce OpenSymphony-on-OpenSymphony development compile cost after the planning alpha while preserving bundled, turnkey DuckDB behavior for normal users and releases.
+
+Tasks:
+
+- OSYM-737 DuckDB Prebuilt Developer Build Mode
+
 ## M10: Web Client And External Gateway
 
 Goal: Deploy the shared frontend as a browser app that connects to local, external, and hosted gateways with reconnect-safe remote transport behavior.

--- a/docs/tasks/osym-737-duckdb-prebuilt-developer-build-mode.md
+++ b/docs/tasks/osym-737-duckdb-prebuilt-developer-build-mode.md
@@ -1,0 +1,77 @@
+---
+id: OSYM-737
+title: DuckDB Prebuilt Developer Build Mode
+milestone: "M9.5: Developer Build Acceleration"
+priority: 2
+estimate: 3
+blockedBy: []
+blocks: []
+areas:
+  - build
+  - developer-experience
+  - memory
+parent: null
+---
+
+## Summary
+
+Add an opt-in developer build mode that links DuckDB from a downloaded prebuilt native library while keeping bundled DuckDB as the default user and release path. Provide stable cargo aliases and agent instructions so OpenSymphony development can avoid repeatedly compiling DuckDB in hot workspaces.
+
+## Scope
+
+### In scope
+
+- Split the DuckDB dependency into explicit `duckdb-bundled` and `duckdb-prebuilt` Cargo feature modes, with bundled remaining the default.
+- Add `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` aliases plus repo-local Cargo configuration that uses `DUCKDB_DOWNLOAD_LIB=1`, disables default features, and enables the prebuilt DuckDB mode.
+- Document the developer-mode commands in `AGENTS.md` and local operations/testing documentation.
+- Verify the prebuilt mode against focused memory tests and standard developer validation commands.
+- Preserve release and `cargo install opensymphony` behavior for users who do not opt into the developer mode.
+
+### Out of scope
+
+- Replacing DuckDB as the memory backend.
+- Introducing the future `MemoryCatalog`, `DocumentStore`, or provider-shaped memory architecture.
+- Changing memory server APIs, capture semantics, schema layout, or runtime behavior.
+- Requiring a system-wide DuckDB installation for normal users.
+
+## Deliverables
+
+- Updated `Cargo.toml` feature declarations and DuckDB dependency configuration.
+- Updated `.cargo/config.toml` aliases for `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev`.
+- Updated `AGENTS.md`, `README.md`, `docs/operations.md`, and `docs/testing-and-operations.md` instructions.
+- Validation evidence for prebuilt developer mode and default bundled mode.
+
+## Acceptance Criteria
+
+- [ ] `cargo install opensymphony` and default local builds still use bundled DuckDB without requiring a system DuckDB install.
+- [ ] `DUCKDB_DOWNLOAD_LIB=1 cargo check --no-default-features --features duckdb-prebuilt` succeeds.
+- [ ] `cargo test-dev --test memory` succeeds and exercises the memory DuckDB path in prebuilt mode.
+- [ ] `cargo clippy-dev` succeeds under the repository lint policy.
+- [ ] Documentation tells OpenSymphony agents to prefer `cargo test-dev` and `cargo clippy-dev` for iterative development, and to run default bundled-mode validation before release-sensitive changes.
+- [ ] The implementation does not alter memory server APIs, memory schema, or capture/query behavior.
+
+## Test Plan
+
+- `cargo fmt --check`
+- `DUCKDB_DOWNLOAD_LIB=1 cargo check --no-default-features --features duckdb-prebuilt`
+- `cargo test-dev --test memory`
+- `cargo clippy-dev`
+- `cargo test --test memory`
+
+## Context
+
+- Before this task, `Cargo.toml` enabled `duckdb` with the `bundled` feature through the workspace dependency.
+- `libduckdb-sys` supports `DUCKDB_DOWNLOAD_LIB=1` for downloaded prebuilt native libraries in non-bundled mode.
+- `.cargo/config.toml` already centralizes repository cargo settings and is the right place for stable aliases.
+- `AGENTS.md` should steer OpenSymphony development tasks toward the faster dev aliases once this work lands.
+- `README.md`, `docs/operations.md`, and `docs/testing-and-operations.md` currently describe bundled DuckDB and validation commands.
+
+## Definition of Ready
+
+- [x] Hidden assumptions from prior discussion are written down.
+- [x] Required files, docs, and dependencies are explicitly referenced.
+- [x] A coding agent could begin execution without additional planning context.
+
+## Notes
+
+Keep this story intentionally narrow. It is complementary to, but distinct from, the later provider-shaped memory backend work that would make DuckDB optional at the API boundary.

--- a/docs/tasks/osym-737-duckdb-prebuilt-developer-build-mode.md
+++ b/docs/tasks/osym-737-duckdb-prebuilt-developer-build-mode.md
@@ -22,7 +22,7 @@ Add an opt-in developer build mode that links DuckDB from a downloaded prebuilt 
 ### In scope
 
 - Split the DuckDB dependency into explicit `duckdb-bundled` and `duckdb-prebuilt` Cargo feature modes, with bundled remaining the default.
-- Add `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` aliases plus repo-local Cargo configuration that uses `DUCKDB_DOWNLOAD_LIB=1`, disables default features, and enables the prebuilt DuckDB mode.
+- Add `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` aliases that set `DUCKDB_DOWNLOAD_LIB=1`, disable default features, and enable the prebuilt DuckDB mode.
 - Document the developer-mode commands in `AGENTS.md` and local operations/testing documentation.
 - Verify the prebuilt mode against focused memory tests and standard developer validation commands.
 - Preserve release and `cargo install opensymphony` behavior for users who do not opt into the developer mode.
@@ -37,7 +37,7 @@ Add an opt-in developer build mode that links DuckDB from a downloaded prebuilt 
 ## Deliverables
 
 - Updated `Cargo.toml` feature declarations and DuckDB dependency configuration.
-- Updated `.cargo/config.toml` aliases for `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev`.
+- Updated `.cargo/config.toml` aliases for `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` without setting a repo-wide DuckDB env var.
 - Updated `AGENTS.md`, `README.md`, `docs/operations.md`, and `docs/testing-and-operations.md` instructions.
 - Validation evidence for prebuilt developer mode and default bundled mode.
 
@@ -62,7 +62,7 @@ Add an opt-in developer build mode that links DuckDB from a downloaded prebuilt 
 
 - Before this task, `Cargo.toml` enabled `duckdb` with the `bundled` feature through the workspace dependency.
 - `libduckdb-sys` supports `DUCKDB_DOWNLOAD_LIB=1` for downloaded prebuilt native libraries in non-bundled mode.
-- `.cargo/config.toml` already centralizes repository cargo settings and is the right place for stable aliases.
+- `.cargo/config.toml` already centralizes repository cargo aliases, but the DuckDB download env var should stay scoped to the developer aliases.
 - `AGENTS.md` should steer OpenSymphony development tasks toward the faster dev aliases once this work lands.
 - `README.md`, `docs/operations.md`, and `docs/testing-and-operations.md` currently describe bundled DuckDB and validation commands.
 

--- a/docs/tasks/task-package.yaml
+++ b/docs/tasks/task-package.yaml
@@ -5,6 +5,7 @@ milestones:
   - "M7: Shared Client And Desktop Alpha"
   - "M8: Task Graph Operations And OpenHands Run UI"
   - "M9: Collaborative Planning Alpha"
+  - "M9.5: Developer Build Acceleration"
   - "M10: Web Client And External Gateway"
   - "M11: Hosted Alpha"
   - "M12: Provider, Harness, And Model Readiness"
@@ -66,6 +67,8 @@ tasks:
     file: docs/tasks/osym-735-planning-workspace-ui.md
   - id: OSYM-736
     file: docs/tasks/osym-736-linear-draft-preview-and-publish-flow.md
+  - id: OSYM-737
+    file: docs/tasks/osym-737-duckdb-prebuilt-developer-build-mode.md
   - id: OSYM-740
     file: docs/tasks/osym-740-web-app-entry-and-deployment-modes.md
   - id: OSYM-741

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -77,6 +77,13 @@ Suggested gates:
 
 Current implementation:
 
+- `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` are repository
+  aliases for iterative OpenSymphony development. Repo-local Cargo
+  configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and the aliases build with
+  `--no-default-features --features duckdb-prebuilt` so the native DuckDB
+  library is downloaded into
+  `target/duckdb-download` and reused across rebuilds in the same target
+  directory.
 - `cargo test` exercises the full root package, including the fake-server contract suite from `tests/fake_server_contract.rs`
 - `cargo test --test linear_client` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
 - `cargo test --test hierarchy_selection --test scheduler` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, cached per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, active-state reconciliation, and manifest-backed workspace recovery against fake tracker/workspace/worker backends

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -78,8 +78,8 @@ Suggested gates:
 Current implementation:
 
 - `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` are repository
-  aliases for iterative OpenSymphony development. Repo-local Cargo
-  configuration sets `DUCKDB_DOWNLOAD_LIB=1`, and the aliases build with
+  aliases for iterative OpenSymphony development. The aliases set
+  `DUCKDB_DOWNLOAD_LIB=1` only for the aliased command and build with
   `--no-default-features --features duckdb-prebuilt` so the native DuckDB
   library is downloaded into
   `target/duckdb-download` and reused across rebuilds in the same target


### PR DESCRIPTION
## Summary

Adds a developer-only DuckDB prebuilt build mode so OpenSymphony contributors and agents can avoid repeatedly compiling bundled DuckDB during iterative work while keeping bundled DuckDB as the default user/release path.

Also documents the future installer/distribution boundary so downloaded or system-linked DuckDB does not get mistaken for a turnkey `cargo install` default before native runtime packaging is solved.

## Changes

- Add explicit `duckdb-bundled` and `duckdb-prebuilt` Cargo feature modes, with bundled remaining the default.
- Add `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev` aliases using the prebuilt DuckDB feature path.
- Scope `DUCKDB_DOWNLOAD_LIB=1` to those developer aliases instead of setting a repo-wide Cargo env var.
- Add the M9.5/OSYM-737 planning task and Linear publish mapping for COE-452.
- Document the fast dev aliases in `AGENTS.md`, README, operations/testing docs, and the development guide.
- Add `docs/installer-and-distribution.md` to define future signed installer, component selection, update staging, and DuckDB runtime ownership.
- Document the manual power-user system-linked DuckDB install/update path separately from normal user installs and repository developer aliases.

## Evidence

### Test output

```text
cargo fmt --check
# passed

cargo check-dev
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 49s

DUCKDB_DOWNLOAD_LIB=1 cargo check --no-default-features --features duckdb-prebuilt
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.40s

cargo test-dev --test memory
# test result: ok. 24 passed; 0 failed; 0 ignored; finished in 0.92s

cargo clippy-dev
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 26s

cargo test --test memory
# test result: ok. 24 passed; 0 failed; 0 ignored; finished in 11.69s

cargo test
# all default tests passed; ignored live tests remained ignored

cargo clippy --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 00s

uv run --script .agents/skills/convert-tasks-to-linear/scripts/convert_tasks_to_linear.py validate --manifest docs/tasks/task-package.yaml
# validation: ok; milestones: 9; tasks: 46; waves: 20

brew install duckdb
/opt/homebrew/bin/duckdb --version
# v1.5.3 (Variegata) 14eca11bd9

CARGO_TARGET_DIR=target/system-duckdb-test \
  DUCKDB_DOWNLOAD_LIB=0 \
  DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib \
  DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include \
  DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib \
  cargo test --no-default-features --features duckdb-prebuilt --test memory
# test result: ok. 24 passed; 0 failed; 0 ignored; finished in 0.33s

Subagent no-hints simulation:
CARGO_TARGET_DIR=/tmp/opensymphony-workspace-manager-target cargo test-dev --test workspace_manager
# test result: ok. 24 passed; 0 failed; 0 ignored; finished in 1.62s

git diff --check
# passed after installer/distribution docs update

env -u DUCKDB_DOWNLOAD_LIB cargo test-dev --test memory
# test result: ok. 24 passed; 0 failed; 0 ignored; finished in 0.49s

env -u DUCKDB_DOWNLOAD_LIB \
  CARGO_TARGET_DIR=target/system-duckdb-no-download-test \
  DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib \
  DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include \
  DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib \
  cargo test --no-default-features --features duckdb-prebuilt --test memory
# test result: ok. 24 passed; 0 failed; 0 ignored; finished in 0.30s
```

### Verification

Verified the feature graph keeps `duckdb/bundled` on the default path and omits it under `--no-default-features --features duckdb-prebuilt`. Verified `target/duckdb-download/aarch64-apple-darwin/1.5.2/` contains the downloaded `libduckdb.dylib` cache used by the dev mode.

Also installed Homebrew DuckDB 1.5.3 and verified an explicit system-link path succeeds with `DUCKDB_LIB_DIR`, `DUCKDB_INCLUDE_DIR`, and no `DUCKDB_DOWNLOAD_LIB` value in the shell. This is separate from the normal `cargo test-dev` path, whose alias intentionally sets `DUCKDB_DOWNLOAD_LIB=1` for that command only.

A no-hints subagent simulation read `AGENTS.md` and related repo instructions, independently chose `cargo test-dev --test workspace_manager`, and passed without modifying tracked files.

The installer/distribution documentation was cold-read against the intended reader: a future implementation agent deciding whether work belongs in the Cargo install path, the developer build acceleration path, or a future managed installer/update path.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: N/A

## Breaking changes

None. Bundled DuckDB remains the default for normal local builds, release builds, `cargo install opensymphony`, and `opensymphony update`.

## Related issues

- [COE-452](https://linear.app/trilogy-ai-coe/issue/COE-452/duckdb-prebuilt-developer-build-mode)

## Additional notes

The Linear task package was validated and COE-452 is published under `M9.5: Developer Build Acceleration`. The broader memory-provider rewrite and future signed installer are out of scope for this implementation PR, but the installer boundary is now documented for future desktop/web/hosted work.
