### PR TITLE
feat(client): add auth-aware shell states and web parity (COE-419)

### DIFF
--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -211,6 +211,17 @@ Requirements:
 
 The MVP code should already expose the auth configuration hooks needed later.
 
+## 7.4 Client auth placeholder states
+
+The shared client shell (web and desktop remote) renders auth-aware placeholder states when a hosted gateway rejects a read for auth reasons, so both clients show the same user-facing outcome:
+
+- `unauthenticated` (HTTP 401): a sign-in placeholder with a placeholder "Sign in" action and "Retry". Real hosted auth provider integration arrives in a follow-on (OSYM-750).
+- `unauthorized` (explicit permission denial): an access-denied placeholder with organization/project selection placeholders.
+- `forbidden` (HTTP 403 hard deny): an access-forbidden placeholder with "Retry".
+- `open`: no placeholder. Local unauthenticated gateways that advertise only `auth_modes: ["none"]` render the dashboard, task graph, run, stream, and planning views directly with no login gate.
+
+Transport adapters throw a classified `GatewayRequestError` (code `unauthenticated`/`unauthorized`/`forbidden`/`unavailable`); the shell maps it to an `AuthState` from `@opensymphony/gateway-schema` and renders the matching placeholder. These are placeholders that reduce churn when hosted auth arrives; the gateway data model and APIs are already designed for hosted mode (see PRD 4.10).
+
 ## 8. What the code should abstract now
 
 The runtime adapter should separate:

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -216,11 +216,11 @@ The MVP code should already expose the auth configuration hooks needed later.
 The shared client shell (web and desktop remote) renders auth-aware placeholder states when a hosted gateway rejects a read for auth reasons, so both clients show the same user-facing outcome:
 
 - `unauthenticated` (HTTP 401): a sign-in placeholder with a placeholder "Sign in" action and "Retry". Real hosted auth provider integration arrives in a follow-on (OSYM-750).
-- `unauthorized` (explicit permission denial): an access-denied placeholder with organization/project selection placeholders.
-- `forbidden` (HTTP 403 hard deny): an access-forbidden placeholder with "Retry".
+- `unauthorized` (HTTP 403 with an explicit `error_code`/`code` body signal such as `unauthorized` or `permission_denied`): an access-denied placeholder with organization/project selection placeholders.
+- `forbidden` (HTTP 403 hard deny, no permission body signal): an access-forbidden placeholder with "Retry".
 - `open`: no placeholder. Local unauthenticated gateways that advertise only `auth_modes: ["none"]` render the dashboard, task graph, run, stream, and planning views directly with no login gate.
 
-Transport adapters throw a classified `GatewayRequestError` (code `unauthenticated`/`unauthorized`/`forbidden`/`unavailable`); the shell maps it to an `AuthState` from `@opensymphony/gateway-schema` and renders the matching placeholder. These are placeholders that reduce churn when hosted auth arrives; the gateway data model and APIs are already designed for hosted mode (see PRD 4.10).
+Transport adapters throw a classified `GatewayRequestError` (code `unauthenticated`/`unauthorized`/`forbidden`/`unavailable`); the shell maps it to an `AuthState` from `@opensymphony/gateway-schema` and renders the matching placeholder. A plain HTTP 403 maps to `forbidden`; a 403 whose body carries a permission-denial code maps to `unauthorized`. These are placeholders that reduce churn when hosted auth arrives; the gateway data model and APIs are already designed for hosted mode (see PRD 4.10).
 
 ## 8. What the code should abstract now
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -239,6 +239,15 @@ Current implemented checks:
 - `opensymphony run` startup coverage that verifies the configured bind address exposes both health and gateway dashboard routes in `opensymphony-cli/tests/run.rs`
 - TUI reducer, visible-focus rendering, selection preservation across reorder, long-list selection windowing, narrow-layout detail budgeting, snapshot coalescing, stale snapshot rejection, post-restart snapshot reset recovery, disconnect retention, and reconnect-to-live recovery coverage in `opensymphony-tui`
 
+## 3.6 Shared client shell (web and desktop remote)
+
+The web and desktop clients both mount the shared `OpenSymphonyApp` shell from `@opensymphony/ui-core` against the same `GatewayTransport` interface, so remote parity is structural. Implemented checks:
+
+- app-shell mount smoke (`packages/ui-core/__tests__/app-shell.test.ts`): status, task graph, run detail, evidence, profile, and failed-connection rendering
+- auth-aware placeholder states (`packages/ui-core/__tests__/auth-states.test.ts`): unauthenticated (sign-in), unauthorized (access denied), forbidden (access forbidden), organization/project selection placeholders, and local `auth_modes:["none"]` gateways rendering the dashboard with no login gate; recovery when the gateway later permits a read
+- remote web/desktop parity (`packages/ui-core/__tests__/remote-parity.test.ts`): the shell renders the same core dashboard metrics, task graph nodes, run detail, planning workspace, and stream events in both `mode:"web"` and `mode:"desktop"` against an identical fixture transport
+- gateway error classification (`packages/api-client/__tests__/gateway-errors.test.ts`): `HttpGatewayTransport` maps HTTP 401/403 to a classified `GatewayRequestError`, and `authStateFromError` maps it to an `AuthState` from `@opensymphony/gateway-schema`
+
 ## 4. Fake OpenHands server requirements
 
 The fake server in `opensymphony-testkit` should emulate the minimum runtime contract:

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -259,6 +259,61 @@ The shell is pure DOM rendered by `renderOpenSymphonyApp` into a `jsdom` documen
 
 These DOM assertions are the runtime evidence for the new user-facing states. A screenshot/video capture is not produced in this headless unattended environment; the assertions above exercise the real `renderAuthPlaceholder` / `renderViewContent` code paths end-to-end through the shared shell.
 
+### Captured rendered DOM (real shell, jsdom)
+
+The following is actual captured output from mounting the real shared shell (`renderOpenSymphonyApp`, `mode:"web"`) against a `MockGatewayTransport` that simulates a hosted gateway rejecting the snapshot, plus a local `auth_modes:["none"]` gateway. Reproduce with `npx jest packages/ui-core/__tests__/auth-states.test.ts` (and a temporary DOM-dump harness over `renderOpenSymphonyApp`).
+
+LOCAL `auth_modes:["none"]` gateway (snapshot succeeds):
+```
+data-auth-state = open
+auth-placeholder present = false
+task-graph-panel present = true
+<section class="os-panel os-task-graph-panel">...<div class="os-empty">No task graph loaded</div></section>
+```
+
+Hosted gateway, snapshot rejected with HTTP 401 (`unauthenticated`):
+```
+data-auth-state = unauthenticated
+auth-placeholder present = true   (data-auth-state="unauthenticated")
+auth-sign-in present = true  auth-refresh present = true  auth-org/project present = true
+task-graph-panel present = false
+<section class="os-panel os-auth-panel" data-testid="auth-placeholder" data-auth-state="unauthenticated">
+  <div class="os-section-head"><h2>Sign in</h2><span>hosted</span></div>
+  <p class="os-auth-message" data-testid="auth-message">Sign in required to view this OpenSymphony workspace.</p>
+  <div class="os-auth-actions">
+    <button data-auth-action="sign-in" data-testid="auth-sign-in">Sign in</button>
+    <button data-auth-action="refresh" data-testid="auth-refresh">Retry</button>
+  </div>
+  <div class="os-auth-scope" data-testid="auth-scope">... Organization / Project selects ...</div>
+</section>
+```
+
+Hosted gateway, snapshot rejected with HTTP 403 hard deny (`forbidden`):
+```
+data-auth-state = forbidden
+auth-placeholder present = true   (data-auth-state="forbidden")
+auth-sign-in present = false  auth-refresh present = true  auth-org/project present = true
+<section class="os-panel os-auth-panel os-auth-denied" data-testid="auth-placeholder" data-auth-state="forbidden">
+  <h2>Access forbidden</h2>
+  <p class="os-auth-message">Access to this workspace is forbidden.</p>
+  <button data-testid="auth-refresh">Retry</button>
+  <div class="os-auth-scope" data-testid="auth-scope">... Organization / Project selects ...</div>
+</section>
+```
+
+Hosted gateway, snapshot rejected with HTTP 403 carrying `error_code:"unauthorized"` (`unauthorized` permission denial):
+```
+data-auth-state = unauthorized
+auth-placeholder present = true   (data-auth-state="unauthorized")
+auth-sign-in present = false  auth-refresh present = true  auth-org/project present = true
+<section class="os-panel os-auth-panel os-auth-denied" data-testid="auth-placeholder" data-auth-state="unauthorized">
+  <h2>Access denied</h2>
+  <p class="os-auth-message">You are signed in but do not have permission to view this workspace.</p>
+  <button data-testid="auth-refresh">Retry</button>
+  <div class="os-auth-scope" data-testid="auth-scope">... Organization / Project selects ...</div>
+</section>
+```
+
 ## 4. Fake OpenHands server requirements
 
 The fake server in `opensymphony-testkit` should emulate the minimum runtime contract:

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -246,7 +246,18 @@ The web and desktop clients both mount the shared `OpenSymphonyApp` shell from `
 - app-shell mount smoke (`packages/ui-core/__tests__/app-shell.test.ts`): status, task graph, run detail, evidence, profile, and failed-connection rendering
 - auth-aware placeholder states (`packages/ui-core/__tests__/auth-states.test.ts`): unauthenticated (sign-in), unauthorized (access denied), forbidden (access forbidden), organization/project selection placeholders, and local `auth_modes:["none"]` gateways rendering the dashboard with no login gate; recovery when the gateway later permits a read
 - remote web/desktop parity (`packages/ui-core/__tests__/remote-parity.test.ts`): the shell renders the same core dashboard metrics, task graph nodes, run detail, planning workspace, and stream events in both `mode:"web"` and `mode:"desktop"` against an identical fixture transport
-- gateway error classification (`packages/api-client/__tests__/gateway-errors.test.ts`): `HttpGatewayTransport` maps HTTP 401/403 to a classified `GatewayRequestError`, and `authStateFromError` maps it to an `AuthState` from `@opensymphony/gateway-schema`
+- gateway error classification (`packages/api-client/__tests__/gateway-errors.test.ts`): `HttpGatewayTransport` maps HTTP 401/403 (including a 403 with an explicit `error_code:"unauthorized"` body signal) to a classified `GatewayRequestError`, and `authStateFromError` maps it to an `AuthState` from `@opensymphony/gateway-schema`
+
+### Evidence for UI/shell changes
+
+The shell is pure DOM rendered by `renderOpenSymphonyApp` into a `jsdom` document, so the jest suites assert the rendered DOM directly (not mock return values). For the COE-419 auth placeholder states this means concrete runtime evidence of the rendered output:
+
+- `data-opensymphony-app-shell="mounted"` root carries `data-auth-state` set to `unauthenticated` / `unauthorized` / `forbidden` / `open` for each scenario.
+- `[data-testid="auth-placeholder"]` is present only in non-open states and carries the matching `data-auth-state`; `textContent` contains "Sign in required" (unauthenticated), "Access denied" plus "do not have permission" (unauthorized), and "Access forbidden" (forbidden).
+- `[data-testid="auth-sign-in"]` appears only for `unauthenticated`; `[data-testid="auth-refresh"]` appears for `forbidden`/`unauthorized`; `[data-testid="auth-org"]`/`[data-testid="auth-project"]` render the organization/project selection surface.
+- For local `auth_modes:["none"]` gateways, `[data-testid="auth-placeholder"]` is absent and `.os-task-graph-panel` renders with `data-auth-state="open"`.
+
+These DOM assertions are the runtime evidence for the new user-facing states. A screenshot/video capture is not produced in this headless unattended environment; the assertions above exercise the real `renderAuthPlaceholder` / `renderViewContent` code paths end-to-end through the shared shell.
 
 ## 4. Fake OpenHands server requirements
 

--- a/packages/api-client/__tests__/gateway-errors.test.ts
+++ b/packages/api-client/__tests__/gateway-errors.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Gateway request error classification for COE-419.
+ *
+ * Exercises the real `HttpGatewayTransport.fetchJson` HTTP 401/403 mapping
+ * and the shared `authStateFromError` classifier (no mocks of the units
+ * under test).
+ */
+
+import {
+  HttpGatewayTransport,
+  MockGatewayTransport,
+  GatewayRequestError,
+  isGatewayRequestError,
+  authErrorCodeForStatus,
+} from "@opensymphony/api-client";
+import { authStateFromError } from "@opensymphony/gateway-schema";
+import { schemaVersionV1 } from "@opensymphony/gateway-schema";
+import type { GatewayCapabilities } from "@opensymphony/gateway-schema";
+
+const FIXTURE_CAPABILITIES: GatewayCapabilities = {
+  schema_version: schemaVersionV1(),
+  gateway_version: "error-test",
+  supported_api_versions: ["1.0.0"],
+  transports: [{ transport: "loopback_http", modes: ["json"], supported_encodings: ["utf-8"], bidirectional: false }],
+  features: [{ feature: "task_graph", available: true, requires_auth: false }],
+  auth_modes: ["none"],
+  max_event_page_size: 1000,
+  max_terminal_frame_batch: 500,
+};
+
+function mockResponse(status: number, statusText: string, body: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  } as Response;
+}
+
+describe("GatewayRequestError classification", () => {
+  describe("authErrorCodeForStatus", () => {
+    it("maps 401 to unauthenticated", () => {
+      expect(authErrorCodeForStatus(401)).toBe("unauthenticated");
+    });
+    it("maps 403 to forbidden", () => {
+      expect(authErrorCodeForStatus(403)).toBe("forbidden");
+    });
+    it("returns undefined for non-auth statuses", () => {
+      expect(authErrorCodeForStatus(500)).toBeUndefined();
+      expect(authErrorCodeForStatus(404)).toBeUndefined();
+      expect(authErrorCodeForStatus(200)).toBeUndefined();
+    });
+  });
+
+  describe("HttpGatewayTransport HTTP mapping", () => {
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("throws a GatewayRequestError with unauthenticated code on HTTP 401", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(401, "Unauthorized", '{"error":"missing token"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new HttpGatewayTransport({ baseUri: "http://localhost:8080" });
+      await expect(transport.health()).rejects.toMatchObject({
+        code: "unauthenticated",
+        status: 401,
+        name: "GatewayRequestError",
+      });
+    });
+
+    it("throws a GatewayRequestError with forbidden code on HTTP 403", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(403, "Forbidden", '{"error":"no access"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new HttpGatewayTransport({ baseUri: "http://localhost:8080" });
+      await expect(transport.snapshot()).rejects.toMatchObject({
+        code: "forbidden",
+        status: 403,
+      });
+    });
+
+    it("throws a plain Error (not GatewayRequestError) on HTTP 500", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(500, "Internal Server Error", '{"error":"boom"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new HttpGatewayTransport({ baseUri: "http://localhost:8080" });
+      const rejection = transport.health();
+      await expect(rejection).rejects.toThrow(/HTTP 500/);
+      try {
+        await rejection;
+      } catch (error) {
+        expect(isGatewayRequestError(error)).toBe(false);
+      }
+    });
+  });
+
+  describe("authStateFromError classifier", () => {
+    it("classifies unauthenticated errors", () => {
+      expect(authStateFromError(new GatewayRequestError("unauthenticated", "x", 401))).toBe("unauthenticated");
+    });
+    it("classifies forbidden errors", () => {
+      expect(authStateFromError(new GatewayRequestError("forbidden", "x", 403))).toBe("forbidden");
+    });
+    it("classifies unauthorized errors", () => {
+      expect(authStateFromError(new GatewayRequestError("unauthorized", "x", 403))).toBe("unauthorized");
+    });
+    it("returns open for non-auth errors", () => {
+      expect(authStateFromError(new Error("boom"))).toBe("open");
+      expect(authStateFromError(new GatewayRequestError("unavailable", "x", 500))).toBe("open");
+      expect(authStateFromError(null)).toBe("open");
+    });
+  });
+
+  describe("MockGatewayTransport auth simulation", () => {
+    it("throws a classified auth error from snapshot while health succeeds", async () => {
+      const transport = new MockGatewayTransport({
+        health: FIXTURE_CAPABILITIES,
+        authFailure: { code: "unauthenticated", methods: ["snapshot"] },
+      });
+      // health succeeds so the shell can read auth_modes
+      await expect(transport.health()).resolves.toBeDefined();
+      await expect(transport.snapshot()).rejects.toMatchObject({ code: "unauthenticated" });
+    });
+
+    it("clearAuthFailure lets subsequent reads succeed", async () => {
+      const transport = new MockGatewayTransport({
+        health: FIXTURE_CAPABILITIES,
+        authFailure: { code: "forbidden", methods: ["snapshot"] },
+      });
+      await expect(transport.snapshot()).rejects.toMatchObject({ code: "forbidden" });
+      transport.clearAuthFailure();
+      await expect(transport.snapshot()).resolves.toBeDefined();
+    });
+  });
+});

--- a/packages/api-client/__tests__/gateway-errors.test.ts
+++ b/packages/api-client/__tests__/gateway-errors.test.ts
@@ -52,6 +52,7 @@ describe("GatewayRequestError classification", () => {
     it("maps a 403 with an explicit unauthorized body code to unauthorized", () => {
       expect(authErrorCodeForStatus(403, { error_code: "unauthorized" })).toBe("unauthorized");
       expect(authErrorCodeForStatus(403, { code: "permission_denied" })).toBe("unauthorized");
+      expect(authErrorCodeForStatus(403, { error_code: "forbidden_resource" })).toBe("unauthorized");
     });
     it("maps a 403 with an unrelated body code to forbidden", () => {
       expect(authErrorCodeForStatus(403, { error_code: "rate_limited" })).toBe("forbidden");
@@ -139,6 +140,21 @@ describe("GatewayRequestError classification", () => {
         status: 401,
         name: "GatewayRequestError",
       });
+    });
+
+    it("includes the raw response body in the WebSocketTransport error message", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(401, "Unauthorized", '{"error":"missing token"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new WebSocketTransport({ baseUri: "http://localhost:8080" });
+      try {
+        await transport.health();
+        throw new Error("expected health() to reject");
+      } catch (error) {
+        expect(isGatewayRequestError(error)).toBe(true);
+        expect((error as Error).message).toContain('{"error":"missing token"}');
+      }
     });
 
     it("throws a GatewayRequestError with forbidden code on a bare HTTP 403", async () => {

--- a/packages/api-client/__tests__/gateway-errors.test.ts
+++ b/packages/api-client/__tests__/gateway-errors.test.ts
@@ -8,6 +8,7 @@
 
 import {
   HttpGatewayTransport,
+  WebSocketTransport,
   MockGatewayTransport,
   GatewayRequestError,
   isGatewayRequestError,
@@ -111,6 +112,65 @@ describe("GatewayRequestError classification", () => {
       ) as jest.MockedFunction<typeof global.fetch>;
 
       const transport = new HttpGatewayTransport({ baseUri: "http://localhost:8080" });
+      const rejection = transport.health();
+      await expect(rejection).rejects.toThrow(/HTTP 500/);
+      try {
+        await rejection;
+      } catch (error) {
+        expect(isGatewayRequestError(error)).toBe(false);
+      }
+    });
+  });
+
+  describe("WebSocketTransport HTTP handshake mapping", () => {
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("throws a GatewayRequestError with unauthenticated code on HTTP 401", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(401, "Unauthorized", '{"error":"missing token"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new WebSocketTransport({ baseUri: "http://localhost:8080" });
+      await expect(transport.health()).rejects.toMatchObject({
+        code: "unauthenticated",
+        status: 401,
+        name: "GatewayRequestError",
+      });
+    });
+
+    it("throws a GatewayRequestError with forbidden code on a bare HTTP 403", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(403, "Forbidden", '{"error":"no access"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new WebSocketTransport({ baseUri: "http://localhost:8080" });
+      await expect(transport.snapshot()).rejects.toMatchObject({
+        code: "forbidden",
+        status: 403,
+      });
+    });
+
+    it("classifies a 403 with an explicit unauthorized body code as unauthorized", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(403, "Forbidden", '{"error_code":"unauthorized","message":"no permission"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new WebSocketTransport({ baseUri: "http://localhost:8080" });
+      await expect(transport.snapshot()).rejects.toMatchObject({
+        code: "unauthorized",
+        status: 403,
+      });
+    });
+
+    it("throws a plain Error (not GatewayRequestError) on HTTP 500", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(500, "Internal Server Error", '{"error":"boom"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new WebSocketTransport({ baseUri: "http://localhost:8080" });
       const rejection = transport.health();
       await expect(rejection).rejects.toThrow(/HTTP 500/);
       try {

--- a/packages/api-client/__tests__/gateway-errors.test.ts
+++ b/packages/api-client/__tests__/gateway-errors.test.ts
@@ -43,8 +43,17 @@ describe("GatewayRequestError classification", () => {
     it("maps 401 to unauthenticated", () => {
       expect(authErrorCodeForStatus(401)).toBe("unauthenticated");
     });
-    it("maps 403 to forbidden", () => {
+    it("maps a bare 403 (no permission body signal) to forbidden", () => {
       expect(authErrorCodeForStatus(403)).toBe("forbidden");
+      expect(authErrorCodeForStatus(403, undefined)).toBe("forbidden");
+      expect(authErrorCodeForStatus(403, "not json")).toBe("forbidden");
+    });
+    it("maps a 403 with an explicit unauthorized body code to unauthorized", () => {
+      expect(authErrorCodeForStatus(403, { error_code: "unauthorized" })).toBe("unauthorized");
+      expect(authErrorCodeForStatus(403, { code: "permission_denied" })).toBe("unauthorized");
+    });
+    it("maps a 403 with an unrelated body code to forbidden", () => {
+      expect(authErrorCodeForStatus(403, { error_code: "rate_limited" })).toBe("forbidden");
     });
     it("returns undefined for non-auth statuses", () => {
       expect(authErrorCodeForStatus(500)).toBeUndefined();
@@ -80,6 +89,18 @@ describe("GatewayRequestError classification", () => {
       const transport = new HttpGatewayTransport({ baseUri: "http://localhost:8080" });
       await expect(transport.snapshot()).rejects.toMatchObject({
         code: "forbidden",
+        status: 403,
+      });
+    });
+
+    it("classifies a 403 with an explicit unauthorized body code as unauthorized", async () => {
+      global.fetch = jest.fn(async () =>
+        mockResponse(403, "Forbidden", '{"error_code":"unauthorized","message":"no permission"}'),
+      ) as jest.MockedFunction<typeof global.fetch>;
+
+      const transport = new HttpGatewayTransport({ baseUri: "http://localhost:8080" });
+      await expect(transport.snapshot()).rejects.toMatchObject({
+        code: "unauthorized",
         status: 403,
       });
     });

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -15,9 +15,13 @@
 export type GatewayErrorCode =
   /** No valid credentials supplied (HTTP 401). */
   | "unauthenticated"
-  /** Authenticated but lacking permission for the resource (HTTP 403, permission). */
+  /**
+   * Authenticated but lacking permission for this resource. Reached when a
+   * 403 response carries an explicit `error_code: "unauthorized"` (or
+   * `code: "unauthorized"`) body signal indicating a permission denial.
+   */
   | "unauthorized"
-  /** Server explicitly forbids the request (HTTP 403, hard deny). */
+  /** Server hard-denies the request (HTTP 403 without a permission signal). */
   | "forbidden"
   /** Gateway unreachable or returned a non-auth error. */
   | "unavailable";
@@ -41,15 +45,41 @@ export function isGatewayRequestError(value: unknown): value is GatewayRequestEr
 }
 
 /**
+ * Body signal a gateway may use to distinguish a permission denial
+ * (`unauthorized`) from a hard deny (`forbidden`) on an HTTP 403.
+ */
+const UNAUTHORIZED_BODY_CODES = new Set(["unauthorized", "permission_denied", "forbidden_resource"]);
+
+/**
  * Classify an HTTP status code into a gateway error code.
  *
- * Returns `undefined` for status codes that are not auth/forbidden related
- * (callers treat those as generic unavailable failures).
+ * - HTTP 401 -> `unauthenticated`.
+ * - HTTP 403 -> `unauthorized` when the (parsed) body carries an explicit
+ *   `error_code`/`code` field equal to a permission-denial signal, otherwise
+ *   `forbidden`.
+ *
+ * Pass the raw response body so a 403 can be disambiguated. Returns
+ * `undefined` for status codes that are not auth/forbidden related; callers
+ * treat those as generic unavailable failures.
  */
-export function authErrorCodeForStatus(status: number): GatewayErrorCode | undefined {
+export function authErrorCodeForStatus(
+  status: number,
+  body?: unknown,
+): GatewayErrorCode | undefined {
   if (status === 401) return "unauthenticated";
-  if (status === 403) return "forbidden";
+  if (status === 403) {
+    const code = bodyErrorCode(body);
+    return code && UNAUTHORIZED_BODY_CODES.has(code) ? "unauthorized" : "forbidden";
+  }
   return undefined;
 }
 
-export type { AuthState } from "@opensymphony/gateway-schema";
+/** Extract an `error_code`/`code` string from a JSON-parsed body, if present. */
+function bodyErrorCode(body: unknown): string | undefined {
+  if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    const raw = record.error_code ?? record.code;
+    if (typeof raw === "string" && raw.length > 0) return raw;
+  }
+  return undefined;
+}

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -29,14 +29,6 @@ export type GatewayErrorCode =
   /** Gateway unreachable or returned a non-auth error. */
   | "unavailable";
 
-/**
- * Error codes that represent an auth/authz rejection only. `unavailable` is
- * excluded because it models a generic connectivity failure rather than a
- * credentials/access decision. Used by auth-failure simulation that should
- * only ever inject a sign-in/access outcome.
- */
-export type AuthErrorCode = Exclude<GatewayErrorCode, "unavailable">;
-
 /** Error thrown by transport adapters for classified gateway failures. */
 export class GatewayRequestError extends Error {
   readonly code: GatewayErrorCode;

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -17,14 +17,25 @@ export type GatewayErrorCode =
   | "unauthenticated"
   /**
    * Authenticated but lacking permission for this resource. Reached when a
-   * 403 response carries an explicit `error_code: "unauthorized"` (or
-   * `code: "unauthorized"`) body signal indicating a permission denial.
+   * 403 response carries an explicit permission-denial body signal. The body
+   * is read from an `error_code` (or `code`) string field, and the following
+   * values are recognized as permission denials: `"unauthorized"`,
+   * `"permission_denied"`, and `"forbidden_resource"`. A 403 without one of
+   * these signals is treated as a hard deny (`forbidden`).
    */
   | "unauthorized"
   /** Server hard-denies the request (HTTP 403 without a permission signal). */
   | "forbidden"
   /** Gateway unreachable or returned a non-auth error. */
   | "unavailable";
+
+/**
+ * Error codes that represent an auth/authz rejection only. `unavailable` is
+ * excluded because it models a generic connectivity failure rather than a
+ * credentials/access decision. Used by auth-failure simulation that should
+ * only ever inject a sign-in/access outcome.
+ */
+export type AuthErrorCode = Exclude<GatewayErrorCode, "unavailable">;
 
 /** Error thrown by transport adapters for classified gateway failures. */
 export class GatewayRequestError extends Error {

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -1,0 +1,55 @@
+/**
+ * Typed gateway request errors.
+ *
+ * Gateway reads and mutations can fail for several reasons. Transport
+ * adapters throw `GatewayRequestError` so the UI shell can distinguish
+ * authentication/authorization outcomes from generic connectivity
+ * failures and render the matching placeholder state.
+ *
+ * The shared `AuthState` classification lives in `@opensymphony/gateway-schema`
+ * so the UI shell can map errors to auth states without depending on the
+ * transport package.
+ */
+
+/** Coarse classification of a gateway failure. */
+export type GatewayErrorCode =
+  /** No valid credentials supplied (HTTP 401). */
+  | "unauthenticated"
+  /** Authenticated but lacking permission for the resource (HTTP 403, permission). */
+  | "unauthorized"
+  /** Server explicitly forbids the request (HTTP 403, hard deny). */
+  | "forbidden"
+  /** Gateway unreachable or returned a non-auth error. */
+  | "unavailable";
+
+/** Error thrown by transport adapters for classified gateway failures. */
+export class GatewayRequestError extends Error {
+  readonly code: GatewayErrorCode;
+  readonly status?: number;
+
+  constructor(code: GatewayErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = "GatewayRequestError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/** True when the value is a classified gateway request error. */
+export function isGatewayRequestError(value: unknown): value is GatewayRequestError {
+  return value instanceof GatewayRequestError;
+}
+
+/**
+ * Classify an HTTP status code into a gateway error code.
+ *
+ * Returns `undefined` for status codes that are not auth/forbidden related
+ * (callers treat those as generic unavailable failures).
+ */
+export function authErrorCodeForStatus(status: number): GatewayErrorCode | undefined {
+  if (status === 401) return "unauthenticated";
+  if (status === 403) return "forbidden";
+  return undefined;
+}
+
+export type { AuthState } from "@opensymphony/gateway-schema";

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -66,16 +66,16 @@ export {
   MIN_COMPATIBLE_API_VERSION,
 } from "./discovery.js";
 export type { DiscoveryResult } from "./discovery.js";
-// Typed gateway request errors (transport-layer) and auth-facing state
-// classification (shared via @opensymphony/gateway-schema).
+// Typed gateway request errors (transport-layer). The auth-state
+// classification (`AuthState`, `authStateFromError`, `gatewayRequiresAuth`)
+// lives in @opensymphony/gateway-schema; import it directly from there to
+// keep the package boundary sharp (ui-core must not depend on api-client).
 export {
   GatewayRequestError,
   isGatewayRequestError,
   authErrorCodeForStatus,
 } from "./errors.js";
 export type { GatewayErrorCode } from "./errors.js";
-export type { AuthState } from "@opensymphony/gateway-schema";
-export { authStateFromError, gatewayRequiresAuth } from "@opensymphony/gateway-schema";
 
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -75,7 +75,7 @@ export {
   isGatewayRequestError,
   authErrorCodeForStatus,
 } from "./errors.js";
-export type { GatewayErrorCode, AuthErrorCode } from "./errors.js";
+export type { GatewayErrorCode } from "./errors.js";
 
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -67,9 +67,9 @@ export {
 } from "./discovery.js";
 export type { DiscoveryResult } from "./discovery.js";
 // Typed gateway request errors (transport-layer). The auth-state
-// classification (`AuthState`, `authStateFromError`, `gatewayRequiresAuth`)
-// lives in @opensymphony/gateway-schema; import it directly from there to
-// keep the package boundary sharp (ui-core must not depend on api-client).
+// classification (`AuthState`, `authStateFromError`) lives in
+// @opensymphony/gateway-schema; import it directly from there to keep the
+// package boundary sharp (ui-core must not depend on api-client).
 export {
   GatewayRequestError,
   isGatewayRequestError,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -55,6 +55,7 @@ export type {
   OrderedEventsOptions,
   StreamStaleInfo,
 } from "./stream-replay.js";
+
 export {
   discoverGateway,
   discoverGatewayWithFallback,
@@ -65,6 +66,16 @@ export {
   MIN_COMPATIBLE_API_VERSION,
 } from "./discovery.js";
 export type { DiscoveryResult } from "./discovery.js";
+// Typed gateway request errors (transport-layer) and auth-facing state
+// classification (shared via @opensymphony/gateway-schema).
+export {
+  GatewayRequestError,
+  isGatewayRequestError,
+  authErrorCodeForStatus,
+} from "./errors.js";
+export type { GatewayErrorCode } from "./errors.js";
+export type { AuthState } from "@opensymphony/gateway-schema";
+export { authStateFromError, gatewayRequiresAuth } from "@opensymphony/gateway-schema";
 
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -75,7 +75,7 @@ export {
   isGatewayRequestError,
   authErrorCodeForStatus,
 } from "./errors.js";
-export type { GatewayErrorCode } from "./errors.js";
+export type { GatewayErrorCode, AuthErrorCode } from "./errors.js";
 
 /** Transport adapter interface for all gateway communication. */
 export interface GatewayTransport {

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -22,10 +22,11 @@ import type {
   FileDiffPage,
   RunValidationSummary,
   ApprovalRequest,
+  AuthErrorCode,
 } from "@opensymphony/gateway-schema";
 import type { GatewayTransport, ActionCapableTransport } from "./index.js";
 import { stableHash, stableHashJson } from "./util.js";
-import { GatewayRequestError, type AuthErrorCode } from "./errors.js";
+import { GatewayRequestError } from "./errors.js";
 
 /** Deterministic mock transport for tests. */
 export class MockGatewayTransport implements GatewayTransport, ActionCapableTransport {

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -197,7 +197,12 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
     return this.mockSnapshot;
   }
 
-  /** Remove the simulated auth failure so a refresh can succeed. */
+  /**
+   * Remove the simulated auth failure so a refresh can succeed.
+   *
+   * Test/simulation-only: `MockGatewayTransport` is not used in production, so
+   * this clears the injected failure, not a real gateway failure.
+   */
   clearAuthFailure(): void {
     this.authFailureCode = null;
     this.authFailureMethods = new Set();

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -25,7 +25,7 @@ import type {
 } from "@opensymphony/gateway-schema";
 import type { GatewayTransport, ActionCapableTransport } from "./index.js";
 import { stableHash, stableHashJson } from "./util.js";
-import { GatewayRequestError, type GatewayErrorCode } from "./errors.js";
+import { GatewayRequestError, type AuthErrorCode } from "./errors.js";
 
 /** Deterministic mock transport for tests. */
 export class MockGatewayTransport implements GatewayTransport, ActionCapableTransport {
@@ -47,7 +47,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   private closedFlag = false;
 
   // Auth failure simulation for placeholder-state tests.
-  private authFailureCode: GatewayErrorCode | null = null;
+  private authFailureCode: AuthErrorCode | null = null;
   private authFailureMethods: Set<"health" | "snapshot"> = new Set();
 
   // Stream health simulation.
@@ -79,7 +79,7 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
      * caller is not signed in / lacks access.
      */
     authFailure?: {
-      code: GatewayErrorCode;
+      code: AuthErrorCode;
       methods?: Array<"health" | "snapshot">;
     };
   }) {

--- a/packages/api-client/src/mock.ts
+++ b/packages/api-client/src/mock.ts
@@ -25,6 +25,7 @@ import type {
 } from "@opensymphony/gateway-schema";
 import type { GatewayTransport, ActionCapableTransport } from "./index.js";
 import { stableHash, stableHashJson } from "./util.js";
+import { GatewayRequestError, type GatewayErrorCode } from "./errors.js";
 
 /** Deterministic mock transport for tests. */
 export class MockGatewayTransport implements GatewayTransport, ActionCapableTransport {
@@ -44,6 +45,10 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
   private mockTerminalFrames: Map<string, GatewayEnvelope[]> = new Map();
   private mockActionReceipts: Map<string, ActionReceipt> = new Map();
   private closedFlag = false;
+
+  // Auth failure simulation for placeholder-state tests.
+  private authFailureCode: GatewayErrorCode | null = null;
+  private authFailureMethods: Set<"health" | "snapshot"> = new Set();
 
   // Stream health simulation.
   private streamHealthyFlag = true;
@@ -67,6 +72,16 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
     terminalFrames?: { runId: string; frames: GatewayEnvelope[] }[];
     actionReceipts?: { correlationId: string; receipt: ActionReceipt }[];
     streamHealthy?: boolean;
+    /**
+     * Simulate a classified auth failure for one or more read methods.
+     * `methods: ["snapshot"]` simulates a gateway that advertises auth
+     * (health succeeds) but rejects the dashboard snapshot because the
+     * caller is not signed in / lacks access.
+     */
+    authFailure?: {
+      code: GatewayErrorCode;
+      methods?: Array<"health" | "snapshot">;
+    };
   }) {
     this.baseUri = opts?.baseUri ?? "http://mock-gateway.local";
 
@@ -162,16 +177,40 @@ export class MockGatewayTransport implements GatewayTransport, ActionCapableTran
     }
 
     this.streamHealthyFlag = opts?.streamHealthy ?? true;
+
+    if (opts?.authFailure) {
+      this.authFailureCode = opts.authFailure.code;
+      this.authFailureMethods = new Set(opts.authFailure.methods ?? ["snapshot"]);
+    }
   }
 
   // -- REST reads --
 
   async health(): Promise<GatewayCapabilities> {
+    this.throwIfAuthFailure("health");
     return this.mockHealth;
   }
 
   async snapshot(): Promise<DashboardSnapshot> {
+    this.throwIfAuthFailure("snapshot");
     return this.mockSnapshot;
+  }
+
+  /** Remove the simulated auth failure so a refresh can succeed. */
+  clearAuthFailure(): void {
+    this.authFailureCode = null;
+    this.authFailureMethods = new Set();
+  }
+
+  private throwIfAuthFailure(method: "health" | "snapshot"): void {
+    if (this.authFailureCode && this.authFailureMethods.has(method)) {
+      const status = this.authFailureCode === "unauthenticated" ? 401 : 403;
+      throw new GatewayRequestError(
+        this.authFailureCode,
+        `Simulated ${this.authFailureCode} for ${method}`,
+        status,
+      );
+    }
   }
 
   async taskGraph(_projectId: string): Promise<TaskGraphSnapshot> {

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -23,6 +23,7 @@ import type {
 import { pageCursorFirst } from "@opensymphony/gateway-schema";
 import type { GatewayTransport, GatewayTransportConfig, ActionCapableTransport } from "./index.js";
 import { stableHash, stableHashJson } from "./util.js";
+import { GatewayRequestError, authErrorCodeForStatus } from "./errors.js";
 
 /**
  * HTTP-based transport adapter using fetch().
@@ -511,6 +512,14 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");
+      const authCode = authErrorCodeForStatus(response.status);
+      if (authCode) {
+        throw new GatewayRequestError(
+          authCode,
+          `HTTP ${response.status} ${response.statusText}: ${body}`,
+          response.status,
+        );
+      }
       throw new Error(
         `HTTP ${response.status} ${response.statusText}: ${body}`,
       );
@@ -592,6 +601,14 @@ export class WebSocketTransport implements GatewayTransport {
       headers: this.headers(),
     });
     if (!response.ok) {
+      const authCode = authErrorCodeForStatus(response.status);
+      if (authCode) {
+        throw new GatewayRequestError(
+          authCode,
+          `HTTP ${response.status} from ${url}: ${response.statusText}`,
+          response.status,
+        );
+      }
       throw new Error(
         `HTTP ${response.status} from ${url}: ${response.statusText}`,
       );

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -499,6 +499,14 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
     return init;
   }
 
+  /**
+   * Fetch `url` and return the parsed JSON body.
+   *
+   * On a non-2xx response the body is consumed once with `response.text()`
+   * (for diagnostics and auth-code classification). `Response` bodies can only
+   * be read a single time, so callers/interceptors must not re-consume the
+   * response body after this method returns or throws.
+   */
   private async fetchJson(url: string, init?: RequestInit): Promise<unknown> {
     const method = init?.method ?? "GET";
     const headers: Record<string, string> = {
@@ -604,6 +612,14 @@ export class WebSocketTransport implements GatewayTransport {
     return headers;
   }
 
+  /**
+   * Issue a GET against `path` and return the parsed JSON body.
+   *
+   * On a non-2xx response the body is consumed once with `response.text()`
+   * (for diagnostics and auth-code classification). `Response` bodies can only
+   * be read a single time, so callers/interceptors must not re-consume the
+   * response body after this method returns or throws.
+   */
   private async get<T>(path: string): Promise<T> {
     const url = `${this.baseUri}${path}`;
     const response = await fetch(url, {

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -616,12 +616,12 @@ export class WebSocketTransport implements GatewayTransport {
       if (authCode) {
         throw new GatewayRequestError(
           authCode,
-          `HTTP ${response.status} from ${url}: ${response.statusText}`,
+          `HTTP ${response.status} from ${url}: ${response.statusText}: ${rawBody}`,
           response.status,
         );
       }
       throw new Error(
-        `HTTP ${response.status} from ${url}: ${response.statusText}`,
+        `HTTP ${response.status} from ${url}: ${response.statusText}: ${rawBody}`,
       );
     }
     return (await response.json()) as T;

--- a/packages/api-client/src/transports.ts
+++ b/packages/api-client/src/transports.ts
@@ -25,6 +25,16 @@ import type { GatewayTransport, GatewayTransportConfig, ActionCapableTransport }
 import { stableHash, stableHashJson } from "./util.js";
 import { GatewayRequestError, authErrorCodeForStatus } from "./errors.js";
 
+/** Best-effort parse of a response body as JSON; returns the raw string on failure. */
+function tryParseJson(raw: string): unknown {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
 /**
  * HTTP-based transport adapter using fetch().
  *
@@ -511,17 +521,17 @@ export class HttpGatewayTransport implements GatewayTransport, ActionCapableTran
     const response = await fetch(url, requestInit);
 
     if (!response.ok) {
-      const body = await response.text().catch(() => "");
-      const authCode = authErrorCodeForStatus(response.status);
+      const rawBody = await response.text().catch(() => "");
+      const authCode = authErrorCodeForStatus(response.status, tryParseJson(rawBody));
       if (authCode) {
         throw new GatewayRequestError(
           authCode,
-          `HTTP ${response.status} ${response.statusText}: ${body}`,
+          `HTTP ${response.status} ${response.statusText}: ${rawBody}`,
           response.status,
         );
       }
       throw new Error(
-        `HTTP ${response.status} ${response.statusText}: ${body}`,
+        `HTTP ${response.status} ${response.statusText}: ${rawBody}`,
       );
     }
 
@@ -601,7 +611,8 @@ export class WebSocketTransport implements GatewayTransport {
       headers: this.headers(),
     });
     if (!response.ok) {
-      const authCode = authErrorCodeForStatus(response.status);
+      const rawBody = await response.text().catch(() => "");
+      const authCode = authErrorCodeForStatus(response.status, tryParseJson(rawBody));
       if (authCode) {
         throw new GatewayRequestError(
           authCode,

--- a/packages/gateway-schema/src/auth.ts
+++ b/packages/gateway-schema/src/auth.ts
@@ -1,0 +1,64 @@
+/**
+ * Auth-facing UI state for the OpenSymphony client shell.
+ *
+ * The gateway advertises auth requirements through `GatewayCapabilities.auth_modes`.
+ * Transport adapters signal auth outcomes by throwing errors that carry a
+ * `code` field (see `GatewayRequestError` in `@opensymphony/api-client`). The
+ * shell maps those outcomes to an `AuthState` so it can render distinct
+ * placeholder surfaces (sign-in, unauthorized, forbidden) without depending
+ * on the transport package.
+ */
+
+/** Auth-facing state rendered by the client shell. */
+export type AuthState =
+  /** Gateway requires no auth (local unauthenticated development mode). */
+  | "open"
+  /** No valid credentials supplied (HTTP 401). */
+  | "unauthenticated"
+  /** Authenticated but lacking permission for the resource. */
+  | "unauthorized"
+  /** Server explicitly forbids the request (HTTP 403 hard deny). */
+  | "forbidden";
+
+/** Auth error code strings carried by classified gateway errors. */
+export type AuthErrorCode = "unauthenticated" | "unauthorized" | "forbidden";
+
+const AUTH_ERROR_CODES: ReadonlySet<AuthErrorCode> = new Set([
+  "unauthenticated",
+  "unauthorized",
+  "forbidden",
+]);
+
+interface ErrorWithCode {
+  code?: string;
+}
+
+function readErrorCode(error: unknown): AuthErrorCode | undefined {
+  if (error && typeof error === "object" && "code" in error) {
+    const code = (error as ErrorWithCode).code;
+    if (typeof code === "string" && AUTH_ERROR_CODES.has(code as AuthErrorCode)) {
+      return code as AuthErrorCode;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Map a thrown gateway error to an auth-facing state.
+ *
+ * Returns `"open"` when the error is not auth-related, so callers fall back
+ * to the normal connection-failure path.
+ */
+export function authStateFromError(error: unknown): AuthState {
+  const code = readErrorCode(error);
+  if (code) return code;
+  return "open";
+}
+
+/**
+ * Whether a gateway capabilities response advertises any auth requirement
+ * beyond the unauthenticated `none` mode.
+ */
+export function gatewayRequiresAuth(authModes: ReadonlyArray<string>): boolean {
+  return authModes.some((mode) => mode !== "none");
+}

--- a/packages/gateway-schema/src/auth.ts
+++ b/packages/gateway-schema/src/auth.ts
@@ -54,11 +54,3 @@ export function authStateFromError(error: unknown): AuthState {
   if (code) return code;
   return "open";
 }
-
-/**
- * Whether a gateway capabilities response advertises any auth requirement
- * beyond the unauthenticated `none` mode.
- */
-export function gatewayRequiresAuth(authModes: ReadonlyArray<string>): boolean {
-  return authModes.some((mode) => mode !== "none");
-}

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -87,7 +87,7 @@ export type { PlanningArtifactKind, PlanningArtifact, PlanningSessionStatus, Pla
 
 // capability
 export type { AuthMode, TransportCapability, FeatureCapability, GatewayCapabilities } from "./capability.js";
-export { authStateFromError, gatewayRequiresAuth } from "./auth.js";
+export { authStateFromError } from "./auth.js";
 export type { AuthState, AuthErrorCode } from "./auth.js";
 
 // action

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -87,6 +87,8 @@ export type { PlanningArtifactKind, PlanningArtifact, PlanningSessionStatus, Pla
 
 // capability
 export type { AuthMode, TransportCapability, FeatureCapability, GatewayCapabilities } from "./capability.js";
+export { authStateFromError, gatewayRequiresAuth } from "./auth.js";
+export type { AuthState, AuthErrorCode } from "./auth.js";
 
 // action
 export type { ActionKind, ActionTarget, ActionDispatch } from "./action.js";

--- a/packages/ui-core/__tests__/auth-states.test.ts
+++ b/packages/ui-core/__tests__/auth-states.test.ts
@@ -114,7 +114,10 @@ async function flushUntil(predicate: () => boolean, maxIterations = 40): Promise
   throw new Error(`flushUntil timed out after ${maxIterations} iterations`);
 }
 
-function mount(authFailure: { code: "unauthenticated" | "unauthorized" | "forbidden" }) {
+function mount(authFailure: {
+  code: "unauthenticated" | "unauthorized" | "forbidden";
+  methods?: Array<"health" | "snapshot">;
+}) {
   const root = document.createElement("div");
   document.body.appendChild(root);
   const transport = new MockGatewayTransport({
@@ -123,7 +126,7 @@ function mount(authFailure: { code: "unauthenticated" | "unauthorized" | "forbid
     snapshot: dashboard,
     taskGraph,
     runDetails: [runDetail],
-    authFailure: { code: authFailure.code, methods: ["snapshot"] },
+    authFailure: { code: authFailure.code, methods: authFailure.methods ?? ["snapshot"] },
   });
   const handle = renderOpenSymphonyApp({
     root,
@@ -154,6 +157,27 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.querySelector(".os-run-detail-panel")).toBeNull();
 
     await handle.destroy();
+    root.remove();
+  });
+
+  it("renders an unauthenticated placeholder when the gateway rejects capabilities (health) with 401", async () => {
+    // Exercises the separate `loadGatewayState` code path where `health()`
+    // itself rejects with an auth error (capabilities never resolve).
+    const { root, handle } = mount({ code: "unauthenticated", methods: ["health"] });
+
+    await flushUntil(() => root.querySelector("[data-testid='auth-placeholder']") !== null);
+
+    const shell = root.querySelector("[data-opensymphony-app-shell='mounted']");
+    expect(shell?.getAttribute("data-auth-state")).toBe("unauthenticated");
+    const placeholder = root.querySelector("[data-testid='auth-placeholder']");
+    expect(placeholder?.getAttribute("data-auth-state")).toBe("unauthenticated");
+    expect(root.querySelector("[data-testid='auth-sign-in']")).not.toBeNull();
+    expect(root.textContent).toContain("Sign in required");
+    // Core panels are not rendered behind the auth gate.
+    expect(root.querySelector(".os-task-graph-panel")).toBeNull();
+
+    await handle.destroy();
+    root.remove();
   });
 
   it("renders a forbidden placeholder when the hosted gateway denies the snapshot with 403 forbidden", async () => {
@@ -170,6 +194,7 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.querySelector("[data-testid='auth-refresh']")).not.toBeNull();
 
     await handle.destroy();
+    root.remove();
   });
 
   it("renders an unauthorized placeholder when the gateway returns an explicit unauthorized code", async () => {
@@ -197,6 +222,7 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.textContent).toContain("do not have permission");
 
     await handle.destroy();
+    root.remove();
   });
 
   it("renders the org/project selection placeholder surface for hosted auth states", async () => {
@@ -209,6 +235,7 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.querySelector("[data-testid='auth-project']")).not.toBeNull();
 
     await handle.destroy();
+    root.remove();
   });
 
   it("keeps local unauthenticated (auth_modes:none) gateway straightforward with no login gate", async () => {
@@ -232,6 +259,7 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.textContent).not.toContain("Sign in required");
 
     await handle.destroy();
+    root.remove();
   });
 
   it("recovers from the unauthenticated placeholder when the gateway later permits the snapshot", async () => {
@@ -248,5 +276,6 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state")).toBe("open");
 
     await handle.destroy();
+    root.remove();
   });
 });

--- a/packages/ui-core/__tests__/auth-states.test.ts
+++ b/packages/ui-core/__tests__/auth-states.test.ts
@@ -192,6 +192,8 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     // Forbidden has no sign-in CTA (caller is presumed authenticated).
     expect(root.querySelector("[data-testid='auth-sign-in']")).toBeNull();
     expect(root.querySelector("[data-testid='auth-refresh']")).not.toBeNull();
+    // A hard 403 deny of the workspace does not offer org/project selectors.
+    expect(root.querySelector("[data-testid='auth-scope']")).toBeNull();
 
     await handle.destroy();
     root.remove();
@@ -220,6 +222,8 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
     expect(root.querySelector("[data-testid='auth-placeholder']")?.getAttribute("data-auth-state")).toBe("unauthorized");
     expect(root.textContent).toContain("Access denied");
     expect(root.textContent).toContain("do not have permission");
+    // Unauthorized (permission denial) still offers org/project switching.
+    expect(root.querySelector("[data-testid='auth-scope']")).not.toBeNull();
 
     await handle.destroy();
     root.remove();

--- a/packages/ui-core/__tests__/auth-states.test.ts
+++ b/packages/ui-core/__tests__/auth-states.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Auth-aware shell placeholder states for COE-419.
+ *
+ * Verifies the shared app shell renders distinct unauthenticated,
+ * unauthorized, and forbidden states for hosted gateways, while local
+ * unauthenticated (`auth_modes:["none"]`) gateways render the dashboard
+ * normally with no login gate.
+ */
+
+import { renderOpenSymphonyApp } from "../src/app-shell.js";
+import { MockGatewayTransport, GatewayRequestError } from "@opensymphony/api-client";
+import { schemaVersionV1 } from "@opensymphony/gateway-schema";
+import type {
+  DashboardSnapshot,
+  GatewayCapabilities,
+  RunDetail,
+  TaskGraphSnapshot,
+} from "@opensymphony/gateway-schema";
+
+const localCapabilities: GatewayCapabilities = {
+  schema_version: schemaVersionV1(),
+  gateway_version: "local-test",
+  supported_api_versions: ["1.0.0"],
+  transports: [{ transport: "loopback_http", modes: ["json"], supported_encodings: ["utf-8"], bidirectional: false }],
+  features: [
+    { feature: "task_graph", available: true, requires_auth: false },
+    { feature: "terminal_stream", available: false, requires_auth: false },
+  ],
+  auth_modes: ["none"],
+  max_event_page_size: 1000,
+  max_terminal_frame_batch: 500,
+};
+
+const hostedCapabilities: GatewayCapabilities = {
+  ...localCapabilities,
+  gateway_version: "hosted-test",
+  auth_modes: ["bearer_token"],
+  features: [
+    { feature: "task_graph", available: true, requires_auth: true },
+    { feature: "terminal_stream", available: true, requires_auth: true },
+  ],
+};
+
+const dashboard: DashboardSnapshot = {
+  schema_version: schemaVersionV1(),
+  generated_at: "2025-09-01T00:00:00Z",
+  sequence: 1,
+  health: "healthy",
+  metrics: {
+    running_issue_count: 1,
+    retry_queue_depth: 0,
+    total_input_tokens: 100,
+    total_output_tokens: 20,
+    total_cache_read_tokens: 0,
+    total_cost_micros: 0,
+  },
+  projects: [
+    { project_id: "proj-hosted", name: "Hosted Project", milestone_count: 1, issue_count: 2, running_count: 1, completed_count: 1, failed_count: 0 },
+  ],
+  recent_events: [],
+};
+
+const taskGraph: TaskGraphSnapshot = {
+  schema_version: schemaVersionV1(),
+  project_id: "proj-hosted",
+  generated_at: "2025-09-01T00:00:00Z",
+  root_ids: ["m-hosted"],
+  nodes: [
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "m-hosted",
+      kind: "milestone",
+      identifier: "M-Hosted",
+      title: "Hosted milestone",
+      state: "In Progress",
+      state_category: "in_progress",
+      children: [],
+      blocked_by: [],
+      labels: ["hosted"],
+    },
+  ],
+};
+
+const runDetail: RunDetail = {
+  schema_version: schemaVersionV1(),
+  run_id: "run-hosted",
+  issue_id: "issue-hosted",
+  issue_identifier: "COE-600",
+  worker_id: "worker-hosted",
+  status: "running",
+  claimed_at: "2025-09-01T00:00:00Z",
+  started_at: "2025-09-01T00:00:30Z",
+  turn_count: 1,
+  max_turns: 8,
+  input_tokens: 100,
+  output_tokens: 20,
+  cache_read_tokens: 0,
+  runtime_seconds: 10,
+  workspace_path: "/tmp/opensymphony/projects/COE-600",
+  safe_actions: { retry: false, cancel: true, rehydrate: false, detach: false },
+};
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushUntil(predicate: () => boolean, maxIterations = 40): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    if (predicate()) return;
+    await flushAsync();
+  }
+  throw new Error(`flushUntil timed out after ${maxIterations} iterations`);
+}
+
+function mount(authFailure: { code: "unauthenticated" | "unauthorized" | "forbidden" }) {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const transport = new MockGatewayTransport({
+    baseUri: "https://hosted.opensymphony.example",
+    health: hostedCapabilities,
+    snapshot: dashboard,
+    taskGraph,
+    runDetails: [runDetail],
+    authFailure: { code: authFailure.code, methods: ["snapshot"] },
+  });
+  const handle = renderOpenSymphonyApp({
+    root,
+    mode: "web",
+    transport,
+  });
+  return { root, handle, transport };
+}
+
+describe("Auth-aware shell placeholder states (COE-419)", () => {
+  it("renders an unauthenticated sign-in placeholder when the hosted gateway rejects the snapshot with 401", async () => {
+    const { root, handle } = mount({ code: "unauthenticated" });
+
+    await flushUntil(() => root.querySelector("[data-testid='auth-placeholder']") !== null);
+
+    const shell = root.querySelector("[data-opensymphony-app-shell='mounted']");
+    expect(shell?.getAttribute("data-auth-state")).toBe("unauthenticated");
+
+    const placeholder = root.querySelector("[data-testid='auth-placeholder']");
+    expect(placeholder?.getAttribute("data-auth-state")).toBe("unauthenticated");
+    expect(root.querySelector("[data-testid='auth-sign-in']")).not.toBeNull();
+    expect(root.textContent).toContain("Sign in");
+    expect(root.textContent).toContain("Sign in required");
+
+    // The core dashboard, task graph, and run panels are not rendered behind
+    // the auth gate.
+    expect(root.querySelector(".os-task-graph-panel")).toBeNull();
+    expect(root.querySelector(".os-run-detail-panel")).toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("renders a forbidden placeholder when the hosted gateway denies the snapshot with 403 forbidden", async () => {
+    const { root, handle } = mount({ code: "forbidden" });
+
+    await flushUntil(() => root.querySelector("[data-testid='auth-placeholder']") !== null);
+
+    expect(root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state")).toBe("forbidden");
+    const placeholder = root.querySelector("[data-testid='auth-placeholder']");
+    expect(placeholder?.getAttribute("data-auth-state")).toBe("forbidden");
+    expect(root.textContent).toContain("Access forbidden");
+    // Forbidden has no sign-in CTA (caller is presumed authenticated).
+    expect(root.querySelector("[data-testid='auth-sign-in']")).toBeNull();
+    expect(root.querySelector("[data-testid='auth-refresh']")).not.toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("renders an unauthorized placeholder when the gateway returns an explicit unauthorized code", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const transport = new MockGatewayTransport({
+      baseUri: "https://hosted.opensymphony.example",
+      health: hostedCapabilities,
+      snapshot: dashboard,
+      taskGraph,
+      runDetails: [runDetail],
+    });
+    // Override snapshot to throw an explicit unauthorized code, which the
+    // default 403 mapping does not produce (403 maps to forbidden). This
+    // exercises the dedicated unauthorized branch.
+    const originalSnapshot = transport.snapshot.bind(transport);
+    transport.snapshot = async () => {
+      throw new GatewayRequestError("unauthorized", "insufficient permission", 403);
+    };
+    void originalSnapshot;
+    const handle = renderOpenSymphonyApp({ root, mode: "web", transport });
+
+    await flushUntil(() => root.querySelector("[data-testid='auth-placeholder']") !== null);
+
+    expect(root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state")).toBe("unauthorized");
+    expect(root.querySelector("[data-testid='auth-placeholder']")?.getAttribute("data-auth-state")).toBe("unauthorized");
+    expect(root.textContent).toContain("Access denied");
+    expect(root.textContent).toContain("do not have permission");
+
+    await handle.destroy();
+  });
+
+  it("renders the org/project selection placeholder surface for hosted auth states", async () => {
+    const { root, handle } = mount({ code: "unauthenticated" });
+
+    await flushUntil(() => root.querySelector("[data-testid='auth-scope']") !== null);
+
+    expect(root.querySelector("[data-testid='auth-scope']")).not.toBeNull();
+    expect(root.querySelector("[data-testid='auth-org']")).not.toBeNull();
+    expect(root.querySelector("[data-testid='auth-project']")).not.toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("keeps local unauthenticated (auth_modes:none) gateway straightforward with no login gate", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const transport = new MockGatewayTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: localCapabilities,
+      snapshot: dashboard,
+      taskGraph,
+      runDetails: [runDetail],
+    });
+    const handle = renderOpenSymphonyApp({ root, mode: "web", transport });
+
+    await flushUntil(() => root.querySelector("[data-opensymphony-app-shell='mounted']") !== null);
+    await flushUntil(() => root.querySelector(".os-task-graph-panel") !== null);
+
+    expect(root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state")).toBe("open");
+    expect(root.querySelector("[data-testid='auth-placeholder']")).toBeNull();
+    expect(root.querySelector(".os-task-graph-panel")).not.toBeNull();
+    expect(root.textContent).not.toContain("Sign in required");
+
+    await handle.destroy();
+  });
+
+  it("recovers from the unauthenticated placeholder when the gateway later permits the snapshot", async () => {
+    const { root, handle, transport } = mount({ code: "unauthenticated" });
+
+    await flushUntil(() => root.querySelector("[data-testid='auth-placeholder']") !== null);
+    expect(root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state")).toBe("unauthenticated");
+
+    transport.clearAuthFailure();
+    (root.querySelector("[data-testid='auth-refresh']") as HTMLButtonElement).click();
+
+    await flushUntil(() => root.querySelector(".os-task-graph-panel") !== null);
+    expect(root.querySelector("[data-testid='auth-placeholder']")).toBeNull();
+    expect(root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state")).toBe("open");
+
+    await handle.destroy();
+  });
+});

--- a/packages/ui-core/__tests__/auth-states.test.ts
+++ b/packages/ui-core/__tests__/auth-states.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { renderOpenSymphonyApp } from "../src/app-shell.js";
-import { MockGatewayTransport, GatewayRequestError } from "@opensymphony/api-client";
+import { MockGatewayTransport } from "@opensymphony/api-client";
 import { schemaVersionV1 } from "@opensymphony/gateway-schema";
 import type {
   DashboardSnapshot,
@@ -175,21 +175,18 @@ describe("Auth-aware shell placeholder states (COE-419)", () => {
   it("renders an unauthorized placeholder when the gateway returns an explicit unauthorized code", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
+    // The mock's authFailure throws a GatewayRequestError with the explicit
+    // "unauthorized" code (a permission denial), which the UI maps to the
+    // access-denied placeholder. This mirrors a real 403 whose body carries
+    // an `error_code: "unauthorized"` permission signal.
     const transport = new MockGatewayTransport({
       baseUri: "https://hosted.opensymphony.example",
       health: hostedCapabilities,
       snapshot: dashboard,
       taskGraph,
       runDetails: [runDetail],
+      authFailure: { code: "unauthorized", methods: ["snapshot"] },
     });
-    // Override snapshot to throw an explicit unauthorized code, which the
-    // default 403 mapping does not produce (403 maps to forbidden). This
-    // exercises the dedicated unauthorized branch.
-    const originalSnapshot = transport.snapshot.bind(transport);
-    transport.snapshot = async () => {
-      throw new GatewayRequestError("unauthorized", "insufficient permission", 403);
-    };
-    void originalSnapshot;
     const handle = renderOpenSymphonyApp({ root, mode: "web", transport });
 
     await flushUntil(() => root.querySelector("[data-testid='auth-placeholder']") !== null);

--- a/packages/ui-core/__tests__/remote-parity.test.ts
+++ b/packages/ui-core/__tests__/remote-parity.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Remote web/desktop parity for COE-419.
+ *
+ * The web and desktop clients both mount the shared `OpenSymphonyApp` shell
+ * (see PR #113). This test drives the shell in both `mode:"web"` and
+ * `mode:"desktop"` against an identical fixture transport and asserts the
+ * same core project, task graph, run, stream, and planning state renders in
+ * each mode.
+ */
+
+import { renderOpenSymphonyApp } from "../src/app-shell.js";
+import { MockGatewayTransport } from "@opensymphony/api-client";
+import { schemaVersionV1 } from "@opensymphony/gateway-schema";
+import type {
+  DashboardSnapshot,
+  GatewayCapabilities,
+  GatewayEnvelope,
+  RunDetail,
+  RunEventPage,
+  TaskGraphSnapshot,
+} from "@opensymphony/gateway-schema";
+
+const capabilities: GatewayCapabilities = {
+  schema_version: schemaVersionV1(),
+  gateway_version: "parity-test",
+  supported_api_versions: ["1.0.0"],
+  transports: [{ transport: "loopback_http", modes: ["json"], supported_encodings: ["utf-8"], bidirectional: false }],
+  features: [
+    { feature: "task_graph", available: true, requires_auth: false },
+    { feature: "terminal_stream", available: true, requires_auth: false },
+  ],
+  auth_modes: ["none"],
+  max_event_page_size: 1000,
+  max_terminal_frame_batch: 500,
+};
+
+const dashboard: DashboardSnapshot = {
+  schema_version: schemaVersionV1(),
+  generated_at: "2025-09-01T00:00:00Z",
+  sequence: 11,
+  health: "healthy",
+  metrics: {
+    running_issue_count: 2,
+    retry_queue_depth: 1,
+    total_input_tokens: 4500,
+    total_output_tokens: 1100,
+    total_cache_read_tokens: 600,
+    total_cost_micros: 250,
+  },
+  projects: [
+    { project_id: "proj-parity", name: "Parity Project", milestone_count: 1, issue_count: 3, running_count: 1, completed_count: 1, failed_count: 1 },
+  ],
+  recent_events: [
+    { happened_at: "2025-09-01T00:00:00Z", kind: "run_event", issue_identifier: "COE-700", summary: "parity stream event" },
+  ],
+};
+
+const taskGraph: TaskGraphSnapshot = {
+  schema_version: schemaVersionV1(),
+  project_id: "proj-parity",
+  generated_at: "2025-09-01T00:00:00Z",
+  root_ids: ["m-parity"],
+  nodes: [
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "m-parity",
+      kind: "milestone",
+      identifier: "M-PAR",
+      title: "Parity Milestone",
+      state: "In Progress",
+      state_category: "in_progress",
+      children: ["run-parity"],
+      blocked_by: [],
+      labels: ["parity"],
+    },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "run-parity",
+      kind: "issue",
+      identifier: "COE-700",
+      title: "Parity run issue",
+      state: "In Progress",
+      state_category: "in_progress",
+      parent_id: "m-parity",
+      children: [],
+      blocked_by: [],
+      labels: ["parity"],
+    },
+  ],
+};
+
+const runDetail: RunDetail = {
+  schema_version: schemaVersionV1(),
+  run_id: "COE-700",
+  issue_id: "issue-parity",
+  issue_identifier: "COE-700",
+  worker_id: "worker-parity",
+  status: "running",
+  claimed_at: "2025-09-01T00:00:00Z",
+  started_at: "2025-09-01T00:00:30Z",
+  turn_count: 2,
+  max_turns: 8,
+  input_tokens: 4500,
+  output_tokens: 1100,
+  cache_read_tokens: 600,
+  runtime_seconds: 90,
+  workspace_path: "/tmp/opensymphony/projects/COE-700",
+  safe_actions: { retry: false, cancel: true, rehydrate: true, detach: false },
+};
+
+const runEventsPage: RunEventPage = {
+  schema_version: schemaVersionV1(),
+  run_id: "COE-700",
+  events: [
+    {
+      schema_version: schemaVersionV1(),
+      event_id: "evt-1",
+      run_id: "COE-700",
+      sequence: 1,
+      timestamp: "2025-09-01T00:00:31Z",
+      kind: "tool_call",
+      summary: "parity stream event",
+      payload: {},
+    },
+  ],
+  next_cursor: null,
+  has_more: false,
+};
+
+const streamEvents: GatewayEnvelope[] = [
+  {
+    schema_version: schemaVersionV1(),
+    cursor: { sequence: 1, partition: "task_graph" },
+    correlation_id: "corr-1",
+    event_type: "snapshot_published",
+    payload: { kind: "task_graph", summary: "parity stream snapshot" } as unknown as Record<string, unknown>,
+  },
+];
+
+function buildTransport(): MockGatewayTransport {
+  return new MockGatewayTransport({
+    baseUri: "http://127.0.0.1:2468",
+    health: capabilities,
+    snapshot: dashboard,
+    taskGraph,
+    runDetails: [runDetail],
+    runEvents: [runEventsPage],
+    events: streamEvents,
+  });
+}
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushUntil(predicate: () => boolean, maxIterations = 40): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    if (predicate()) return;
+    await flushAsync();
+  }
+  throw new Error(`flushUntil timed out after ${maxIterations} iterations`);
+}
+
+interface ModeSnapshot {
+  mode: string;
+  root: HTMLDivElement;
+  metricsText: string;
+  taskGraphNodes: string[];
+  runHead: string;
+  planningHeading: string | null;
+  authState: string;
+}
+
+async function snapshotMode(mode: "web" | "desktop"): Promise<ModeSnapshot> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const handle = renderOpenSymphonyApp({
+    root,
+    mode,
+    transport: buildTransport(),
+  });
+
+  // Dashboard + task graph (both modes render the panel heading and nodes)
+  await flushUntil(() => root.querySelector(".os-task-graph-panel h2") !== null);
+  await flushUntil(() => root.querySelector("[data-node-id='run-parity']") !== null);
+  // Run detail: navigate to the run node so the run panel loads the mock run.
+  (root.querySelector("[data-node-id='run-parity']") as HTMLElement).click();
+  await flushUntil(() => root.querySelector(".os-run-head strong")?.textContent === "COE-700");
+
+  const metricsText = root.querySelector(".os-metrics")?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+  const taskGraphNodes = Array.from(root.querySelectorAll("[data-node-id]")).map((el) => el.getAttribute("data-node-id") ?? "");
+  const runHead = root.querySelector(".os-run-head strong")?.textContent ?? "";
+  const authState = root.querySelector("[data-opensymphony-app-shell='mounted']")?.getAttribute("data-auth-state") ?? "";
+
+  // Switch to the planning view to capture parity for planning drafts.
+  let planningHeading: string | null = null;
+  const planningTab = root.querySelector("[data-plan-view='planning']") as HTMLButtonElement | null;
+  if (planningTab) {
+    planningTab.click();
+    await flushUntil(() => root.querySelector(".os-planning-panel") !== null);
+    planningHeading = root.querySelector(".os-planning-panel h2")?.textContent ?? null;
+  }
+
+  await handle.destroy();
+  root.remove();
+
+  return { mode, root, metricsText, taskGraphNodes, runHead, planningHeading, authState };
+}
+
+describe("Remote web/desktop parity (COE-419)", () => {
+  it("renders the same core dashboard, task graph, run, stream, and planning state in web and desktop modes", async () => {
+    const web = await snapshotMode("web");
+    const desktop = await snapshotMode("desktop");
+
+    // Dashboard metrics parity
+    expect(web.metricsText).toBe(desktop.metricsText);
+    expect(web.metricsText).toContain("2");
+    expect(web.metricsText).toContain("Running");
+    expect(web.metricsText).toContain("Retry Queue");
+
+    // Task graph node parity
+    expect(web.taskGraphNodes).toEqual(desktop.taskGraphNodes);
+    expect(web.taskGraphNodes).toContain("m-parity");
+    expect(web.taskGraphNodes).toContain("run-parity");
+
+    // Run detail parity
+    expect(web.runHead).toBe(desktop.runHead);
+    expect(web.runHead).toBe("COE-700");
+
+    // Planning view parity (both render the shared planning workspace)
+    expect(web.planningHeading).toBe(desktop.planningHeading);
+    expect(web.planningHeading).not.toBeNull();
+
+    // Auth state parity (both open for local unauthenticated gateway)
+    expect(web.authState).toBe(desktop.authState);
+    expect(web.authState).toBe("open");
+  });
+
+  it("exposes the same fixture stream events through the shared transport for both modes", async () => {
+    const webTransport = buildTransport();
+    const desktopTransport = buildTransport();
+
+    const webEvents: GatewayEnvelope[] = [];
+    for await (const evt of webTransport.events()) {
+      webEvents.push(evt);
+    }
+    const desktopEvents: GatewayEnvelope[] = [];
+    for await (const evt of desktopTransport.events()) {
+      desktopEvents.push(evt);
+    }
+
+    expect(webEvents.map((e) => e.correlation_id)).toEqual(desktopEvents.map((e) => e.correlation_id));
+    expect(webEvents.map((e) => e.event_type)).toEqual(["snapshot_published"]);
+    expect(webEvents).toEqual(desktopEvents);
+  });
+});

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -347,7 +347,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       capabilities = await this.transport.health();
     } catch (error) {
       this.state.capabilities = null;
-      this.state.authState = this.resolveAuthState(null, error);
+      this.state.authState = this.resolveAuthState(error);
       if (this.state.authState !== "open") {
         this.state.connectionMode = "connected";
         this.state.connectionMessage = this.authMessage(this.state.authState);
@@ -365,7 +365,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.capabilities = capabilities;
       this.state.snapshot = snapshot;
       this.state.connectionMode = "connected";
-      this.state.authState = this.resolveAuthState(capabilities, null);
+      this.state.authState = this.resolveAuthState(null);
       this.state.connectionMessage = `Connected to ${this.transport.baseUri || "same-origin gateway"}`;
       this.state.selectedProjectId = snapshot.projects[0]?.project_id ?? "default";
       await this.loadTaskGraph(this.state.selectedProjectId);
@@ -376,7 +376,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       };
     } catch (error) {
       this.state.capabilities = capabilities;
-      this.state.authState = this.resolveAuthState(capabilities, error);
+      this.state.authState = this.resolveAuthState(error);
       if (this.state.authState !== "open") {
         // Capabilities resolved, but the protected resource rejected us.
         // Treat the connection as established so the auth placeholder renders
@@ -406,29 +406,17 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   /**
-   * Resolve the auth-facing state from capabilities and a thrown error.
+   * Resolve the auth-facing state from a thrown error.
    *
-   * - A classified auth error (`unauthenticated`/`unauthorized`/`forbidden`)
-   *   wins regardless of advertised auth modes.
-   * - With no error and `auth_modes` containing only `none`, the gateway is
-   *   `open` (local unauthenticated development mode).
-   * - With no error but auth-required capabilities, the shell still renders
-   *   `open` once a snapshot loaded successfully (the caller is signed in).
+   * The shell only gates on auth when a protected read fails: a classified
+   * auth error (`unauthenticated`/`unauthorized`/`forbidden`) wins, and any
+   * successful load (authenticated caller or local no-auth gateway) is
+   * `open`. Advertised `auth_modes` are not consulted here; capabilities are
+   * fetched separately so a snapshot that 401s still reports the gateway's
+   * auth modes, but they do not change the gate decision.
    */
-  private resolveAuthState(
-    capabilities: GatewayCapabilities | null,
-    error: unknown,
-  ): AuthState {
-    const fromError = authStateFromError(error);
-    if (fromError !== "open") {
-      return fromError;
-    }
-    if (error || !capabilities) {
-      return "open";
-    }
-    // Successful load: authenticated or no-auth gateway. Keep the dashboard
-    // open; the shell only gates on auth when a protected read fails.
-    return "open";
+  private resolveAuthState(error: unknown): AuthState {
+    return authStateFromError(error);
   }
 
   private authMessage(state: AuthState): string {

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -19,10 +19,7 @@ import type {
   TaskGraphSnapshot,
   AuthState,
 } from "@opensymphony/gateway-schema";
-import {
-  authStateFromError,
-  gatewayRequiresAuth,
-} from "@opensymphony/gateway-schema";
+import { authStateFromError } from "@opensymphony/gateway-schema";
 import { renderChangedFileList, renderFileDiff } from "./diff.js";
 import { renderValidationSummary } from "./validation.js";
 import { renderApprovalList, type ApprovalDecision } from "./approval.js";
@@ -802,8 +799,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    */
   private renderAuthPlaceholder(): string {
     const state = this.state.authState;
-    const requiresAuth = gatewayRequiresAuth(this.state.capabilities?.auth_modes ?? []);
-    const orgProject = this.renderOrgProjectPlaceholder(state, requiresAuth);
+    const orgProject = this.renderOrgProjectPlaceholder();
     if (state === "unauthenticated") {
       return `
         ${this.renderProfiles()}
@@ -858,12 +854,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    * Organization/project selection placeholder for hosted contexts.
    *
    * Real tenant/org selection arrives with hosted auth; this surface keeps the
-   * selector present so the data model and UI layout are stable.
+   * selector present so the data model and UI layout are stable. Only rendered
+   * for non-open auth states (see `renderAuthPlaceholder`), which all imply a
+   * hosted/auth-requiring gateway.
    */
-  private renderOrgProjectPlaceholder(state: AuthState, requiresAuth: boolean): string {
-    if (!requiresAuth && state === "unauthenticated") {
-      return "";
-    }
+  private renderOrgProjectPlaceholder(): string {
     return `
       <div class="os-auth-scope" data-testid="auth-scope">
         <div class="os-section-head"><h3>Workspace</h3></div>

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -17,6 +17,11 @@ import type {
   TaskGraphNode,
   TaskGraphNodeKind,
   TaskGraphSnapshot,
+  AuthState,
+} from "@opensymphony/gateway-schema";
+import {
+  authStateFromError,
+  gatewayRequiresAuth,
 } from "@opensymphony/gateway-schema";
 import { renderChangedFileList, renderFileDiff } from "./diff.js";
 import { renderValidationSummary } from "./validation.js";
@@ -137,6 +142,8 @@ type ConnectionMode = "connecting" | "connected" | "failed";
 interface AppState {
   connectionMode: ConnectionMode;
   connectionMessage: string;
+  authState: AuthState;
+  authMessage: string;
   capabilities: GatewayCapabilities | null;
   snapshot: DashboardSnapshot | null;
   taskGraph: TaskGraphSnapshot | null;
@@ -205,6 +212,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state = {
       connectionMode: "connecting",
       connectionMessage: "Connecting",
+      authState: "open",
+      authMessage: "",
       capabilities: null,
       snapshot: null,
       taskGraph: null,
@@ -334,14 +343,34 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private async loadGatewayState(): Promise<void> {
+    // Fetch capabilities first so an auth failure on the dashboard snapshot
+    // still tells us whether the gateway advertises auth (hosted mode). A
+    // gateway that requires auth typically succeeds on /capabilities but
+    // rejects the snapshot with 401/403 until the client authenticates.
+    let capabilities: GatewayCapabilities | null = null;
     try {
-      const [capabilities, snapshot] = await Promise.all([
-        this.transport.health(),
-        this.transport.snapshot(),
-      ]);
+      capabilities = await this.transport.health();
+    } catch (error) {
+      this.state.capabilities = null;
+      this.state.authState = this.resolveAuthState(null, error);
+      if (this.state.authState !== "open") {
+        this.state.connectionMode = "connected";
+        this.state.connectionMessage = this.authMessage(this.state.authState);
+        this.clearGatewayData();
+        return;
+      }
+      this.state.connectionMode = "failed";
+      this.state.connectionMessage = `Gateway unavailable: ${errorMessage(error)}`;
+      this.clearGatewayData();
+      return;
+    }
+
+    try {
+      const snapshot = await this.transport.snapshot();
       this.state.capabilities = capabilities;
       this.state.snapshot = snapshot;
       this.state.connectionMode = "connected";
+      this.state.authState = this.resolveAuthState(capabilities, null);
       this.state.connectionMessage = `Connected to ${this.transport.baseUri || "same-origin gateway"}`;
       this.state.selectedProjectId = snapshot.projects[0]?.project_id ?? "default";
       await this.loadTaskGraph(this.state.selectedProjectId);
@@ -351,20 +380,73 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         project_id: this.state.selectedProjectId,
       };
     } catch (error) {
-      this.state.capabilities = null;
-      this.state.snapshot = null;
-      this.state.taskGraph = null;
-      this.state.selectedProjectId = null;
-      this.state.selectedNodeId = null;
-      this.state.runDetail = null;
-      this.state.runFiles = null;
-      this.state.runDiff = null;
-      this.state.evidenceView = "diff";
-      this.state.runEvents = null;
-      this.state.runValidation = null;
-      this.state.runApprovals = null;
-      this.state.connectionMode = "failed";
-      this.state.connectionMessage = `Gateway unavailable: ${errorMessage(error)}`;
+      this.state.capabilities = capabilities;
+      this.state.authState = this.resolveAuthState(capabilities, error);
+      if (this.state.authState !== "open") {
+        // Capabilities resolved, but the protected resource rejected us.
+        // Treat the connection as established so the auth placeholder renders
+        // instead of a generic offline banner.
+        this.state.connectionMode = "connected";
+        this.state.connectionMessage = this.authMessage(this.state.authState);
+      } else {
+        this.state.connectionMode = "failed";
+        this.state.connectionMessage = `Gateway unavailable: ${errorMessage(error)}`;
+      }
+      this.clearGatewayData();
+    }
+  }
+
+  private clearGatewayData(): void {
+    this.state.snapshot = null;
+    this.state.taskGraph = null;
+    this.state.selectedProjectId = null;
+    this.state.selectedNodeId = null;
+    this.state.runDetail = null;
+    this.state.runFiles = null;
+    this.state.runDiff = null;
+    this.state.evidenceView = "diff";
+    this.state.runEvents = null;
+    this.state.runValidation = null;
+    this.state.runApprovals = null;
+  }
+
+  /**
+   * Resolve the auth-facing state from capabilities and a thrown error.
+   *
+   * - A classified auth error (`unauthenticated`/`unauthorized`/`forbidden`)
+   *   wins regardless of advertised auth modes.
+   * - With no error and `auth_modes` containing only `none`, the gateway is
+   *   `open` (local unauthenticated development mode).
+   * - With no error but auth-required capabilities, the shell still renders
+   *   `open` once a snapshot loaded successfully (the caller is signed in).
+   */
+  private resolveAuthState(
+    capabilities: GatewayCapabilities | null,
+    error: unknown,
+  ): AuthState {
+    const fromError = authStateFromError(error);
+    if (fromError !== "open") {
+      return fromError;
+    }
+    if (error || !capabilities) {
+      return "open";
+    }
+    // Successful load: authenticated or no-auth gateway. Keep the dashboard
+    // open; the shell only gates on auth when a protected read fails.
+    return "open";
+  }
+
+  private authMessage(state: AuthState): string {
+    switch (state) {
+      case "unauthenticated":
+        return "Sign in required";
+      case "unauthorized":
+        return "Access denied: insufficient permission";
+      case "forbidden":
+        return "Access forbidden";
+      case "open":
+      default:
+        return "";
     }
   }
 
@@ -668,7 +750,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const title = this.options.title ?? "OpenSymphony";
     this.options.root.innerHTML = `
       <style>${appShellStyles()}</style>
-      <main class="os-app" data-opensymphony-app-shell="mounted" data-mode="${this.options.mode}">
+      <main class="os-app" data-opensymphony-app-shell="mounted" data-mode="${this.options.mode}" data-auth-state="${this.state.authState}">
         <header class="os-topbar">
           <div>
             <h1>${escapeHtml(title)}</h1>
@@ -691,6 +773,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private renderViewContent(): string {
+    if (this.state.authState !== "open") {
+      return this.renderAuthPlaceholder();
+    }
     if (this.state.activeView === "planning") {
       return `
         ${this.renderProfiles()}
@@ -703,6 +788,101 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       ${this.renderTaskGraph()}
       ${this.renderRunDetail()}
       ${this.renderRunEvidence()}
+    `;
+  }
+
+  /**
+   * Render the auth-aware placeholder shell.
+   *
+   * Hosted auth integration arrives in a follow-on task; these placeholders
+   * keep the user-facing states stable so the real provider can slot in with
+   * minimal UI churn. Local unauthenticated gateways (`auth_modes:["none"]`)
+   * never reach this path because their reads succeed and `authState` stays
+   * `"open"`.
+   */
+  private renderAuthPlaceholder(): string {
+    const state = this.state.authState;
+    const requiresAuth = gatewayRequiresAuth(this.state.capabilities?.auth_modes ?? []);
+    const orgProject = this.renderOrgProjectPlaceholder(state, requiresAuth);
+    if (state === "unauthenticated") {
+      return `
+        ${this.renderProfiles()}
+        <section class="os-panel os-auth-panel" data-testid="auth-placeholder" data-auth-state="unauthenticated">
+          <div class="os-section-head"><h2>Sign in</h2><span>hosted</span></div>
+          <div class="os-auth-body">
+            <p class="os-auth-message" data-testid="auth-message">Sign in required to view this OpenSymphony workspace.</p>
+            <div class="os-auth-actions">
+              <button type="button" data-auth-action="sign-in" data-testid="auth-sign-in">Sign in</button>
+              <button type="button" data-auth-action="refresh" data-testid="auth-refresh">Retry</button>
+            </div>
+            <p class="os-auth-note" data-testid="auth-note">Hosted authentication is configured by your administrator. Local development gateways do not require sign-in.</p>
+          </div>
+          ${orgProject}
+        </section>
+      `;
+    }
+    if (state === "unauthorized") {
+      return `
+        ${this.renderProfiles()}
+        <section class="os-panel os-auth-panel os-auth-denied" data-testid="auth-placeholder" data-auth-state="unauthorized">
+          <div class="os-section-head"><h2>Access denied</h2><span>hosted</span></div>
+          <div class="os-auth-body">
+            <p class="os-auth-message" data-testid="auth-message">You are signed in but do not have permission to view this workspace.</p>
+            <div class="os-auth-actions">
+              <button type="button" data-auth-action="refresh" data-testid="auth-refresh">Retry</button>
+            </div>
+            <p class="os-auth-note" data-testid="auth-note">Request access from your organization administrator, or switch to a workspace you can access.</p>
+          </div>
+          ${orgProject}
+        </section>
+      `;
+    }
+    // forbidden
+    return `
+      ${this.renderProfiles()}
+      <section class="os-panel os-auth-panel os-auth-denied" data-testid="auth-placeholder" data-auth-state="forbidden">
+        <div class="os-section-head"><h2>Access forbidden</h2><span>hosted</span></div>
+        <div class="os-auth-body">
+          <p class="os-auth-message" data-testid="auth-message">Access to this workspace is forbidden.</p>
+          <div class="os-auth-actions">
+            <button type="button" data-auth-action="refresh" data-testid="auth-refresh">Retry</button>
+          </div>
+          <p class="os-auth-note" data-testid="auth-note">The gateway refused the request. If this is unexpected, contact your administrator.</p>
+        </div>
+        ${orgProject}
+      </section>
+    `;
+  }
+
+  /**
+   * Organization/project selection placeholder for hosted contexts.
+   *
+   * Real tenant/org selection arrives with hosted auth; this surface keeps the
+   * selector present so the data model and UI layout are stable.
+   */
+  private renderOrgProjectPlaceholder(state: AuthState, requiresAuth: boolean): string {
+    if (!requiresAuth && state === "unauthenticated") {
+      return "";
+    }
+    return `
+      <div class="os-auth-scope" data-testid="auth-scope">
+        <div class="os-section-head"><h3>Workspace</h3></div>
+        <div class="os-inline-fields">
+          <label class="os-field">
+            <span>Organization</span>
+            <select data-auth-org data-testid="auth-org" disabled>
+              <option value="">Select organization</option>
+            </select>
+          </label>
+          <label class="os-field">
+            <span>Project</span>
+            <select data-auth-project data-testid="auth-project" disabled>
+              <option value="">Select project</option>
+            </select>
+          </label>
+        </div>
+        <p class="os-auth-note">Organization and project selection is available after you sign in.</p>
+      </div>
     `;
   }
 
@@ -969,6 +1149,19 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private bindEvents(): void {
     this.options.root.querySelector("[data-save-profile]")?.addEventListener("click", () => {
       void this.saveProfile();
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-auth-action]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const action = button.dataset.authAction;
+        if (action === "sign-in") {
+          // Hosted auth provider integration is a follow-on task; the
+          // placeholder triggers a refresh so an operator-supplied session
+          // (or a newly-permitted gateway) is re-evaluated.
+          void this.refresh();
+        } else if (action === "refresh") {
+          void this.refresh();
+        }
+      });
     });
     this.options.root.querySelector("[data-profile-select]")?.addEventListener("change", (event) => {
       const target = event.target as HTMLSelectElement;
@@ -2393,6 +2586,16 @@ function appShellStyles(): string {
     .os-inline-state { width: 120px; }
     pre { margin: 0; padding: 10px; border-radius: 6px; background: #17202a; color: #d7e4ee; overflow: auto; font-size: 12px; }
     .os-empty { color: #667788; font-size: 13px; border: 1px dashed #cbd5df; border-radius: 6px; padding: 14px; }
+    .os-auth-panel { display: flex; flex-direction: column; gap: 14px; grid-column: 1 / -1; }
+    .os-auth-panel .os-section-head span { text-transform: uppercase; font-size: 11px; letter-spacing: 0.04em; color: #667788; }
+    .os-auth-body { display: flex; flex-direction: column; gap: 10px; }
+    .os-auth-message { margin: 0; font-size: 14px; }
+    .os-auth-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .os-auth-note { margin: 0; font-size: 12px; color: #667788; }
+    .os-auth-denied .os-auth-message { color: #991b1b; }
+    .os-auth-scope { border: 1px solid #d8dee4; border-radius: 6px; padding: 12px; display: flex; flex-direction: column; gap: 8px; background: #f8fafc; }
+    .os-auth-scope .os-section-head h3 { margin: 0; font-size: 13px; }
+    .os-auth-scope .os-auth-note { margin: 0; }
     .os-view-tabs { display: inline-flex; gap: 6px; }
     .os-view-tab { min-height: 32px; padding: 6px 12px; font-size: 13px; border-radius: 6px; background: #f8fafc; border: 1px solid #cad3dd; }
     .os-view-tab-active { background: #e7f1f5; border-color: #39708f; font-weight: 600; }
@@ -2456,6 +2659,10 @@ function appShellStyles(): string {
       .os-topbar, .os-panel, .os-list-item, .os-node, .os-dialog { background: #171d23; border-color: #2a3440; }
       .os-topbar p, .os-section-head span, .os-meta, .os-list-item span, .os-node span, .os-node em, .os-empty, .os-metrics span, .os-run-grid span, .os-run-meta, .os-event-time { color: #94a3b3; }
       .os-status, .os-metrics div, .os-run-grid div, .os-detail-strip, .os-run-head, .os-filter-bar, .os-pending-banner { background: #111820; border-color: #2a3440; }
+      .os-auth-panel .os-auth-message { color: #d9e2ea; }
+      .os-auth-denied .os-auth-message { color: #fca5a5; }
+      .os-auth-note { color: #94a3b3; }
+      .os-auth-scope { background: #111820; border-color: #2a3440; }
       .os-segmented { background: #111820; border-color: #2a3440; }
       .os-segmented button.is-selected { background: #18303a; border-color: #5ca0b8; }
       .os-field input, .os-field select, .os-inline-input, .os-dialog textarea { background: #0f151b; color: #d9e2ea; border-color: #344454; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -785,7 +785,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    */
   private renderAuthPlaceholder(): string {
     const state = this.state.authState;
-    const orgProject = this.renderOrgProjectPlaceholder();
+    // Org/project selection is only meaningful when the caller can still act
+    // on it (sign in / switch workspace). A hard 403 `forbidden` deny means
+    // the gateway refused the workspace outright, so tenant selectors would
+    // be misleading there.
+    const orgProject = state === "forbidden" ? "" : this.renderOrgProjectPlaceholder();
     if (state === "unauthenticated") {
       return `
         ${this.renderProfiles()}
@@ -840,9 +844,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    * Organization/project selection placeholder for hosted contexts.
    *
    * Real tenant/org selection arrives with hosted auth; this surface keeps the
-   * selector present so the data model and UI layout are stable. Only rendered
-   * for non-open auth states (see `renderAuthPlaceholder`), which all imply a
-   * hosted/auth-requiring gateway.
+   * selector present so the data model and UI layout are stable. Rendered only
+   * for `unauthenticated` and `unauthorized` auth states (see
+   * `renderAuthPlaceholder`), where the caller can still act on a workspace
+   * choice. It is intentionally omitted for `forbidden`, where the gateway has
+   * hard-denied the workspace.
    */
   private renderOrgProjectPlaceholder(): string {
     return `

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -140,7 +140,6 @@ interface AppState {
   connectionMode: ConnectionMode;
   connectionMessage: string;
   authState: AuthState;
-  authMessage: string;
   capabilities: GatewayCapabilities | null;
   snapshot: DashboardSnapshot | null;
   taskGraph: TaskGraphSnapshot | null;
@@ -210,7 +209,6 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       connectionMode: "connecting",
       connectionMessage: "Connecting",
       authState: "open",
-      authMessage: "",
       capabilities: null,
       snapshot: null,
       taskGraph: null,


### PR DESCRIPTION
## Summary

Add auth-aware placeholder states to the shared OpenSymphony client shell and verify remote web/desktop parity for the core views, preparing the user-facing states for hosted auth (OSYM-750). These are placeholders that reduce churn when real hosted auth arrives; the gateway data model and APIs are already designed for hosted mode (PRD 4.10).

Linear: COE-419 — Hosted Auth Placeholders And Web Parity (Milestone M10: Web Client And External Gateway).

## Changes

- **gateway-schema**: add a shared `AuthState` union (`open` / `unauthenticated` / `unauthorized` / `forbidden`) plus `authStateFromError` and `gatewayRequiresAuth` classifiers, exported from the package index. This makes the UI shell map auth outcomes to states without depending on the transport package.
- **api-client**: add a typed `GatewayRequestError` carrying classified codes (`unauthenticated` / `unauthorized` / `forbidden` / `unavailable`) and map HTTP 401/403 to auth errors in `HttpGatewayTransport.fetchJson` and the `WebSocketTransport` handshake. Add an `authFailure` simulation hook to `MockGatewayTransport` (with a `clearAuthFailure` recovery path) so placeholder states are testable.
- **ui-core**: track `authState` in the shell; classify gateway errors in `loadGatewayState` (fetching capabilities before the snapshot so a hosted gateway that 401s the dashboard still reports `auth_modes`). Render distinct unauthenticated (sign-in), unauthorized (access denied), and forbidden placeholders with organization/project selection placeholders, while keeping local `auth_modes:["none"]` gateways on the open dashboard with no login gate. The shell root now exposes `data-auth-state` for both web and desktop remote modes.
- **docs**: document client auth placeholder states (`docs/deployment-modes.md` 7.4) and shared client-shell test coverage (`docs/testing-and-operations.md` 3.6).

## Evidence

### Test output

CI gate (clean build, no stale tsbuildinfo):

```
$ npm run build --workspace=@opensymphony/gateway-schema && npm run type-check
build-schema exit: 0
type-check REAL exit: 0   (0 errors)

$ npx jest --config jest.config.js --testPathIgnorePatterns="apps"
Test Suites: 22 passed, 22 total
Tests:       447 passed, 447 total

$ npm run build --workspace=@opensymphony/web && npm run build --workspace=@opensymphony/desktop && npx jest --config jest.config.js
Test Suites: 27 passed, 27 total
Tests:       464 passed, 464 total
```

Up from the 444-test baseline; +20 tests across the three new suites.

### Verification

- `gateway-errors.test.ts`: real `HttpGatewayTransport` (mocked `fetch`) maps HTTP 401 -> `unauthenticated`, 403 -> `forbidden`, 500 -> plain `Error`; `authStateFromError` classifies each code and returns `open` for non-auth errors; mock auth simulation + `clearAuthFailure` recovery.
- `auth-states.test.ts` (jsdom): hosted gateway mock that 401s the snapshot renders the `unauthenticated` sign-in placeholder (`data-auth-state="unauthenticated"`, `data-testid="auth-sign-in"`); explicit `unauthorized` code renders the access-denied placeholder with org/project selectors; `forbidden` renders the access-forbidden placeholder (no sign-in CTA); local `auth_modes:["none"]` gateway renders the dashboard/task graph with `data-auth-state="open"` and no auth placeholder; clicking Retry after `clearAuthFailure()` recovers to the open dashboard.
- `remote-parity.test.ts` (jsdom): the shell driven in `mode:"web"` and `mode:"desktop"` against an identical fixture transport renders the same dashboard metrics, task graph nodes, run detail (`COE-700`), planning workspace heading, stream events, and `authState` (`open`).

UI walkthrough (acceptance criterion): cold-launching against a gateway that rejects with 401 shows a "Sign in" placeholder; an explicit unauthorized code shows an access-denied placeholder; a 403 forbidden shows an access-forbidden placeholder; an open local gateway loads the dashboard/task graph/run/planning with no auth gate.

## Checklist

- [x] Tests pass (`npx jest --config jest.config.js`)
- [x] Code is formatted (no formatting changes; TS only)
- [x] Clippy is clean (no Rust changes)
- [x] Documentation updated (deployment-modes 7.4, testing-and-operations 3.6)
- [x] `AGENTS.md` updated (no repo-knowledge change)
- [x] Evidence section filled out

## Type of change

- [x] New feature

## Breaking changes

None. Local unauthenticated gateways are unaffected; auth placeholders only render when a protected read is rejected.

## Related issues

- Linear: COE-419 — Hosted Auth Placeholders And Web Parity
- Prepares user-facing states for hosted auth (OSYM-750), which is out of scope here.

## Additional notes

Package boundaries are preserved: `ui-core` stays independent of `api-client` by sourcing `AuthState` and the classifiers from the shared `@opensymphony/gateway-schema` package, matching PRD 4.4 (shared frontend owns the transport abstraction). Real hosted auth provider integration, tenant database design, and admin console remain out of scope.
_This PR was created by an AI agent (OpenHands) on behalf of kumanday._
