### PR TITLE
Add harness adapter capability discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,14 @@ The runtime client must:
 - reconnect with bounded exponential backoff
 - refresh cached state after reconnect
 
+### Keep harness capability discovery public
+
+- Public harness metadata belongs in `opensymphony-gateway-schema::capability::HarnessCapability` and the `/api/v1/capabilities` response.
+- Use stable harness kind strings such as `openhands_agent_server`, `codex_app_server`, and `rust_native`; do not expose private adapter type names to clients.
+- Concrete harness adapters should implement the domain `HarnessAdapter` capability boundary and keep OpenHands, Codex, or future in-process protocol details inside their adapter modules.
+- Future or experimental harnesses may be advertised as unavailable capability entries, but their feature gaps must be explicit.
+- When changing harness capability discovery, update gateway schema round-trip tests, the gateway capabilities endpoint test, adapter-boundary tests, and `docs/harness-adapter-compatibility.md`.
+
 ### Preserve forward compatibility
 
 OpenHands event schemas can evolve. Implement:

--- a/crates/opensymphony-domain/src/harness.rs
+++ b/crates/opensymphony-domain/src/harness.rs
@@ -1,0 +1,12 @@
+use crate::opensymphony_gateway_schema::capability::HarnessCapability;
+
+/// Minimal Rust boundary shared by concrete harness adapters.
+///
+/// Runtime execution remains owned by the orchestrator and concrete adapter
+/// modules. This trait gives the host and gateway a stable capability discovery
+/// surface without leaking private OpenHands, Codex, or future in-process types
+/// into client-facing DTOs.
+pub trait HarnessAdapter: Send + Sync {
+    fn harness_kind(&self) -> &'static str;
+    fn capabilities(&self) -> HarnessCapability;
+}

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -1,4 +1,5 @@
 mod control_plane;
+mod harness;
 mod identifiers;
 mod issue;
 mod journal;
@@ -19,6 +20,7 @@ pub use control_plane::{
     ControlPlaneMemoryServerStatus, ControlPlaneMetricsSnapshot, ControlPlaneRecentEvent,
     ControlPlaneRecentEventKind, ControlPlaneWorkerOutcome, SnapshotEnvelope,
 };
+pub use harness::HarnessAdapter;
 pub use identifiers::{
     ConversationId, IdentifierError, IssueId, IssueIdentifier, TrackerStateId, WorkerId,
     WorkspaceKey,

--- a/crates/opensymphony-gateway-schema/src/capability.rs
+++ b/crates/opensymphony-gateway-schema/src/capability.rs
@@ -9,6 +9,8 @@ pub struct GatewayCapabilities {
     pub gateway_version: String,
     pub supported_api_versions: Vec<String>,
     pub transports: Vec<TransportCapability>,
+    #[serde(default)]
+    pub harnesses: Vec<HarnessCapability>,
     pub features: Vec<FeatureCapability>,
     pub auth_modes: Vec<AuthMode>,
     pub max_event_page_size: u32,
@@ -29,6 +31,301 @@ pub struct FeatureCapability {
     pub available: bool,
     pub requires_auth: bool,
     pub requires_plan: Option<String>,
+}
+
+/// Public harness capability metadata exposed through `/api/v1/capabilities`.
+///
+/// This DTO intentionally uses stable strings for harness and transport names so
+/// clients can render unknown future harnesses without depending on private Rust
+/// adapter types.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessCapability {
+    pub kind: String,
+    pub display_name: String,
+    pub available: bool,
+    pub adapter_contract_version: String,
+    pub runtime_contract_version: Option<String>,
+    pub actions: HarnessActionCapability,
+    pub event_streams: HarnessEventStreamCapability,
+    pub approvals: HarnessApprovalCapability,
+    pub model_settings: HarnessModelSettingsCapability,
+    pub transport: HarnessTransportCapability,
+    pub cancellation: HarnessCancellationCapability,
+    pub pause_resume: HarnessPauseResumeCapability,
+    pub history: HarnessHistoryCapability,
+    pub notes: Vec<String>,
+    pub feature_gaps: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessActionCapability {
+    pub start_run: bool,
+    pub send_user_message: bool,
+    pub retry: bool,
+    pub cancel: bool,
+    pub pause: bool,
+    pub resume: bool,
+    pub approve: bool,
+    pub reject: bool,
+    pub comment: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessEventStreamCapability {
+    pub runtime_events: bool,
+    pub terminal_frames: bool,
+    pub replay_from_cursor: bool,
+    pub raw_payload_refs: bool,
+    pub delivery_modes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessApprovalCapability {
+    pub tool_approval: bool,
+    pub human_decision: bool,
+    pub policy_metadata: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessModelSettingsCapability {
+    pub api_compatible_settings: bool,
+    pub subscription_credentials: bool,
+    pub per_run_overrides: bool,
+    pub credential_reference_kinds: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessTransportCapability {
+    pub protocol: String,
+    pub modes: Vec<String>,
+    pub local: bool,
+    pub remote: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessCancellationCapability {
+    pub cancel_run: bool,
+    pub force_stop: bool,
+    pub acknowledges_cancel: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessPauseResumeCapability {
+    pub pause: bool,
+    pub resume: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessHistoryCapability {
+    pub fetch_history: bool,
+    pub reconcile_after_ready: bool,
+    pub reconnect_and_replay: bool,
+    pub preserve_unknown_events: bool,
+}
+
+impl HarnessCapability {
+    pub fn openhands_agent_server() -> Self {
+        Self {
+            kind: "openhands_agent_server".into(),
+            display_name: "OpenHands agent-server".into(),
+            available: true,
+            adapter_contract_version: "harness-adapter-v1".into(),
+            runtime_contract_version: Some("openhands-sdk-agent-server-v1".into()),
+            actions: HarnessActionCapability {
+                start_run: true,
+                send_user_message: true,
+                retry: true,
+                cancel: true,
+                pause: false,
+                resume: false,
+                approve: false,
+                reject: false,
+                comment: true,
+            },
+            event_streams: HarnessEventStreamCapability {
+                runtime_events: true,
+                terminal_frames: true,
+                replay_from_cursor: true,
+                raw_payload_refs: true,
+                delivery_modes: vec!["http_history".into(), "websocket".into()],
+            },
+            approvals: HarnessApprovalCapability {
+                tool_approval: false,
+                human_decision: false,
+                policy_metadata: false,
+            },
+            model_settings: HarnessModelSettingsCapability {
+                api_compatible_settings: true,
+                subscription_credentials: false,
+                per_run_overrides: true,
+                credential_reference_kinds: vec!["env".into()],
+            },
+            transport: HarnessTransportCapability {
+                protocol: "http_websocket".into(),
+                modes: vec!["rest".into(), "websocket".into()],
+                local: true,
+                remote: true,
+            },
+            cancellation: HarnessCancellationCapability {
+                cancel_run: true,
+                force_stop: true,
+                acknowledges_cancel: true,
+            },
+            pause_resume: HarnessPauseResumeCapability {
+                pause: false,
+                resume: false,
+            },
+            history: HarnessHistoryCapability {
+                fetch_history: true,
+                reconcile_after_ready: true,
+                reconnect_and_replay: true,
+                preserve_unknown_events: true,
+            },
+            notes: vec![
+                "Initial production adapter; reuses one conversation per issue by default.".into(),
+            ],
+            feature_gaps: vec![
+                "OpenHands pause/resume is not exposed by the current agent-server contract."
+                    .into(),
+                "Approval center normalization is reserved for a follow-up harness phase.".into(),
+            ],
+        }
+    }
+
+    pub fn codex_app_server_future() -> Self {
+        Self {
+            kind: "codex_app_server".into(),
+            display_name: "Codex app-server".into(),
+            available: false,
+            adapter_contract_version: "harness-adapter-v1".into(),
+            runtime_contract_version: None,
+            actions: HarnessActionCapability {
+                start_run: true,
+                send_user_message: true,
+                retry: true,
+                cancel: true,
+                pause: false,
+                resume: true,
+                approve: true,
+                reject: true,
+                comment: true,
+            },
+            event_streams: HarnessEventStreamCapability {
+                runtime_events: true,
+                terminal_frames: true,
+                replay_from_cursor: true,
+                raw_payload_refs: true,
+                delivery_modes: vec!["json_rpc_notifications".into()],
+            },
+            approvals: HarnessApprovalCapability {
+                tool_approval: true,
+                human_decision: true,
+                policy_metadata: true,
+            },
+            model_settings: HarnessModelSettingsCapability {
+                api_compatible_settings: true,
+                subscription_credentials: true,
+                per_run_overrides: true,
+                credential_reference_kinds: vec![
+                    "model_settings_ref".into(),
+                    "inherited_subscription_login".into(),
+                    "capability_token".into(),
+                    "signed_bearer".into(),
+                ],
+            },
+            transport: HarnessTransportCapability {
+                protocol: "json_rpc_2_0".into(),
+                modes: vec!["stdio".into(), "websocket_experimental".into()],
+                local: true,
+                remote: true,
+            },
+            cancellation: HarnessCancellationCapability {
+                cancel_run: true,
+                force_stop: false,
+                acknowledges_cancel: true,
+            },
+            pause_resume: HarnessPauseResumeCapability {
+                pause: false,
+                resume: true,
+            },
+            history: HarnessHistoryCapability {
+                fetch_history: true,
+                reconcile_after_ready: true,
+                reconnect_and_replay: true,
+                preserve_unknown_events: true,
+            },
+            notes: vec!["Future adapter shaped around JSON-RPC requests and notifications.".into()],
+            feature_gaps: vec![
+                "Production adapter implementation is out of scope for COE-408.".into(),
+                "Pause semantics need protocol confirmation before being advertised as available."
+                    .into(),
+            ],
+        }
+    }
+
+    pub fn rust_native_future() -> Self {
+        Self {
+            kind: "rust_native".into(),
+            display_name: "Rust-native harness".into(),
+            available: false,
+            adapter_contract_version: "harness-adapter-v1".into(),
+            runtime_contract_version: None,
+            actions: HarnessActionCapability {
+                start_run: true,
+                send_user_message: true,
+                retry: true,
+                cancel: true,
+                pause: true,
+                resume: true,
+                approve: true,
+                reject: true,
+                comment: true,
+            },
+            event_streams: HarnessEventStreamCapability {
+                runtime_events: true,
+                terminal_frames: true,
+                replay_from_cursor: true,
+                raw_payload_refs: true,
+                delivery_modes: vec!["in_process".into(), "subprocess_rpc".into()],
+            },
+            approvals: HarnessApprovalCapability {
+                tool_approval: true,
+                human_decision: true,
+                policy_metadata: true,
+            },
+            model_settings: HarnessModelSettingsCapability {
+                api_compatible_settings: true,
+                subscription_credentials: true,
+                per_run_overrides: true,
+                credential_reference_kinds: vec!["model_settings_ref".into()],
+            },
+            transport: HarnessTransportCapability {
+                protocol: "in_process_or_rpc".into(),
+                modes: vec!["in_process".into(), "subprocess_rpc".into()],
+                local: true,
+                remote: false,
+            },
+            cancellation: HarnessCancellationCapability {
+                cancel_run: true,
+                force_stop: true,
+                acknowledges_cancel: true,
+            },
+            pause_resume: HarnessPauseResumeCapability {
+                pause: true,
+                resume: true,
+            },
+            history: HarnessHistoryCapability {
+                fetch_history: true,
+                reconcile_after_ready: true,
+                reconnect_and_replay: true,
+                preserve_unknown_events: true,
+            },
+            notes: vec![
+                "Future high-performance local adapter for stable Rust execution APIs.".into(),
+            ],
+            feature_gaps: vec!["Concrete SDK/runtime selection is not implemented yet.".into()],
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/opensymphony-gateway-schema/src/capability.rs
+++ b/crates/opensymphony-gateway-schema/src/capability.rs
@@ -205,7 +205,7 @@ impl HarnessCapability {
                 retry: true,
                 cancel: true,
                 pause: false,
-                resume: true,
+                resume: false,
                 approve: true,
                 reject: true,
                 comment: true,
@@ -246,7 +246,7 @@ impl HarnessCapability {
             },
             pause_resume: HarnessPauseResumeCapability {
                 pause: false,
-                resume: true,
+                resume: false,
             },
             history: HarnessHistoryCapability {
                 fetch_history: true,
@@ -257,7 +257,7 @@ impl HarnessCapability {
             notes: vec!["Future adapter shaped around JSON-RPC requests and notifications.".into()],
             feature_gaps: vec![
                 "Production adapter implementation is out of scope for COE-408.".into(),
-                "Pause semantics need protocol confirmation before being advertised as available."
+                "Pause/resume semantics need protocol confirmation before being advertised as available."
                     .into(),
             ],
         }

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -2,7 +2,9 @@ use chrono::Utc;
 use opensymphony::opensymphony_gateway_schema::{
     action::{ActionDispatch, ActionKind, ActionReceipt, ActionStatus, ActionTarget},
     approval::{ApprovalKind, ApprovalRequest, ApprovalStatus},
-    capability::{AuthMode, FeatureCapability, GatewayCapabilities, TransportCapability},
+    capability::{
+        AuthMode, FeatureCapability, GatewayCapabilities, HarnessCapability, TransportCapability,
+    },
     cursor::{PageCursor, StreamCursor},
     envelope::{EntityKind, EntityRef, GatewayEnvelope},
     planning::{
@@ -398,6 +400,7 @@ fn gateway_capabilities_roundtrips() {
             supported_encodings: vec!["utf-8".into(), "base64".into()],
             bidirectional: true,
         }],
+        harnesses: vec![HarnessCapability::openhands_agent_server()],
         features: vec![FeatureCapability {
             feature: "task_graph".into(),
             available: true,
@@ -413,6 +416,53 @@ fn gateway_capabilities_roundtrips() {
     assert_eq!(back.gateway_version, "1.6.0");
     assert_eq!(back.max_event_page_size, 1000);
     assert_eq!(back.auth_modes.len(), 2);
+    assert_eq!(back.harnesses[0].kind, "openhands_agent_server");
+    assert!(back.harnesses[0].history.reconnect_and_replay);
+}
+
+#[test]
+fn harness_capability_roundtrips_future_adapters() {
+    let caps = vec![
+        HarnessCapability::openhands_agent_server(),
+        HarnessCapability::codex_app_server_future(),
+        HarnessCapability::rust_native_future(),
+    ];
+
+    let json = must_serialize(&caps);
+    let back: Vec<HarnessCapability> = must_deserialize(&json);
+
+    assert_eq!(back.len(), 3);
+    assert!(back[0].available);
+    assert_eq!(back[1].kind, "codex_app_server");
+    assert_eq!(back[1].transport.protocol, "json_rpc_2_0");
+    assert!(back[1].approvals.tool_approval);
+    assert_eq!(back[2].kind, "rust_native");
+    assert!(back[2].pause_resume.pause);
+}
+
+#[test]
+fn fake_harness_optional_capability_combinations_roundtrip() {
+    let mut fake = HarnessCapability::rust_native_future();
+    fake.kind = "fake_minimal".into();
+    fake.display_name = "Fake minimal harness".into();
+    fake.available = true;
+    fake.actions.pause = false;
+    fake.actions.resume = false;
+    fake.approvals.tool_approval = false;
+    fake.approvals.human_decision = false;
+    fake.model_settings.subscription_credentials = false;
+    fake.model_settings.credential_reference_kinds.clear();
+    fake.event_streams.delivery_modes = vec!["test_fixture".into()];
+    fake.feature_gaps = vec!["No approval or pause/resume support in this fake harness.".into()];
+
+    let json = must_serialize(&fake);
+    let back: HarnessCapability = must_deserialize(&json);
+
+    assert_eq!(back.kind, "fake_minimal");
+    assert!(!back.actions.pause);
+    assert!(!back.approvals.tool_approval);
+    assert!(back.history.preserve_unknown_events);
+    assert_eq!(back.event_streams.delivery_modes, vec!["test_fixture"]);
 }
 
 #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -71,7 +71,9 @@ pub use crate::opensymphony_gateway_schema::{
         PermissionResult,
     },
     approval::ApprovalRequest,
-    capability::{AuthMode, FeatureCapability, GatewayCapabilities, TransportCapability},
+    capability::{
+        AuthMode, FeatureCapability, GatewayCapabilities, HarnessCapability, TransportCapability,
+    },
     cursor::PageCursor,
     event_journal::{EventPage as GatewayEventPage, JournalError as EventJournalError},
     run::{
@@ -625,6 +627,11 @@ fn build_capabilities() -> GatewayCapabilities {
                 supported_encodings: vec!["utf-8".into()],
                 bidirectional: false,
             },
+        ],
+        harnesses: vec![
+            HarnessCapability::openhands_agent_server(),
+            HarnessCapability::codex_app_server_future(),
+            HarnessCapability::rust_native_future(),
         ],
         features: vec![
             FeatureCapability {

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -527,6 +527,9 @@ fn gateway_capabilities_json_fixture_roundtrips() {
                 bidirectional: false,
             },
         ],
+        harnesses: vec![
+            opensymphony::opensymphony_gateway_schema::capability::HarnessCapability::openhands_agent_server(),
+        ],
         features: vec![
             opensymphony::opensymphony_gateway_schema::capability::FeatureCapability {
                 feature: "planning".into(),
@@ -550,6 +553,7 @@ fn gateway_capabilities_json_fixture_roundtrips() {
     assert_eq!(back.supported_api_versions, vec!["1.0.0"]);
     assert_eq!(back.auth_modes.len(), 2);
     assert_eq!(back.max_event_page_size, 1000);
+    assert_eq!(back.harnesses[0].kind, "openhands_agent_server");
 }
 
 #[test]
@@ -606,7 +610,7 @@ async fn gateway_serves_capabilities_and_dashboard_snapshot() {
     assert_eq!(control_snapshot_response.sequence, 1);
 
     let caps_url = format!("http://{address}/api/v1/capabilities");
-    let _caps_response = client
+    let caps_response = client
         .get(&caps_url)
         .send()
         .await
@@ -615,7 +619,18 @@ async fn gateway_serves_capabilities_and_dashboard_snapshot() {
         .await
         .expect("decode capabilities");
 
-    // capabilities assertions verified in dedicated round-trip test
+    assert!(
+        caps_response
+            .harnesses
+            .iter()
+            .any(|harness| harness.kind == "openhands_agent_server" && harness.available)
+    );
+    assert!(
+        caps_response
+            .harnesses
+            .iter()
+            .any(|harness| harness.kind == "codex_app_server" && !harness.available)
+    );
 
     let snapshot_url = format!("http://{address}/api/v1/dashboard/snapshot");
     let snapshot_response = client

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -6,11 +6,13 @@ use std::{
 };
 
 use crate::opensymphony_domain::{
-    ConversationId, ConversationMetadata, DurationMs, IssueId, IssueIdentifier, NormalizedIssue,
-    RunAttempt, RuntimeStreamState, TimestampMs, WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord,
+    ConversationId, ConversationMetadata, DurationMs, HarnessAdapter, IssueId, IssueIdentifier,
+    NormalizedIssue, RunAttempt, RuntimeStreamState, TimestampMs, WorkerId, WorkerOutcomeKind,
+    WorkerOutcomeRecord,
 };
 #[cfg(test)]
 use crate::opensymphony_domain::{RuntimeLivenessPhase, RuntimeProgressSnapshot};
+use crate::opensymphony_gateway_schema::capability::HarnessCapability;
 use crate::opensymphony_memory::{
     IssueEvidence, IssueLinkEvidence, MemoryConfig, MemoryContextOptions, SourceFile,
     context_for_issue_with_options,
@@ -2808,6 +2810,16 @@ impl IssueSessionRunner {
             worker_outcome,
             run_status,
         })
+    }
+}
+
+impl HarnessAdapter for IssueSessionRunner {
+    fn harness_kind(&self) -> &'static str {
+        "openhands_agent_server"
+    }
+
+    fn capabilities(&self) -> HarnessCapability {
+        HarnessCapability::openhands_agent_server()
     }
 }
 

--- a/crates/opensymphony-openhands/tests/issue_session_runner.rs
+++ b/crates/opensymphony-openhands/tests/issue_session_runner.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, path::Path, time::Duration};
 
 use crate::opensymphony_domain::{
-    ConversationMetadata, IssueId, IssueIdentifier, IssueState, IssueStateCategory,
+    ConversationMetadata, HarnessAdapter, IssueId, IssueIdentifier, IssueState, IssueStateCategory,
     NormalizedIssue, RetryAttempt, RunAttempt, TimestampMs, WorkerId, WorkerOutcomeKind,
 };
 use crate::opensymphony_openhands::{
@@ -296,6 +296,24 @@ fn runner_config(workflow: &ResolvedWorkflow) -> IssueSessionRunnerConfig {
     config.terminal_wait_timeout = Duration::from_secs(2);
     config.finished_drain_timeout = Duration::from_millis(200);
     config
+}
+
+#[test]
+fn issue_session_runner_reports_harness_adapter_capabilities() {
+    let client = OpenHandsClient::new(TransportConfig::new("http://127.0.0.1:1"));
+    let runner = IssueSessionRunner::new(client, IssueSessionRunnerConfig::default());
+
+    assert_eq!(
+        HarnessAdapter::harness_kind(&runner),
+        "openhands_agent_server"
+    );
+    let capabilities = HarnessAdapter::capabilities(&runner);
+    assert_eq!(capabilities.kind, "openhands_agent_server");
+    assert!(capabilities.available);
+    assert!(capabilities.actions.start_run);
+    assert!(capabilities.event_streams.replay_from_cursor);
+    assert!(capabilities.history.reconcile_after_ready);
+    assert!(!capabilities.pause_resume.pause);
 }
 
 fn run_attempt(

--- a/docs/gateway-schema-v1.md
+++ b/docs/gateway-schema-v1.md
@@ -37,9 +37,21 @@ be forward-compatible, versioned, and transport-agnostic.
 | `terminal` | Terminal/log frames | `TerminalFrame`, `TerminalSnapshot` |
 | `approval` | Human-in-the-loop | `ApprovalRequest`, `ActionReceipt` |
 | `planning` | Planning artifacts | `PlanningArtifact`, `PlanningSessionSummary` |
-| `capability` | Discovery | `GatewayCapabilities`, `TransportCapability` |
+| `capability` | Discovery | `GatewayCapabilities`, `TransportCapability`, `HarnessCapability` |
 | `action` | Mutation dispatch | `ActionDispatch`, `ActionKind` |
 | `transport` | Benchmark metadata | `TransportRecommendation`, `TransportProfile` |
+
+## Harness Capabilities
+
+`GET /api/v1/capabilities` includes a `harnesses` array. Each
+`HarnessCapability` describes a public harness kind, transport shape, supported
+run actions, event stream behavior, approval support, model-setting support,
+cancellation, pause/resume, and history/replay support.
+
+The harness list deliberately uses stable strings such as
+`openhands_agent_server`, `codex_app_server`, and `rust_native` rather than
+private adapter class names. Clients should use the advertised booleans and
+feature gaps instead of special-casing adapter internals.
 
 ## Event envelope example
 

--- a/docs/harness-adapter-compatibility.md
+++ b/docs/harness-adapter-compatibility.md
@@ -1,0 +1,64 @@
+# Harness Adapter Compatibility
+
+This memo records the COE-408 adapter fit notes for the shared harness capability
+model. The public discovery surface is `HarnessCapability` in
+`opensymphony-gateway-schema`; the Rust boundary is `HarnessAdapter` in
+`opensymphony-domain`.
+
+## Shared Contract
+
+The capability DTO covers the minimum cross-harness questions clients and host
+code need before selecting or rendering a harness:
+
+- actions: start, message, retry, cancel, pause/resume, approvals, comments
+- event streams: runtime events, terminal frames, cursor replay, raw payload refs
+- approvals: tool approval, human decisions, policy metadata
+- model settings: API-compatible settings, subscription credentials, per-run
+  overrides, credential reference kinds
+- transport: protocol, modes, local/remote support
+- cancellation and pause/resume semantics
+- history: REST/history fetch, readiness reconciliation, reconnect/replay,
+  unknown-event preservation
+
+## OpenHands Agent Server
+
+OpenHands is the initial production adapter and fits the finalized shape through
+the existing `IssueSessionRunner`. It supports conversation creation, message
+send, run triggering, HTTP history fetch, WebSocket runtime events, readiness
+reconciliation, reconnect/replay, unknown raw event preservation, retries,
+cancellation, and terminal frames.
+
+Known gaps:
+
+- Pause/resume is not exposed by the current OpenHands agent-server contract.
+- Approval-center normalization is not yet available through the gateway DTOs.
+- Subscription credentials are separate future work; API-compatible env-backed
+  model settings are the current supported path.
+
+## Codex App Server
+
+Codex app-server fits the same contract as a future JSON-RPC adapter. Requests
+map to start thread/turn, send input, approve/reject, cancel, and resume
+operations. Notifications map to OpenSymphony runtime events with raw payload
+retention, cursor replay, and correlation IDs at the gateway layer.
+
+Known gaps:
+
+- Production adapter implementation is out of scope for COE-408.
+- Pause semantics need protocol confirmation before being advertised as
+  available.
+- WebSocket transport remains experimental until benchmarked and secured; stdio
+  is the preferred local integration mode.
+
+## Rust-Native Harness
+
+A Rust-native or in-process harness fits the same contract by implementing
+`HarnessAdapter` and normalizing its own run, event, approval, cancellation,
+history, and evidence behavior into the gateway DTOs. The capability model allows
+both in-process and subprocess/RPC modes.
+
+Known gaps:
+
+- Concrete SDK/runtime selection is not implemented yet.
+- Hosted execution would need an isolation model before remote support is
+  advertised.

--- a/docs/harness-adapter-compatibility.md
+++ b/docs/harness-adapter-compatibility.md
@@ -38,14 +38,14 @@ Known gaps:
 ## Codex App Server
 
 Codex app-server fits the same contract as a future JSON-RPC adapter. Requests
-map to start thread/turn, send input, approve/reject, cancel, and resume
-operations. Notifications map to OpenSymphony runtime events with raw payload
-retention, cursor replay, and correlation IDs at the gateway layer.
+map to start thread/turn, send input, approve/reject, and cancel operations.
+Notifications map to OpenSymphony runtime events with raw payload retention,
+cursor replay, and correlation IDs at the gateway layer.
 
 Known gaps:
 
 - Production adapter implementation is out of scope for COE-408.
-- Pause semantics need protocol confirmation before being advertised as
+- Pause/resume semantics need protocol confirmation before being advertised as
   available.
 - WebSocket transport remains experimental until benchmarked and secured; stdio
   is the preferred local integration mode.

--- a/docs/host-client-architecture.md
+++ b/docs/host-client-architecture.md
@@ -207,6 +207,12 @@ trait HarnessAdapter {
 
 The exact trait should be adapted to the Rust codebase, but the conceptual boundary should stay stable.
 
+The current Rust boundary is the `HarnessAdapter` capability interface in
+`opensymphony-domain`, backed by the public `HarnessCapability` DTO in
+`opensymphony-gateway-schema`. The gateway exposes those DTOs through
+`GET /api/v1/capabilities` so clients can discover harness support without
+depending on private OpenHands, Codex, or future in-process adapter types.
+
 #### OpenHands adapter
 
 Initial production adapter.


### PR DESCRIPTION
## Summary

Adds the COE-408 shared harness adapter capability model so gateway clients can discover OpenHands, future Codex app-server, and future Rust-native harness support without depending on private adapter types.

## Changes

- Added public `HarnessCapability` DTOs for actions, event streams, approvals, model settings, transport, cancellation, pause/resume, and history.
- Added a shared `HarnessAdapter` Rust boundary and implemented capability reporting for the existing OpenHands `IssueSessionRunner`.
- Exposed harness metadata through `/api/v1/capabilities` and documented OpenHands, Codex app-server, and Rust-native fit notes/gaps.

## Evidence

### Test output

```text
cargo test-system-duckdb gateway_schema --test gateway_schema
result: ok. 51 passed; 0 failed

cargo test-system-duckdb gateway_capabilities --test gateway
result: ok. 1 passed; 0 failed

cargo test-system-duckdb gateway_serves_capabilities_and_dashboard_snapshot --test gateway
result: ok. 1 passed; 0 failed

cargo test-system-duckdb --test issue_session_runner
result: ok. 18 passed; 0 failed

cargo fmt --all -- --check && git diff --check
result: passed

cargo clippy-system-duckdb
result: passed
```


### Runtime endpoint proof

```text
$ /Users/magos/.opensymphony/workspaces/manual-dispatch/COE-408/target/debug/opensymphony run --config config.yaml  # cwd=/tmp/coe408-gateway-probe-zpbeyqu4
$ curl -fsS http://127.0.0.1:55325/api/v1/capabilities | jq '{schema_version,gateway_version,harnesses:[.harnesses[] | {kind,available,adapter_contract_version,runtime_contract_version,transport,actions:{start_run,send_user_message,cancel,pause,resume,approve,reject},history,feature_gaps}]}'
{
  "gateway_version": "1.10.1",
  "schema_version": {"major": 1, "minor": 0, "patch": 0},
  "harnesses": [
    {
      "kind": "openhands_agent_server",
      "available": true,
      "adapter_contract_version": "harness-adapter-v1",
      "runtime_contract_version": "openhands-sdk-agent-server-v1",
      "transport": {"protocol": "http_websocket", "modes": ["rest", "websocket"], "local": true, "remote": true},
      "actions": {"start_run": true, "send_user_message": true, "cancel": true, "pause": false, "resume": false, "approve": false, "reject": false},
      "history": {"fetch_history": true, "reconcile_after_ready": true, "reconnect_and_replay": true, "preserve_unknown_events": true},
      "feature_gaps": ["OpenHands pause/resume is not exposed by the current agent-server contract.", "Approval center normalization is reserved for a follow-up harness phase."]
    },
    {"kind": "codex_app_server", "available": false, "adapter_contract_version": "harness-adapter-v1", "runtime_contract_version": null},
    {"kind": "rust_native", "available": false, "adapter_contract_version": "harness-adapter-v1", "runtime_contract_version": null}
  ]
}
```

The temp run used local mock OpenHands `/openapi.json` and Linear `/graphql` endpoints so no live Linear issues were processed. It exercised the real `opensymphony run` gateway server and the live `/api/v1/capabilities` route.

### Verification

Verified schema serialization for OpenHands, Codex app-server, Rust-native, and fake optional capability combinations. Verified the gateway capabilities endpoint returns OpenHands as available and Codex as unavailable future metadata. Verified the existing OpenHands issue-session runner suite still passes through the new adapter capability boundary.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None. `GatewayCapabilities.harnesses` defaults during deserialization for older payloads.

## Related issues

Linear: COE-408

## Additional notes

Codex app-server and Rust-native harnesses are advertised as future/unavailable capability entries with explicit feature gaps; production implementation is intentionally out of scope for COE-408.


