### PR TITLE
feat(gateway): add model credential settings seam

### DIFF
--- a/crates/opensymphony-gateway-schema/src/lib.rs
+++ b/crates/opensymphony-gateway-schema/src/lib.rs
@@ -4,6 +4,7 @@ pub mod capability;
 pub mod cursor;
 pub mod envelope;
 pub mod event_journal;
+pub mod model_settings;
 pub mod planning;
 pub mod run;
 pub mod snapshot;

--- a/crates/opensymphony-gateway-schema/src/model_settings.rs
+++ b/crates/opensymphony-gateway-schema/src/model_settings.rs
@@ -1,0 +1,311 @@
+use serde::{Deserialize, Serialize};
+
+use super::version::SchemaVersion;
+
+/// Public model and credential settings shape exposed for client rendering.
+///
+/// References intentionally point at secret storage locations or environment
+/// variables. They never carry API key values, OAuth refresh tokens, or access
+/// tokens.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSettingsResponse {
+    pub schema_version: SchemaVersion,
+    pub profiles: Vec<ModelSettingsProfile>,
+    pub credential_statuses: Vec<CredentialStatus>,
+    pub supported_credential_statuses: Vec<CredentialStatusKind>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialStatusResponse {
+    pub schema_version: SchemaVersion,
+    pub statuses: Vec<CredentialStatus>,
+    pub supported_statuses: Vec<CredentialStatusKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSettingsProfile {
+    pub id: String,
+    pub display_name: String,
+    pub owner_scope: OwnerScope,
+    pub provider: CredentialProvider,
+    pub credential_mode: CredentialMode,
+    pub storage_mode: CredentialStorageMode,
+    pub model: ConfiguredValueReference,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<ConfiguredValueReference>,
+    pub credential_reference: CredentialReference,
+    pub compatible_harnesses: Vec<String>,
+    pub status: CredentialStatusKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfiguredValueReference {
+    pub source: ConfiguredValueSource,
+    pub reference: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialReference {
+    pub id: String,
+    pub kind: CredentialReferenceKind,
+    pub provider: CredentialProvider,
+    pub storage_mode: CredentialStorageMode,
+    pub reference: String,
+    pub redacted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialStatus {
+    pub credential_reference_id: String,
+    pub provider: CredentialProvider,
+    pub status: CredentialStatusKind,
+    pub checked_by: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnerScope {
+    LocalUser,
+    Workspace,
+    Project,
+    Organization,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialProvider {
+    OpenAiCompatibleApi,
+    OpenAiChatGptCodex,
+    HostedCredentialBroker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialMode {
+    ApiKey,
+    Subscription,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialStorageMode {
+    Environment,
+    LocalKeychain,
+    OpenHandsAuthDirectory,
+    HostedBroker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfiguredValueSource {
+    EnvironmentVariable,
+    Literal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialReferenceKind {
+    EnvironmentVariable,
+    LocalKeychainServiceAccount,
+    OpenHandsAuthDirectory,
+    HostedBrokerReference,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialStatusKind {
+    Installed,
+    LoggedOut,
+    Expired,
+    Unsupported,
+    PermissionDenied,
+    Unknown,
+}
+
+impl ModelSettingsResponse {
+    pub fn local_default(llm_api_key_installed: bool) -> Self {
+        let api_key_status = if llm_api_key_installed {
+            CredentialStatusKind::Installed
+        } else {
+            CredentialStatusKind::LoggedOut
+        };
+        let profiles = vec![
+            openhands_api_key_profile(api_key_status),
+            codex_subscription_keychain_profile(),
+            openhands_auth_directory_profile(),
+            hosted_broker_future_profile(),
+        ];
+        let credential_statuses = profiles
+            .iter()
+            .map(CredentialStatus::from_profile)
+            .collect::<Vec<_>>();
+
+        Self {
+            schema_version: SchemaVersion::v1(),
+            profiles,
+            credential_statuses,
+            supported_credential_statuses: supported_credential_statuses(),
+            notes: vec![
+                "API-key profiles preserve OpenHands-compatible LLM_MODEL, LLM_API_KEY, and LLM_BASE_URL environment wiring.".into(),
+                "Subscription profiles expose credential references only; raw OAuth and API-key material stays in the selected storage backend.".into(),
+                "Hosted broker references are shape-compatible placeholders for the follow-up hosted secret-store implementation.".into(),
+            ],
+        }
+    }
+}
+
+impl CredentialStatusResponse {
+    pub fn from_model_settings(settings: &ModelSettingsResponse) -> Self {
+        Self {
+            schema_version: settings.schema_version.clone(),
+            statuses: settings.credential_statuses.clone(),
+            supported_statuses: settings.supported_credential_statuses.clone(),
+        }
+    }
+}
+
+impl CredentialStatus {
+    pub fn from_profile(profile: &ModelSettingsProfile) -> Self {
+        Self {
+            credential_reference_id: profile.credential_reference.id.clone(),
+            provider: profile.provider,
+            status: profile.status,
+            checked_by: "gateway_static_settings".into(),
+            detail: status_detail(profile),
+        }
+    }
+}
+
+pub fn supported_credential_statuses() -> Vec<CredentialStatusKind> {
+    vec![
+        CredentialStatusKind::Installed,
+        CredentialStatusKind::LoggedOut,
+        CredentialStatusKind::Expired,
+        CredentialStatusKind::Unsupported,
+        CredentialStatusKind::PermissionDenied,
+        CredentialStatusKind::Unknown,
+    ]
+}
+
+fn openhands_api_key_profile(status: CredentialStatusKind) -> ModelSettingsProfile {
+    ModelSettingsProfile {
+        id: "openhands-env-api-key".into(),
+        display_name: "OpenHands API-compatible environment profile".into(),
+        owner_scope: OwnerScope::LocalUser,
+        provider: CredentialProvider::OpenAiCompatibleApi,
+        credential_mode: CredentialMode::ApiKey,
+        storage_mode: CredentialStorageMode::Environment,
+        model: env_ref("LLM_MODEL"),
+        base_url: Some(env_ref("LLM_BASE_URL")),
+        credential_reference: CredentialReference {
+            id: "credential:env:LLM_API_KEY".into(),
+            kind: CredentialReferenceKind::EnvironmentVariable,
+            provider: CredentialProvider::OpenAiCompatibleApi,
+            storage_mode: CredentialStorageMode::Environment,
+            reference: "LLM_API_KEY".into(),
+            redacted: true,
+        },
+        compatible_harnesses: vec!["openhands_agent_server".into()],
+        status,
+    }
+}
+
+fn codex_subscription_keychain_profile() -> ModelSettingsProfile {
+    ModelSettingsProfile {
+        id: "codex-chatgpt-local-keychain".into(),
+        display_name: "Codex ChatGPT subscription keychain reference".into(),
+        owner_scope: OwnerScope::LocalUser,
+        provider: CredentialProvider::OpenAiChatGptCodex,
+        credential_mode: CredentialMode::Subscription,
+        storage_mode: CredentialStorageMode::LocalKeychain,
+        model: literal_ref("openai/chatgpt-codex-subscription"),
+        base_url: None,
+        credential_reference: CredentialReference {
+            id: "credential:keychain:openai-chatgpt-codex".into(),
+            kind: CredentialReferenceKind::LocalKeychainServiceAccount,
+            provider: CredentialProvider::OpenAiChatGptCodex,
+            storage_mode: CredentialStorageMode::LocalKeychain,
+            reference: "service=opensymphony,account=openai-chatgpt-codex".into(),
+            redacted: true,
+        },
+        compatible_harnesses: vec!["codex_app_server".into()],
+        status: CredentialStatusKind::LoggedOut,
+    }
+}
+
+fn openhands_auth_directory_profile() -> ModelSettingsProfile {
+    ModelSettingsProfile {
+        id: "openhands-chatgpt-auth-directory".into(),
+        display_name: "OpenHands ChatGPT subscription auth-directory reference".into(),
+        owner_scope: OwnerScope::LocalUser,
+        provider: CredentialProvider::OpenAiChatGptCodex,
+        credential_mode: CredentialMode::Subscription,
+        storage_mode: CredentialStorageMode::OpenHandsAuthDirectory,
+        model: literal_ref("openai/chatgpt-codex-subscription"),
+        base_url: None,
+        credential_reference: CredentialReference {
+            id: "credential:openhands-auth-dir:openai".into(),
+            kind: CredentialReferenceKind::OpenHandsAuthDirectory,
+            provider: CredentialProvider::OpenAiChatGptCodex,
+            storage_mode: CredentialStorageMode::OpenHandsAuthDirectory,
+            reference: "OPENHANDS_AUTH_DIR/openai".into(),
+            redacted: true,
+        },
+        compatible_harnesses: vec!["openhands_agent_server".into()],
+        status: CredentialStatusKind::Unsupported,
+    }
+}
+
+fn hosted_broker_future_profile() -> ModelSettingsProfile {
+    ModelSettingsProfile {
+        id: "hosted-openai-subscription-broker".into(),
+        display_name: "Hosted OpenAI subscription broker reference".into(),
+        owner_scope: OwnerScope::Organization,
+        provider: CredentialProvider::HostedCredentialBroker,
+        credential_mode: CredentialMode::Subscription,
+        storage_mode: CredentialStorageMode::HostedBroker,
+        model: literal_ref("openai/chatgpt-codex-subscription"),
+        base_url: None,
+        credential_reference: CredentialReference {
+            id: "credential:hosted-broker:openai-chatgpt-codex".into(),
+            kind: CredentialReferenceKind::HostedBrokerReference,
+            provider: CredentialProvider::HostedCredentialBroker,
+            storage_mode: CredentialStorageMode::HostedBroker,
+            reference: "hosted://credentials/openai-chatgpt-codex".into(),
+            redacted: true,
+        },
+        compatible_harnesses: vec!["codex_app_server".into(), "openhands_agent_server".into()],
+        status: CredentialStatusKind::Unsupported,
+    }
+}
+
+fn env_ref(reference: impl Into<String>) -> ConfiguredValueReference {
+    ConfiguredValueReference {
+        source: ConfiguredValueSource::EnvironmentVariable,
+        reference: reference.into(),
+    }
+}
+
+fn literal_ref(reference: impl Into<String>) -> ConfiguredValueReference {
+    ConfiguredValueReference {
+        source: ConfiguredValueSource::Literal,
+        reference: reference.into(),
+    }
+}
+
+fn status_detail(profile: &ModelSettingsProfile) -> String {
+    match profile.status {
+        CredentialStatusKind::Installed => "Credential reference is available.".into(),
+        CredentialStatusKind::LoggedOut => "Credential reference exists, but no login or secret material is installed.".into(),
+        CredentialStatusKind::Expired => "Credential reference exists, but stored credentials need refresh.".into(),
+        CredentialStatusKind::Unsupported => {
+            "Credential reference shape is advertised for compatibility; runtime adapter support is not implemented in this milestone.".into()
+        }
+        CredentialStatusKind::PermissionDenied => {
+            "Credential reference exists, but this process cannot read the backing storage.".into()
+        }
+        CredentialStatusKind::Unknown => "Credential reference has not been checked yet.".into(),
+    }
+}

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -34,7 +34,7 @@ use opensymphony::opensymphony_gateway_schema::{
     transport::{TransportProfile, TransportRecommendation},
     version::{GATEWAY_SCHEMA_VERSION, SchemaVersion},
 };
-use serde_json::json;
+use serde_json::{Value, json};
 
 fn must_serialize<T: serde::Serialize>(value: &T) -> String {
     serde_json::to_string(value).expect("must serialize")
@@ -42,6 +42,32 @@ fn must_serialize<T: serde::Serialize>(value: &T) -> String {
 
 fn must_deserialize<T: serde::de::DeserializeOwned>(json: &str) -> T {
     serde_json::from_str(json).expect("must deserialize")
+}
+
+fn assert_no_raw_secret_field_names(value: &Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, nested) in map {
+                let key = key.to_ascii_lowercase();
+                assert_ne!(key, "value", "raw value field must not be serialized");
+                assert!(
+                    !key.contains("token"),
+                    "token-bearing field must not be serialized"
+                );
+                assert!(
+                    !key.contains("secret"),
+                    "secret-bearing field must not be serialized"
+                );
+                assert_no_raw_secret_field_names(nested);
+            }
+        }
+        Value::Array(values) => {
+            for nested in values {
+                assert_no_raw_secret_field_names(nested);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
 }
 
 fn sample_schema_version() -> SchemaVersion {
@@ -91,6 +117,9 @@ fn model_settings_roundtrip_and_redact_secret_material() {
             && profile.credential_reference.redacted
             && profile.compatible_harnesses == vec!["codex_app_server"]
     }));
+    assert_no_raw_secret_field_names(
+        &serde_json::to_value(&back.profiles).expect("profiles serialize as JSON value"),
+    );
     assert!(
         back.supported_credential_statuses
             .contains(&CredentialStatusKind::Installed)

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -7,6 +7,10 @@ use opensymphony::opensymphony_gateway_schema::{
     },
     cursor::{PageCursor, StreamCursor},
     envelope::{EntityKind, EntityRef, GatewayEnvelope},
+    model_settings::{
+        CredentialStatusKind, CredentialStatusResponse, CredentialStorageMode,
+        ModelSettingsResponse,
+    },
     planning::{
         ArtifactDiff, ArtifactRevision, ConversationTurn, LinearPublishReceipt, PlanningArtifact,
         PlanningArtifactKind, PlanningSession, PlanningSessionStatus, PlanningSessionSummary,
@@ -57,6 +61,81 @@ fn schema_version_roundtrips() {
 #[test]
 fn gateway_schema_version_constant_matches() {
     assert_eq!(GATEWAY_SCHEMA_VERSION, "1.0.0");
+}
+
+#[test]
+fn model_settings_roundtrip_and_redact_secret_material() {
+    let settings = ModelSettingsResponse::local_default(false);
+    let json = must_serialize(&settings);
+    let back: ModelSettingsResponse = must_deserialize(&json);
+
+    assert_eq!(back.schema_version, sample_schema_version());
+    assert!(back.profiles.iter().any(|profile| {
+        profile.id == "openhands-env-api-key"
+            && profile.credential_reference.reference == "LLM_API_KEY"
+            && profile.model.reference == "LLM_MODEL"
+            && profile
+                .base_url
+                .as_ref()
+                .is_some_and(|base_url| base_url.reference == "LLM_BASE_URL")
+            && profile.compatible_harnesses == vec!["openhands_agent_server"]
+            && profile.status == CredentialStatusKind::LoggedOut
+    }));
+    assert!(back.profiles.iter().any(|profile| {
+        profile.storage_mode == CredentialStorageMode::HostedBroker
+            && profile.credential_reference.redacted
+            && profile.status == CredentialStatusKind::Unsupported
+    }));
+    assert!(back.profiles.iter().any(|profile| {
+        profile.storage_mode == CredentialStorageMode::LocalKeychain
+            && profile.credential_reference.redacted
+            && profile.compatible_harnesses == vec!["codex_app_server"]
+    }));
+    assert!(
+        back.supported_credential_statuses
+            .contains(&CredentialStatusKind::Installed)
+    );
+    assert!(
+        back.supported_credential_statuses
+            .contains(&CredentialStatusKind::Expired)
+    );
+    assert!(
+        back.supported_credential_statuses
+            .contains(&CredentialStatusKind::PermissionDenied)
+    );
+    assert!(!json.contains("sk-live-secret"));
+    assert!(!json.contains("refresh_token"));
+}
+
+#[test]
+fn credential_status_response_supports_ui_status_states() {
+    let settings = ModelSettingsResponse::local_default(true);
+    let statuses = CredentialStatusResponse::from_model_settings(&settings);
+    let json = must_serialize(&statuses);
+    let back: CredentialStatusResponse = must_deserialize(&json);
+
+    assert_eq!(back.schema_version, sample_schema_version());
+    assert!(
+        back.statuses
+            .iter()
+            .any(
+                |status| status.credential_reference_id == "credential:env:LLM_API_KEY"
+                    && status.status == CredentialStatusKind::Installed
+            )
+    );
+    assert_eq!(
+        back.supported_statuses,
+        vec![
+            CredentialStatusKind::Installed,
+            CredentialStatusKind::LoggedOut,
+            CredentialStatusKind::Expired,
+            CredentialStatusKind::Unsupported,
+            CredentialStatusKind::PermissionDenied,
+            CredentialStatusKind::Unknown,
+        ]
+    );
+    assert!(json.contains("\"installed\""));
+    assert!(json.contains("\"permission_denied\""));
 }
 
 #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -76,6 +76,7 @@ pub use crate::opensymphony_gateway_schema::{
     },
     cursor::PageCursor,
     event_journal::{EventPage as GatewayEventPage, JournalError as EventJournalError},
+    model_settings::{CredentialStatusResponse, ModelSettingsResponse},
     run::{
         ChangedFileEntry, DiffHunk, DiffLine, FileChangeKind, FileDiffPage, ReleaseReason,
         RunAction, RunDetail, RunDiagnostics, RunEvent, RunEventPage, RunFilesPage,
@@ -454,6 +455,11 @@ impl GatewayServer {
             .route("/api/v1/snapshot", get(control_snapshot))
             .route("/api/v1/control/events", get(control_events))
             .route("/api/v1/capabilities", get(capabilities))
+            .route("/api/v1/model-settings", get(model_settings))
+            .route(
+                "/api/v1/model-settings/credential-status",
+                get(model_credential_statuses),
+            )
             .route("/api/v1/dashboard/snapshot", get(dashboard_snapshot))
             .route("/api/v1/events", get(events))
             .route("/api/v1/event-journal", get(event_journal_query))
@@ -713,6 +719,12 @@ fn build_capabilities() -> GatewayCapabilities {
                 requires_plan: None,
             },
             FeatureCapability {
+                feature: "model_settings".into(),
+                available: true,
+                requires_auth: false,
+                requires_plan: None,
+            },
+            FeatureCapability {
                 feature: "hosted_mode".into(),
                 available: false,
                 requires_auth: true,
@@ -727,6 +739,20 @@ fn build_capabilities() -> GatewayCapabilities {
 
 async fn capabilities() -> Json<GatewayCapabilities> {
     Json(build_capabilities())
+}
+
+fn build_model_settings() -> ModelSettingsResponse {
+    ModelSettingsResponse::local_default(std::env::var_os("LLM_API_KEY").is_some())
+}
+
+async fn model_settings() -> Json<ModelSettingsResponse> {
+    Json(build_model_settings())
+}
+
+async fn model_credential_statuses() -> Json<CredentialStatusResponse> {
+    Json(CredentialStatusResponse::from_model_settings(
+        &build_model_settings(),
+    ))
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -741,14 +741,13 @@ async fn capabilities() -> Json<GatewayCapabilities> {
     Json(build_capabilities())
 }
 
-pub fn model_settings_for_llm_api_key_installed(
-    llm_api_key_installed: bool,
-) -> ModelSettingsResponse {
-    ModelSettingsResponse::local_default(llm_api_key_installed)
+pub fn model_settings_for_llm_api_key(llm_api_key: Option<&str>) -> ModelSettingsResponse {
+    ModelSettingsResponse::local_default(llm_api_key.is_some_and(|value| !value.trim().is_empty()))
 }
 
 fn build_model_settings() -> ModelSettingsResponse {
-    model_settings_for_llm_api_key_installed(std::env::var_os("LLM_API_KEY").is_some())
+    let llm_api_key = std::env::var("LLM_API_KEY").ok();
+    model_settings_for_llm_api_key(llm_api_key.as_deref())
 }
 
 async fn model_settings() -> Json<ModelSettingsResponse> {

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -741,8 +741,14 @@ async fn capabilities() -> Json<GatewayCapabilities> {
     Json(build_capabilities())
 }
 
+pub fn model_settings_for_llm_api_key_installed(
+    llm_api_key_installed: bool,
+) -> ModelSettingsResponse {
+    ModelSettingsResponse::local_default(llm_api_key_installed)
+}
+
 fn build_model_settings() -> ModelSettingsResponse {
-    ModelSettingsResponse::local_default(std::env::var_os("LLM_API_KEY").is_some())
+    model_settings_for_llm_api_key_installed(std::env::var_os("LLM_API_KEY").is_some())
 }
 
 async fn model_settings() -> Json<ModelSettingsResponse> {

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -16,7 +16,7 @@ use opensymphony::opensymphony_domain::{
 };
 use opensymphony::opensymphony_gateway::{
     GatewayCapabilities, GatewayServer, LinearTaskGraphClient, control_plane_to_dashboard_snapshot,
-    model_settings_for_llm_api_key_installed,
+    model_settings_for_llm_api_key,
 };
 use opensymphony::opensymphony_gateway_schema::action::{
     ActionDispatch, ActionKind, ActionReceipt, ActionStatus, ActionTarget,
@@ -562,7 +562,7 @@ fn gateway_capabilities_json_fixture_roundtrips() {
 
 #[test]
 fn gateway_model_settings_status_reflects_api_key_presence() {
-    let installed_settings = model_settings_for_llm_api_key_installed(true);
+    let installed_settings = model_settings_for_llm_api_key(Some("provider-secret"));
     let installed_profile = installed_settings
         .profiles
         .iter()
@@ -574,22 +574,29 @@ fn gateway_model_settings_status_reflects_api_key_presence() {
             && status.status == CredentialStatusKind::Installed
     }));
 
-    let logged_out_settings = model_settings_for_llm_api_key_installed(false);
-    let logged_out_profile = logged_out_settings
+    let missing_settings = model_settings_for_llm_api_key(None);
+    let missing_profile = missing_settings
         .profiles
         .iter()
         .find(|profile| profile.id == "openhands-env-api-key")
         .expect("OpenHands env profile should exist");
-    assert_eq!(logged_out_profile.status, CredentialStatusKind::LoggedOut);
-    assert!(
-        logged_out_settings
-            .credential_statuses
-            .iter()
-            .any(|status| {
-                status.credential_reference_id == "credential:env:LLM_API_KEY"
-                    && status.status == CredentialStatusKind::LoggedOut
-            })
-    );
+    assert_eq!(missing_profile.status, CredentialStatusKind::LoggedOut);
+    assert!(missing_settings.credential_statuses.iter().any(|status| {
+        status.credential_reference_id == "credential:env:LLM_API_KEY"
+            && status.status == CredentialStatusKind::LoggedOut
+    }));
+
+    let blank_settings = model_settings_for_llm_api_key(Some("   "));
+    let blank_profile = blank_settings
+        .profiles
+        .iter()
+        .find(|profile| profile.id == "openhands-env-api-key")
+        .expect("OpenHands env profile should exist");
+    assert_eq!(blank_profile.status, CredentialStatusKind::LoggedOut);
+    assert!(blank_settings.credential_statuses.iter().any(|status| {
+        status.credential_reference_id == "credential:env:LLM_API_KEY"
+            && status.status == CredentialStatusKind::LoggedOut
+    }));
 }
 
 #[test]
@@ -683,6 +690,10 @@ async fn gateway_serves_capabilities_and_dashboard_snapshot() {
         .json::<ModelSettingsResponse>()
         .await
         .expect("decode model settings");
+    // The endpoint derives API-key status from process environment. To avoid
+    // mutating global env in an async integration test, installed, missing, and
+    // blank-key cases are covered by
+    // `gateway_model_settings_status_reflects_api_key_presence`.
     assert!(model_settings_response.profiles.iter().any(|profile| {
         profile.id == "openhands-env-api-key"
             && profile.compatible_harnesses == vec!["openhands_agent_server"]

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -21,6 +21,9 @@ use opensymphony::opensymphony_gateway_schema::action::{
     ActionDispatch, ActionKind, ActionReceipt, ActionStatus, ActionTarget,
 };
 use opensymphony::opensymphony_gateway_schema::envelope::EntityKind;
+use opensymphony::opensymphony_gateway_schema::model_settings::{
+    CredentialStatusKind, CredentialStatusResponse, ModelSettingsResponse,
+};
 use opensymphony::opensymphony_gateway_schema::run::DiffLine;
 use opensymphony::opensymphony_gateway_schema::validation::ValidationStatus;
 use tokio::net::TcpListener;
@@ -630,6 +633,51 @@ async fn gateway_serves_capabilities_and_dashboard_snapshot() {
             .harnesses
             .iter()
             .any(|harness| harness.kind == "codex_app_server" && !harness.available)
+    );
+    assert!(
+        caps_response
+            .features
+            .iter()
+            .any(|feature| feature.feature == "model_settings" && feature.available)
+    );
+
+    let model_settings_url = format!("http://{address}/api/v1/model-settings");
+    let model_settings_response = client
+        .get(&model_settings_url)
+        .send()
+        .await
+        .expect("fetch model settings")
+        .json::<ModelSettingsResponse>()
+        .await
+        .expect("decode model settings");
+    assert!(model_settings_response.profiles.iter().any(|profile| {
+        profile.id == "openhands-env-api-key"
+            && profile.compatible_harnesses == vec!["openhands_agent_server"]
+            && profile.credential_reference.redacted
+    }));
+    assert!(model_settings_response.profiles.iter().any(|profile| {
+        profile.id == "hosted-openai-subscription-broker"
+            && profile.status == CredentialStatusKind::Unsupported
+    }));
+
+    let credential_status_url = format!("http://{address}/api/v1/model-settings/credential-status");
+    let credential_status_response = client
+        .get(&credential_status_url)
+        .send()
+        .await
+        .expect("fetch credential statuses")
+        .json::<CredentialStatusResponse>()
+        .await
+        .expect("decode credential statuses");
+    assert!(
+        credential_status_response
+            .supported_statuses
+            .contains(&CredentialStatusKind::Expired)
+    );
+    assert!(
+        credential_status_response
+            .supported_statuses
+            .contains(&CredentialStatusKind::PermissionDenied)
     );
 
     let snapshot_url = format!("http://{address}/api/v1/dashboard/snapshot");

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -16,6 +16,7 @@ use opensymphony::opensymphony_domain::{
 };
 use opensymphony::opensymphony_gateway::{
     GatewayCapabilities, GatewayServer, LinearTaskGraphClient, control_plane_to_dashboard_snapshot,
+    model_settings_for_llm_api_key_installed,
 };
 use opensymphony::opensymphony_gateway_schema::action::{
     ActionDispatch, ActionKind, ActionReceipt, ActionStatus, ActionTarget,
@@ -557,6 +558,38 @@ fn gateway_capabilities_json_fixture_roundtrips() {
     assert_eq!(back.auth_modes.len(), 2);
     assert_eq!(back.max_event_page_size, 1000);
     assert_eq!(back.harnesses[0].kind, "openhands_agent_server");
+}
+
+#[test]
+fn gateway_model_settings_status_reflects_api_key_presence() {
+    let installed_settings = model_settings_for_llm_api_key_installed(true);
+    let installed_profile = installed_settings
+        .profiles
+        .iter()
+        .find(|profile| profile.id == "openhands-env-api-key")
+        .expect("OpenHands env profile should exist");
+    assert_eq!(installed_profile.status, CredentialStatusKind::Installed);
+    assert!(installed_settings.credential_statuses.iter().any(|status| {
+        status.credential_reference_id == "credential:env:LLM_API_KEY"
+            && status.status == CredentialStatusKind::Installed
+    }));
+
+    let logged_out_settings = model_settings_for_llm_api_key_installed(false);
+    let logged_out_profile = logged_out_settings
+        .profiles
+        .iter()
+        .find(|profile| profile.id == "openhands-env-api-key")
+        .expect("OpenHands env profile should exist");
+    assert_eq!(logged_out_profile.status, CredentialStatusKind::LoggedOut);
+    assert!(
+        logged_out_settings
+            .credential_statuses
+            .iter()
+            .any(|status| {
+                status.credential_reference_id == "credential:env:LLM_API_KEY"
+                    && status.status == CredentialStatusKind::LoggedOut
+            })
+    );
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,19 @@ export LLM_API_KEY="fw-..."
 export LLM_BASE_URL="https://api.fireworks.ai/inference/v1"
 ```
 
+The gateway also exposes the local model settings seam through
+`GET /api/v1/model-settings`. The default API-compatible profile maps to the
+same three environment variables:
+
+- `LLM_MODEL` identifies the configured model string.
+- `LLM_API_KEY` is exposed only as a credential reference.
+- `LLM_BASE_URL` identifies the optional OpenAI-compatible base URL.
+
+Subscription-backed model profiles are represented as credential references for
+local keychain storage, isolated OpenHands auth-directory storage, and future
+hosted broker storage. Those references are safe to render in clients because
+they do not contain raw API keys, OAuth access tokens, or refresh tokens.
+
 The workflow supports `${VAR}` syntax for environment variable substitution in
 the front matter:
 

--- a/docs/gateway-schema-v1.md
+++ b/docs/gateway-schema-v1.md
@@ -38,6 +38,7 @@ be forward-compatible, versioned, and transport-agnostic.
 | `approval` | Human-in-the-loop | `ApprovalRequest`, `ActionReceipt` |
 | `planning` | Planning artifacts | `PlanningArtifact`, `PlanningSessionSummary` |
 | `capability` | Discovery | `GatewayCapabilities`, `TransportCapability`, `HarnessCapability` |
+| `model_settings` | Model profile and credential references | `ModelSettingsResponse`, `ModelSettingsProfile`, `CredentialStatusResponse` |
 | `action` | Mutation dispatch | `ActionDispatch`, `ActionKind` |
 | `transport` | Benchmark metadata | `TransportRecommendation`, `TransportProfile` |
 
@@ -52,6 +53,25 @@ The harness list deliberately uses stable strings such as
 `openhands_agent_server`, `codex_app_server`, and `rust_native` rather than
 private adapter class names. Clients should use the advertised booleans and
 feature gaps instead of special-casing adapter internals.
+
+## Model And Credential Settings
+
+`GET /api/v1/model-settings` returns the local model profile and credential
+reference catalog. The response preserves the current OpenHands-compatible
+environment profile by describing `LLM_MODEL`, `LLM_API_KEY`, and
+`LLM_BASE_URL` as references, not values. Subscription-backed entries use the
+same public profile shape for local keychain references, isolated OpenHands auth
+directory references, and future hosted broker references.
+
+`GET /api/v1/model-settings/credential-status` returns the status rows that UI
+clients can render for those references. Supported status values are
+`installed`, `logged_out`, `expired`, `unsupported`, `permission_denied`, and
+`unknown`.
+
+Credential references deliberately avoid raw secret material. API keys, OAuth
+refresh tokens, access tokens, and hosted broker payloads must stay in their
+backing storage and must not appear in gateway DTOs, logs, workspaces, browser
+payloads, or Linear comments.
 
 ## Event envelope example
 

--- a/docs/harness-adapter-compatibility.md
+++ b/docs/harness-adapter-compatibility.md
@@ -33,7 +33,10 @@ Known gaps:
 - Pause/resume is not exposed by the current OpenHands agent-server contract.
 - Approval-center normalization is not yet available through the gateway DTOs.
 - Subscription credentials are separate future work; API-compatible env-backed
-  model settings are the current supported path.
+  model settings are the current supported execution path.
+- The model settings endpoint can represent isolated OpenHands auth-directory
+  references for ChatGPT/Codex subscription credentials, but the adapter that
+  consumes those references is follow-up work.
 
 ## Codex App Server
 
@@ -49,6 +52,9 @@ Known gaps:
   available.
 - WebSocket transport remains experimental until benchmarked and secured; stdio
   is the preferred local integration mode.
+- Codex subscription readiness can build on the local keychain and hosted broker
+  credential reference shapes without requiring raw subscription tokens in
+  OpenSymphony workspaces or browser payloads.
 
 ## Rust-Native Harness
 


### PR DESCRIPTION
## Summary

Adds the COE-423 model and credential settings seam: redacted model profile DTOs, credential reference/status DTOs, and read-only gateway endpoints that preserve OpenHands API-compatible `LLM_*` behavior while exposing subscription-reference shapes for Codex and hosted follow-ups.

## Changes

- Add `model_settings` gateway schema DTOs for API-key profiles, subscription credential references, storage modes, owner scope, harness compatibility, and credential statuses.
- Expose `GET /api/v1/model-settings` and `GET /api/v1/model-settings/credential-status`, plus a `model_settings` capability flag.
- Add schema/gateway tests for structural redaction, status rendering, endpoint responses, hosted broker reference shape, local keychain references, dynamic `LLM_API_KEY` installed/logged-out status, and OpenHands env compatibility.
- Document the endpoint shape and harness fit notes in gateway, configuration, and compatibility docs.

## Evidence

### Test output

```
cargo fmt
# passed

git diff --check
# passed

cargo check-system-duckdb
# passed

cargo clippy-system-duckdb
# passed

cargo test-system-duckdb gateway_schema --test gateway_schema
# 53 passed; 0 failed

cargo test-system-duckdb gateway_model_settings_status_reflects_api_key_presence --test gateway
# 1 passed; 0 failed

cargo test-system-duckdb gateway_serves_capabilities_and_dashboard_snapshot --test gateway
# 1 passed; 0 failed

cargo test-system-duckdb issue_session_runner_forwards_workflow_owned_llm_provider_overrides --test issue_session_runner
# 1 passed; 0 failed
```

### Live gateway verification

Started the real gateway surface with:

```
LLM_MODEL=fake-model \
DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib \
DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include \
DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib \
cargo run --no-default-features --features duckdb-prebuilt -- run --config /tmp/coe423-config.yaml
```

Then exercised both new endpoints with `curl`:

```
curl -sS http://127.0.0.1:2472/api/v1/model-settings | jq '{schema_version, profiles: [.profiles[] | {id, credential_mode, storage_mode, status, credential_reference, compatible_harnesses}], supported_credential_statuses}'
```

```json
{
  "schema_version": {"major": 1, "minor": 0, "patch": 0},
  "profiles": [
    {
      "id": "openhands-env-api-key",
      "credential_mode": "api_key",
      "storage_mode": "environment",
      "status": "logged_out",
      "credential_reference": {
        "id": "credential:env:LLM_API_KEY",
        "kind": "environment_variable",
        "provider": "open_ai_compatible_api",
        "storage_mode": "environment",
        "reference": "LLM_API_KEY",
        "redacted": true
      },
      "compatible_harnesses": ["openhands_agent_server"]
    },
    {
      "id": "codex-chatgpt-local-keychain",
      "credential_mode": "subscription",
      "storage_mode": "local_keychain",
      "status": "logged_out",
      "credential_reference": {
        "id": "credential:keychain:openai-chatgpt-codex",
        "kind": "local_keychain_service_account",
        "provider": "open_ai_chat_gpt_codex",
        "storage_mode": "local_keychain",
        "reference": "service=opensymphony,account=openai-chatgpt-codex",
        "redacted": true
      },
      "compatible_harnesses": ["codex_app_server"]
    },
    {
      "id": "openhands-chatgpt-auth-directory",
      "credential_mode": "subscription",
      "storage_mode": "open_hands_auth_directory",
      "status": "unsupported",
      "credential_reference": {
        "id": "credential:openhands-auth-dir:openai",
        "kind": "open_hands_auth_directory",
        "provider": "open_ai_chat_gpt_codex",
        "storage_mode": "open_hands_auth_directory",
        "reference": "OPENHANDS_AUTH_DIR/openai",
        "redacted": true
      },
      "compatible_harnesses": ["openhands_agent_server"]
    },
    {
      "id": "hosted-openai-subscription-broker",
      "credential_mode": "subscription",
      "storage_mode": "hosted_broker",
      "status": "unsupported",
      "credential_reference": {
        "id": "credential:hosted-broker:openai-chatgpt-codex",
        "kind": "hosted_broker_reference",
        "provider": "hosted_credential_broker",
        "storage_mode": "hosted_broker",
        "reference": "hosted://credentials/openai-chatgpt-codex",
        "redacted": true
      },
      "compatible_harnesses": ["codex_app_server", "openhands_agent_server"]
    }
  ],
  "supported_credential_statuses": ["installed", "logged_out", "expired", "unsupported", "permission_denied", "unknown"]
}
```

```
curl -sS http://127.0.0.1:2472/api/v1/model-settings/credential-status | jq '{schema_version, statuses, supported_statuses}'
```

```json
{
  "schema_version": {"major": 1, "minor": 0, "patch": 0},
  "statuses": [
    {"credential_reference_id": "credential:env:LLM_API_KEY", "provider": "open_ai_compatible_api", "status": "logged_out", "checked_by": "gateway_static_settings", "detail": "Credential reference exists, but no login or secret material is installed."},
    {"credential_reference_id": "credential:keychain:openai-chatgpt-codex", "provider": "open_ai_chat_gpt_codex", "status": "logged_out", "checked_by": "gateway_static_settings", "detail": "Credential reference exists, but no login or secret material is installed."},
    {"credential_reference_id": "credential:openhands-auth-dir:openai", "provider": "open_ai_chat_gpt_codex", "status": "unsupported", "checked_by": "gateway_static_settings", "detail": "Credential reference shape is advertised for compatibility; runtime adapter support is not implemented in this milestone."},
    {"credential_reference_id": "credential:hosted-broker:openai-chatgpt-codex", "provider": "hosted_credential_broker", "status": "unsupported", "checked_by": "gateway_static_settings", "detail": "Credential reference shape is advertised for compatibility; runtime adapter support is not implemented in this milestone."}
  ],
  "supported_statuses": ["installed", "logged_out", "expired", "unsupported", "permission_denied", "unknown"]
}
```

### Verification

Confirmed the previous behavior still forwards workflow-owned OpenHands `LLM_API_KEY` and `LLM_BASE_URL` values into the agent-server conversation create request. Confirmed the new schema serializes credential references and supported UI status states without raw `value`, `token`, or `secret` fields. Confirmed the gateway serves the model settings and credential-status endpoints and advertises `model_settings` as an available feature.

## Checklist

- [x] Tests pass (`cargo test` equivalent focused/system-DuckDB commands listed above)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

Linear: COE-423

## Additional notes

Hosted credential-broker storage, OpenHands subscription login execution, Codex app-server execution, and dynamic cross-harness routing remain out of scope for COE-423 and are represented only as compatible reference/status shapes here.
