### PR TITLE
Add Codex app-server prototype benchmark

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Preferred crate and trait boundaries:
 - `opensymphony-workspace`
 - `opensymphony-linear`
 - `opensymphony-openhands`
+- `opensymphony-codex`
 - `opensymphony-orchestrator`
 - `opensymphony-control`
 - `opensymphony-cli`
@@ -119,6 +120,12 @@ The runtime client must:
 - Concrete harness adapters should implement the domain `HarnessAdapter` capability boundary and keep OpenHands, Codex, or future in-process protocol details inside their adapter modules.
 - Future or experimental harnesses may be advertised as unavailable capability entries, but their feature gaps must be explicit.
 - When changing harness capability discovery, update gateway schema round-trip tests, the gateway capabilities endpoint test, adapter-boundary tests, and `docs/harness-adapter-compatibility.md`.
+
+The feature-gated Codex app-server prototype uses the `codex-app-server-prototype`
+feature and the `opensymphony_codex` internal module boundary. Keep Codex
+app-server launch, JSON-RPC, and benchmark evidence documented in
+`docs/codex-app-server-prototype.md`; do not enable production routing while
+`codex_app_server` is advertised as unavailable.
 
 ### Preserve forward compatibility
 
@@ -271,6 +278,8 @@ When changing the pinned OpenHands assumptions, update `docs/sources.md`.
 - `docs/architecture.md`: runtime architecture
 - `docs/symphony-spec-alignment.md`: upstream spec mapping
 - `docs/openhands-agent-server.md`: agent-server integration choices
+- `docs/codex-app-server-prototype.md`: feature-gated Codex app-server
+  prototype, launch contract, JSON-RPC evidence, and benchmark results
 - `docs/websocket-runtime.md`: wire contract and recovery behavior
 - `docs/workspace-and-lifecycle.md`: workspace ownership and hooks
 - `docs/linear-and-tools.md`: Linear integration and GraphQL helper assets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ resolver = "2"
 
 [features]
 default = ["duckdb-bundled"]
+codex-app-server-prototype = []
 duckdb-bundled = ["duckdb/bundled"]
 duckdb-prebuilt = []
 

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -99,7 +99,7 @@ impl CodexAppServerLaunch {
                                 "--ws-auth".into(),
                                 "capability-token".into(),
                                 "--ws-token-file".into(),
-                                token_file.display().to_string(),
+                                token_file.to_string_lossy().to_string(),
                                 "--ws-token-sha256".into(),
                                 token_sha256.clone(),
                             ]);
@@ -114,7 +114,7 @@ impl CodexAppServerLaunch {
                                 "--ws-auth".into(),
                                 "signed-bearer-token".into(),
                                 "--ws-shared-secret-file".into(),
-                                shared_secret_file.display().to_string(),
+                                shared_secret_file.to_string_lossy().to_string(),
                                 "--ws-issuer".into(),
                                 issuer.clone(),
                                 "--ws-audience".into(),

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -34,7 +34,7 @@ pub enum CodexWebSocketAuth {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodexAppServerLaunch {
-    pub program: String,
+    program: String,
     pub transport: CodexAppServerTransport,
     pub extra_args: Vec<String>,
     pub websocket_auth: Option<CodexWebSocketAuth>,
@@ -42,8 +42,12 @@ pub struct CodexAppServerLaunch {
 
 impl CodexAppServerLaunch {
     pub fn stdio() -> Self {
+        Self::stdio_with_program("codex")
+    }
+
+    pub fn stdio_with_program(program: impl Into<String>) -> Self {
         Self {
-            program: "codex".into(),
+            program: program.into(),
             transport: CodexAppServerTransport::Stdio,
             extra_args: Vec::new(),
             websocket_auth: None,
@@ -51,16 +55,24 @@ impl CodexAppServerLaunch {
     }
 
     pub fn loopback_websocket(port: u16) -> Self {
+        Self::loopback_websocket_with_program("codex", port)
+    }
+
+    pub fn loopback_websocket_with_program(program: impl Into<String>, port: u16) -> Self {
         Self {
-            program: "codex".into(),
+            program: program.into(),
             transport: CodexAppServerTransport::WebSocketLoopback { port },
             extra_args: Vec::new(),
             websocket_auth: None,
         }
     }
 
-    pub fn command(&self) -> (&str, Vec<String>) {
-        (&self.program, self.command_args())
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    pub fn to_command(&self) -> (String, Vec<String>) {
+        (self.program.clone(), self.command_args())
     }
 
     pub fn command_args(&self) -> Vec<String> {

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -25,6 +25,13 @@ pub enum CodexAppServerTransport {
     WebSocketLoopback { port: u16 },
 }
 
+/// WebSocket auth arguments for the Codex app-server prototype.
+///
+/// This prototype's launch helpers return UTF-8 `String` arguments for stable
+/// tests and documentation snapshots. Token and shared-secret file paths are
+/// therefore limited to paths that can be passed losslessly as UTF-8; non-UTF-8
+/// local paths are out of scope until a production adapter carries `OsString`
+/// arguments or constructs a `std::process::Command` directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodexWebSocketAuth {
     CapabilityToken {
@@ -82,6 +89,12 @@ impl CodexAppServerLaunch {
         (self.program.clone(), self.command_args())
     }
 
+    /// Builds UTF-8 CLI arguments for prototype evidence and tests.
+    ///
+    /// Auth file paths are converted with `Path::to_string_lossy()` because this
+    /// helper returns `Vec<String>`. Use UTF-8 paths with the prototype; a
+    /// production harness should preserve native path bytes with `OsString` or
+    /// `std::process::Command` arguments.
     pub fn command_args(&self) -> Vec<String> {
         let mut args = vec!["app-server".into()];
         args.extend(self.extra_args.clone());

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -66,41 +66,44 @@ impl CodexAppServerLaunch {
             CodexAppServerTransport::Stdio => args.push("--stdio".into()),
             CodexAppServerTransport::WebSocketLoopback { port } => {
                 args.extend(["--listen".into(), format!("ws://127.0.0.1:{port}")]);
-            }
-        }
-        if let Some(auth) = &self.websocket_auth {
-            match auth {
-                CodexWebSocketAuth::CapabilityToken {
-                    token_file,
-                    token_sha256,
-                } => {
-                    args.extend([
-                        "--ws-auth".into(),
-                        "capability-token".into(),
-                        "--ws-token-file".into(),
-                        token_file.display().to_string(),
-                        "--ws-token-sha256".into(),
-                        token_sha256.clone(),
-                    ]);
-                }
-                CodexWebSocketAuth::SignedBearerToken {
-                    shared_secret_file,
-                    issuer,
-                    audience,
-                    max_clock_skew_seconds,
-                } => {
-                    args.extend([
-                        "--ws-auth".into(),
-                        "signed-bearer-token".into(),
-                        "--ws-shared-secret-file".into(),
-                        shared_secret_file.display().to_string(),
-                        "--ws-issuer".into(),
-                        issuer.clone(),
-                        "--ws-audience".into(),
-                        audience.clone(),
-                    ]);
-                    if let Some(seconds) = max_clock_skew_seconds {
-                        args.extend(["--ws-max-clock-skew-seconds".into(), seconds.to_string()]);
+                if let Some(auth) = &self.websocket_auth {
+                    match auth {
+                        CodexWebSocketAuth::CapabilityToken {
+                            token_file,
+                            token_sha256,
+                        } => {
+                            args.extend([
+                                "--ws-auth".into(),
+                                "capability-token".into(),
+                                "--ws-token-file".into(),
+                                token_file.display().to_string(),
+                                "--ws-token-sha256".into(),
+                                token_sha256.clone(),
+                            ]);
+                        }
+                        CodexWebSocketAuth::SignedBearerToken {
+                            shared_secret_file,
+                            issuer,
+                            audience,
+                            max_clock_skew_seconds,
+                        } => {
+                            args.extend([
+                                "--ws-auth".into(),
+                                "signed-bearer-token".into(),
+                                "--ws-shared-secret-file".into(),
+                                shared_secret_file.display().to_string(),
+                                "--ws-issuer".into(),
+                                issuer.clone(),
+                                "--ws-audience".into(),
+                                audience.clone(),
+                            ]);
+                            if let Some(seconds) = max_clock_skew_seconds {
+                                args.extend([
+                                    "--ws-max-clock-skew-seconds".into(),
+                                    seconds.to_string(),
+                                ]);
+                            }
+                        }
                     }
                 }
             }

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -131,19 +131,13 @@ impl CodexAppServerLaunch {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodexModelCredentialReuse {
     pub profile_id: String,
-    pub model_source: CodexConfiguredValueSource,
+    pub model_source: ConfiguredValueSource,
     pub model_reference: String,
     pub credential_reference_id: String,
     pub credential_reference_kind: CredentialReferenceKind,
     pub storage_mode: CredentialStorageMode,
     pub can_supply_subscription_credentials: bool,
     pub config_overrides: BTreeMap<String, String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CodexConfiguredValueSource {
-    EnvironmentVariable,
-    Literal,
 }
 
 impl CodexModelCredentialReuse {
@@ -163,12 +157,7 @@ impl CodexModelCredentialReuse {
 
         Some(Self {
             profile_id: profile.id.clone(),
-            model_source: match profile.model.source {
-                ConfiguredValueSource::EnvironmentVariable => {
-                    CodexConfiguredValueSource::EnvironmentVariable
-                }
-                ConfiguredValueSource::Literal => CodexConfiguredValueSource::Literal,
-            },
+            model_source: profile.model.source,
             model_reference: profile.model.reference.clone(),
             credential_reference_id: profile.credential_reference.id.clone(),
             credential_reference_kind: profile.credential_reference.kind,
@@ -183,6 +172,9 @@ impl CodexModelCredentialReuse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JsonRpcRequestEnvelope {
     pub jsonrpc: String,
+    /// OpenSymphony-generated prototype requests use numeric JSON-RPC IDs so a
+    /// session can allocate a monotonic sequence and correlate responses without
+    /// accepting client-supplied null IDs.
     pub id: u64,
     pub method: String,
     #[serde(default)]

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -61,6 +61,7 @@ impl CodexAppServerLaunch {
 
     pub fn command_args(&self) -> Vec<String> {
         let mut args = vec!["app-server".into()];
+        args.extend(self.extra_args.clone());
         match &self.transport {
             CodexAppServerTransport::Stdio => args.push("--stdio".into()),
             CodexAppServerTransport::WebSocketLoopback { port } => {
@@ -104,7 +105,6 @@ impl CodexAppServerLaunch {
                 }
             }
         }
-        args.extend(self.extra_args.clone());
         args
     }
 }

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -59,6 +59,10 @@ impl CodexAppServerLaunch {
         }
     }
 
+    pub fn command(&self) -> (&str, Vec<String>) {
+        (&self.program, self.command_args())
+    }
+
     pub fn command_args(&self) -> Vec<String> {
         let mut args = vec!["app-server".into()];
         args.extend(self.extra_args.clone());

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -115,8 +115,8 @@ pub struct CodexModelCredentialReuse {
     pub model_source: CodexConfiguredValueSource,
     pub model_reference: String,
     pub credential_reference_id: String,
-    pub credential_reference_kind: String,
-    pub storage_mode: String,
+    pub credential_reference_kind: CredentialReferenceKind,
+    pub storage_mode: CredentialStorageMode,
     pub can_supply_subscription_credentials: bool,
     pub config_overrides: BTreeMap<String, String>,
 }
@@ -152,31 +152,12 @@ impl CodexModelCredentialReuse {
             },
             model_reference: profile.model.reference.clone(),
             credential_reference_id: profile.credential_reference.id.clone(),
-            credential_reference_kind: credential_reference_kind_name(profile),
-            storage_mode: storage_mode_name(profile.storage_mode).into(),
+            credential_reference_kind: profile.credential_reference.kind,
+            storage_mode: profile.storage_mode,
             can_supply_subscription_credentials: profile.credential_mode
                 == CredentialMode::Subscription,
             config_overrides,
         })
-    }
-}
-
-fn credential_reference_kind_name(profile: &ModelSettingsProfile) -> String {
-    match profile.credential_reference.kind {
-        CredentialReferenceKind::EnvironmentVariable => "environment_variable",
-        CredentialReferenceKind::LocalKeychainServiceAccount => "local_keychain_service_account",
-        CredentialReferenceKind::OpenHandsAuthDirectory => "openhands_auth_directory",
-        CredentialReferenceKind::HostedBrokerReference => "hosted_broker_reference",
-    }
-    .into()
-}
-
-fn storage_mode_name(storage_mode: CredentialStorageMode) -> &'static str {
-    match storage_mode {
-        CredentialStorageMode::Environment => "environment",
-        CredentialStorageMode::LocalKeychain => "local_keychain",
-        CredentialStorageMode::OpenHandsAuthDirectory => "openhands_auth_directory",
-        CredentialStorageMode::HostedBroker => "hosted_broker",
     }
 }
 

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -315,6 +315,8 @@ pub struct NormalizedCodexEvent {
     pub raw: Value,
 }
 
+/// Normalize a server notification after the transport layer has accepted the
+/// JSON-RPC envelope version.
 pub fn normalize_server_notification(raw: Value) -> Option<NormalizedCodexEvent> {
     if raw.get("id").is_some() {
         return None;

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -1,3 +1,10 @@
+//! Feature-gated Codex app-server prototype helpers.
+//!
+//! OpenSymphony-generated JSON-RPC requests intentionally use monotonic numeric
+//! IDs in this prototype. The session owns outgoing request allocation and
+//! response correlation; benchmark tooling still compares IDs by string so it
+//! can report future Codex response-shape changes cleanly.
+
 use std::{collections::BTreeMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -218,18 +218,18 @@ impl CodexJsonRpcSession {
         )
     }
 
-    pub fn thread_start(&mut self, params: CodexThreadStartParams) -> JsonRpcRequestEnvelope {
-        self.request(
-            "thread/start",
-            serde_json::to_value(params).unwrap_or(Value::Null),
-        )
+    pub fn thread_start(
+        &mut self,
+        params: CodexThreadStartParams,
+    ) -> Result<JsonRpcRequestEnvelope, serde_json::Error> {
+        Ok(self.request("thread/start", serde_json::to_value(params)?))
     }
 
-    pub fn turn_start(&mut self, params: CodexTurnStartParams) -> JsonRpcRequestEnvelope {
-        self.request(
-            "turn/start",
-            serde_json::to_value(params).unwrap_or(Value::Null),
-        )
+    pub fn turn_start(
+        &mut self,
+        params: CodexTurnStartParams,
+    ) -> Result<JsonRpcRequestEnvelope, serde_json::Error> {
+        Ok(self.request("turn/start", serde_json::to_value(params)?))
     }
 
     pub fn request(&mut self, method: impl Into<String>, params: Value) -> JsonRpcRequestEnvelope {

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -32,6 +32,11 @@ pub enum CodexAppServerTransport {
 /// therefore limited to paths that can be passed losslessly as UTF-8; non-UTF-8
 /// local paths are out of scope until a production adapter carries `OsString`
 /// arguments or constructs a `std::process::Command` directly.
+///
+/// Auth file paths and token hashes are passed as command-line arguments by the
+/// current Codex CLI contract, so they may be visible through process-list
+/// inspection on shared hosts. Do not use this prototype with real shared-host
+/// secrets.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodexWebSocketAuth {
     CapabilityToken {
@@ -95,6 +100,10 @@ impl CodexAppServerLaunch {
     /// helper returns `Vec<String>`. Use UTF-8 paths with the prototype; a
     /// production harness should preserve native path bytes with `OsString` or
     /// `std::process::Command` arguments.
+    ///
+    /// Auth-related CLI arguments may be visible in process listings. Keep
+    /// prototype runs to local trusted environments and avoid real shared-host
+    /// secrets.
     pub fn command_args(&self) -> Vec<String> {
         let mut args = vec!["app-server".into()];
         args.extend(self.extra_args.clone());

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -1,0 +1,383 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::opensymphony_gateway_schema::model_settings::{
+    ConfiguredValueSource, CredentialMode, CredentialReferenceKind, CredentialStorageMode,
+    ModelSettingsProfile,
+};
+
+pub const CODEX_APP_SERVER_FEATURE: &str = "codex-app-server-prototype";
+pub const CODEX_APP_SERVER_KIND: &str = "codex_app_server";
+pub const CODEX_APP_SERVER_CONTRACT: &str = "codex-app-server-json-rpc-v2";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodexAppServerTransport {
+    Stdio,
+    WebSocketLoopback { port: u16 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodexWebSocketAuth {
+    CapabilityToken {
+        token_file: PathBuf,
+        token_sha256: String,
+    },
+    SignedBearerToken {
+        shared_secret_file: PathBuf,
+        issuer: String,
+        audience: String,
+        max_clock_skew_seconds: Option<u64>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexAppServerLaunch {
+    pub program: String,
+    pub transport: CodexAppServerTransport,
+    pub extra_args: Vec<String>,
+    pub websocket_auth: Option<CodexWebSocketAuth>,
+}
+
+impl CodexAppServerLaunch {
+    pub fn stdio() -> Self {
+        Self {
+            program: "codex".into(),
+            transport: CodexAppServerTransport::Stdio,
+            extra_args: Vec::new(),
+            websocket_auth: None,
+        }
+    }
+
+    pub fn loopback_websocket(port: u16) -> Self {
+        Self {
+            program: "codex".into(),
+            transport: CodexAppServerTransport::WebSocketLoopback { port },
+            extra_args: Vec::new(),
+            websocket_auth: None,
+        }
+    }
+
+    pub fn command_args(&self) -> Vec<String> {
+        let mut args = vec!["app-server".into()];
+        match &self.transport {
+            CodexAppServerTransport::Stdio => args.push("--stdio".into()),
+            CodexAppServerTransport::WebSocketLoopback { port } => {
+                args.extend(["--listen".into(), format!("ws://127.0.0.1:{port}")]);
+            }
+        }
+        if let Some(auth) = &self.websocket_auth {
+            match auth {
+                CodexWebSocketAuth::CapabilityToken {
+                    token_file,
+                    token_sha256,
+                } => {
+                    args.extend([
+                        "--ws-auth".into(),
+                        "capability-token".into(),
+                        "--ws-token-file".into(),
+                        token_file.display().to_string(),
+                        "--ws-token-sha256".into(),
+                        token_sha256.clone(),
+                    ]);
+                }
+                CodexWebSocketAuth::SignedBearerToken {
+                    shared_secret_file,
+                    issuer,
+                    audience,
+                    max_clock_skew_seconds,
+                } => {
+                    args.extend([
+                        "--ws-auth".into(),
+                        "signed-bearer-token".into(),
+                        "--ws-shared-secret-file".into(),
+                        shared_secret_file.display().to_string(),
+                        "--ws-issuer".into(),
+                        issuer.clone(),
+                        "--ws-audience".into(),
+                        audience.clone(),
+                    ]);
+                    if let Some(seconds) = max_clock_skew_seconds {
+                        args.extend(["--ws-max-clock-skew-seconds".into(), seconds.to_string()]);
+                    }
+                }
+            }
+        }
+        args.extend(self.extra_args.clone());
+        args
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexModelCredentialReuse {
+    pub profile_id: String,
+    pub model_source: CodexConfiguredValueSource,
+    pub model_reference: String,
+    pub credential_reference_id: String,
+    pub credential_reference_kind: String,
+    pub storage_mode: String,
+    pub can_supply_subscription_credentials: bool,
+    pub config_overrides: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexConfiguredValueSource {
+    EnvironmentVariable,
+    Literal,
+}
+
+impl CodexModelCredentialReuse {
+    pub fn from_profile(profile: &ModelSettingsProfile) -> Option<Self> {
+        if !profile
+            .compatible_harnesses
+            .iter()
+            .any(|kind| kind == CODEX_APP_SERVER_KIND)
+        {
+            return None;
+        }
+
+        let mut config_overrides = BTreeMap::new();
+        if profile.model.source == ConfiguredValueSource::Literal {
+            config_overrides.insert("model".into(), profile.model.reference.clone());
+        }
+
+        Some(Self {
+            profile_id: profile.id.clone(),
+            model_source: match profile.model.source {
+                ConfiguredValueSource::EnvironmentVariable => {
+                    CodexConfiguredValueSource::EnvironmentVariable
+                }
+                ConfiguredValueSource::Literal => CodexConfiguredValueSource::Literal,
+            },
+            model_reference: profile.model.reference.clone(),
+            credential_reference_id: profile.credential_reference.id.clone(),
+            credential_reference_kind: credential_reference_kind_name(profile),
+            storage_mode: storage_mode_name(profile.storage_mode).into(),
+            can_supply_subscription_credentials: profile.credential_mode
+                == CredentialMode::Subscription,
+            config_overrides,
+        })
+    }
+}
+
+fn credential_reference_kind_name(profile: &ModelSettingsProfile) -> String {
+    match profile.credential_reference.kind {
+        CredentialReferenceKind::EnvironmentVariable => "environment_variable",
+        CredentialReferenceKind::LocalKeychainServiceAccount => "local_keychain_service_account",
+        CredentialReferenceKind::OpenHandsAuthDirectory => "openhands_auth_directory",
+        CredentialReferenceKind::HostedBrokerReference => "hosted_broker_reference",
+    }
+    .into()
+}
+
+fn storage_mode_name(storage_mode: CredentialStorageMode) -> &'static str {
+    match storage_mode {
+        CredentialStorageMode::Environment => "environment",
+        CredentialStorageMode::LocalKeychain => "local_keychain",
+        CredentialStorageMode::OpenHandsAuthDirectory => "openhands_auth_directory",
+        CredentialStorageMode::HostedBroker => "hosted_broker",
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JsonRpcRequestEnvelope {
+    pub jsonrpc: String,
+    pub id: u64,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexJsonRpcSession {
+    next_id: u64,
+    pub client_name: String,
+    pub client_version: String,
+}
+
+impl CodexJsonRpcSession {
+    pub fn new(client_name: impl Into<String>, client_version: impl Into<String>) -> Self {
+        Self {
+            next_id: 1,
+            client_name: client_name.into(),
+            client_version: client_version.into(),
+        }
+    }
+
+    pub fn initialize(&mut self) -> JsonRpcRequestEnvelope {
+        self.request(
+            "initialize",
+            json!({
+                "clientInfo": {
+                    "name": self.client_name,
+                    "version": self.client_version,
+                },
+                "capabilities": {},
+            }),
+        )
+    }
+
+    pub fn thread_start(&mut self, params: CodexThreadStartParams) -> JsonRpcRequestEnvelope {
+        self.request(
+            "thread/start",
+            serde_json::to_value(params).unwrap_or(Value::Null),
+        )
+    }
+
+    pub fn turn_start(&mut self, params: CodexTurnStartParams) -> JsonRpcRequestEnvelope {
+        self.request(
+            "turn/start",
+            serde_json::to_value(params).unwrap_or(Value::Null),
+        )
+    }
+
+    pub fn request(&mut self, method: impl Into<String>, params: Value) -> JsonRpcRequestEnvelope {
+        let id = self.next_id;
+        self.next_id += 1;
+        JsonRpcRequestEnvelope {
+            jsonrpc: "2.0".into(),
+            id,
+            method: method.into(),
+            params,
+        }
+    }
+
+    pub fn encode_line(request: &JsonRpcRequestEnvelope) -> Result<String, serde_json::Error> {
+        serde_json::to_string(request).map(|line| format!("{line}\n"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexThreadStartParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub developer_instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ephemeral: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexTurnStartParams {
+    pub thread_id: String,
+    pub input: Vec<CodexUserInput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_user_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CodexUserInput {
+    #[serde(rename = "text")]
+    Text {
+        text: String,
+        #[serde(default)]
+        text_elements: Vec<Value>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NormalizedCodexEventKind {
+    ThreadStarted,
+    ThreadStatusChanged,
+    TurnStarted,
+    TurnCompleted,
+    ItemStarted,
+    ItemCompleted,
+    AgentMessageDelta,
+    PlanDelta,
+    Error,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizedCodexEvent {
+    pub kind: NormalizedCodexEventKind,
+    pub method: String,
+    pub thread_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub item_id: Option<String>,
+    pub message_delta: Option<String>,
+    pub raw: Value,
+}
+
+pub fn normalize_server_notification(raw: Value) -> Option<NormalizedCodexEvent> {
+    if raw.get("id").is_some() {
+        return None;
+    }
+    let method = raw.get("method")?.as_str()?.to_owned();
+    let params = raw.get("params").cloned().unwrap_or(Value::Null);
+    let kind = match method.as_str() {
+        "thread/started" => NormalizedCodexEventKind::ThreadStarted,
+        "thread/status/changed" => NormalizedCodexEventKind::ThreadStatusChanged,
+        "turn/started" => NormalizedCodexEventKind::TurnStarted,
+        "turn/completed" => NormalizedCodexEventKind::TurnCompleted,
+        "item/started" => NormalizedCodexEventKind::ItemStarted,
+        "item/completed" => NormalizedCodexEventKind::ItemCompleted,
+        "item/agentMessage/delta" => NormalizedCodexEventKind::AgentMessageDelta,
+        "item/plan/delta" => NormalizedCodexEventKind::PlanDelta,
+        "error" => NormalizedCodexEventKind::Error,
+        _ => NormalizedCodexEventKind::Unknown,
+    };
+
+    Some(NormalizedCodexEvent {
+        kind,
+        method,
+        thread_id: string_param(&params, "threadId"),
+        turn_id: string_param(&params, "turnId"),
+        item_id: string_param(&params, "itemId"),
+        message_delta: string_param(&params, "delta"),
+        raw,
+    })
+}
+
+fn string_param(params: &Value, key: &str) -> Option<String> {
+    params.get(key)?.as_str().map(str::to_owned)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexBenchmarkRequirement {
+    pub dimension: &'static str,
+    pub probe: &'static str,
+    pub acceptance_signal: &'static str,
+}
+
+pub fn websocket_benchmark_requirements() -> Vec<CodexBenchmarkRequirement> {
+    vec![
+        CodexBenchmarkRequirement {
+            dimension: "throughput",
+            probe: "send a batch of JSON-RPC thread/loaded/list requests over ws://127.0.0.1",
+            acceptance_signal: "all responses arrive with matching ids and measured requests/sec",
+        },
+        CodexBenchmarkRequirement {
+            dimension: "queue behavior",
+            probe: "enqueue many requests without awaiting per-request responses",
+            acceptance_signal: "response count matches sent count and p50/p95 latency is recorded",
+        },
+        CodexBenchmarkRequirement {
+            dimension: "reconnect",
+            probe: "close the WebSocket, reconnect, and run initialize again",
+            acceptance_signal: "new connection reaches ready state and responds after reconnect",
+        },
+        CodexBenchmarkRequirement {
+            dimension: "secure exposure",
+            probe: "verify localhost-only default plus capability-token and signed-bearer flags",
+            acceptance_signal: "non-loopback exposure remains gated by explicit auth settings",
+        },
+    ]
+}

--- a/crates/opensymphony-gateway-schema/src/capability.rs
+++ b/crates/opensymphony-gateway-schema/src/capability.rs
@@ -256,7 +256,7 @@ impl HarnessCapability {
             },
             notes: vec!["Future adapter shaped around JSON-RPC requests and notifications.".into()],
             feature_gaps: vec![
-                "Production adapter implementation is out of scope for COE-408.".into(),
+                "Production adapter implementation is out of scope for COE-426.".into(),
                 "Pause/resume semantics need protocol confirmation before being advertised as available."
                     .into(),
             ],

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -544,6 +544,18 @@ fn harness_capability_roundtrips_future_adapters() {
     assert_eq!(back[1].kind, "codex_app_server");
     assert_eq!(back[1].transport.protocol, "json_rpc_2_0");
     assert!(back[1].approvals.tool_approval);
+    assert!(
+        back[1]
+            .feature_gaps
+            .iter()
+            .any(|gap| gap.contains("COE-426"))
+    );
+    assert!(
+        !back[1]
+            .feature_gaps
+            .iter()
+            .any(|gap| gap.contains("COE-408"))
+    );
     assert_eq!(back[2].kind, "rust_native");
     assert!(back[2].pause_resume.pause);
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ OpenSymphony is split into five layers:
    - workspace manager
    - OpenHands REST client
    - OpenHands WebSocket runtime stream
+   - feature-gated Codex app-server prototype adapter
    - issue session runner
 5. Observability layer
    - structured logs
@@ -127,6 +128,9 @@ This keeps one canonical Linear API surface for the agent path.
   - issue capsules, DuckDB memory index, docs sync, and archive eligibility
 - `opensymphony_openhands`
   - OpenHands transport and session runner
+- `opensymphony_codex`
+  - feature-gated Codex app-server launch, JSON-RPC, credential reuse, and
+    benchmark prototype helpers
 - `opensymphony_orchestrator`
   - scheduler loop and reconciliation
 - `opensymphony_control`

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -94,6 +94,9 @@ The script performs:
   `codex app-server --help`.
 
 Use `--skip-websocket` when the installed Codex version lacks WebSocket support.
+Queued WebSocket requests use a derived per-request deadline of
+`--request-timeout-ms + --iterations`, so the documented high-iteration range
+does not inherit the default 5s timeout as an accidental whole-batch deadline.
 
 ## Local Benchmark Result
 

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -1,0 +1,148 @@
+# Codex App-Server Prototype And Benchmark Report
+
+COE-426 establishes a feature-gated Codex app-server integration shape. It does
+not enable Codex as a production harness and does not route OpenSymphony issues
+to Codex.
+
+## Prototype Scope
+
+- Feature gate: `codex-app-server-prototype`.
+- Runtime kind: `codex_app_server`.
+- Local transport: `codex app-server --stdio`.
+- Experimental remote transport: `codex app-server --listen ws://127.0.0.1:<port>`.
+- Contract source: generated Codex app-server JSON Schema and TypeScript
+  bindings from the installed Codex CLI.
+
+The prototype adds a small Rust module for:
+
+- launch argument construction for stdio and loopback WebSocket,
+- JSON-RPC request construction for `initialize`, `thread/start`, and
+  `turn/start`,
+- normalization of basic thread, turn, item, plan, error, and unknown
+  notifications while preserving the raw payload,
+- mapping existing OpenSymphony model and credential setting profiles to future
+  Codex app-server use.
+
+## Installed Codex Evidence
+
+Captured on 2026-06-20 from this checkout:
+
+```text
+$ codex --version
+codex-cli 0.138.0
+
+$ codex app-server --help
+Usage: codex app-server [OPTIONS] [COMMAND]
+Commands: daemon, proxy, generate-ts, generate-json-schema
+Options include --listen <URL>, --stdio, --ws-auth <MODE>,
+--ws-token-file, --ws-token-sha256, --ws-shared-secret-file,
+--ws-issuer, --ws-audience, and --ws-max-clock-skew-seconds.
+```
+
+A local stdio probe successfully started a JSON-RPC session:
+
+```text
+$ codex app-server --stdio
+request: {"jsonrpc":"2.0","id":1,"method":"initialize",...}
+response: {"id":1,"result":{"userAgent":"opensymphony-probe/0.138.0 ...",
+"codexHome":"/Users/magos/.codex","platformFamily":"unix","platformOs":"macos"}}
+```
+
+Schema generation is supported:
+
+```text
+codex app-server generate-json-schema --out <dir>
+codex app-server generate-ts --out <dir>
+```
+
+The generated protocol includes `initialize`, `thread/start`, `turn/start`,
+`thread/started`, `turn/started`, `turn/completed`,
+`item/agentMessage/delta`, `item/started`, `item/completed`, and server-side
+approval request shapes.
+
+## Benchmark Script
+
+Run:
+
+```bash
+node scripts/codex_app_server_benchmark.mjs --iterations 50 --port 18765
+```
+
+The script performs:
+
+- stdio `initialize` latency,
+- loopback WebSocket readiness via `/readyz`,
+- WebSocket `initialize` latency,
+- queued `thread/loaded/list` request throughput and p50/p95 latency,
+- reconnect by closing the socket, opening a new socket, and initializing again,
+- secure exposure checks for localhost-only listener output and advertised
+  capability-token/signed-bearer WebSocket auth flags.
+
+Use `--skip-websocket` when the installed Codex version lacks WebSocket support.
+
+## Local Benchmark Result
+
+On this machine with `codex-cli 0.138.0`, stdio initialize and loopback
+WebSocket probes are supported. A 10-request local run produced:
+
+```json
+{
+  "stdioInitializeLatencyMs": 261.716,
+  "websocketInitializeLatencyMs": 6.088,
+  "websocketQueuedRequests": 10,
+  "websocketQueuedResponses": 10,
+  "websocketRequestsPerSecond": 1459.77,
+  "websocketLatencyMs": { "p50": 6.263, "p95": 6.69, "max": 6.69 },
+  "websocketReconnectLatencyMs": 3.22,
+  "websocketReconnectResponse": "ok",
+  "websocketLocalhostOnly": true,
+  "capabilityTokenModeAdvertised": true,
+  "signedBearerModeAdvertised": true
+}
+```
+
+Loopback WebSocket starts with:
+
+```text
+codex app-server (WebSockets)
+  listening on: ws://127.0.0.1:<port>
+  readyz: http://127.0.0.1:<port>/readyz
+  healthz: http://127.0.0.1:<port>/healthz
+  note: binds localhost only (use SSH port-forwarding for remote access)
+```
+
+The production recommendation is to keep WebSocket feature-gated until CI or a
+repeatable developer benchmark records stable throughput, queue, reconnect, and
+auth behavior for the pinned Codex version.
+
+## Model And Credential Reuse
+
+Codex must reuse the gateway model settings shape instead of owning
+subscription credentials. The current mapping is:
+
+- `codex-chatgpt-local-keychain`: local subscription credential reference for
+  future desktop/local Codex app-server use.
+- `hosted-openai-subscription-broker`: hosted broker reference for future
+  hosted Codex app-server or OpenHands subscription use.
+- literal model references are converted into Codex config overrides where the
+  app-server supports them.
+
+Gaps:
+
+- No production Codex credential reader is implemented in this issue.
+- No raw subscription token is stored in an OpenSymphony workspace or sent to
+  browser clients.
+- Hosted credential broker support remains a follow-up implementation.
+
+## Readiness Recommendation
+
+Codex app-server is suitable for a feature-gated local prototype and contract
+test path. Production enablement should wait for:
+
+- a pinned Codex app-server protocol version and generated schema artifact
+  policy,
+- replay/history semantics for reconnect beyond one-shot request recovery,
+- approval request mapping into OpenSymphony approval DTOs,
+- subscription credential adapter completion,
+- security review of non-loopback WebSocket exposure with capability-token and
+  signed-bearer modes.

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -9,7 +9,8 @@ to Codex.
 - Feature gate: `codex-app-server-prototype`.
 - Runtime kind: `codex_app_server`.
 - Local transport: `codex app-server --stdio`.
-- Experimental remote transport: `codex app-server --listen ws://127.0.0.1:<port>`.
+- Experimental loopback WebSocket transport:
+  `codex app-server --listen ws://127.0.0.1:<port>`.
 - Contract source: generated Codex app-server JSON Schema and TypeScript
   bindings from the installed Codex CLI.
 

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -67,7 +67,7 @@ approval request shapes.
 Run:
 
 ```bash
-node scripts/codex_app_server_benchmark.mjs --iterations 50 --port 18765
+node scripts/codex_app_server_benchmark.mjs --iterations 10 --port 18778
 ```
 
 The loopback WebSocket probe uses Node's global `WebSocket` and `fetch`
@@ -93,11 +93,11 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "generatedAt": "2026-06-20T06:34:40.884Z",
+  "generatedAt": "2026-06-20T06:41:49.453Z",
   "codexVersion": "codex-cli 0.138.0",
   "stdio": {
     "transport": "stdio",
-    "initializeLatencyMs": 117.115,
+    "initializeLatencyMs": 115.315,
     "response": {
       "id": 1,
       "result": {
@@ -111,21 +111,22 @@ WebSocket probes are supported. A 10-request local run produced:
   },
   "websocket": {
     "transport": "websocket_loopback",
-    "port": 18777,
-    "initializeLatencyMs": 1.103,
+    "port": 18778,
+    "initializeLatencyMs": 1.299,
     "queuedRequests": 10,
     "queuedResponses": 10,
-    "queueElapsedMs": 0.905,
-    "requestsPerSecond": 11049.22,
+    "queueElapsedMs": 0.779,
+    "requestsPerSecond": 12838.35,
     "latencyMs": {
-      "p50": 0.558,
-      "p95": 0.67,
-      "max": 0.67
+      "p50": 0.476,
+      "p95": 0.507,
+      "max": 0.507
     },
-    "reconnectLatencyMs": 1.027,
+    "reconnectLatencyMs": 0.959,
     "reconnectResponse": "ok",
+    "stdoutBytes": 0,
     "exposure": {
-      "listener": "ws://127.0.0.1:18777",
+      "listener": "ws://127.0.0.1:18778",
       "localhostOnly": true,
       "authModesFromHelp": [
         "capability-token",

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -18,6 +18,8 @@ The prototype adds a small Rust module for:
 - launch argument construction for stdio and loopback WebSocket,
 - JSON-RPC request construction for `initialize`, `thread/start`, and
   `turn/start`,
+- `thread/loaded/list` request use in the benchmark loop so throughput can be
+  measured without starting model-backed turns,
 - normalization of basic thread, turn, item, plan, error, and unknown
   notifications while preserving the raw payload,
 - mapping existing OpenSymphony model and credential setting profiles to future
@@ -87,13 +89,13 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "stdioInitializeLatencyMs": 233.467,
-  "websocketInitializeLatencyMs": 1.446,
+  "stdioInitializeLatencyMs": 126.222,
+  "websocketInitializeLatencyMs": 1.247,
   "websocketQueuedRequests": 10,
   "websocketQueuedResponses": 10,
-  "websocketRequestsPerSecond": 5196.27,
-  "websocketLatencyMs": { "p50": 1.606, "p95": 1.811, "max": 1.811 },
-  "websocketReconnectLatencyMs": 1.33,
+  "websocketRequestsPerSecond": 11511.35,
+  "websocketLatencyMs": { "p50": 0.526, "p95": 0.603, "max": 0.603 },
+  "websocketReconnectLatencyMs": 6.024,
   "websocketReconnectResponse": "ok",
   "websocketLocalhostOnly": true,
   "capabilityTokenModeAdvertised": true,

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -144,6 +144,7 @@ WebSocket probes are supported. A 10-request local run produced:
     "hasCapabilityTokenMode": true,
     "hasSignedBearerMode": true,
     "hasTokenFileFlag": true,
+    "hasTokenSha256Flag": true,
     "hasSharedSecretFlag": true,
     "hasIssuerFlag": true,
     "hasAudienceFlag": true,

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -89,11 +89,11 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "generatedAt": "2026-06-20T06:18:53.559Z",
+  "generatedAt": "2026-06-20T06:25:55.254Z",
   "codexVersion": "codex-cli 0.138.0",
   "stdio": {
     "transport": "stdio",
-    "initializeLatencyMs": 119.594,
+    "initializeLatencyMs": 123.147,
     "response": {
       "id": 1,
       "result": {
@@ -106,21 +106,21 @@ WebSocket probes are supported. A 10-request local run produced:
   },
   "websocket": {
     "transport": "websocket_loopback",
-    "port": 18772,
-    "initializeLatencyMs": 1.096,
+    "port": 18775,
+    "initializeLatencyMs": 1.131,
     "queuedRequests": 10,
     "queuedResponses": 10,
-    "queueElapsedMs": 0.934,
-    "requestsPerSecond": 10701.86,
+    "queueElapsedMs": 0.896,
+    "requestsPerSecond": 11164.34,
     "latencyMs": {
-      "p50": 0.488,
-      "p95": 0.586,
-      "max": 0.586
+      "p50": 0.494,
+      "p95": 0.567,
+      "max": 0.567
     },
-    "reconnectLatencyMs": 1.466,
+    "reconnectLatencyMs": 1.128,
     "reconnectResponse": "ok",
     "exposure": {
-      "listener": "ws://127.0.0.1:18772",
+      "listener": "ws://127.0.0.1:18775",
       "localhostOnly": true,
       "authModesFromHelp": [
         "capability-token",

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -82,6 +82,8 @@ node scripts/codex_app_server_benchmark.mjs --iterations 10 --port 18779
 The loopback WebSocket probe uses Node's global `WebSocket` and `fetch`
 implementations and therefore requires Node.js 22 or newer. Use
 `--skip-websocket` for stdio-only evidence on older Node runtimes.
+Use `--codex-path <path>` to benchmark a specific Codex CLI binary instead of
+the first `codex` on `PATH`.
 
 The script performs:
 
@@ -149,15 +151,15 @@ WebSocket probes are supported. A 10-request local run produced:
     "stdoutBytes": 0,
     "stderrBytes": 222,
     "stderrPreview": "codex app-server (WebSockets)\n  listening on: ws://127.0.0.1:18779\n  readyz: http://127.0.0.1:18779/readyz\n  healthz: http://127.0.0.1:18779/healthz\n  note: binds localhost only (use SSH port-forwarding for remote access)",
-	    "exposure": {
-	      "listener": "ws://127.0.0.1:18779",
-	      "listenerHost": "127.0.0.1",
-	      "localhostOnly": true,
-	      "localhostOnlyEvidence": [
-	        "configured_loopback_listener",
-	        "startup_banner"
-	      ],
-	      "authModesAdvertisedInHelp": [
+    "exposure": {
+      "listener": "ws://127.0.0.1:18779",
+      "listenerHost": "127.0.0.1",
+      "localhostOnly": true,
+      "localhostOnlyEvidence": [
+        "configured_loopback_listener",
+        "startup_banner"
+      ],
+      "authModesAdvertisedInHelp": [
         "capability-token",
         "signed-bearer-token"
       ]

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -87,13 +87,13 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "stdioInitializeLatencyMs": 261.716,
-  "websocketInitializeLatencyMs": 6.088,
+  "stdioInitializeLatencyMs": 233.467,
+  "websocketInitializeLatencyMs": 1.446,
   "websocketQueuedRequests": 10,
   "websocketQueuedResponses": 10,
-  "websocketRequestsPerSecond": 1459.77,
-  "websocketLatencyMs": { "p50": 6.263, "p95": 6.69, "max": 6.69 },
-  "websocketReconnectLatencyMs": 3.22,
+  "websocketRequestsPerSecond": 5196.27,
+  "websocketLatencyMs": { "p50": 1.606, "p95": 1.811, "max": 1.811 },
+  "websocketReconnectLatencyMs": 1.33,
   "websocketReconnectResponse": "ok",
   "websocketLocalhostOnly": true,
   "capabilityTokenModeAdvertised": true,

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -47,7 +47,7 @@ A local stdio probe successfully started a JSON-RPC session:
 $ codex app-server --stdio
 request: {"jsonrpc":"2.0","id":1,"method":"initialize",...}
 response: {"id":1,"result":{"userAgent":"opensymphony-probe/0.138.0 ...",
-"codexHome":"/Users/magos/.codex","platformFamily":"unix","platformOs":"macos"}}
+"codexHome":"/home/user/.codex","platformFamily":"unix","platformOs":"macos"}}
 ```
 
 Schema generation is supported:
@@ -89,13 +89,13 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "stdioInitializeLatencyMs": 126.222,
-  "websocketInitializeLatencyMs": 1.247,
+  "stdioInitializeLatencyMs": 126.372,
+  "websocketInitializeLatencyMs": 1.363,
   "websocketQueuedRequests": 10,
   "websocketQueuedResponses": 10,
-  "websocketRequestsPerSecond": 11511.35,
-  "websocketLatencyMs": { "p50": 0.526, "p95": 0.603, "max": 0.603 },
-  "websocketReconnectLatencyMs": 6.024,
+  "websocketRequestsPerSecond": 10822.99,
+  "websocketLatencyMs": { "p50": 0.526, "p95": 0.554, "max": 0.554 },
+  "websocketReconnectLatencyMs": 1.571,
   "websocketReconnectResponse": "ok",
   "websocketLocalhostOnly": true,
   "capabilityTokenModeAdvertised": true,

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -50,6 +50,10 @@ response: {"id":1,"result":{"userAgent":"opensymphony-probe/0.138.0 ...",
 "codexHome":"/home/user/.codex","platformFamily":"unix","platformOs":"macos"}}
 ```
 
+Codex CLI `0.138.0` omits the `jsonrpc` field in successful responses. The
+benchmark rejects unsupported `jsonrpc` values when the field is present and
+otherwise validates the observed `id` plus `result` response shape.
+
 Schema generation is supported:
 
 ```text
@@ -67,7 +71,7 @@ approval request shapes.
 Run:
 
 ```bash
-node scripts/codex_app_server_benchmark.mjs --iterations 10 --port 18778
+node scripts/codex_app_server_benchmark.mjs --iterations 10 --port 18779
 ```
 
 The loopback WebSocket probe uses Node's global `WebSocket` and `fetch`
@@ -93,11 +97,11 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "generatedAt": "2026-06-20T06:41:49.453Z",
+  "generatedAt": "2026-06-20T06:50:07.988Z",
   "codexVersion": "codex-cli 0.138.0",
   "stdio": {
     "transport": "stdio",
-    "initializeLatencyMs": 115.315,
+    "initializeLatencyMs": 120.332,
     "response": {
       "id": 1,
       "result": {
@@ -111,22 +115,22 @@ WebSocket probes are supported. A 10-request local run produced:
   },
   "websocket": {
     "transport": "websocket_loopback",
-    "port": 18778,
-    "initializeLatencyMs": 1.299,
+    "port": 18779,
+    "initializeLatencyMs": 1.252,
     "queuedRequests": 10,
     "queuedResponses": 10,
-    "queueElapsedMs": 0.779,
-    "requestsPerSecond": 12838.35,
+    "queueElapsedMs": 0.856,
+    "requestsPerSecond": 11678.26,
     "latencyMs": {
-      "p50": 0.476,
-      "p95": 0.507,
-      "max": 0.507
+      "p50": 0.475,
+      "p95": 0.569,
+      "max": 0.569
     },
-    "reconnectLatencyMs": 0.959,
+    "reconnectLatencyMs": 0.853,
     "reconnectResponse": "ok",
     "stdoutBytes": 0,
     "exposure": {
-      "listener": "ws://127.0.0.1:18778",
+      "listener": "ws://127.0.0.1:18779",
       "localhostOnly": true,
       "authModesFromHelp": [
         "capability-token",
@@ -140,7 +144,10 @@ WebSocket probes are supported. A 10-request local run produced:
     "hasCapabilityTokenMode": true,
     "hasSignedBearerMode": true,
     "hasTokenFileFlag": true,
-    "hasSharedSecretFlag": true
+    "hasSharedSecretFlag": true,
+    "hasIssuerFlag": true,
+    "hasAudienceFlag": true,
+    "hasClockSkewFlag": true
   }
 }
 ```

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -131,8 +131,16 @@ WebSocket probes are supported. A 10-request local run produced:
       "p95": 0.569,
       "max": 0.569
     },
-    "reconnectLatencyMs": 0.853,
-    "reconnectResponse": "ok",
+    "reconnectLatencyMs": 0.867,
+    "reconnectResponse": {
+      "id": 12,
+      "result": {
+        "userAgent": "opensymphony-codex-benchmark/0.138.0 (Mac OS 26.4.0; arm64) dumb (opensymphony-codex-benchmark-reconnect; 0.0.0)",
+        "codexHome": "/home/user/.codex",
+        "platformFamily": "unix",
+        "platformOs": "macos"
+      }
+    },
     "stdoutBytes": 0,
     "stderrBytes": 222,
     "stderrPreview": "codex app-server (WebSockets)\n  listening on: ws://127.0.0.1:18779\n  readyz: http://127.0.0.1:18779/readyz\n  healthz: http://127.0.0.1:18779/healthz\n  note: binds localhost only (use SSH port-forwarding for remote access)",

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -70,6 +70,10 @@ Run:
 node scripts/codex_app_server_benchmark.mjs --iterations 50 --port 18765
 ```
 
+The loopback WebSocket probe uses Node's global `WebSocket` and `fetch`
+implementations and therefore requires Node.js 22 or newer. Use
+`--skip-websocket` for stdio-only evidence on older Node runtimes.
+
 The script performs:
 
 - stdio `initialize` latency,
@@ -89,11 +93,11 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "generatedAt": "2026-06-20T06:25:55.254Z",
+  "generatedAt": "2026-06-20T06:34:40.884Z",
   "codexVersion": "codex-cli 0.138.0",
   "stdio": {
     "transport": "stdio",
-    "initializeLatencyMs": 123.147,
+    "initializeLatencyMs": 117.115,
     "response": {
       "id": 1,
       "result": {
@@ -102,25 +106,26 @@ WebSocket probes are supported. A 10-request local run produced:
         "platformFamily": "unix",
         "platformOs": "macos"
       }
-    }
+    },
+    "stderrBytes": 0
   },
   "websocket": {
     "transport": "websocket_loopback",
-    "port": 18775,
-    "initializeLatencyMs": 1.131,
+    "port": 18777,
+    "initializeLatencyMs": 1.103,
     "queuedRequests": 10,
     "queuedResponses": 10,
-    "queueElapsedMs": 0.896,
-    "requestsPerSecond": 11164.34,
+    "queueElapsedMs": 0.905,
+    "requestsPerSecond": 11049.22,
     "latencyMs": {
-      "p50": 0.494,
-      "p95": 0.567,
-      "max": 0.567
+      "p50": 0.558,
+      "p95": 0.67,
+      "max": 0.67
     },
-    "reconnectLatencyMs": 1.128,
+    "reconnectLatencyMs": 1.027,
     "reconnectResponse": "ok",
     "exposure": {
-      "listener": "ws://127.0.0.1:18775",
+      "listener": "ws://127.0.0.1:18777",
       "localhostOnly": true,
       "authModesFromHelp": [
         "capability-token",

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -89,7 +89,7 @@ The script performs:
 - WebSocket `initialize` latency,
 - queued `thread/loaded/list` request throughput and p50/p95 latency,
 - reconnect by closing the socket, opening a new socket, and initializing again,
-- secure exposure checks for runtime localhost-only listener output and
+- secure exposure checks for runtime localhost-only listener output and static
   capability-token/signed-bearer WebSocket auth flags advertised by
   `codex app-server --help`.
 
@@ -150,7 +150,7 @@ WebSocket probes are supported. A 10-request local run produced:
     "exposure": {
       "listener": "ws://127.0.0.1:18779",
       "localhostOnly": true,
-      "authModesFromHelp": [
+      "authModesAdvertisedInHelp": [
         "capability-token",
         "signed-bearer-token"
       ]

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -100,9 +100,9 @@ The script performs:
 
 Use `--skip-websocket` when the installed Codex version lacks WebSocket support;
 the flag is presence-based and does not take a value.
-Queued WebSocket requests use a derived per-request deadline of
-`--request-timeout-ms + --iterations`, so the documented high-iteration range
-does not inherit the default 5s timeout as an accidental whole-batch deadline.
+Queued WebSocket requests use `--batch-timeout-ms`, which defaults to
+`min(300000, --request-timeout-ms + --iterations * 100)`, so the timeout remains
+an explicit duration even for high-iteration runs.
 
 ## Local Benchmark Result
 

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -89,17 +89,53 @@ WebSocket probes are supported. A 10-request local run produced:
 
 ```json
 {
-  "stdioInitializeLatencyMs": 126.372,
-  "websocketInitializeLatencyMs": 1.363,
-  "websocketQueuedRequests": 10,
-  "websocketQueuedResponses": 10,
-  "websocketRequestsPerSecond": 10822.99,
-  "websocketLatencyMs": { "p50": 0.526, "p95": 0.554, "max": 0.554 },
-  "websocketReconnectLatencyMs": 1.571,
-  "websocketReconnectResponse": "ok",
-  "websocketLocalhostOnly": true,
-  "capabilityTokenModeAdvertised": true,
-  "signedBearerModeAdvertised": true
+  "generatedAt": "2026-06-20T06:18:53.559Z",
+  "codexVersion": "codex-cli 0.138.0",
+  "stdio": {
+    "transport": "stdio",
+    "initializeLatencyMs": 119.594,
+    "response": {
+      "id": 1,
+      "result": {
+        "userAgent": "opensymphony-codex-benchmark/0.138.0 (Mac OS 26.4.0; arm64) dumb (opensymphony-codex-benchmark; 0.0.0)",
+        "codexHome": "/home/user/.codex",
+        "platformFamily": "unix",
+        "platformOs": "macos"
+      }
+    }
+  },
+  "websocket": {
+    "transport": "websocket_loopback",
+    "port": 18772,
+    "initializeLatencyMs": 1.096,
+    "queuedRequests": 10,
+    "queuedResponses": 10,
+    "queueElapsedMs": 0.934,
+    "requestsPerSecond": 10701.86,
+    "latencyMs": {
+      "p50": 0.488,
+      "p95": 0.586,
+      "max": 0.586
+    },
+    "reconnectLatencyMs": 1.466,
+    "reconnectResponse": "ok",
+    "exposure": {
+      "listener": "ws://127.0.0.1:18772",
+      "localhostOnly": true,
+      "authModesFromHelp": [
+        "capability-token",
+        "signed-bearer-token"
+      ]
+    }
+  },
+  "secureExposure": {
+    "transport": "websocket_secure_exposure",
+    "helpSha256": "ebddcbae81d5d6520609ad5605d069ddaf1d4c02cc97cc99d2585757aa4364ff",
+    "hasCapabilityTokenMode": true,
+    "hasSignedBearerMode": true,
+    "hasTokenFileFlag": true,
+    "hasSharedSecretFlag": true
+  }
 }
 ```
 

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -89,8 +89,9 @@ The script performs:
 - WebSocket `initialize` latency,
 - queued `thread/loaded/list` request throughput and p50/p95 latency,
 - reconnect by closing the socket, opening a new socket, and initializing again,
-- secure exposure checks for localhost-only listener output and advertised
-  capability-token/signed-bearer WebSocket auth flags.
+- secure exposure checks for runtime localhost-only listener output and
+  capability-token/signed-bearer WebSocket auth flags advertised by
+  `codex app-server --help`.
 
 Use `--skip-websocket` when the installed Codex version lacks WebSocket support.
 
@@ -133,6 +134,8 @@ WebSocket probes are supported. A 10-request local run produced:
     "reconnectLatencyMs": 0.853,
     "reconnectResponse": "ok",
     "stdoutBytes": 0,
+    "stderrBytes": 222,
+    "stderrPreview": "codex app-server (WebSockets)\n  listening on: ws://127.0.0.1:18779\n  readyz: http://127.0.0.1:18779/readyz\n  healthz: http://127.0.0.1:18779/healthz\n  note: binds localhost only (use SSH port-forwarding for remote access)",
     "exposure": {
       "listener": "ws://127.0.0.1:18779",
       "localhostOnly": true,
@@ -144,6 +147,7 @@ WebSocket probes are supported. A 10-request local run produced:
   },
   "secureExposure": {
     "transport": "websocket_secure_exposure",
+    "authEvidence": "advertised_in_help",
     "helpSha256": "ebddcbae81d5d6520609ad5605d069ddaf1d4c02cc97cc99d2585757aa4364ff",
     "hasCapabilityTokenMode": true,
     "hasSignedBearerMode": true,
@@ -168,8 +172,9 @@ codex app-server (WebSockets)
 ```
 
 The production recommendation is to keep WebSocket feature-gated until CI or a
-repeatable developer benchmark records stable throughput, queue, reconnect, and
-auth behavior for the pinned Codex version.
+repeatable developer benchmark records stable throughput, queue, reconnect,
+runtime localhost exposure, and runtime authenticated-listener behavior for the
+pinned Codex version.
 
 ## Model And Credential Reuse
 

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -159,9 +159,9 @@ WebSocket probes are supported. A 10-request local run produced:
       "localhostOnly": true,
       "localhostOnlyEvidence": [
         "configured_loopback_listener",
-        "startup_banner"
+        "parsed_listener_address"
       ],
-      "authEvidence": "advertised_in_help_only",
+      "authEvidence": "advertised_in_help",
       "runtimeAuthProbe": "not_measured_by_loopback_smoke",
       "authModesAdvertisedInHelp": [
         "capability-token",

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -19,12 +19,13 @@ The prototype adds a small Rust module for:
 - launch argument construction for stdio and loopback WebSocket,
 - JSON-RPC request construction for `initialize`, `thread/start`, and
   `turn/start`,
-- `thread/loaded/list` request use in the benchmark loop so throughput can be
-  measured without starting model-backed turns,
 - normalization of basic thread, turn, item, plan, error, and unknown
   notifications while preserving the raw payload,
 - mapping existing OpenSymphony model and credential setting profiles to future
   Codex app-server use.
+
+The companion benchmark script issues `thread/loaded/list` requests directly so
+throughput can be measured without starting model-backed turns.
 
 ## Installed Codex Evidence
 
@@ -93,8 +94,9 @@ The script performs:
 - queued `thread/loaded/list` request throughput and p50/p95 latency,
 - reconnect by closing the socket, opening a new socket, and initializing again,
 - secure exposure checks for runtime localhost-only listener output and static
-  capability-token/signed-bearer WebSocket auth flags advertised by
-  `codex app-server --help`.
+  capability-token/signed-bearer WebSocket auth flags advertised by anchored
+  `codex app-server --help` option lines. The loopback benchmark does not
+  perform a runtime authenticated-listener probe.
 
 Use `--skip-websocket` when the installed Codex version lacks WebSocket support;
 the flag is presence-based and does not take a value.
@@ -159,6 +161,8 @@ WebSocket probes are supported. A 10-request local run produced:
         "configured_loopback_listener",
         "startup_banner"
       ],
+      "authEvidence": "advertised_in_help_only",
+      "runtimeAuthProbe": "not_measured_by_loopback_smoke",
       "authModesAdvertisedInHelp": [
         "capability-token",
         "signed-bearer-token"

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -94,7 +94,8 @@ The script performs:
   capability-token/signed-bearer WebSocket auth flags advertised by
   `codex app-server --help`.
 
-Use `--skip-websocket` when the installed Codex version lacks WebSocket support.
+Use `--skip-websocket` when the installed Codex version lacks WebSocket support;
+the flag is presence-based and does not take a value.
 Queued WebSocket requests use a derived per-request deadline of
 `--request-timeout-ms + --iterations`, so the documented high-iteration range
 does not inherit the default 5s timeout as an accidental whole-batch deadline.
@@ -148,10 +149,15 @@ WebSocket probes are supported. A 10-request local run produced:
     "stdoutBytes": 0,
     "stderrBytes": 222,
     "stderrPreview": "codex app-server (WebSockets)\n  listening on: ws://127.0.0.1:18779\n  readyz: http://127.0.0.1:18779/readyz\n  healthz: http://127.0.0.1:18779/healthz\n  note: binds localhost only (use SSH port-forwarding for remote access)",
-    "exposure": {
-      "listener": "ws://127.0.0.1:18779",
-      "localhostOnly": true,
-      "authModesAdvertisedInHelp": [
+	    "exposure": {
+	      "listener": "ws://127.0.0.1:18779",
+	      "listenerHost": "127.0.0.1",
+	      "localhostOnly": true,
+	      "localhostOnlyEvidence": [
+	        "configured_loopback_listener",
+	        "startup_banner"
+	      ],
+	      "authModesAdvertisedInHelp": [
         "capability-token",
         "signed-bearer-token"
       ]

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -85,6 +85,8 @@ implementations and therefore requires Node.js 22 or newer. Use
 `--skip-websocket` for stdio-only evidence on older Node runtimes.
 Use `--codex-path <path>` to benchmark a specific Codex CLI binary instead of
 the first `codex` on `PATH`.
+Use `--request-timeout-ms <ms>` for single-request probes and
+`--batch-timeout-ms <ms>` for the queued WebSocket request batch.
 
 The script performs:
 
@@ -103,6 +105,10 @@ the flag is presence-based and does not take a value.
 Queued WebSocket requests use `--batch-timeout-ms`, which defaults to
 `min(300000, --request-timeout-ms + --iterations * 100)`, so the timeout remains
 an explicit duration even for high-iteration runs.
+
+Do not point this prototype at real shared-environment secrets. Codex WebSocket
+auth file paths and token hashes are passed as process arguments, so they can be
+visible to local process-list inspection on some systems.
 
 ## Local Benchmark Result
 
@@ -155,6 +161,7 @@ WebSocket probes are supported. A 10-request local run produced:
     "stderrPreview": "codex app-server (WebSockets)\n  listening on: ws://127.0.0.1:18779\n  readyz: http://127.0.0.1:18779/readyz\n  healthz: http://127.0.0.1:18779/healthz\n  note: binds localhost only (use SSH port-forwarding for remote access)",
     "exposure": {
       "listener": "ws://127.0.0.1:18779",
+      "observedListenerSource": "observed",
       "listenerHost": "127.0.0.1",
       "localhostOnly": true,
       "localhostOnlyEvidence": [

--- a/docs/codex-app-server-prototype.md
+++ b/docs/codex-app-server-prototype.md
@@ -66,6 +66,10 @@ The generated protocol includes `initialize`, `thread/start`, `turn/start`,
 `item/agentMessage/delta`, `item/started`, `item/completed`, and server-side
 approval request shapes.
 
+The benchmark loop uses `thread/loaded/list` as its queued request probe because
+it exercises JSON-RPC request/response routing without starting model-backed
+turns or consuming subscription/API quota.
+
 ## Benchmark Script
 
 Run:

--- a/docs/harness-adapter-compatibility.md
+++ b/docs/harness-adapter-compatibility.md
@@ -45,9 +45,23 @@ map to start thread/turn, send input, approve/reject, and cancel operations.
 Notifications map to OpenSymphony runtime events with raw payload retention,
 cursor replay, and correlation IDs at the gateway layer.
 
+COE-426 adds a feature-gated local prototype under
+`codex-app-server-prototype`. The prototype can construct stdio launch
+arguments, build `initialize`, `thread/start`, and `turn/start` JSON-RPC
+requests, normalize basic thread/turn/item notifications, and map the existing
+model credential settings profiles to future Codex use. Production routing
+remains disabled; `codex_app_server` is still advertised as unavailable through
+capability discovery.
+
+Benchmark and contract evidence lives in
+`docs/codex-app-server-prototype.md`. The companion script
+`scripts/codex_app_server_benchmark.mjs` exercises stdio initialize, loopback
+WebSocket throughput, queued request behavior, reconnect, and secure exposure
+flags against the installed Codex CLI.
+
 Known gaps:
 
-- Production adapter implementation is out of scope for COE-408.
+- Production adapter implementation is out of scope for COE-426.
 - Pause/resume semantics need protocol confirmation before being advertised as
   available.
 - WebSocket transport remains experimental until benchmarked and secured; stdio

--- a/docs/host-client-architecture.md
+++ b/docs/host-client-architecture.md
@@ -777,6 +777,15 @@ CodexHarnessAdapter
 
 Initial implementation should prepare the interfaces and settings. Production enablement should come after a benchmark and contract-test phase. Codex app-server must reuse model and credential settings rather than becoming the owner of subscription credentials.
 
+COE-426 adds the first feature-gated local prototype for this shape. The
+prototype is intentionally limited to stdio/WebSocket launch metadata,
+JSON-RPC request construction for `initialize`, `thread/start`, and
+`turn/start`, basic notification normalization with raw payload retention, and
+model/credential reference reuse. The Codex harness remains unavailable in
+gateway capability discovery until the benchmark, approval, credential, and
+history gaps are closed. See `docs/codex-app-server-prototype.md` for the
+current contract evidence and benchmark procedure.
+
 ## 9. Hosted mode architecture
 
 ### 9.1 Hosted components

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -72,6 +72,13 @@ package, not standalone published crates.
 - WebSocket event stream
 - issue session runner
 
+### `opensymphony_codex`
+
+- feature-gated Codex app-server launch argument builder
+- Codex JSON-RPC request and notification normalization helpers
+- model credential reuse mapping from gateway model settings
+- prototype benchmark requirement descriptors
+
 ### `opensymphony_orchestrator`
 
 - scheduler loop

--- a/docs/stream-benchmark-report.md
+++ b/docs/stream-benchmark-report.md
@@ -29,13 +29,16 @@ mode numbers would be significantly higher.
 2. **Native IPC** (Unix domain sockets / named pipes) — separate process, still loopback.
 3. **Tauri channels** — from Rust backend into webview for high-volume frames.
 4. **Loopback HTTP/WebSocket** — compatibility path and baseline contract test path.
-5. **Codex app-server loopback WebSocket** — feature-gated future harness path;
-   benchmark with `scripts/codex_app_server_benchmark.mjs` before production
-   exposure.
 
 All four paths expose the same gateway DTOs, event envelopes, cursors, and action
 receipts. Local native transport is a performance optimization; it must not bypass
 the event journal, permission checks, or orchestrator-owned state transitions.
+
+Codex app-server loopback WebSocket is a feature-gated future harness transport,
+not an OpenSymphony gateway transport. It speaks the Codex JSON-RPC contract
+rather than gateway DTOs, so production exposure must be justified with
+`scripts/codex_app_server_benchmark.mjs` evidence for throughput, queue behavior,
+reconnect, and secure exposure.
 
 ### Remote hosted transport strategy
 

--- a/docs/stream-benchmark-report.md
+++ b/docs/stream-benchmark-report.md
@@ -29,6 +29,9 @@ mode numbers would be significantly higher.
 2. **Native IPC** (Unix domain sockets / named pipes) — separate process, still loopback.
 3. **Tauri channels** — from Rust backend into webview for high-volume frames.
 4. **Loopback HTTP/WebSocket** — compatibility path and baseline contract test path.
+5. **Codex app-server loopback WebSocket** — feature-gated future harness path;
+   benchmark with `scripts/codex_app_server_benchmark.mjs` before production
+   exposure.
 
 All four paths expose the same gateway DTOs, event envelopes, cursors, and action
 receipts. Local native transport is a performance optimization; it must not bypass
@@ -45,6 +48,12 @@ the event journal, permission checks, or orchestrator-owned state transitions.
     explicit.
   - A standard envelope simplifies client SDK generation.
 - **Fallback**: SSE for simple snapshot streams where WebSocket is unavailable.
+
+For Codex app-server specifically, stdio remains the preferred local prototype
+transport. Loopback WebSocket is experimental and must keep secure exposure
+controls enabled before any non-local use: localhost-only by default,
+capability-token or signed-bearer authentication for exposed listeners, and
+repeatable reconnect/queue throughput evidence for the pinned Codex version.
 
 ### Stream split
 

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -422,19 +422,31 @@ async function runWebSocketProbe(secureExposure) {
       stdio: ["ignore", "pipe", "pipe"],
     }),
   );
-  let stdout = "";
-  let stderr = "";
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  const decodeOutput = () => ({
+    stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+    stderr: Buffer.concat(stderrChunks).toString("utf8"),
+  });
   child.stdout.on("data", (chunk) => {
-    stdout += chunk.toString("utf8");
+    stdoutChunks.push(chunk);
   });
   child.stderr.on("data", (chunk) => {
-    stderr += chunk.toString("utf8");
+    stderrChunks.push(chunk);
   });
 
   let ws = null;
   let ws2 = null;
   try {
-    await waitForReadyz(`http://127.0.0.1:${port}/readyz`);
+    const exitedBeforeReadyz = once(child, "exit").then(([code, signal]) => {
+      const { stdout, stderr } = decodeOutput();
+      const suffix = signal ? `signal ${signal}` : `code ${code}`;
+      throw new Error(
+        `codex app-server exited before readyz with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
+      );
+    });
+    exitedBeforeReadyz.catch(() => {});
+    await Promise.race([waitForReadyz(`http://127.0.0.1:${port}/readyz`), exitedBeforeReadyz]);
 
     ws = await openSocket(`ws://127.0.0.1:${port}`);
     const initialize = await requestOverSocket(ws, 1, "initialize", {
@@ -471,6 +483,8 @@ async function runWebSocketProbe(secureExposure) {
     });
     assertJsonRpcResult("websocket reconnect initialize", reconnectInitialize.response);
     const reconnectMs = performance.now() - reconnectStartedAt;
+    const { stdout, stderr } = decodeOutput();
+    const stderrTrimmed = stderr.trim();
 
     return {
       transport: "websocket_loopback",
@@ -488,6 +502,8 @@ async function runWebSocketProbe(secureExposure) {
       reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
       reconnectResponse: "ok",
       stdoutBytes: Buffer.byteLength(stdout, "utf8"),
+      stderrBytes: Buffer.byteLength(stderr, "utf8"),
+      stderrPreview: stderrTrimmed ? stderrTrimmed.slice(-1000) : null,
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
         localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),
@@ -513,6 +529,7 @@ async function runHelpProbe() {
   const help = await collectChildOutput(child, "codex app-server --help");
   return {
     transport: "websocket_secure_exposure",
+    authEvidence: "advertised_in_help",
     helpSha256: createHash("sha256").update(help).digest("hex"),
     hasCapabilityTokenMode: help.includes("capability-token"),
     hasSignedBearerMode: help.includes("signed-bearer-token"),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -392,45 +392,86 @@ function waitForSocketClose(ws, timeoutMs = requestTimeoutMs) {
   });
 }
 
-function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeoutMs) {
-  const startedAt = performance.now();
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      clearTimeout(timeout);
-      ws.removeEventListener("message", onMessage);
-      ws.removeEventListener("error", onError);
-      ws.removeEventListener("close", onClose);
-    };
-    const onMessage = (event) => {
-      let parsed;
+class WebSocketJsonRpcClient {
+  constructor(ws) {
+    this.ws = ws;
+    this.pending = new Map();
+    this.onMessage = this.onMessage.bind(this);
+    this.onError = this.onError.bind(this);
+    this.onClose = this.onClose.bind(this);
+    ws.addEventListener("message", this.onMessage);
+    ws.addEventListener("error", this.onError);
+    ws.addEventListener("close", this.onClose);
+  }
+
+  request(id, method, params = {}, timeoutMs = requestTimeoutMs) {
+    const startedAt = performance.now();
+    const key = String(id);
+    if (this.pending.has(key)) {
+      throw new Error(`duplicate JSON-RPC request id ${key}`);
+    }
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(key);
+        reject(new Error(`${method} request ${id} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(key, {
+        method,
+        resolve: (response) => {
+          clearTimeout(timeout);
+          resolve({ latencyMs: performance.now() - startedAt, response });
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
       try {
-        parsed = JSON.parse(event.data);
+        this.ws.send(request(id, method, params));
       } catch (error) {
-        cleanup();
+        this.pending.delete(key);
+        clearTimeout(timeout);
         reject(error);
-        return;
       }
-      if (String(parsed.id) !== String(id)) return;
-      cleanup();
-      resolve({ latencyMs: performance.now() - startedAt, response: parsed });
-    };
-    const onError = (error) => {
-      cleanup();
-      reject(error);
-    };
-    const onClose = () => {
-      cleanup();
-      reject(new Error(`${method} request ${id} closed before response`));
-    };
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error(`${method} request ${id} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    ws.addEventListener("message", onMessage);
-    ws.addEventListener("error", onError);
-    ws.addEventListener("close", onClose);
-    ws.send(request(id, method, params));
-  });
+    });
+  }
+
+  onMessage(event) {
+    let parsed;
+    try {
+      parsed = JSON.parse(event.data);
+    } catch (error) {
+      this.rejectAll(error);
+      return;
+    }
+    if (parsed == null || typeof parsed !== "object" || !Object.hasOwn(parsed, "id")) return;
+    const pending = this.pending.get(String(parsed.id));
+    if (!pending) return;
+    this.pending.delete(String(parsed.id));
+    pending.resolve(parsed);
+  }
+
+  onError(error) {
+    this.rejectAll(error);
+  }
+
+  onClose() {
+    this.rejectAll(new Error("WebSocket closed before all pending JSON-RPC responses arrived"));
+  }
+
+  rejectAll(error) {
+    for (const [key, pending] of this.pending) {
+      this.pending.delete(key);
+      pending.reject(error);
+    }
+  }
+
+  dispose() {
+    this.ws.removeEventListener("message", this.onMessage);
+    this.ws.removeEventListener("error", this.onError);
+    this.ws.removeEventListener("close", this.onClose);
+    this.rejectAll(new Error("WebSocket JSON-RPC client disposed"));
+  }
 }
 
 async function runWebSocketProbe(secureExposure) {
@@ -454,6 +495,8 @@ async function runWebSocketProbe(secureExposure) {
 
   let ws = null;
   let ws2 = null;
+  let client = null;
+  let reconnectClient = null;
   try {
     const exitedBeforeReadyz = once(child, "exit").then(([code, signal]) => {
       const { stdout, stderr } = decodeOutput();
@@ -463,13 +506,19 @@ async function runWebSocketProbe(secureExposure) {
       );
     });
     exitedBeforeReadyz.catch(() => {});
+    const failedBeforeReadyz = once(child, "error").then(([error]) => {
+      throw new Error(`codex app-server failed to start before readyz: ${error.message}`);
+    });
+    failedBeforeReadyz.catch(() => {});
     await Promise.race([
       waitForReadyz(`http://127.0.0.1:${port}/readyz`, requestTimeoutMs),
       exitedBeforeReadyz,
+      failedBeforeReadyz,
     ]);
 
     ws = await openSocket(`ws://127.0.0.1:${port}`);
-    const initialize = await requestOverSocket(ws, 1, "initialize", {
+    client = new WebSocketJsonRpcClient(ws);
+    const initialize = await client.request(1, "initialize", {
       clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
       capabilities: {},
     });
@@ -479,7 +528,7 @@ async function runWebSocketProbe(secureExposure) {
     const requests = [];
     let nextRequestId = 2;
     for (let i = 0; i < iterations; i += 1) {
-      requests.push(requestOverSocket(ws, nextRequestId, "thread/loaded/list", { limit: 1 }));
+      requests.push(client.request(nextRequestId, "thread/loaded/list", { limit: 1 }));
       nextRequestId += 1;
     }
     const responses = await Promise.all(requests);
@@ -492,12 +541,15 @@ async function runWebSocketProbe(secureExposure) {
       elapsedMs > 0 ? Number(((responses.length / elapsedMs) * 1000).toFixed(2)) : 0;
 
     const closed = waitForSocketClose(ws);
+    client.dispose();
+    client = null;
     ws.close();
     await closed;
     ws = null;
     const reconnectStartedAt = performance.now();
     ws2 = await openSocket(`ws://127.0.0.1:${port}`);
-    const reconnectInitialize = await requestOverSocket(ws2, nextRequestId, "initialize", {
+    reconnectClient = new WebSocketJsonRpcClient(ws2);
+    const reconnectInitialize = await reconnectClient.request(nextRequestId, "initialize", {
       clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
       capabilities: {},
     });
@@ -534,6 +586,8 @@ async function runWebSocketProbe(secureExposure) {
       },
     };
   } finally {
+    if (client) client.dispose();
+    if (reconnectClient) reconnectClient.dispose();
     if (ws && ws.readyState < WebSocket.CLOSING) ws.close();
     if (ws2 && ws2.readyState < WebSocket.CLOSING) ws2.close();
     await terminateChild(child);

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -165,6 +165,7 @@ async function waitForReadyz(url, timeoutMs = 5000) {
     const abort = setTimeout(() => controller.abort(), Math.min(remainingMs, 500));
     try {
       const response = await fetch(url, { signal: controller.signal });
+      await response.arrayBuffer();
       if (response.ok) return true;
       lastError = new Error(`readyz returned ${response.status}`);
     } catch (error) {
@@ -222,7 +223,7 @@ function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeo
         reject(error);
         return;
       }
-      if (parsed.id !== id) return;
+      if (String(parsed.id) !== String(id)) return;
       cleanup();
       resolve({ latencyMs: performance.now() - startedAt, response: parsed });
     };

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -32,6 +32,8 @@ const iterations = parseIntegerOption("--iterations", 50, 1, 100000);
 const port = parseIntegerOption("--port", 18765, 1, 65535);
 const runWebSocket = args.get("--skip-websocket") !== "true";
 const requestTimeoutMs = parseIntegerOption("--request-timeout-ms", 5000, 1, 300000);
+const activeChildren = new Set();
+const activeSockets = new Set();
 
 function assertWebSocketRuntime() {
   const nodeVersion = process.versions?.node ?? "unknown";
@@ -60,6 +62,32 @@ async function terminateChild(child, graceMs = 1000) {
   if (await Promise.race([exited, sleep(graceMs).then(() => false)])) return;
   child.kill("SIGKILL");
   await Promise.race([exited, sleep(graceMs)]);
+}
+
+function trackChild(child) {
+  activeChildren.add(child);
+  child.once("exit", () => activeChildren.delete(child));
+  return child;
+}
+
+function trackSocket(ws) {
+  activeSockets.add(ws);
+  ws.addEventListener("close", () => activeSockets.delete(ws), { once: true });
+  return ws;
+}
+
+async function cleanupActiveResources() {
+  for (const ws of activeSockets) {
+    if (ws.readyState < WebSocket.CLOSING) ws.close();
+  }
+  await Promise.all([...activeChildren].map((child) => terminateChild(child)));
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    const exitCode = signal === "SIGINT" ? 130 : 143;
+    cleanupActiveResources().finally(() => process.exit(exitCode));
+  });
 }
 
 function assertJsonRpcResult(label, response) {
@@ -184,9 +212,11 @@ async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
 }
 
 async function runStdioProbe() {
-  const child = spawn("codex", ["app-server", "--stdio"], {
-    stdio: ["pipe", "pipe", "pipe"],
-  });
+  const child = trackChild(
+    spawn("codex", ["app-server", "--stdio"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    }),
+  );
   try {
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
@@ -243,7 +273,7 @@ async function waitForReadyz(url, timeoutMs = 5000) {
 }
 
 async function openSocket(url, timeoutMs = requestTimeoutMs) {
-  const ws = new WebSocket(url);
+  const ws = trackSocket(new WebSocket(url));
   setMaxListeners(0, ws);
   await new Promise((resolve, reject) => {
     const cleanup = () => {
@@ -296,6 +326,7 @@ function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeo
       clearTimeout(timeout);
       ws.removeEventListener("message", onMessage);
       ws.removeEventListener("error", onError);
+      ws.removeEventListener("close", onClose);
     };
     const onMessage = (event) => {
       let parsed;
@@ -314,21 +345,32 @@ function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeo
       cleanup();
       reject(error);
     };
+    const onClose = () => {
+      cleanup();
+      reject(new Error(`${method} request ${id} closed before response`));
+    };
     const timeout = setTimeout(() => {
       cleanup();
       reject(new Error(`${method} request ${id} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     ws.addEventListener("message", onMessage);
     ws.addEventListener("error", onError);
+    ws.addEventListener("close", onClose);
     ws.send(request(id, method, params));
   });
 }
 
 async function runWebSocketProbe(secureExposure) {
-  const child = spawn("codex", ["app-server", "--listen", `ws://127.0.0.1:${port}`], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const child = trackChild(
+    spawn("codex", ["app-server", "--listen", `ws://127.0.0.1:${port}`], {
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+  let stdoutBytes = 0;
   let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdoutBytes += chunk.length;
+  });
   child.stderr.on("data", (chunk) => {
     stderr += chunk.toString("utf8");
   });
@@ -387,6 +429,7 @@ async function runWebSocketProbe(secureExposure) {
       },
       reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
       reconnectResponse: "ok",
+      stdoutBytes,
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
         localhostOnly: /binds localhost only/.test(stderr),
@@ -404,9 +447,11 @@ async function runWebSocketProbe(secureExposure) {
 }
 
 async function runHelpProbe() {
-  const child = spawn("codex", ["app-server", "--help"], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const child = trackChild(
+    spawn("codex", ["app-server", "--help"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
   const help = await collectChildOutput(child, "codex app-server --help");
   return {
     transport: "websocket_secure_exposure",
@@ -427,7 +472,7 @@ const report = {
 };
 
 try {
-  const version = spawn("codex", ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+  const version = trackChild(spawn("codex", ["--version"], { stdio: ["ignore", "pipe", "pipe"] }));
   report.codexVersion = (await collectChildOutput(version, "codex --version")).trim();
   report.stdio = await runStdioProbe();
   report.secureExposure = await runHelpProbe();

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -6,7 +6,13 @@ import { once, setMaxListeners } from "node:events";
 import { setTimeout as sleep } from "node:timers/promises";
 
 const booleanFlags = new Set(["--skip-websocket"]);
-const valueFlags = new Set(["--codex-path", "--iterations", "--port", "--request-timeout-ms"]);
+const valueFlags = new Set([
+  "--batch-timeout-ms",
+  "--codex-path",
+  "--iterations",
+  "--port",
+  "--request-timeout-ms",
+]);
 const args = new Map();
 for (let i = 2; i < process.argv.length; i += 1) {
   const rawArg = process.argv[i];
@@ -57,6 +63,12 @@ const iterations = parseIntegerOption("--iterations", 50, 1, 100000);
 const port = parseIntegerOption("--port", 18765, 1, 65535);
 const runWebSocket = !args.has("--skip-websocket");
 const requestTimeoutMs = parseIntegerOption("--request-timeout-ms", 5000, 1, 300000);
+const batchTimeoutMs = parseIntegerOption(
+  "--batch-timeout-ms",
+  Math.min(300000, requestTimeoutMs + iterations * 100),
+  1,
+  300000,
+);
 const codexPath = args.get("--codex-path") ?? "codex";
 const activeChildren = new Set();
 const activeSockets = new Set();
@@ -82,7 +94,7 @@ function request(id, method, params = {}) {
 }
 
 function websocketBatchTimeoutMs() {
-  return requestTimeoutMs + iterations;
+  return batchTimeoutMs;
 }
 
 async function terminateChild(child, graceMs = 1000) {
@@ -279,12 +291,14 @@ async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
   child.stdout?.on("data", (chunk) => stdout.push(chunk));
   child.stderr?.on("data", (chunk) => stderr.push(chunk));
 
-  const exitPromise =
-    child.exitCode !== null || child.signalCode !== null
+  const closePromise =
+    child.exitCode !== null &&
+    child.stdout?.readableEnded !== false &&
+    child.stderr?.readableEnded !== false
       ? Promise.resolve({ code: child.exitCode, signal: child.signalCode, timedOut: false })
-      : once(child, "exit").then(([code, signal]) => ({ code, signal, timedOut: false }));
+      : once(child, "close").then(([code, signal]) => ({ code, signal, timedOut: false }));
   const result = await Promise.race([
-    exitPromise,
+    closePromise,
     once(child, "error").then(([error]) => ({ error, timedOut: false })),
     sleep(timeoutMs).then(() => ({ code: null, signal: null, timedOut: true })),
   ]);
@@ -321,20 +335,29 @@ async function runStdioProbe() {
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString("utf8");
     });
-    const childFailure = new Promise((_, reject) => {
-      child.once("error", (error) => {
-        reject(new Error(`${codexPath} app-server --stdio failed to start: ${error.message}`));
-      });
-      child.once("exit", (code, signal) => {
-        if (shuttingDown) return;
-        const suffix = signal ? `signal ${signal}` : `code ${code}`;
-        reject(
-          new Error(
-            `${codexPath} app-server --stdio exited before initialize completed with ${suffix}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
-          ),
-        );
-      });
-    });
+    const childFailure =
+      child.exitCode !== null || child.signalCode !== null
+        ? Promise.reject(
+            new Error(
+              `${codexPath} app-server --stdio exited before initialize completed with ${
+                child.signalCode ? `signal ${child.signalCode}` : `code ${child.exitCode}`
+              }${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
+            ),
+          )
+        : new Promise((_, reject) => {
+            child.once("error", (error) => {
+              reject(new Error(`${codexPath} app-server --stdio failed to start: ${error.message}`));
+            });
+            child.once("exit", (code, signal) => {
+              if (shuttingDown) return;
+              const suffix = signal ? `signal ${signal}` : `code ${code}`;
+              reject(
+                new Error(
+                  `${codexPath} app-server --stdio exited before initialize completed with ${suffix}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
+                ),
+              );
+            });
+          });
     childFailure.catch(() => {});
     const withChildFailure = (promise) => {
       promise.catch(() => {});
@@ -552,21 +575,30 @@ async function runWebSocketProbe(secureExposure) {
   let client = null;
   let reconnectClient = null;
   let shuttingDown = false;
-  const childFailure = new Promise((_, reject) => {
-    child.once("error", (error) => {
-      reject(new Error(`${codexPath} app-server failed during WebSocket probe: ${error.message}`));
-    });
-    child.once("exit", (code, signal) => {
-      if (shuttingDown) return;
-      const { stdout, stderr } = decodeOutput();
-      const suffix = signal ? `signal ${signal}` : `code ${code}`;
-      reject(
-        new Error(
-          `${codexPath} app-server exited unexpectedly during WebSocket probe with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
-        ),
-      );
-    });
-  });
+  const childFailure =
+    child.exitCode !== null || child.signalCode !== null
+      ? Promise.reject(
+          new Error(
+            `${codexPath} app-server exited unexpectedly during WebSocket probe with ${
+              child.signalCode ? `signal ${child.signalCode}` : `code ${child.exitCode}`
+            }; stdout=${JSON.stringify(decodeOutput().stdout.trim())}; stderr=${JSON.stringify(decodeOutput().stderr.trim())}`,
+          ),
+        )
+      : new Promise((_, reject) => {
+          child.once("error", (error) => {
+            reject(new Error(`${codexPath} app-server failed during WebSocket probe: ${error.message}`));
+          });
+          child.once("exit", (code, signal) => {
+            if (shuttingDown) return;
+            const { stdout, stderr } = decodeOutput();
+            const suffix = signal ? `signal ${signal}` : `code ${code}`;
+            reject(
+              new Error(
+                `${codexPath} app-server exited unexpectedly during WebSocket probe with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
+              ),
+            );
+          });
+        });
   childFailure.catch(() => {});
   const withChildFailure = (promise) => {
     promise.catch(() => {});

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -20,9 +20,13 @@ for (let i = 2; i < process.argv.length; i += 1) {
 
 function parseIntegerOption(flag, defaultValue, min, max) {
   const raw = args.get(flag) ?? String(defaultValue);
-  const value = Number(raw);
+  if (!/^\d+$/.test(raw)) {
+    console.error(`${flag} must be a base-10 integer from ${min} to ${max}; received ${JSON.stringify(raw)}`);
+    process.exit(1);
+  }
+  const value = Number.parseInt(raw, 10);
   if (!Number.isInteger(value) || value < min || value > max) {
-    console.error(`${flag} must be an integer from ${min} to ${max}; received ${JSON.stringify(raw)}`);
+    console.error(`${flag} must be a base-10 integer from ${min} to ${max}; received ${JSON.stringify(raw)}`);
     process.exit(1);
   }
   return value;
@@ -274,6 +278,10 @@ async function runStdioProbe() {
     }),
   );
   try {
+    const childError = once(child, "error").then(([error]) => {
+      throw new Error(`codex app-server --stdio failed to start: ${error.message}`);
+    });
+    childError.catch(() => {});
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     let stderr = "";
@@ -282,19 +290,28 @@ async function runStdioProbe() {
     });
     const stdout = new LineReader(child.stdout);
     const startedAt = performance.now();
-    await writeToStream(
-      child.stdin,
-      `${request(1, "initialize", {
-        clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
-        capabilities: {},
-      })}\n`,
-      "stdio initialize",
-      requestTimeoutMs,
-    );
-    const response = await readJsonRpcResponse(stdout, "stdio initialize", requestTimeoutMs);
+    await Promise.race([
+      writeToStream(
+        child.stdin,
+        `${request(1, "initialize", {
+          clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
+          capabilities: {},
+        })}\n`,
+        "stdio initialize",
+        requestTimeoutMs,
+      ),
+      childError,
+    ]);
+    const response = await Promise.race([
+      readJsonRpcResponse(stdout, "stdio initialize", requestTimeoutMs),
+      childError,
+    ]);
     const latencyMs = performance.now() - startedAt;
     assertJsonRpcResult("stdio initialize", response);
-    await endStream(child.stdin, "stdio initialize", requestTimeoutMs);
+    await Promise.race([
+      endStream(child.stdin, "stdio initialize", requestTimeoutMs),
+      childError,
+    ]);
     return {
       transport: "stdio",
       initializeLatencyMs: Number(latencyMs.toFixed(3)),
@@ -503,7 +520,7 @@ async function runWebSocketProbe(secureExposure) {
         max: Number(latencies.reduce((max, latency) => Math.max(max, latency), 0).toFixed(3)),
       },
       reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
-      reconnectResponse: "ok",
+      reconnectResponse: reconnectInitialize.response,
       stdoutBytes: Buffer.byteLength(stdout, "utf8"),
       stderrBytes: Buffer.byteLength(stderr, "utf8"),
       stderrPreview: stderrTrimmed ? stderrTrimmed.slice(-1000) : null,

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -97,6 +97,9 @@ function assertJsonRpcResult(label, response) {
   if (response.error) {
     throw new Error(`${label} returned JSON-RPC error: ${JSON.stringify(response.error)}`);
   }
+  if (Object.hasOwn(response, "jsonrpc") && response.jsonrpc !== "2.0") {
+    throw new Error(`${label} returned unsupported JSON-RPC version: ${JSON.stringify(response.jsonrpc)}`);
+  }
   if (!Object.hasOwn(response, "result")) {
     throw new Error(`${label} did not include a JSON-RPC result`);
   }
@@ -460,6 +463,9 @@ async function runHelpProbe() {
     hasSignedBearerMode: help.includes("signed-bearer-token"),
     hasTokenFileFlag: help.includes("--ws-token-file"),
     hasSharedSecretFlag: help.includes("--ws-shared-secret-file"),
+    hasIssuerFlag: help.includes("--ws-issuer"),
+    hasAudienceFlag: help.includes("--ws-audience"),
+    hasClockSkewFlag: help.includes("--ws-max-clock-skew-seconds"),
   };
 }
 

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -531,7 +531,10 @@ async function runWebSocketProbe(secureExposure) {
     });
   });
   childFailure.catch(() => {});
-  const withChildFailure = (promise) => Promise.race([promise, childFailure]);
+  const withChildFailure = (promise) => {
+    promise.catch(() => {});
+    return Promise.race([promise, childFailure]);
+  };
   try {
     await withChildFailure(waitForReadyz(`http://127.0.0.1:${port}/readyz`, requestTimeoutMs));
 

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -5,10 +5,15 @@ import { createHash } from "node:crypto";
 import { once, setMaxListeners } from "node:events";
 import { setTimeout as sleep } from "node:timers/promises";
 
+const booleanFlags = new Set(["--skip-websocket"]);
 const args = new Map();
 for (let i = 2; i < process.argv.length; i += 1) {
   const arg = process.argv[i];
   if (!arg.startsWith("--")) continue;
+  if (booleanFlags.has(arg)) {
+    args.set(arg, "true");
+    continue;
+  }
   const next = process.argv[i + 1];
   if (next && !next.startsWith("--")) {
     args.set(arg, next);

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -279,8 +279,12 @@ async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
   child.stdout?.on("data", (chunk) => stdout.push(chunk));
   child.stderr?.on("data", (chunk) => stderr.push(chunk));
 
+  const exitPromise =
+    child.exitCode !== null || child.signalCode !== null
+      ? Promise.resolve({ code: child.exitCode, signal: child.signalCode, timedOut: false })
+      : once(child, "exit").then(([code, signal]) => ({ code, signal, timedOut: false }));
   const result = await Promise.race([
-    once(child, "exit").then(([code, signal]) => ({ code, signal, timedOut: false })),
+    exitPromise,
     once(child, "error").then(([error]) => ({ error, timedOut: false })),
     sleep(timeoutMs).then(() => ({ code: null, signal: null, timedOut: true })),
   ]);
@@ -654,6 +658,8 @@ async function runWebSocketProbe(secureExposure) {
         listenerHost: "127.0.0.1",
         localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),
         localhostOnlyEvidence: ["configured_loopback_listener", "startup_banner"],
+        authEvidence: "advertised_in_help_only",
+        runtimeAuthProbe: "not_measured_by_loopback_smoke",
         authModesAdvertisedInHelp: [
           ...(secureExposure.hasCapabilityTokenMode ? ["capability-token"] : []),
           ...(secureExposure.hasSignedBearerMode ? ["signed-bearer-token"] : []),
@@ -677,18 +683,33 @@ async function runHelpProbe() {
     }),
   );
   const help = await collectChildOutput(child, `${codexPath} app-server --help`);
+  const optionLinePattern = (flag) => new RegExp(`^\\s*(?:-\\w,\\s*)?${flag}\\b`);
+  const optionHeaderPattern = /^\s*(?:-\w,\s*)?--[\w-]+\b/;
+  const optionBlock = (flag) => {
+    const lines = help.split(/\r?\n/);
+    const start = lines.findIndex((line) => optionLinePattern(flag).test(line));
+    if (start < 0) return "";
+    const block = [];
+    for (let i = start; i < lines.length; i += 1) {
+      if (i > start && optionHeaderPattern.test(lines[i])) break;
+      block.push(lines[i]);
+    }
+    return block.join("\n");
+  };
+  const optionLine = (flag) => optionBlock(flag).length > 0;
+  const wsAuthBlock = optionBlock("--ws-auth");
   return {
     transport: "websocket_secure_exposure",
     authEvidence: "advertised_in_help",
     helpSha256: createHash("sha256").update(help).digest("hex"),
-    hasCapabilityTokenMode: help.includes("capability-token"),
-    hasSignedBearerMode: help.includes("signed-bearer-token"),
-    hasTokenFileFlag: help.includes("--ws-token-file"),
-    hasTokenSha256Flag: help.includes("--ws-token-sha256"),
-    hasSharedSecretFlag: help.includes("--ws-shared-secret-file"),
-    hasIssuerFlag: help.includes("--ws-issuer"),
-    hasAudienceFlag: help.includes("--ws-audience"),
-    hasClockSkewFlag: help.includes("--ws-max-clock-skew-seconds"),
+    hasCapabilityTokenMode: /\bcapability-token\b/.test(wsAuthBlock),
+    hasSignedBearerMode: /\bsigned-bearer-token\b/.test(wsAuthBlock),
+    hasTokenFileFlag: optionLine("--ws-token-file"),
+    hasTokenSha256Flag: optionLine("--ws-token-sha256"),
+    hasSharedSecretFlag: optionLine("--ws-shared-secret-file"),
+    hasIssuerFlag: optionLine("--ws-issuer"),
+    hasAudienceFlag: optionLine("--ws-audience"),
+    hasClockSkewFlag: optionLine("--ws-max-clock-skew-seconds"),
   };
 }
 

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -446,7 +446,10 @@ async function runWebSocketProbe(secureExposure) {
       );
     });
     exitedBeforeReadyz.catch(() => {});
-    await Promise.race([waitForReadyz(`http://127.0.0.1:${port}/readyz`), exitedBeforeReadyz]);
+    await Promise.race([
+      waitForReadyz(`http://127.0.0.1:${port}/readyz`, requestTimeoutMs),
+      exitedBeforeReadyz,
+    ]);
 
     ws = await openSocket(`ws://127.0.0.1:${port}`);
     const initialize = await requestOverSocket(ws, 1, "initialize", {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -60,7 +60,7 @@ function request(id, method, params = {}) {
 }
 
 function websocketBatchTimeoutMs() {
-  return Math.max(requestTimeoutMs, requestTimeoutMs + iterations);
+  return requestTimeoutMs + iterations;
 }
 
 async function terminateChild(child, graceMs = 1000) {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -329,7 +329,8 @@ async function runStdioProbe() {
     );
     const latencyMs = performance.now() - startedAt;
     assertJsonRpcResult("stdio initialize", response);
-    await withChildFailure(endStream(child.stdin, "stdio initialize", requestTimeoutMs));
+    shuttingDown = true;
+    await endStream(child.stdin, "stdio initialize", requestTimeoutMs).catch(() => {});
     return {
       transport: "stdio",
       initializeLatencyMs: Number(latencyMs.toFixed(3)),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -501,31 +501,35 @@ async function runWebSocketProbe(secureExposure) {
   let ws2 = null;
   let client = null;
   let reconnectClient = null;
-  try {
-    const exitedBeforeReadyz = once(child, "exit").then(([code, signal]) => {
+  let shuttingDown = false;
+  const childFailure = new Promise((_, reject) => {
+    child.once("error", (error) => {
+      reject(new Error(`codex app-server failed during WebSocket probe: ${error.message}`));
+    });
+    child.once("exit", (code, signal) => {
+      if (shuttingDown) return;
       const { stdout, stderr } = decodeOutput();
       const suffix = signal ? `signal ${signal}` : `code ${code}`;
-      throw new Error(
-        `codex app-server exited before readyz with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
+      reject(
+        new Error(
+          `codex app-server exited unexpectedly during WebSocket probe with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
+        ),
       );
     });
-    exitedBeforeReadyz.catch(() => {});
-    const failedBeforeReadyz = once(child, "error").then(([error]) => {
-      throw new Error(`codex app-server failed to start before readyz: ${error.message}`);
-    });
-    failedBeforeReadyz.catch(() => {});
-    await Promise.race([
-      waitForReadyz(`http://127.0.0.1:${port}/readyz`, requestTimeoutMs),
-      exitedBeforeReadyz,
-      failedBeforeReadyz,
-    ]);
+  });
+  childFailure.catch(() => {});
+  const withChildFailure = (promise) => Promise.race([promise, childFailure]);
+  try {
+    await withChildFailure(waitForReadyz(`http://127.0.0.1:${port}/readyz`, requestTimeoutMs));
 
-    ws = await openSocket(`ws://127.0.0.1:${port}`);
+    ws = await withChildFailure(openSocket(`ws://127.0.0.1:${port}`));
     client = new WebSocketJsonRpcClient(ws);
-    const initialize = await client.request(1, "initialize", {
-      clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
-      capabilities: {},
-    });
+    const initialize = await withChildFailure(
+      client.request(1, "initialize", {
+        clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
+        capabilities: {},
+      }),
+    );
     assertJsonRpcResult("websocket initialize", initialize.response);
 
     const batchStartedAt = performance.now();
@@ -533,7 +537,11 @@ async function runWebSocketProbe(secureExposure) {
     let nextRequestId = 2;
     const batchTimeoutMs = websocketBatchTimeoutMs();
     for (let i = 0; i < iterations; i += 1) {
-      requests.push(client.request(nextRequestId, "thread/loaded/list", { limit: 1 }, batchTimeoutMs));
+      requests.push(
+        withChildFailure(
+          client.request(nextRequestId, "thread/loaded/list", { limit: 1 }, batchTimeoutMs),
+        ),
+      );
       nextRequestId += 1;
     }
     const responses = await Promise.all(requests);
@@ -549,15 +557,17 @@ async function runWebSocketProbe(secureExposure) {
     client.dispose();
     client = null;
     ws.close();
-    await closed;
+    await withChildFailure(closed);
     ws = null;
     const reconnectStartedAt = performance.now();
-    ws2 = await openSocket(`ws://127.0.0.1:${port}`);
+    ws2 = await withChildFailure(openSocket(`ws://127.0.0.1:${port}`));
     reconnectClient = new WebSocketJsonRpcClient(ws2);
-    const reconnectInitialize = await reconnectClient.request(nextRequestId, "initialize", {
-      clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
-      capabilities: {},
-    });
+    const reconnectInitialize = await withChildFailure(
+      reconnectClient.request(nextRequestId, "initialize", {
+        clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
+        capabilities: {},
+      }),
+    );
     assertJsonRpcResult("websocket reconnect initialize", reconnectInitialize.response);
     const reconnectMs = performance.now() - reconnectStartedAt;
     const { stdout, stderr } = decodeOutput();
@@ -584,13 +594,14 @@ async function runWebSocketProbe(secureExposure) {
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
         localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),
-        authModesFromHelp: [
+        authModesAdvertisedInHelp: [
           ...(secureExposure.hasCapabilityTokenMode ? ["capability-token"] : []),
           ...(secureExposure.hasSignedBearerMode ? ["signed-bearer-token"] : []),
         ],
       },
     };
   } finally {
+    shuttingDown = true;
     if (client) client.dispose();
     if (reconnectClient) reconnectClient.dispose();
     if (ws && ws.readyState < WebSocket.CLOSING) ws.close();

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -156,6 +156,7 @@ function waitForStreamProgress(stream, timeoutMs) {
     const onClose = () => complete("close");
     const onError = (error) => {
       cleanup();
+      ws.close();
       reject(error);
     };
     const timeout = setTimeout(() => complete("timeout"), timeoutMs);
@@ -634,6 +635,16 @@ async function runWebSocketProbe(secureExposure) {
     const reconnectMs = performance.now() - reconnectStartedAt;
     const { stdout, stderr } = decodeOutput();
     const stderrTrimmed = stderr.trim();
+    const output = `${stdout}\n${stderr}`;
+    const configuredListener = `ws://127.0.0.1:${port}`;
+    const observedListener = output.match(/\blistening on:\s*(ws:\/\/[^\s]+)/)?.[1] ?? configuredListener;
+    let listenerHost = null;
+    try {
+      listenerHost = new URL(observedListener).hostname;
+    } catch {
+      listenerHost = null;
+    }
+    const localhostOnly = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(listenerHost ?? "");
 
     return {
       transport: "websocket_loopback",
@@ -654,11 +665,11 @@ async function runWebSocketProbe(secureExposure) {
       stderrBytes: Buffer.byteLength(stderr, "utf8"),
       stderrPreview: stderrTrimmed ? [...stderrTrimmed].slice(-1000).join("") : null,
       exposure: {
-        listener: `ws://127.0.0.1:${port}`,
-        listenerHost: "127.0.0.1",
-        localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),
-        localhostOnlyEvidence: ["configured_loopback_listener", "startup_banner"],
-        authEvidence: "advertised_in_help_only",
+        listener: observedListener,
+        listenerHost,
+        localhostOnly,
+        localhostOnlyEvidence: ["configured_loopback_listener", "parsed_listener_address"],
+        authEvidence: "advertised_in_help",
         runtimeAuthProbe: "not_measured_by_loopback_smoke",
         authModesAdvertisedInHelp: [
           ...(secureExposure.hasCapabilityTokenMode ? ["capability-token"] : []),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -34,7 +34,7 @@ function parseIntegerOption(flag, defaultValue, min, max) {
 
 const iterations = parseIntegerOption("--iterations", 50, 1, 100000);
 const port = parseIntegerOption("--port", 18765, 1, 65535);
-const runWebSocket = args.get("--skip-websocket") !== "true";
+const runWebSocket = !args.has("--skip-websocket");
 const requestTimeoutMs = parseIntegerOption("--request-timeout-ms", 5000, 1, 300000);
 const activeChildren = new Set();
 const activeSockets = new Set();
@@ -102,7 +102,10 @@ function assertJsonRpcResult(label, response) {
   if (response == null || typeof response !== "object") {
     throw new Error(`${label} returned non-object JSON-RPC response: ${JSON.stringify(response)}`);
   }
-  if (response.error) {
+  if (Object.hasOwn(response, "error")) {
+    if (response.error == null || typeof response.error !== "object") {
+      throw new Error(`${label} returned malformed JSON-RPC error: ${JSON.stringify(response.error)}`);
+    }
     throw new Error(`${label} returned JSON-RPC error: ${JSON.stringify(response.error)}`);
   }
   if (Object.hasOwn(response, "jsonrpc") && response.jsonrpc !== "2.0") {
@@ -588,6 +591,7 @@ async function runWebSocketProbe(secureExposure) {
     await withChildFailure(closed);
     ws = null;
     const reconnectStartedAt = performance.now();
+    await withChildFailure(waitForReadyz(`http://127.0.0.1:${port}/readyz`, requestTimeoutMs));
     ws2 = await withChildFailure(openSocket(`ws://127.0.0.1:${port}`));
     reconnectClient = new WebSocketJsonRpcClient(ws2);
     const reconnectInitialize = await withChildFailure(
@@ -621,7 +625,9 @@ async function runWebSocketProbe(secureExposure) {
       stderrPreview: stderrTrimmed ? [...stderrTrimmed].slice(-1000).join("") : null,
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
+        listenerHost: "127.0.0.1",
         localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),
+        localhostOnlyEvidence: ["configured_loopback_listener", "startup_banner"],
         authModesAdvertisedInHelp: [
           ...(secureExposure.hasCapabilityTokenMode ? ["capability-token"] : []),
           ...(secureExposure.hasSignedBearerMode ? ["signed-bearer-token"] : []),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -36,6 +36,7 @@ const iterations = parseIntegerOption("--iterations", 50, 1, 100000);
 const port = parseIntegerOption("--port", 18765, 1, 65535);
 const runWebSocket = !args.has("--skip-websocket");
 const requestTimeoutMs = parseIntegerOption("--request-timeout-ms", 5000, 1, 300000);
+const codexPath = args.get("--codex-path") ?? "codex";
 const activeChildren = new Set();
 const activeSockets = new Set();
 
@@ -283,7 +284,7 @@ async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
 
 async function runStdioProbe() {
   const child = trackChild(
-    spawn("codex", ["app-server", "--stdio"], {
+    spawn(codexPath, ["app-server", "--stdio"], {
       stdio: ["pipe", "pipe", "pipe"],
     }),
   );
@@ -297,14 +298,14 @@ async function runStdioProbe() {
     });
     const childFailure = new Promise((_, reject) => {
       child.once("error", (error) => {
-        reject(new Error(`codex app-server --stdio failed to start: ${error.message}`));
+        reject(new Error(`${codexPath} app-server --stdio failed to start: ${error.message}`));
       });
       child.once("exit", (code, signal) => {
         if (shuttingDown) return;
         const suffix = signal ? `signal ${signal}` : `code ${code}`;
         reject(
           new Error(
-            `codex app-server --stdio exited before initialize completed with ${suffix}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
+            `${codexPath} app-server --stdio exited before initialize completed with ${suffix}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
           ),
         );
       });
@@ -499,7 +500,7 @@ class WebSocketJsonRpcClient {
 
 async function runWebSocketProbe(secureExposure) {
   const child = trackChild(
-    spawn("codex", ["app-server", "--listen", `ws://127.0.0.1:${port}`], {
+    spawn(codexPath, ["app-server", "--listen", `ws://127.0.0.1:${port}`], {
       stdio: ["ignore", "pipe", "pipe"],
     }),
   );
@@ -523,7 +524,7 @@ async function runWebSocketProbe(secureExposure) {
   let shuttingDown = false;
   const childFailure = new Promise((_, reject) => {
     child.once("error", (error) => {
-      reject(new Error(`codex app-server failed during WebSocket probe: ${error.message}`));
+      reject(new Error(`${codexPath} app-server failed during WebSocket probe: ${error.message}`));
     });
     child.once("exit", (code, signal) => {
       if (shuttingDown) return;
@@ -531,7 +532,7 @@ async function runWebSocketProbe(secureExposure) {
       const suffix = signal ? `signal ${signal}` : `code ${code}`;
       reject(
         new Error(
-          `codex app-server exited unexpectedly during WebSocket probe with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
+          `${codexPath} app-server exited unexpectedly during WebSocket probe with ${suffix}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}`,
         ),
       );
     });
@@ -646,11 +647,11 @@ async function runWebSocketProbe(secureExposure) {
 
 async function runHelpProbe() {
   const child = trackChild(
-    spawn("codex", ["app-server", "--help"], {
+    spawn(codexPath, ["app-server", "--help"], {
       stdio: ["ignore", "pipe", "pipe"],
     }),
   );
-  const help = await collectChildOutput(child, "codex app-server --help");
+  const help = await collectChildOutput(child, `${codexPath} app-server --help`);
   return {
     transport: "websocket_secure_exposure",
     authEvidence: "advertised_in_help",
@@ -675,8 +676,8 @@ const report = {
 };
 
 try {
-  const version = trackChild(spawn("codex", ["--version"], { stdio: ["ignore", "pipe", "pipe"] }));
-  report.codexVersion = (await collectChildOutput(version, "codex --version")).trim();
+  const version = trackChild(spawn(codexPath, ["--version"], { stdio: ["ignore", "pipe", "pipe"] }));
+  report.codexVersion = (await collectChildOutput(version, `${codexPath} --version`)).trim();
   report.stdio = await runStdioProbe();
   report.secureExposure = await runHelpProbe();
   if (runWebSocket) {
@@ -686,5 +687,9 @@ try {
   console.log(JSON.stringify(report, null, 2));
 } catch (error) {
   console.error(error.stack || String(error));
+  if (report.codexVersion || report.stdio || report.websocket || report.secureExposure) {
+    console.error("Partial benchmark report:");
+    console.error(JSON.stringify(report, null, 2));
+  }
   process.exit(1);
 }

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -235,7 +235,6 @@ function writeToStream(stream, data, label, timeoutMs) {
     };
     const onError = (error) => {
       cleanup();
-      ws.close();
       reject(error);
     };
     const timeout = setTimeout(() => {
@@ -410,6 +409,7 @@ async function openSocket(url, timeoutMs = requestTimeoutMs) {
     };
     const onError = (error) => {
       cleanup();
+      ws.close();
       reject(error);
     };
     const timeout = setTimeout(() => {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -44,12 +44,43 @@ async function terminateChild(child, graceMs = 1000) {
 }
 
 function assertJsonRpcResult(label, response) {
+  if (response == null || typeof response !== "object") {
+    throw new Error(`${label} returned non-object JSON-RPC response: ${JSON.stringify(response)}`);
+  }
   if (response.error) {
     throw new Error(`${label} returned JSON-RPC error: ${JSON.stringify(response.error)}`);
   }
   if (!Object.hasOwn(response, "result")) {
     throw new Error(`${label} did not include a JSON-RPC result`);
   }
+}
+
+function waitForStreamProgress(stream, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stream.removeListener("readable", onReadable);
+      stream.removeListener("end", onEnd);
+      stream.removeListener("close", onClose);
+      stream.removeListener("error", onError);
+    };
+    const complete = (event) => {
+      cleanup();
+      resolve(event);
+    };
+    const onReadable = () => complete("readable");
+    const onEnd = () => complete("end");
+    const onClose = () => complete("close");
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const timeout = setTimeout(() => complete("timeout"), timeoutMs);
+    stream.once("readable", onReadable);
+    stream.once("end", onEnd);
+    stream.once("close", onClose);
+    stream.once("error", onError);
+  });
 }
 
 async function readLine(stream, timeoutMs) {
@@ -63,8 +94,38 @@ async function readLine(stream, timeoutMs) {
       if (newline >= 0) return buffer.slice(0, newline);
     }
     if (performance.now() > deadline) throw new Error("timed out waiting for line");
-    await once(stream, "readable");
+    const remainingMs = Math.max(1, deadline - performance.now());
+    const event = await waitForStreamProgress(stream, remainingMs);
+    if (event === "timeout") throw new Error("timed out waiting for line");
+    if (event === "end" || event === "close") {
+      throw new Error(`stream ${event} before a complete line`);
+    }
   }
+}
+
+async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
+  const stdout = [];
+  const stderr = [];
+  child.stdout?.on("data", (chunk) => stdout.push(chunk));
+  child.stderr?.on("data", (chunk) => stderr.push(chunk));
+
+  const result = await Promise.race([
+    once(child, "exit").then(([code, signal]) => ({ code, signal, timedOut: false })),
+    sleep(timeoutMs).then(() => ({ code: null, signal: null, timedOut: true })),
+  ]);
+
+  if (result.timedOut) {
+    await terminateChild(child);
+    throw new Error(`${label} timed out after ${timeoutMs}ms`);
+  }
+
+  if (result.code !== 0) {
+    const suffix = result.signal ? ` signal ${result.signal}` : ` code ${result.code}`;
+    const stderrText = Buffer.concat(stderr).toString("utf8").trim();
+    throw new Error(`${label} exited with${suffix}${stderrText ? `: ${stderrText}` : ""}`);
+  }
+
+  return Buffer.concat(stdout).toString("utf8");
 }
 
 async function runStdioProbe() {
@@ -258,13 +319,7 @@ async function runHelpProbe() {
   const child = spawn("codex", ["app-server", "--help"], {
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const chunks = [];
-  child.stdout.on("data", (chunk) => chunks.push(chunk));
-  const [code] = await once(child, "exit");
-  if (code !== 0) {
-    throw new Error(`codex app-server --help exited with code ${code}`);
-  }
-  const help = Buffer.concat(chunks).toString("utf8");
+  const help = await collectChildOutput(child, "codex app-server --help");
   return {
     transport: "websocket_secure_exposure",
     helpSha256: createHash("sha256").update(help).digest("hex"),
@@ -285,10 +340,7 @@ const report = {
 
 try {
   const version = spawn("codex", ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
-  const chunks = [];
-  version.stdout.on("data", (chunk) => chunks.push(chunk));
-  await once(version, "exit");
-  report.codexVersion = Buffer.concat(chunks).toString("utf8").trim();
+  report.codexVersion = (await collectChildOutput(version, "codex --version")).trim();
   report.stdio = await runStdioProbe();
   report.secureExposure = await runHelpProbe();
   if (runWebSocket) {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -281,17 +281,29 @@ async function runStdioProbe() {
       stdio: ["pipe", "pipe", "pipe"],
     }),
   );
+  let shuttingDown = false;
   try {
-    const childError = once(child, "error").then(([error]) => {
-      throw new Error(`codex app-server --stdio failed to start: ${error.message}`);
-    });
-    childError.catch(() => {});
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     let stderr = "";
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString("utf8");
     });
+    const childFailure = new Promise((_, reject) => {
+      child.once("error", (error) => {
+        reject(new Error(`codex app-server --stdio failed to start: ${error.message}`));
+      });
+      child.once("exit", (code, signal) => {
+        if (shuttingDown) return;
+        const suffix = signal ? `signal ${signal}` : `code ${code}`;
+        reject(
+          new Error(
+            `codex app-server --stdio exited before initialize completed with ${suffix}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
+          ),
+        );
+      });
+    });
+    childFailure.catch(() => {});
     const stdout = new LineReader(child.stdout);
     const startedAt = performance.now();
     await Promise.race([
@@ -304,17 +316,17 @@ async function runStdioProbe() {
         "stdio initialize",
         requestTimeoutMs,
       ),
-      childError,
+      childFailure,
     ]);
     const response = await Promise.race([
       readJsonRpcResponse(stdout, "stdio initialize", 1, requestTimeoutMs),
-      childError,
+      childFailure,
     ]);
     const latencyMs = performance.now() - startedAt;
     assertJsonRpcResult("stdio initialize", response);
     await Promise.race([
       endStream(child.stdin, "stdio initialize", requestTimeoutMs),
-      childError,
+      childFailure,
     ]);
     return {
       transport: "stdio",
@@ -323,6 +335,7 @@ async function runStdioProbe() {
       stderrBytes: Buffer.byteLength(stderr, "utf8"),
     };
   } finally {
+    shuttingDown = true;
     await terminateChild(child);
   }
 }

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -557,7 +557,16 @@ async function runWebSocketProbe(secureExposure) {
       );
       nextRequestId += 1;
     }
-    const responses = await Promise.all(requests);
+    const settledResponses = await Promise.allSettled(requests);
+    const failures = settledResponses.filter((response) => response.status === "rejected");
+    if (failures.length > 0) {
+      throw new Error(
+        `websocket queued request batch failed (${failures.length}/${requests.length}): ${failures
+          .map((failure) => failure.reason?.message ?? String(failure.reason))
+          .join("; ")}`,
+      );
+    }
+    const responses = settledResponses.map((response) => response.value);
     for (const response of responses) {
       assertJsonRpcResult("websocket queued request", response.response);
     }

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -83,24 +83,60 @@ function waitForStreamProgress(stream, timeoutMs) {
   });
 }
 
-async function readLine(stream, timeoutMs) {
-  let buffer = "";
-  const deadline = performance.now() + timeoutMs;
-  for (;;) {
-    const chunk = stream.read();
-    if (chunk) {
-      buffer += chunk.toString("utf8");
-      const newline = buffer.indexOf("\n");
-      if (newline >= 0) return buffer.slice(0, newline);
-    }
-    if (performance.now() > deadline) throw new Error("timed out waiting for line");
-    const remainingMs = Math.max(1, deadline - performance.now());
-    const event = await waitForStreamProgress(stream, remainingMs);
-    if (event === "timeout") throw new Error("timed out waiting for line");
-    if (event === "end" || event === "close") {
-      throw new Error(`stream ${event} before a complete line`);
+class LineReader {
+  constructor(stream) {
+    this.stream = stream;
+    this.buffer = "";
+  }
+
+  async readLine(timeoutMs) {
+    const deadline = performance.now() + timeoutMs;
+    for (;;) {
+      const newline = this.buffer.indexOf("\n");
+      if (newline >= 0) {
+        const line = this.buffer.slice(0, newline);
+        this.buffer = this.buffer.slice(newline + 1);
+        return line;
+      }
+
+      const chunk = this.stream.read();
+      if (chunk) {
+        this.buffer += chunk.toString("utf8");
+        continue;
+      }
+
+      if (performance.now() > deadline) throw new Error("timed out waiting for line");
+      const remainingMs = Math.max(1, deadline - performance.now());
+      const event = await waitForStreamProgress(this.stream, remainingMs);
+      if (event === "timeout") throw new Error("timed out waiting for line");
+      if (event === "end" || event === "close") {
+        throw new Error(`stream ${event} before a complete line`);
+      }
     }
   }
+}
+
+function writeToStream(stream, data, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stream.removeListener("error", onError);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${label} write timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    stream.once("error", onError);
+    stream.write(data, (error) => {
+      cleanup();
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 }
 
 async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
@@ -135,14 +171,18 @@ async function runStdioProbe() {
   try {
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
+    const stdout = new LineReader(child.stdout);
     const startedAt = performance.now();
-    child.stdin.write(
+    await writeToStream(
+      child.stdin,
       `${request(1, "initialize", {
         clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
         capabilities: {},
       })}\n`,
+      "stdio initialize",
+      requestTimeoutMs,
     );
-    const line = await readLine(child.stdout, requestTimeoutMs);
+    const line = await stdout.readLine(requestTimeoutMs);
     const latencyMs = performance.now() - startedAt;
     const response = JSON.parse(line);
     assertJsonRpcResult("stdio initialize", response);
@@ -204,6 +244,25 @@ async function openSocket(url, timeoutMs = requestTimeoutMs) {
     ws.addEventListener("error", onError);
   });
   return ws;
+}
+
+function waitForSocketClose(ws, timeoutMs = requestTimeoutMs) {
+  if (ws.readyState === WebSocket.CLOSED) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      ws.removeEventListener("close", onClose);
+    };
+    const onClose = () => {
+      cleanup();
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`WebSocket close timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    ws.addEventListener("close", onClose);
+  });
 }
 
 function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeoutMs) {
@@ -273,9 +332,13 @@ async function runWebSocketProbe(secureExposure) {
     }
     const elapsedMs = performance.now() - batchStartedAt;
     const latencies = responses.map((response) => response.latencyMs);
+    const requestsPerSecond =
+      elapsedMs > 0 ? Number(((responses.length / elapsedMs) * 1000).toFixed(2)) : 0;
 
+    const closed = waitForSocketClose(ws);
     ws.close();
-    await sleep(100);
+    await closed;
+    ws = null;
     const reconnectStartedAt = performance.now();
     ws2 = await openSocket(`ws://127.0.0.1:${port}`);
     const reconnectInitialize = await requestOverSocket(ws2, iterations + 2, "initialize", {
@@ -292,7 +355,7 @@ async function runWebSocketProbe(secureExposure) {
       queuedRequests: iterations,
       queuedResponses: responses.length,
       queueElapsedMs: Number(elapsedMs.toFixed(3)),
-      requestsPerSecond: Number(((responses.length / elapsedMs) * 1000).toFixed(2)),
+      requestsPerSecond,
       latencyMs: {
         p50: percentile(latencies, 50),
         p95: percentile(latencies, 95),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -6,6 +6,7 @@ import { once, setMaxListeners } from "node:events";
 import { setTimeout as sleep } from "node:timers/promises";
 
 const booleanFlags = new Set(["--skip-websocket"]);
+const valueFlags = new Set(["--codex-path", "--iterations", "--port", "--request-timeout-ms"]);
 const args = new Map();
 for (let i = 2; i < process.argv.length; i += 1) {
   const rawArg = process.argv[i];
@@ -17,17 +18,25 @@ for (let i = 2; i < process.argv.length; i += 1) {
     args.set(arg, "true");
     continue;
   }
+  if (!valueFlags.has(arg)) {
+    console.error(`unknown option ${arg}`);
+    process.exit(1);
+  }
   if (inlineValue != null) {
+    if (inlineValue.length === 0) {
+      console.error(`${arg} requires a non-empty value`);
+      process.exit(1);
+    }
     args.set(arg, inlineValue);
     continue;
   }
   const next = process.argv[i + 1];
-  if (next && !next.startsWith("--")) {
-    args.set(arg, next);
-    i += 1;
-  } else {
-    args.set(arg, "true");
+  if (!next || next.startsWith("--")) {
+    console.error(`${arg} requires a value`);
+    process.exit(1);
   }
+  args.set(arg, next);
+  i += 1;
 }
 
 function parseIntegerOption(flag, defaultValue, min, max) {
@@ -484,6 +493,10 @@ class WebSocketJsonRpcClient {
     const pending = this.pending.get(String(parsed.id));
     if (!pending) return;
     this.pending.delete(String(parsed.id));
+    if (!Object.hasOwn(parsed, "result") && !Object.hasOwn(parsed, "error")) {
+      pending.reject(new Error(`malformed JSON-RPC response for ${pending.method}: ${JSON.stringify(parsed)}`));
+      return;
+    }
     pending.resolve(parsed);
   }
 

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -323,7 +323,7 @@ async function runStdioProbe() {
   }
 }
 
-async function waitForReadyz(url, timeoutMs = 5000) {
+async function waitForReadyz(url, timeoutMs = requestTimeoutMs) {
   const deadline = performance.now() + timeoutMs;
   let lastError = null;
   while (performance.now() < deadline) {
@@ -523,7 +523,7 @@ async function runWebSocketProbe(secureExposure) {
       reconnectResponse: reconnectInitialize.response,
       stdoutBytes: Buffer.byteLength(stdout, "utf8"),
       stderrBytes: Buffer.byteLength(stderr, "utf8"),
-      stderrPreview: stderrTrimmed ? stderrTrimmed.slice(-1000) : null,
+      stderrPreview: stderrTrimmed ? [...stderrTrimmed].slice(-1000).join("") : null,
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
         localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -669,7 +669,9 @@ async function runWebSocketProbe(secureExposure) {
     const stderrTrimmed = stderr.trim();
     const output = `${stdout}\n${stderr}`;
     const configuredListener = `ws://127.0.0.1:${port}`;
-    const observedListener = output.match(/\blistening on:\s*(ws:\/\/[^\s]+)/)?.[1] ?? configuredListener;
+    const listenerMatch = output.match(/\blistening on:\s*(ws:\/\/[^\s]+)/);
+    const observedListener = listenerMatch?.[1] ?? configuredListener;
+    const observedListenerSource = listenerMatch ? "observed" : "configured_fallback";
     let listenerHost = null;
     try {
       listenerHost = new URL(observedListener).hostname;
@@ -698,9 +700,13 @@ async function runWebSocketProbe(secureExposure) {
       stderrPreview: stderrTrimmed ? [...stderrTrimmed].slice(-1000).join("") : null,
       exposure: {
         listener: observedListener,
+        observedListenerSource,
         listenerHost,
         localhostOnly,
-        localhostOnlyEvidence: ["configured_loopback_listener", "parsed_listener_address"],
+        localhostOnlyEvidence: [
+          "configured_loopback_listener",
+          ...(listenerMatch ? ["parsed_listener_address"] : ["configured_listener_fallback"]),
+        ],
         authEvidence: "advertised_in_help",
         runtimeAuthProbe: "not_measured_by_loopback_smoke",
         authModesAdvertisedInHelp: [

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -156,7 +156,6 @@ function waitForStreamProgress(stream, timeoutMs) {
     const onClose = () => complete("close");
     const onError = (error) => {
       cleanup();
-      ws.close();
       reject(error);
     };
     const timeout = setTimeout(() => complete("timeout"), timeoutMs);
@@ -236,6 +235,7 @@ function writeToStream(stream, data, label, timeoutMs) {
     };
     const onError = (error) => {
       cleanup();
+      ws.close();
       reject(error);
     };
     const timeout = setTimeout(() => {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -18,10 +18,29 @@ for (let i = 2; i < process.argv.length; i += 1) {
   }
 }
 
-const iterations = Number(args.get("--iterations") ?? "50");
-const port = Number(args.get("--port") ?? "18765");
+function parseIntegerOption(flag, defaultValue, min, max) {
+  const raw = args.get(flag) ?? String(defaultValue);
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    console.error(`${flag} must be an integer from ${min} to ${max}; received ${JSON.stringify(raw)}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const iterations = parseIntegerOption("--iterations", 50, 1, 100000);
+const port = parseIntegerOption("--port", 18765, 1, 65535);
 const runWebSocket = args.get("--skip-websocket") !== "true";
-const requestTimeoutMs = Number(args.get("--request-timeout-ms") ?? "5000");
+const requestTimeoutMs = parseIntegerOption("--request-timeout-ms", 5000, 1, 300000);
+
+function assertWebSocketRuntime() {
+  const nodeVersion = process.versions?.node ?? "unknown";
+  if (typeof globalThis.WebSocket !== "function" || typeof globalThis.fetch !== "function") {
+    throw new Error(
+      `WebSocket benchmark requires Node.js 22+ globals WebSocket and fetch; current Node.js is ${nodeVersion}. Use --skip-websocket to run stdio-only probes.`,
+    );
+  }
+}
 
 function percentile(values, pct) {
   if (values.length === 0) return null;
@@ -171,6 +190,10 @@ async function runStdioProbe() {
   try {
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
     const stdout = new LineReader(child.stdout);
     const startedAt = performance.now();
     await writeToStream(
@@ -190,6 +213,7 @@ async function runStdioProbe() {
       transport: "stdio",
       initializeLatencyMs: Number(latencyMs.toFixed(3)),
       response,
+      stderrBytes: Buffer.byteLength(stderr, "utf8"),
     };
   } finally {
     await terminateChild(child);
@@ -408,6 +432,7 @@ try {
   report.stdio = await runStdioProbe();
   report.secureExposure = await runHelpProbe();
   if (runWebSocket) {
+    assertWebSocketRuntime();
     report.websocket = await runWebSocketProbe(report.secureExposure);
   }
   console.log(JSON.stringify(report, null, 2));

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -428,7 +428,7 @@ async function runWebSocketProbe(secureExposure) {
       latencyMs: {
         p50: percentile(latencies, 50),
         p95: percentile(latencies, 95),
-        max: Number(Math.max(...latencies).toFixed(3)),
+        max: Number(latencies.reduce((max, latency) => Math.max(max, latency), 0).toFixed(3)),
       },
       reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
       reconnectResponse: "ok",

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -166,6 +166,31 @@ class LineReader {
   }
 }
 
+async function readJsonRpcResponse(reader, label, timeoutMs) {
+  const deadline = performance.now() + timeoutMs;
+  for (;;) {
+    const remainingMs = Math.max(1, deadline - performance.now());
+    if (performance.now() > deadline) {
+      throw new Error(`${label} timed out waiting for JSON-RPC response`);
+    }
+    const line = await reader.readLine(remainingMs);
+    let response;
+    try {
+      response = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (
+      response != null &&
+      typeof response === "object" &&
+      Object.hasOwn(response, "id") &&
+      (Object.hasOwn(response, "result") || Object.hasOwn(response, "error"))
+    ) {
+      return response;
+    }
+  }
+}
+
 function writeToStream(stream, data, label, timeoutMs) {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
@@ -238,9 +263,8 @@ async function runStdioProbe() {
       "stdio initialize",
       requestTimeoutMs,
     );
-    const line = await stdout.readLine(requestTimeoutMs);
+    const response = await readJsonRpcResponse(stdout, "stdio initialize", requestTimeoutMs);
     const latencyMs = performance.now() - startedAt;
-    const response = JSON.parse(line);
     assertJsonRpcResult("stdio initialize", response);
     return {
       transport: "stdio",
@@ -462,6 +486,7 @@ async function runHelpProbe() {
     hasCapabilityTokenMode: help.includes("capability-token"),
     hasSignedBearerMode: help.includes("signed-bearer-token"),
     hasTokenFileFlag: help.includes("--ws-token-file"),
+    hasTokenSha256Flag: help.includes("--ws-token-sha256"),
     hasSharedSecretFlag: help.includes("--ws-shared-secret-file"),
     hasIssuerFlag: help.includes("--ws-issuer"),
     hasAudienceFlag: help.includes("--ws-audience"),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -8,10 +8,17 @@ import { setTimeout as sleep } from "node:timers/promises";
 const booleanFlags = new Set(["--skip-websocket"]);
 const args = new Map();
 for (let i = 2; i < process.argv.length; i += 1) {
-  const arg = process.argv[i];
-  if (!arg.startsWith("--")) continue;
+  const rawArg = process.argv[i];
+  if (!rawArg.startsWith("--")) continue;
+  const equalsIndex = rawArg.indexOf("=");
+  const arg = equalsIndex >= 0 ? rawArg.slice(0, equalsIndex) : rawArg;
+  const inlineValue = equalsIndex >= 0 ? rawArg.slice(equalsIndex + 1) : null;
   if (booleanFlags.has(arg)) {
     args.set(arg, "true");
+    continue;
+  }
+  if (inlineValue != null) {
+    args.set(arg, inlineValue);
     continue;
   }
   const next = process.argv[i + 1];

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -445,8 +445,10 @@ async function runWebSocketProbe(secureExposure) {
 
     const batchStartedAt = performance.now();
     const requests = [];
+    let nextRequestId = 2;
     for (let i = 0; i < iterations; i += 1) {
-      requests.push(requestOverSocket(ws, i + 2, "thread/loaded/list", { limit: 1 }));
+      requests.push(requestOverSocket(ws, nextRequestId, "thread/loaded/list", { limit: 1 }));
+      nextRequestId += 1;
     }
     const responses = await Promise.all(requests);
     for (const response of responses) {
@@ -463,7 +465,7 @@ async function runWebSocketProbe(secureExposure) {
     ws = null;
     const reconnectStartedAt = performance.now();
     ws2 = await openSocket(`ws://127.0.0.1:${port}`);
-    const reconnectInitialize = await requestOverSocket(ws2, iterations + 2, "initialize", {
+    const reconnectInitialize = await requestOverSocket(ws2, nextRequestId, "initialize", {
       clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
       capabilities: {},
     });

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -21,6 +21,7 @@ for (let i = 2; i < process.argv.length; i += 1) {
 const iterations = Number(args.get("--iterations") ?? "50");
 const port = Number(args.get("--port") ?? "18765");
 const runWebSocket = args.get("--skip-websocket") !== "true";
+const requestTimeoutMs = Number(args.get("--request-timeout-ms") ?? "5000");
 
 function percentile(values, pct) {
   if (values.length === 0) return null;
@@ -31,6 +32,24 @@ function percentile(values, pct) {
 
 function request(id, method, params = {}) {
   return JSON.stringify({ jsonrpc: "2.0", id, method, params });
+}
+
+async function terminateChild(child, graceMs = 1000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = once(child, "exit").then(() => true);
+  child.kill("SIGTERM");
+  if (await Promise.race([exited, sleep(graceMs).then(() => false)])) return;
+  child.kill("SIGKILL");
+  await Promise.race([exited, sleep(graceMs)]);
+}
+
+function assertJsonRpcResult(label, response) {
+  if (response.error) {
+    throw new Error(`${label} returned JSON-RPC error: ${JSON.stringify(response.error)}`);
+  }
+  if (!response.result) {
+    throw new Error(`${label} did not include a JSON-RPC result`);
+  }
 }
 
 async function readLine(stream, timeoutMs) {
@@ -52,24 +71,28 @@ async function runStdioProbe() {
   const child = spawn("codex", ["app-server", "--stdio"], {
     stdio: ["pipe", "pipe", "pipe"],
   });
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  const startedAt = performance.now();
-  child.stdin.write(
-    `${request(1, "initialize", {
-      clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
-      capabilities: {},
-    })}\n`,
-  );
-  const line = await readLine(child.stdout, 5000);
-  const latencyMs = performance.now() - startedAt;
-  child.kill("SIGTERM");
-  await Promise.race([once(child, "exit"), sleep(1000)]);
-  return {
-    transport: "stdio",
-    initializeLatencyMs: Number(latencyMs.toFixed(3)),
-    response: JSON.parse(line),
-  };
+  try {
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const startedAt = performance.now();
+    child.stdin.write(
+      `${request(1, "initialize", {
+        clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
+        capabilities: {},
+      })}\n`,
+    );
+    const line = await readLine(child.stdout, requestTimeoutMs);
+    const latencyMs = performance.now() - startedAt;
+    const response = JSON.parse(line);
+    assertJsonRpcResult("stdio initialize", response);
+    return {
+      transport: "stdio",
+      initializeLatencyMs: Number(latencyMs.toFixed(3)),
+      response,
+    };
+  } finally {
+    await terminateChild(child);
+  }
 }
 
 async function waitForReadyz(url, timeoutMs = 5000) {
@@ -98,17 +121,30 @@ async function openSocket(url) {
   return ws;
 }
 
-function requestOverSocket(ws, id, method, params = {}) {
+function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeoutMs) {
   const startedAt = performance.now();
   return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      ws.removeEventListener("message", onMessage);
+      ws.removeEventListener("error", onError);
+    };
     const onMessage = (event) => {
       const parsed = JSON.parse(event.data);
       if (parsed.id !== id) return;
-      ws.removeEventListener("message", onMessage);
+      cleanup();
       resolve({ latencyMs: performance.now() - startedAt, response: parsed });
     };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${method} request ${id} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
     ws.addEventListener("message", onMessage);
-    ws.addEventListener("error", reject, { once: true });
+    ws.addEventListener("error", onError);
     ws.send(request(id, method, params));
   });
 }
@@ -122,58 +158,67 @@ async function runWebSocketProbe() {
     stderr += chunk.toString("utf8");
   });
 
-  await waitForReadyz(`http://127.0.0.1:${port}/readyz`);
+  let ws = null;
+  let ws2 = null;
+  try {
+    await waitForReadyz(`http://127.0.0.1:${port}/readyz`);
 
-  const ws = await openSocket(`ws://127.0.0.1:${port}`);
-  const initialize = await requestOverSocket(ws, 1, "initialize", {
-    clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
-    capabilities: {},
-  });
+    ws = await openSocket(`ws://127.0.0.1:${port}`);
+    const initialize = await requestOverSocket(ws, 1, "initialize", {
+      clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
+      capabilities: {},
+    });
+    assertJsonRpcResult("websocket initialize", initialize.response);
 
-  const batchStartedAt = performance.now();
-  const requests = [];
-  for (let i = 0; i < iterations; i += 1) {
-    requests.push(requestOverSocket(ws, i + 2, "thread/loaded/list", { limit: 1 }));
+    const batchStartedAt = performance.now();
+    const requests = [];
+    for (let i = 0; i < iterations; i += 1) {
+      requests.push(requestOverSocket(ws, i + 2, "thread/loaded/list", { limit: 1 }));
+    }
+    const responses = await Promise.all(requests);
+    for (const response of responses) {
+      assertJsonRpcResult("websocket queued request", response.response);
+    }
+    const elapsedMs = performance.now() - batchStartedAt;
+    const latencies = responses.map((response) => response.latencyMs);
+
+    ws.close();
+    await sleep(100);
+    const reconnectStartedAt = performance.now();
+    ws2 = await openSocket(`ws://127.0.0.1:${port}`);
+    const reconnectInitialize = await requestOverSocket(ws2, iterations + 2, "initialize", {
+      clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
+      capabilities: {},
+    });
+    assertJsonRpcResult("websocket reconnect initialize", reconnectInitialize.response);
+    const reconnectMs = performance.now() - reconnectStartedAt;
+
+    return {
+      transport: "websocket_loopback",
+      port,
+      initializeLatencyMs: Number(initialize.latencyMs.toFixed(3)),
+      queuedRequests: iterations,
+      queuedResponses: responses.length,
+      queueElapsedMs: Number(elapsedMs.toFixed(3)),
+      requestsPerSecond: Number(((responses.length / elapsedMs) * 1000).toFixed(2)),
+      latencyMs: {
+        p50: percentile(latencies, 50),
+        p95: percentile(latencies, 95),
+        max: Number(Math.max(...latencies).toFixed(3)),
+      },
+      reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
+      reconnectResponse: "ok",
+      exposure: {
+        listener: `ws://127.0.0.1:${port}`,
+        localhostOnly: /binds localhost only/.test(stderr),
+        authModesFromHelp: ["capability-token", "signed-bearer-token"],
+      },
+    };
+  } finally {
+    if (ws && ws.readyState < WebSocket.CLOSING) ws.close();
+    if (ws2 && ws2.readyState < WebSocket.CLOSING) ws2.close();
+    await terminateChild(child);
   }
-  const responses = await Promise.all(requests);
-  const elapsedMs = performance.now() - batchStartedAt;
-  const latencies = responses.map((response) => response.latencyMs);
-
-  ws.close();
-  await sleep(100);
-  const reconnectStartedAt = performance.now();
-  const ws2 = await openSocket(`ws://127.0.0.1:${port}`);
-  const reconnectInitialize = await requestOverSocket(ws2, iterations + 2, "initialize", {
-    clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
-    capabilities: {},
-  });
-  const reconnectMs = performance.now() - reconnectStartedAt;
-  ws2.close();
-
-  child.kill("SIGTERM");
-  await Promise.race([once(child, "exit"), sleep(1000)]);
-
-  return {
-    transport: "websocket_loopback",
-    port,
-    initializeLatencyMs: Number(initialize.latencyMs.toFixed(3)),
-    queuedRequests: iterations,
-    queuedResponses: responses.length,
-    queueElapsedMs: Number(elapsedMs.toFixed(3)),
-    requestsPerSecond: Number(((responses.length / elapsedMs) * 1000).toFixed(2)),
-    latencyMs: {
-      p50: percentile(latencies, 50),
-      p95: percentile(latencies, 95),
-      max: Number(Math.max(...latencies).toFixed(3)),
-    },
-    reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
-    reconnectResponse: reconnectInitialize.response.result ? "ok" : "missing_result",
-    exposure: {
-      listener: `ws://127.0.0.1:${port}`,
-      localhostOnly: /binds localhost only/.test(stderr),
-      authModesFromHelp: ["capability-token", "signed-bearer-token"],
-    },
-  };
 }
 
 async function runHelpProbe() {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -164,6 +164,9 @@ class LineReader {
       }
 
       if (performance.now() > deadline) throw new Error("timed out waiting for line");
+      if (this.stream.readableEnded || this.stream.destroyed) {
+        throw new Error("stream ended before a complete line");
+      }
       const remainingMs = Math.max(1, deadline - performance.now());
       const event = await waitForStreamProgress(this.stream, remainingMs);
       if (event === "timeout") throw new Error("timed out waiting for line");
@@ -304,9 +307,13 @@ async function runStdioProbe() {
       });
     });
     childFailure.catch(() => {});
+    const withChildFailure = (promise) => {
+      promise.catch(() => {});
+      return Promise.race([promise, childFailure]);
+    };
     const stdout = new LineReader(child.stdout);
     const startedAt = performance.now();
-    await Promise.race([
+    await withChildFailure(
       writeToStream(
         child.stdin,
         `${request(1, "initialize", {
@@ -316,18 +323,13 @@ async function runStdioProbe() {
         "stdio initialize",
         requestTimeoutMs,
       ),
-      childFailure,
-    ]);
-    const response = await Promise.race([
+    );
+    const response = await withChildFailure(
       readJsonRpcResponse(stdout, "stdio initialize", 1, requestTimeoutMs),
-      childFailure,
-    ]);
+    );
     const latencyMs = performance.now() - startedAt;
     assertJsonRpcResult("stdio initialize", response);
-    await Promise.race([
-      endStream(child.stdin, "stdio initialize", requestTimeoutMs),
-      childFailure,
-    ]);
+    await withChildFailure(endStream(child.stdin, "stdio initialize", requestTimeoutMs));
     return {
       transport: "stdio",
       initializeLatencyMs: Number(latencyMs.toFixed(3)),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -99,24 +99,47 @@ async function waitForReadyz(url, timeoutMs = 5000) {
   const deadline = performance.now() + timeoutMs;
   let lastError = null;
   while (performance.now() < deadline) {
+    const controller = new AbortController();
+    const remainingMs = Math.max(1, deadline - performance.now());
+    const abort = setTimeout(() => controller.abort(), Math.min(remainingMs, 500));
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: controller.signal });
       if (response.ok) return true;
       lastError = new Error(`readyz returned ${response.status}`);
     } catch (error) {
       lastError = error;
+    } finally {
+      clearTimeout(abort);
     }
     await sleep(100);
   }
   throw lastError ?? new Error("readyz timed out");
 }
 
-async function openSocket(url) {
+async function openSocket(url, timeoutMs = requestTimeoutMs) {
   const ws = new WebSocket(url);
   setMaxListeners(0, ws);
   await new Promise((resolve, reject) => {
-    ws.addEventListener("open", resolve, { once: true });
-    ws.addEventListener("error", reject, { once: true });
+    const cleanup = () => {
+      clearTimeout(timeout);
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("error", onError);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      ws.close();
+      reject(new Error(`WebSocket connection to ${url} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
   });
   return ws;
 }
@@ -130,7 +153,14 @@ function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeo
       ws.removeEventListener("error", onError);
     };
     const onMessage = (event) => {
-      const parsed = JSON.parse(event.data);
+      let parsed;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch (error) {
+        cleanup();
+        reject(error);
+        return;
+      }
       if (parsed.id !== id) return;
       cleanup();
       resolve({ latencyMs: performance.now() - startedAt, response: parsed });

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -214,6 +214,29 @@ function writeToStream(stream, data, label, timeoutMs) {
   });
 }
 
+function endStream(stream, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stream.removeListener("error", onError);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${label} end timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    stream.once("error", onError);
+    stream.end((error) => {
+      cleanup();
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
 async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
   const stdout = [];
   const stderr = [];
@@ -222,8 +245,13 @@ async function collectChildOutput(child, label, timeoutMs = requestTimeoutMs) {
 
   const result = await Promise.race([
     once(child, "exit").then(([code, signal]) => ({ code, signal, timedOut: false })),
+    once(child, "error").then(([error]) => ({ error, timedOut: false })),
     sleep(timeoutMs).then(() => ({ code: null, signal: null, timedOut: true })),
   ]);
+
+  if (result.error) {
+    throw new Error(`${label} failed to start: ${result.error.message}`);
+  }
 
   if (result.timedOut) {
     await terminateChild(child);
@@ -266,6 +294,7 @@ async function runStdioProbe() {
     const response = await readJsonRpcResponse(stdout, "stdio initialize", requestTimeoutMs);
     const latencyMs = performance.now() - startedAt;
     assertJsonRpcResult("stdio initialize", response);
+    await endStream(child.stdin, "stdio initialize", requestTimeoutMs);
     return {
       transport: "stdio",
       initializeLatencyMs: Number(latencyMs.toFixed(3)),
@@ -393,10 +422,10 @@ async function runWebSocketProbe(secureExposure) {
       stdio: ["ignore", "pipe", "pipe"],
     }),
   );
-  let stdoutBytes = 0;
+  let stdout = "";
   let stderr = "";
   child.stdout.on("data", (chunk) => {
-    stdoutBytes += chunk.length;
+    stdout += chunk.toString("utf8");
   });
   child.stderr.on("data", (chunk) => {
     stderr += chunk.toString("utf8");
@@ -456,10 +485,10 @@ async function runWebSocketProbe(secureExposure) {
       },
       reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
       reconnectResponse: "ok",
-      stdoutBytes,
+      stdoutBytes: Buffer.byteLength(stdout, "utf8"),
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
-        localhostOnly: /binds localhost only/.test(stderr),
+        localhostOnly: /binds localhost only/.test(`${stdout}\n${stderr}`),
         authModesFromHelp: [
           ...(secureExposure.hasCapabilityTokenMode ? ["capability-token"] : []),
           ...(secureExposure.hasSignedBearerMode ? ["signed-bearer-token"] : []),

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -47,7 +47,7 @@ function assertJsonRpcResult(label, response) {
   if (response.error) {
     throw new Error(`${label} returned JSON-RPC error: ${JSON.stringify(response.error)}`);
   }
-  if (!response.result) {
+  if (!Object.hasOwn(response, "result")) {
     throw new Error(`${label} did not include a JSON-RPC result`);
   }
 }
@@ -179,7 +179,7 @@ function requestOverSocket(ws, id, method, params = {}, timeoutMs = requestTimeo
   });
 }
 
-async function runWebSocketProbe() {
+async function runWebSocketProbe(secureExposure) {
   const child = spawn("codex", ["app-server", "--listen", `ws://127.0.0.1:${port}`], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -241,7 +241,10 @@ async function runWebSocketProbe() {
       exposure: {
         listener: `ws://127.0.0.1:${port}`,
         localhostOnly: /binds localhost only/.test(stderr),
-        authModesFromHelp: ["capability-token", "signed-bearer-token"],
+        authModesFromHelp: [
+          ...(secureExposure.hasCapabilityTokenMode ? ["capability-token"] : []),
+          ...(secureExposure.hasSignedBearerMode ? ["signed-bearer-token"] : []),
+        ],
       },
     };
   } finally {
@@ -257,7 +260,10 @@ async function runHelpProbe() {
   });
   const chunks = [];
   child.stdout.on("data", (chunk) => chunks.push(chunk));
-  await once(child, "exit");
+  const [code] = await once(child, "exit");
+  if (code !== 0) {
+    throw new Error(`codex app-server --help exited with code ${code}`);
+  }
   const help = Buffer.concat(chunks).toString("utf8");
   return {
     transport: "websocket_secure_exposure",
@@ -286,7 +292,7 @@ try {
   report.stdio = await runStdioProbe();
   report.secureExposure = await runHelpProbe();
   if (runWebSocket) {
-    report.websocket = await runWebSocketProbe();
+    report.websocket = await runWebSocketProbe(report.secureExposure);
   }
   console.log(JSON.stringify(report, null, 2));
 } catch (error) {

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once, setMaxListeners } from "node:events";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (!arg.startsWith("--")) continue;
+  const next = process.argv[i + 1];
+  if (next && !next.startsWith("--")) {
+    args.set(arg, next);
+    i += 1;
+  } else {
+    args.set(arg, "true");
+  }
+}
+
+const iterations = Number(args.get("--iterations") ?? "50");
+const port = Number(args.get("--port") ?? "18765");
+const runWebSocket = args.get("--skip-websocket") !== "true";
+
+function percentile(values, pct) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.ceil((pct / 100) * sorted.length) - 1);
+  return Number(sorted[idx].toFixed(3));
+}
+
+function request(id, method, params = {}) {
+  return JSON.stringify({ jsonrpc: "2.0", id, method, params });
+}
+
+async function readLine(stream, timeoutMs) {
+  let buffer = "";
+  const deadline = performance.now() + timeoutMs;
+  for (;;) {
+    const chunk = stream.read();
+    if (chunk) {
+      buffer += chunk.toString("utf8");
+      const newline = buffer.indexOf("\n");
+      if (newline >= 0) return buffer.slice(0, newline);
+    }
+    if (performance.now() > deadline) throw new Error("timed out waiting for line");
+    await once(stream, "readable");
+  }
+}
+
+async function runStdioProbe() {
+  const child = spawn("codex", ["app-server", "--stdio"], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  const startedAt = performance.now();
+  child.stdin.write(
+    `${request(1, "initialize", {
+      clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
+      capabilities: {},
+    })}\n`,
+  );
+  const line = await readLine(child.stdout, 5000);
+  const latencyMs = performance.now() - startedAt;
+  child.kill("SIGTERM");
+  await Promise.race([once(child, "exit"), sleep(1000)]);
+  return {
+    transport: "stdio",
+    initializeLatencyMs: Number(latencyMs.toFixed(3)),
+    response: JSON.parse(line),
+  };
+}
+
+async function waitForReadyz(url, timeoutMs = 5000) {
+  const deadline = performance.now() + timeoutMs;
+  let lastError = null;
+  while (performance.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return true;
+      lastError = new Error(`readyz returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(100);
+  }
+  throw lastError ?? new Error("readyz timed out");
+}
+
+async function openSocket(url) {
+  const ws = new WebSocket(url);
+  setMaxListeners(0, ws);
+  await new Promise((resolve, reject) => {
+    ws.addEventListener("open", resolve, { once: true });
+    ws.addEventListener("error", reject, { once: true });
+  });
+  return ws;
+}
+
+function requestOverSocket(ws, id, method, params = {}) {
+  const startedAt = performance.now();
+  return new Promise((resolve, reject) => {
+    const onMessage = (event) => {
+      const parsed = JSON.parse(event.data);
+      if (parsed.id !== id) return;
+      ws.removeEventListener("message", onMessage);
+      resolve({ latencyMs: performance.now() - startedAt, response: parsed });
+    };
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("error", reject, { once: true });
+    ws.send(request(id, method, params));
+  });
+}
+
+async function runWebSocketProbe() {
+  const child = spawn("codex", ["app-server", "--listen", `ws://127.0.0.1:${port}`], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  await waitForReadyz(`http://127.0.0.1:${port}/readyz`);
+
+  const ws = await openSocket(`ws://127.0.0.1:${port}`);
+  const initialize = await requestOverSocket(ws, 1, "initialize", {
+    clientInfo: { name: "opensymphony-codex-benchmark", version: "0.0.0" },
+    capabilities: {},
+  });
+
+  const batchStartedAt = performance.now();
+  const requests = [];
+  for (let i = 0; i < iterations; i += 1) {
+    requests.push(requestOverSocket(ws, i + 2, "thread/loaded/list", { limit: 1 }));
+  }
+  const responses = await Promise.all(requests);
+  const elapsedMs = performance.now() - batchStartedAt;
+  const latencies = responses.map((response) => response.latencyMs);
+
+  ws.close();
+  await sleep(100);
+  const reconnectStartedAt = performance.now();
+  const ws2 = await openSocket(`ws://127.0.0.1:${port}`);
+  const reconnectInitialize = await requestOverSocket(ws2, iterations + 2, "initialize", {
+    clientInfo: { name: "opensymphony-codex-benchmark-reconnect", version: "0.0.0" },
+    capabilities: {},
+  });
+  const reconnectMs = performance.now() - reconnectStartedAt;
+  ws2.close();
+
+  child.kill("SIGTERM");
+  await Promise.race([once(child, "exit"), sleep(1000)]);
+
+  return {
+    transport: "websocket_loopback",
+    port,
+    initializeLatencyMs: Number(initialize.latencyMs.toFixed(3)),
+    queuedRequests: iterations,
+    queuedResponses: responses.length,
+    queueElapsedMs: Number(elapsedMs.toFixed(3)),
+    requestsPerSecond: Number(((responses.length / elapsedMs) * 1000).toFixed(2)),
+    latencyMs: {
+      p50: percentile(latencies, 50),
+      p95: percentile(latencies, 95),
+      max: Number(Math.max(...latencies).toFixed(3)),
+    },
+    reconnectLatencyMs: Number(reconnectMs.toFixed(3)),
+    reconnectResponse: reconnectInitialize.response.result ? "ok" : "missing_result",
+    exposure: {
+      listener: `ws://127.0.0.1:${port}`,
+      localhostOnly: /binds localhost only/.test(stderr),
+      authModesFromHelp: ["capability-token", "signed-bearer-token"],
+    },
+  };
+}
+
+async function runHelpProbe() {
+  const child = spawn("codex", ["app-server", "--help"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const chunks = [];
+  child.stdout.on("data", (chunk) => chunks.push(chunk));
+  await once(child, "exit");
+  const help = Buffer.concat(chunks).toString("utf8");
+  return {
+    transport: "websocket_secure_exposure",
+    helpSha256: createHash("sha256").update(help).digest("hex"),
+    hasCapabilityTokenMode: help.includes("capability-token"),
+    hasSignedBearerMode: help.includes("signed-bearer-token"),
+    hasTokenFileFlag: help.includes("--ws-token-file"),
+    hasSharedSecretFlag: help.includes("--ws-shared-secret-file"),
+  };
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  codexVersion: null,
+  stdio: null,
+  websocket: null,
+  secureExposure: null,
+};
+
+try {
+  const version = spawn("codex", ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+  const chunks = [];
+  version.stdout.on("data", (chunk) => chunks.push(chunk));
+  await once(version, "exit");
+  report.codexVersion = Buffer.concat(chunks).toString("utf8").trim();
+  report.stdio = await runStdioProbe();
+  report.secureExposure = await runHelpProbe();
+  if (runWebSocket) {
+    report.websocket = await runWebSocketProbe();
+  }
+  console.log(JSON.stringify(report, null, 2));
+} catch (error) {
+  console.error(error.stack || String(error));
+  process.exit(1);
+}

--- a/scripts/codex_app_server_benchmark.mjs
+++ b/scripts/codex_app_server_benchmark.mjs
@@ -59,6 +59,10 @@ function request(id, method, params = {}) {
   return JSON.stringify({ jsonrpc: "2.0", id, method, params });
 }
 
+function websocketBatchTimeoutMs() {
+  return Math.max(requestTimeoutMs, requestTimeoutMs + iterations);
+}
+
 async function terminateChild(child, graceMs = 1000) {
   if (child.exitCode !== null || child.signalCode !== null) return;
   const exited = once(child, "exit").then(() => true);
@@ -170,7 +174,7 @@ class LineReader {
   }
 }
 
-async function readJsonRpcResponse(reader, label, timeoutMs) {
+async function readJsonRpcResponse(reader, label, expectedId, timeoutMs) {
   const deadline = performance.now() + timeoutMs;
   for (;;) {
     const remainingMs = Math.max(1, deadline - performance.now());
@@ -190,7 +194,7 @@ async function readJsonRpcResponse(reader, label, timeoutMs) {
       Object.hasOwn(response, "id") &&
       (Object.hasOwn(response, "result") || Object.hasOwn(response, "error"))
     ) {
-      return response;
+      if (String(response.id) === String(expectedId)) return response;
     }
   }
 }
@@ -303,7 +307,7 @@ async function runStdioProbe() {
       childError,
     ]);
     const response = await Promise.race([
-      readJsonRpcResponse(stdout, "stdio initialize", requestTimeoutMs),
+      readJsonRpcResponse(stdout, "stdio initialize", 1, requestTimeoutMs),
       childError,
     ]);
     const latencyMs = performance.now() - startedAt;
@@ -527,8 +531,9 @@ async function runWebSocketProbe(secureExposure) {
     const batchStartedAt = performance.now();
     const requests = [];
     let nextRequestId = 2;
+    const batchTimeoutMs = websocketBatchTimeoutMs();
     for (let i = 0; i < iterations; i += 1) {
-      requests.push(client.request(nextRequestId, "thread/loaded/list", { limit: 1 }));
+      requests.push(client.request(nextRequestId, "thread/loaded/list", { limit: 1 }, batchTimeoutMs));
       nextRequestId += 1;
     }
     const responses = await Promise.all(requests);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #[path = "../crates/opensymphony-cli/src/lib.rs"]
 pub mod opensymphony_cli;
+#[cfg(feature = "codex-app-server-prototype")]
+#[path = "../crates/opensymphony-codex/src/lib.rs"]
+pub mod opensymphony_codex;
 #[path = "../crates/opensymphony-control/src/lib.rs"]
 pub mod opensymphony_control;
 #[path = "../crates/opensymphony-domain/src/lib.rs"]

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -5,7 +5,9 @@ use opensymphony::opensymphony_codex::{
     CodexUserInput, CodexWebSocketAuth, NormalizedCodexEventKind, normalize_server_notification,
     websocket_benchmark_requirements,
 };
-use opensymphony::opensymphony_gateway_schema::model_settings::ModelSettingsResponse;
+use opensymphony::opensymphony_gateway_schema::model_settings::{
+    CredentialReferenceKind, CredentialStorageMode, ModelSettingsResponse,
+};
 use serde_json::json;
 
 #[test]
@@ -109,11 +111,14 @@ fn codex_model_and_credential_reuse_maps_existing_settings_profiles() {
     assert!(codex_profiles.iter().any(|profile| {
         profile.profile_id == "codex-chatgpt-local-keychain"
             && profile.can_supply_subscription_credentials
-            && profile.storage_mode == "local_keychain"
+            && profile.credential_reference_kind
+                == CredentialReferenceKind::LocalKeychainServiceAccount
+            && profile.storage_mode == CredentialStorageMode::LocalKeychain
     }));
     assert!(codex_profiles.iter().any(|profile| {
         profile.profile_id == "hosted-openai-subscription-broker"
-            && profile.storage_mode == "hosted_broker"
+            && profile.credential_reference_kind == CredentialReferenceKind::HostedBrokerReference
+            && profile.storage_mode == CredentialStorageMode::HostedBroker
     }));
     assert!(
         codex_profiles

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -135,6 +135,24 @@ fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
     assert!(args.contains(&"--ws-auth".to_owned()));
     assert!(args.contains(&"capability-token".to_owned()));
 
+    let mut signed_bearer = CodexAppServerLaunch::loopback_websocket(18766);
+    signed_bearer.websocket_auth = Some(CodexWebSocketAuth::SignedBearerToken {
+        shared_secret_file: std::env::temp_dir().join("opensymphony-codex-jwt-secret"),
+        issuer: "opensymphony".into(),
+        audience: "codex-app-server".into(),
+        max_clock_skew_seconds: Some(30),
+    });
+    let signed_bearer_args = signed_bearer.command_args();
+    assert!(signed_bearer_args.contains(&"--ws-auth".to_owned()));
+    assert!(signed_bearer_args.contains(&"signed-bearer-token".to_owned()));
+    assert!(signed_bearer_args.contains(&"--ws-shared-secret-file".to_owned()));
+    assert!(signed_bearer_args.contains(&"--ws-issuer".to_owned()));
+    assert!(signed_bearer_args.contains(&"opensymphony".to_owned()));
+    assert!(signed_bearer_args.contains(&"--ws-audience".to_owned()));
+    assert!(signed_bearer_args.contains(&"codex-app-server".to_owned()));
+    assert!(signed_bearer_args.contains(&"--ws-max-clock-skew-seconds".to_owned()));
+    assert!(signed_bearer_args.contains(&"30".to_owned()));
+
     let dimensions = websocket_benchmark_requirements()
         .into_iter()
         .map(|requirement| requirement.dimension)

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -12,7 +12,11 @@ use serde_json::json;
 
 #[test]
 fn codex_stdio_launch_and_json_rpc_request_shape_are_stable() {
-    let launch = CodexAppServerLaunch::stdio();
+    let mut launch = CodexAppServerLaunch::stdio();
+    launch.program = "codex-test".into();
+    let (program, args) = launch.command();
+    assert_eq!(program, "codex-test");
+    assert_eq!(args, vec!["app-server", "--stdio"]);
     assert_eq!(launch.command_args(), vec!["app-server", "--stdio"]);
 
     let mut session = CodexJsonRpcSession::new("opensymphony-test", "0.0.0");

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -129,6 +129,16 @@ fn codex_model_and_credential_reuse_maps_existing_settings_profiles() {
 
 #[test]
 fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
+    let mut stdio_with_auth = CodexAppServerLaunch::stdio();
+    stdio_with_auth.websocket_auth = Some(CodexWebSocketAuth::CapabilityToken {
+        token_file: std::env::temp_dir().join("opensymphony-codex-stdio-token"),
+        token_sha256: "1".repeat(64),
+    });
+    assert_eq!(
+        stdio_with_auth.command_args(),
+        vec!["app-server", "--stdio"]
+    );
+
     let mut launch = CodexAppServerLaunch::loopback_websocket(18765);
     launch.extra_args = vec!["--stdio".into()];
     launch.websocket_auth = Some(CodexWebSocketAuth::CapabilityToken {
@@ -140,6 +150,7 @@ fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
     assert!(args.contains(&"ws://127.0.0.1:18765".to_owned()));
     assert!(args.contains(&"--ws-auth".to_owned()));
     assert!(args.contains(&"capability-token".to_owned()));
+    assert!(args.contains(&"--ws-token-sha256".to_owned()));
     let extra_stdio = args
         .iter()
         .position(|arg| arg == "--stdio")

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "codex-app-server-prototype")]
 
-use std::path::PathBuf;
-
 use opensymphony::opensymphony_codex::{
     CodexAppServerLaunch, CodexJsonRpcSession, CodexThreadStartParams, CodexTurnStartParams,
     CodexUserInput, CodexWebSocketAuth, NormalizedCodexEventKind, normalize_server_notification,
@@ -21,30 +19,34 @@ fn codex_stdio_launch_and_json_rpc_request_shape_are_stable() {
     assert_eq!(initialize.method, "initialize");
     assert_eq!(initialize.params["clientInfo"]["name"], "opensymphony-test");
 
-    let thread = session.thread_start(CodexThreadStartParams {
-        cwd: Some("/tmp/issue-workspace".into()),
-        model: Some("gpt-5-codex".into()),
-        model_provider: Some("openai".into()),
-        base_instructions: Some("OpenSymphony workflow prompt".into()),
-        developer_instructions: None,
-        ephemeral: Some(true),
-        config: Some(json!({ "model": "gpt-5-codex" })),
-    });
+    let thread = session
+        .thread_start(CodexThreadStartParams {
+            cwd: Some("/tmp/issue-workspace".into()),
+            model: Some("gpt-5-codex".into()),
+            model_provider: Some("openai".into()),
+            base_instructions: Some("OpenSymphony workflow prompt".into()),
+            developer_instructions: None,
+            ephemeral: Some(true),
+            config: Some(json!({ "model": "gpt-5-codex" })),
+        })
+        .expect("serialize thread/start request");
     assert_eq!(thread.id, 2);
     assert_eq!(thread.method, "thread/start");
     assert_eq!(thread.params["cwd"], "/tmp/issue-workspace");
     assert_eq!(thread.params["model"], "gpt-5-codex");
 
-    let turn = session.turn_start(CodexTurnStartParams {
-        thread_id: "thread-1".into(),
-        input: vec![CodexUserInput::Text {
-            text: "continue".into(),
-            text_elements: Vec::new(),
-        }],
-        cwd: Some("/tmp/issue-workspace".into()),
-        model: Some("gpt-5-codex".into()),
-        client_user_message_id: Some("client-msg-1".into()),
-    });
+    let turn = session
+        .turn_start(CodexTurnStartParams {
+            thread_id: "thread-1".into(),
+            input: vec![CodexUserInput::Text {
+                text: "continue".into(),
+                text_elements: Vec::new(),
+            }],
+            cwd: Some("/tmp/issue-workspace".into()),
+            model: Some("gpt-5-codex".into()),
+            client_user_message_id: Some("client-msg-1".into()),
+        })
+        .expect("serialize turn/start request");
     assert_eq!(turn.id, 3);
     assert_eq!(turn.method, "turn/start");
     assert_eq!(turn.params["threadId"], "thread-1");
@@ -124,7 +126,7 @@ fn codex_model_and_credential_reuse_maps_existing_settings_profiles() {
 fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
     let mut launch = CodexAppServerLaunch::loopback_websocket(18765);
     launch.websocket_auth = Some(CodexWebSocketAuth::CapabilityToken {
-        token_file: PathBuf::from("/tmp/codex-token"),
+        token_file: std::env::temp_dir().join("opensymphony-codex-token"),
         token_sha256: "0".repeat(64),
     });
     let args = launch.command_args();

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -125,6 +125,7 @@ fn codex_model_and_credential_reuse_maps_existing_settings_profiles() {
 #[test]
 fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
     let mut launch = CodexAppServerLaunch::loopback_websocket(18765);
+    launch.extra_args = vec!["--stdio".into()];
     launch.websocket_auth = Some(CodexWebSocketAuth::CapabilityToken {
         token_file: std::env::temp_dir().join("opensymphony-codex-token"),
         token_sha256: "0".repeat(64),
@@ -134,6 +135,15 @@ fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
     assert!(args.contains(&"ws://127.0.0.1:18765".to_owned()));
     assert!(args.contains(&"--ws-auth".to_owned()));
     assert!(args.contains(&"capability-token".to_owned()));
+    let extra_stdio = args
+        .iter()
+        .position(|arg| arg == "--stdio")
+        .expect("extra stdio arg is present");
+    let selected_transport = args
+        .iter()
+        .position(|arg| arg == "--listen")
+        .expect("selected websocket transport is present");
+    assert!(selected_transport > extra_stdio);
 
     let mut signed_bearer = CodexAppServerLaunch::loopback_websocket(18766);
     signed_bearer.websocket_auth = Some(CodexWebSocketAuth::SignedBearerToken {

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -12,11 +12,11 @@ use serde_json::json;
 
 #[test]
 fn codex_stdio_launch_and_json_rpc_request_shape_are_stable() {
-    let mut launch = CodexAppServerLaunch::stdio();
-    launch.program = "codex-test".into();
-    let (program, args) = launch.command();
+    let launch = CodexAppServerLaunch::stdio_with_program("codex-test");
+    let (program, args) = launch.to_command();
     assert_eq!(program, "codex-test");
     assert_eq!(args, vec!["app-server", "--stdio"]);
+    assert_eq!(launch.program(), "codex-test");
     assert_eq!(launch.command_args(), vec!["app-server", "--stdio"]);
 
     let mut session = CodexJsonRpcSession::new("opensymphony-test", "0.0.0");

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -154,6 +154,7 @@ fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
     assert!(args.contains(&"ws://127.0.0.1:18765".to_owned()));
     assert!(args.contains(&"--ws-auth".to_owned()));
     assert!(args.contains(&"capability-token".to_owned()));
+    assert!(args.contains(&"--ws-token-file".to_owned()));
     assert!(args.contains(&"--ws-token-sha256".to_owned()));
     let extra_stdio = args
         .iter()

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -1,0 +1,149 @@
+#![cfg(feature = "codex-app-server-prototype")]
+
+use std::path::PathBuf;
+
+use opensymphony::opensymphony_codex::{
+    CodexAppServerLaunch, CodexJsonRpcSession, CodexThreadStartParams, CodexTurnStartParams,
+    CodexUserInput, CodexWebSocketAuth, NormalizedCodexEventKind, normalize_server_notification,
+    websocket_benchmark_requirements,
+};
+use opensymphony::opensymphony_gateway_schema::model_settings::ModelSettingsResponse;
+use serde_json::json;
+
+#[test]
+fn codex_stdio_launch_and_json_rpc_request_shape_are_stable() {
+    let launch = CodexAppServerLaunch::stdio();
+    assert_eq!(launch.command_args(), vec!["app-server", "--stdio"]);
+
+    let mut session = CodexJsonRpcSession::new("opensymphony-test", "0.0.0");
+    let initialize = session.initialize();
+    assert_eq!(initialize.id, 1);
+    assert_eq!(initialize.method, "initialize");
+    assert_eq!(initialize.params["clientInfo"]["name"], "opensymphony-test");
+
+    let thread = session.thread_start(CodexThreadStartParams {
+        cwd: Some("/tmp/issue-workspace".into()),
+        model: Some("gpt-5-codex".into()),
+        model_provider: Some("openai".into()),
+        base_instructions: Some("OpenSymphony workflow prompt".into()),
+        developer_instructions: None,
+        ephemeral: Some(true),
+        config: Some(json!({ "model": "gpt-5-codex" })),
+    });
+    assert_eq!(thread.id, 2);
+    assert_eq!(thread.method, "thread/start");
+    assert_eq!(thread.params["cwd"], "/tmp/issue-workspace");
+    assert_eq!(thread.params["model"], "gpt-5-codex");
+
+    let turn = session.turn_start(CodexTurnStartParams {
+        thread_id: "thread-1".into(),
+        input: vec![CodexUserInput::Text {
+            text: "continue".into(),
+            text_elements: Vec::new(),
+        }],
+        cwd: Some("/tmp/issue-workspace".into()),
+        model: Some("gpt-5-codex".into()),
+        client_user_message_id: Some("client-msg-1".into()),
+    });
+    assert_eq!(turn.id, 3);
+    assert_eq!(turn.method, "turn/start");
+    assert_eq!(turn.params["threadId"], "thread-1");
+
+    let encoded = CodexJsonRpcSession::encode_line(&turn).expect("encode JSON-RPC request");
+    assert!(encoded.ends_with('\n'));
+    assert!(encoded.contains("\"jsonrpc\":\"2.0\""));
+}
+
+#[test]
+fn codex_notification_normalization_preserves_thread_turn_and_raw_payload() {
+    let raw = json!({
+        "jsonrpc": "2.0",
+        "method": "item/agentMessage/delta",
+        "params": {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "itemId": "item-1",
+            "delta": "hello"
+        }
+    });
+
+    let event = normalize_server_notification(raw.clone()).expect("notification normalizes");
+    assert_eq!(event.kind, NormalizedCodexEventKind::AgentMessageDelta);
+    assert_eq!(event.thread_id.as_deref(), Some("thread-1"));
+    assert_eq!(event.turn_id.as_deref(), Some("turn-1"));
+    assert_eq!(event.item_id.as_deref(), Some("item-1"));
+    assert_eq!(event.message_delta.as_deref(), Some("hello"));
+    assert_eq!(event.raw, raw);
+
+    let unknown = normalize_server_notification(json!({
+        "jsonrpc": "2.0",
+        "method": "future/event",
+        "params": { "threadId": "thread-2" }
+    }))
+    .expect("unknown notifications are retained");
+    assert_eq!(unknown.kind, NormalizedCodexEventKind::Unknown);
+    assert_eq!(unknown.thread_id.as_deref(), Some("thread-2"));
+
+    assert!(
+        normalize_server_notification(json!({
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "item/permissions/requestApproval",
+            "params": {}
+        }))
+        .is_none()
+    );
+}
+
+#[test]
+fn codex_model_and_credential_reuse_maps_existing_settings_profiles() {
+    let settings = ModelSettingsResponse::local_default(true);
+    let codex_profiles = settings
+        .profiles
+        .iter()
+        .filter_map(opensymphony::opensymphony_codex::CodexModelCredentialReuse::from_profile)
+        .collect::<Vec<_>>();
+
+    assert!(codex_profiles.iter().any(|profile| {
+        profile.profile_id == "codex-chatgpt-local-keychain"
+            && profile.can_supply_subscription_credentials
+            && profile.storage_mode == "local_keychain"
+    }));
+    assert!(codex_profiles.iter().any(|profile| {
+        profile.profile_id == "hosted-openai-subscription-broker"
+            && profile.storage_mode == "hosted_broker"
+    }));
+    assert!(
+        codex_profiles
+            .iter()
+            .all(|profile| !profile.credential_reference_id.is_empty())
+    );
+}
+
+#[test]
+fn codex_websocket_auth_and_benchmark_dimensions_are_explicit() {
+    let mut launch = CodexAppServerLaunch::loopback_websocket(18765);
+    launch.websocket_auth = Some(CodexWebSocketAuth::CapabilityToken {
+        token_file: PathBuf::from("/tmp/codex-token"),
+        token_sha256: "0".repeat(64),
+    });
+    let args = launch.command_args();
+    assert!(args.contains(&"--listen".to_owned()));
+    assert!(args.contains(&"ws://127.0.0.1:18765".to_owned()));
+    assert!(args.contains(&"--ws-auth".to_owned()));
+    assert!(args.contains(&"capability-token".to_owned()));
+
+    let dimensions = websocket_benchmark_requirements()
+        .into_iter()
+        .map(|requirement| requirement.dimension)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        dimensions,
+        vec![
+            "throughput",
+            "queue behavior",
+            "reconnect",
+            "secure exposure"
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Adds the feature-gated Codex app-server prototype and benchmark evidence required for COE-426 without enabling production Codex harness routing.

## Changes

- Add `codex-app-server-prototype` and a gated `opensymphony-codex` module for stdio/WebSocket launch arguments, JSON-RPC request builders, notification normalization, and model credential reference reuse.
- Add feature-gated contract tests for `initialize`, `thread/start`, `turn/start`, basic notification normalization, credential reuse, and WebSocket benchmark coverage dimensions.
- Add a dependency-free Codex app-server benchmark script plus docs/report updates covering stdio initialize, loopback WebSocket throughput, reconnect, queue behavior, auth flags, and production readiness gaps.

## Evidence

### Test output

```text
cargo fmt --check
# passed

cargo test-system-duckdb --features codex-app-server-prototype --test codex_app_server
# passed: 4 tests

cargo check-system-duckdb --features codex-app-server-prototype
# passed

DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib cargo clippy --no-default-features --features duckdb-prebuilt,codex-app-server-prototype --test codex_app_server -- -D warnings
# passed

node scripts/codex_app_server_benchmark.mjs --iterations 10 --port 18767
# passed: stdio initialize, 10/10 queued WebSocket responses, reconnect ok,
# localhost-only exposure, capability-token and signed-bearer flags advertised

codex app-server generate-json-schema --out <tmp>/json
codex app-server generate-ts --out <tmp>/ts
# passed: expected ThreadStart artifacts generated
```

### Verification

- Confirmed installed `codex-cli 0.138.0` exposes `app-server --stdio`, `--listen`, `generate-ts`, `generate-json-schema`, and WebSocket auth flags.
- Captured a live stdio `initialize` response from `codex app-server --stdio`.
- Ran the benchmark script against loopback WebSocket and recorded throughput, queue, reconnect, and secure exposure evidence in `docs/codex-app-server-prototype.md`.
- Kept `codex_app_server` unavailable in production capability discovery; this PR only adds the gated prototype path and readiness evidence.

## Checklist

- [x] Tests pass (`cargo test` equivalent targeted feature-gated test)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- COE-426: Codex App-Server Prototype And Benchmarks

## Additional notes

The benchmark script uses only the installed Codex CLI and Node's built-in WebSocket support. Production Codex harness enablement, hosted Codex runtime pools, and cross-harness routing remain out of scope.
