### PR TITLE
Resume Codex debug sessions

### DIFF
--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -4,10 +4,11 @@ use std::{
     env, io,
     io::{IsTerminal, Write},
     path::{Path, PathBuf},
-    process::ExitCode,
+    process::{ExitCode, Stdio},
     time::Duration,
 };
 
+use crate::opensymphony_codex::{CODEX_APP_SERVER_CONTRACT, CODEX_APP_SERVER_KIND};
 use crate::opensymphony_openhands::{
     ConversationLaunchProfile, ConversationMoveOutcome, ConversationStoreKind, EventEnvelope,
     IssueConversationManifest, IssueSessionRunnerConfig, KnownEvent, LocalServerSupervisor,
@@ -33,7 +34,7 @@ use crossterm::{
 };
 use serde::Deserialize;
 use thiserror::Error;
-use tokio::{fs, time::timeout_at};
+use tokio::{fs, process::Command, time::timeout_at};
 use url::Url;
 use uuid::Uuid;
 
@@ -49,6 +50,9 @@ pub struct DebugArgs {
     #[arg(help = "Runtime config YAML path; defaults to ./config.yaml when present")]
     #[arg(long)]
     pub config: Option<PathBuf>,
+    #[arg(help = "Print the Codex app deep link for a Codex-backed issue")]
+    #[arg(long)]
+    pub app: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -118,6 +122,32 @@ enum DebugCommandError {
         #[source]
         source: serde_json::Error,
     },
+    #[error(
+        "issue `{issue_reference}` was not run by the Codex app-server harness; recorded transport target is `{transport_target}`. Use `opensymphony debug {issue_reference}` for OpenHands-backed issues."
+    )]
+    NotCodexRun {
+        issue_reference: String,
+        transport_target: String,
+    },
+    #[error(
+        "Codex-backed issue `{issue_reference}` has no recorded Codex thread id in {path}. Re-run the issue with the Codex harness to record the thread id before debugging."
+    )]
+    CodexThreadIdMissing {
+        issue_reference: String,
+        path: PathBuf,
+    },
+    #[error(
+        "installed Codex CLI `{program}` does not expose the required `codex resume <session-id>` path: {detail}. Update Codex, then retry."
+    )]
+    CodexResumeUnsupported { program: String, detail: String },
+    #[error("failed to launch Codex CLI `{program}`: {source}")]
+    CodexLaunch {
+        program: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("Codex resume command exited with status {status}")]
+    CodexResumeFailed { status: std::process::ExitStatus },
     #[error("conversation manifest contains invalid conversation id `{value}`: {source}")]
     InvalidConversationId {
         value: String,
@@ -333,8 +363,27 @@ async fn run_debug_session(args: DebugArgs) -> Result<(), DebugCommandError> {
             issue_reference: args.issue_id.clone(),
             workspace_root: runtime.workflow.config.workspace.root.clone(),
         })?;
+    let manifest_path = workspace.conversation_manifest_path();
+    let raw_manifest = load_conversation_manifest_raw(&manager, &workspace).await?;
+    if let Some(codex) = codex_debug_metadata_from_raw_manifest(
+        &raw_manifest,
+        &manifest_path,
+        args.issue_id.as_str(),
+    )? {
+        if args.app {
+            println!("{}", codex.deep_link());
+            return Ok(());
+        }
+        return run_codex_resume(&workspace, &codex).await;
+    }
+    if args.app {
+        return Err(DebugCommandError::NotCodexRun {
+            issue_reference: args.issue_id,
+            transport_target: manifest_transport_target(&raw_manifest),
+        });
+    }
     let issue_manifest = manager.load_issue_manifest(&workspace).await?;
-    let manifest = load_conversation_manifest(&manager, &workspace).await?;
+    let manifest = parse_openhands_conversation_manifest(&raw_manifest, &manifest_path)?;
     let config = IssueSessionRunnerConfig::from_workflow(&runtime.workflow);
     let conversation_id = parse_conversation_id(&manifest)?;
     let store_kind =
@@ -419,6 +468,129 @@ async fn run_debug_session(args: DebugArgs) -> Result<(), DebugCommandError> {
     result?;
     close_result?;
     Ok(())
+}
+
+#[derive(Debug)]
+struct CodexDebugMetadata {
+    thread_id: String,
+}
+
+impl CodexDebugMetadata {
+    fn deep_link(&self) -> String {
+        format!("codex://threads/{}", self.thread_id)
+    }
+}
+
+async fn run_codex_resume(
+    workspace: &WorkspaceHandle,
+    metadata: &CodexDebugMetadata,
+) -> Result<(), DebugCommandError> {
+    let program = env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
+    validate_codex_resume_support(&program).await?;
+    let status = Command::new(&program)
+        .arg("resume")
+        .arg(&metadata.thread_id)
+        .current_dir(workspace.workspace_path())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .await
+        .map_err(|source| DebugCommandError::CodexLaunch {
+            program: program.clone(),
+            source,
+        })?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(DebugCommandError::CodexResumeFailed { status })
+    }
+}
+
+async fn validate_codex_resume_support(program: &str) -> Result<(), DebugCommandError> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(5),
+        Command::new(program).arg("resume").arg("--help").output(),
+    )
+    .await
+    .map_err(|_| DebugCommandError::CodexResumeUnsupported {
+        program: program.to_string(),
+        detail: "timed out running `resume --help`".into(),
+    })?
+    .map_err(|source| DebugCommandError::CodexLaunch {
+        program: program.to_string(),
+        source,
+    })?;
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if output.status.success() && help.contains("resume") && help.contains("SESSION_ID") {
+        Ok(())
+    } else {
+        Err(DebugCommandError::CodexResumeUnsupported {
+            program: program.to_string(),
+            detail: help
+                .lines()
+                .next()
+                .unwrap_or("empty help output")
+                .to_string(),
+        })
+    }
+}
+
+fn codex_debug_metadata_from_raw_manifest(
+    raw: &str,
+    path: &Path,
+    issue_reference: &str,
+) -> Result<Option<CodexDebugMetadata>, DebugCommandError> {
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|source| {
+        DebugCommandError::DecodeConversationManifest {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+    if !manifest_is_codex(&value) {
+        return Ok(None);
+    }
+    let thread_id = value
+        .get("codex_thread_id")
+        .or_else(|| value.get("thread_id"))
+        .or_else(|| value.get("conversation_id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|thread_id| !thread_id.is_empty())
+        .ok_or_else(|| DebugCommandError::CodexThreadIdMissing {
+            issue_reference: issue_reference.to_string(),
+            path: path.to_path_buf(),
+        })?;
+    Ok(Some(CodexDebugMetadata {
+        thread_id: thread_id.to_string(),
+    }))
+}
+
+fn manifest_is_codex(value: &serde_json::Value) -> bool {
+    value
+        .get("transport_target")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|target| target == CODEX_APP_SERVER_KIND)
+        || value
+            .get("runtime_contract_version")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|contract| contract == CODEX_APP_SERVER_CONTRACT)
+}
+
+fn manifest_transport_target(raw: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("transport_target")
+                .and_then(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| "<unknown>".to_string())
 }
 
 async fn resolve_runtime_config(args: &DebugArgs) -> Result<DebugRuntimeConfig, DebugCommandError> {
@@ -687,17 +859,25 @@ fn transport_port_override(url: &Url) -> Result<u16, DebugCommandError> {
         })
 }
 
-async fn load_conversation_manifest(
+async fn load_conversation_manifest_raw(
     manager: &WorkspaceManager,
     workspace: &WorkspaceHandle,
-) -> Result<IssueConversationManifest, DebugCommandError> {
+) -> Result<String, DebugCommandError> {
     let path = workspace.conversation_manifest_path();
-    let raw = manager
+    manager
         .read_text_artifact(workspace, &path)
         .await?
-        .ok_or_else(|| DebugCommandError::ConversationManifestMissing { path: path.clone() })?;
-    serde_json::from_str(&raw)
-        .map_err(|source| DebugCommandError::DecodeConversationManifest { path, source })
+        .ok_or(DebugCommandError::ConversationManifestMissing { path })
+}
+
+fn parse_openhands_conversation_manifest(
+    raw: &str,
+    path: &Path,
+) -> Result<IssueConversationManifest, DebugCommandError> {
+    serde_json::from_str(raw).map_err(|source| DebugCommandError::DecodeConversationManifest {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 fn parse_conversation_id(manifest: &IssueConversationManifest) -> Result<Uuid, DebugCommandError> {
@@ -1434,8 +1614,8 @@ mod tests {
 
     use super::{
         DebugCommandError, DebugInput, DebugRuntimeConfig, build_debug_client,
-        normalize_debug_input_fragment, parse_debug_input, prepare_debug_conversation_store,
-        should_rehydrate_after_attach_failure,
+        codex_debug_metadata_from_raw_manifest, normalize_debug_input_fragment, parse_debug_input,
+        prepare_debug_conversation_store, should_rehydrate_after_attach_failure,
     };
 
     #[test]
@@ -1471,6 +1651,38 @@ mod tests {
             normalize_debug_input_fragment("one\r\ntwo\rthree\nfour"),
             "one\ntwo\nthree\nfour"
         );
+    }
+
+    #[test]
+    fn codex_debug_metadata_uses_recorded_thread_id() {
+        let metadata = codex_debug_metadata_from_raw_manifest(
+            r#"{
+                "transport_target": "codex_app_server",
+                "conversation_id": "thread-123"
+            }"#,
+            std::path::Path::new(".opensymphony/conversation.json"),
+            "COE-479",
+        )
+        .expect("Codex manifest should parse")
+        .expect("Codex metadata should be detected");
+
+        assert_eq!(metadata.thread_id, "thread-123");
+        assert_eq!(metadata.deep_link(), "codex://threads/thread-123");
+    }
+
+    #[test]
+    fn codex_debug_metadata_reports_missing_thread_id() {
+        let error = codex_debug_metadata_from_raw_manifest(
+            r#"{"transport_target": "codex_app_server"}"#,
+            std::path::Path::new(".opensymphony/conversation.json"),
+            "COE-479",
+        )
+        .expect_err("Codex manifest without thread id should fail");
+
+        assert!(matches!(
+            error,
+            DebugCommandError::CodexThreadIdMissing { .. }
+        ));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -9,8 +9,9 @@ use std::{
 };
 
 use crate::opensymphony_codex::{
-    CodexAppServerAdapter, CodexAppServerSchemaValidator, CodexContractGeneration,
-    CodexJsonRpcSession, JsonRpcRequestEnvelope, NormalizedCodexEvent, NormalizedCodexEventKind,
+    CODEX_APP_SERVER_CONTRACT, CODEX_APP_SERVER_KIND, CodexAppServerAdapter,
+    CodexAppServerSchemaValidator, CodexContractGeneration, CodexJsonRpcSession,
+    JsonRpcRequestEnvelope, NormalizedCodexEvent, NormalizedCodexEventKind,
     codex_approval_request_from_event, normalize_server_notification,
 };
 use crate::opensymphony_domain::{
@@ -21,8 +22,8 @@ use crate::opensymphony_domain::{
 use crate::opensymphony_linear::{LinearClient, LinearConfig, LinearError, WorkpadComment};
 use crate::opensymphony_openhands::{
     ConversationMoveOutcome, ConversationStoreKind, IssueConversationManifest, IssueSessionError,
-    IssueSessionObserver, IssueSessionResult, IssueSessionRunner, IssueSessionRunnerConfig,
-    LocalServerSupervisor, LocalServerTooling, MemoryWorkerAccess,
+    IssueSessionObserver, IssueSessionPromptKind, IssueSessionResult, IssueSessionRunner,
+    IssueSessionRunnerConfig, LocalServerSupervisor, LocalServerTooling, MemoryWorkerAccess,
     OPENHANDS_CONVERSATIONS_PATH_ENV, OpenHandsClient, OpenHandsConversationStorePaths,
     OpenHandsError, SupervisedServerConfig, SupervisorConfig, TransportConfig,
     WorkpadComment as SessionWorkpadComment, WorkpadCommentSource,
@@ -341,6 +342,9 @@ async fn migrate_legacy_workspace_conversations(
                 continue;
             }
         };
+        if manifest.transport_target.as_deref() == Some(CODEX_APP_SERVER_KIND) {
+            continue;
+        }
 
         match conversation_store.move_conversation_to(
             manifest.conversation_id.as_str(),
@@ -409,6 +413,9 @@ async fn prepare_active_conversation_store_for_issues(
                 continue;
             }
         };
+        if manifest.transport_target.as_deref() == Some(CODEX_APP_SERVER_KIND) {
+            continue;
+        }
 
         match conversation_store.move_conversation_to(
             manifest.conversation_id.as_str(),
@@ -1030,6 +1037,7 @@ async fn run_codex_stdio_issue(
 ) -> WorkerOutcomeRecord {
     match try_run_codex_stdio_issue(
         route,
+        workspace_manager,
         workspace,
         issue,
         run,
@@ -1102,6 +1110,7 @@ async fn run_codex_stdio_issue(
 #[allow(clippy::too_many_arguments)]
 async fn try_run_codex_stdio_issue(
     route: &crate::opensymphony_orchestrator::HarnessRouteDecision,
+    workspace_manager: &WorkspaceManager,
     workspace: &WorkspaceHandle,
     issue: &NormalizedIssue,
     run: &crate::opensymphony_domain::RunAttempt,
@@ -1203,6 +1212,9 @@ async fn try_run_codex_stdio_issue(
     .map_err(|error| with_codex_stderr(error, &stderr_tail))?;
     let conversation_id = codex_thread_id_from_start_response(&thread_start_response)
         .map_err(|error| with_codex_stderr(error, &stderr_tail))?;
+    write_codex_conversation_manifest(workspace_manager, workspace, issue, &conversation_id, route)
+        .await
+        .map_err(|error| with_codex_stderr(error.to_string(), &stderr_tail))?;
     if let Some(sender) = launch_tx.take() {
         let _ = sender.send(LaunchReport::Conversation(Box::new(
             codex_conversation_metadata(conversation_id.clone(), route),
@@ -1723,6 +1735,57 @@ async fn record_codex_finish_failure(
         return format!("{detail}; additionally failed to persist failed status: {failed_error}");
     }
     detail
+}
+
+async fn write_codex_conversation_manifest(
+    workspace_manager: &WorkspaceManager,
+    workspace: &WorkspaceHandle,
+    issue: &NormalizedIssue,
+    thread_id: &str,
+    route: &crate::opensymphony_orchestrator::HarnessRouteDecision,
+) -> Result<(), WorkspaceError> {
+    let now = chrono::Utc::now();
+    let manifest = IssueConversationManifest {
+        issue_id: issue.id.clone(),
+        identifier: issue.identifier.clone(),
+        conversation_id: ConversationId::new(thread_id.to_string())
+            .expect("Codex thread id should not be empty"),
+        reuse_policy: "per_issue".to_string(),
+        server_base_url: None,
+        transport_target: Some(CODEX_APP_SERVER_KIND.to_string()),
+        http_auth_mode: None,
+        websocket_auth_mode: None,
+        websocket_query_param_name: None,
+        persistence_dir: workspace.metadata_dir(),
+        created_at: now,
+        updated_at: now,
+        last_attached_at: now,
+        launch_profile: None,
+        llm_config_fingerprint: None,
+        fresh_conversation: true,
+        workflow_prompt_seeded: true,
+        reset_reason: None,
+        runtime_contract_version: Some(CODEX_APP_SERVER_CONTRACT.to_string()),
+        last_prompt_kind: Some(IssueSessionPromptKind::Full),
+        last_prompt_at: Some(now),
+        last_prompt_path: None,
+        last_execution_status: None,
+        last_event_id: None,
+        last_event_kind: Some("thread/start".into()),
+        last_event_at: Some(now),
+        last_event_summary: Some(route.summary()),
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        last_token_accumulation_at: None,
+    };
+    workspace_manager
+        .write_json_artifact(
+            workspace,
+            &workspace.conversation_manifest_path(),
+            &manifest,
+        )
+        .await
 }
 
 fn codex_conversation_metadata(
@@ -2252,6 +2315,20 @@ mod tests {
         assert!(log.contains("\"method\":\"initialize\""));
         assert!(log.contains("\"method\":\"thread/start\""));
         assert!(log.contains("\"method\":\"turn/start\""));
+        let manifest: IssueConversationManifest = serde_json::from_str(
+            &fs::read_to_string(ensured.handle.conversation_manifest_path())
+                .expect("Codex conversation manifest should exist"),
+        )
+        .expect("Codex conversation manifest should decode");
+        assert_eq!(manifest.conversation_id.as_str(), "fake-thread");
+        assert_eq!(
+            manifest.transport_target.as_deref(),
+            Some(CODEX_APP_SERVER_KIND)
+        );
+        assert_eq!(
+            manifest.runtime_contract_version.as_deref(),
+            Some(CODEX_APP_SERVER_CONTRACT)
+        );
         assert!(
             std::iter::from_fn(|| updates_rx.try_recv().ok()).any(|update| {
                 matches!(

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -342,7 +342,7 @@ async fn migrate_legacy_workspace_conversations(
                 continue;
             }
         };
-        if manifest.transport_target.as_deref() == Some(CODEX_APP_SERVER_KIND) {
+        if conversation_manifest_is_codex(&manifest) {
             continue;
         }
 
@@ -413,7 +413,7 @@ async fn prepare_active_conversation_store_for_issues(
                 continue;
             }
         };
-        if manifest.transport_target.as_deref() == Some(CODEX_APP_SERVER_KIND) {
+        if conversation_manifest_is_codex(&manifest) {
             continue;
         }
 
@@ -445,6 +445,11 @@ async fn prepare_active_conversation_store_for_issues(
     }
 
     Ok(report)
+}
+
+fn conversation_manifest_is_codex(manifest: &IssueConversationManifest) -> bool {
+    manifest.transport_target.as_deref() == Some(CODEX_APP_SERVER_KIND)
+        || manifest.runtime_contract_version.as_deref() == Some(CODEX_APP_SERVER_CONTRACT)
 }
 
 pub(super) fn build_workspace_manager_config(
@@ -1743,13 +1748,14 @@ async fn write_codex_conversation_manifest(
     issue: &NormalizedIssue,
     thread_id: &str,
     route: &crate::opensymphony_orchestrator::HarnessRouteDecision,
-) -> Result<(), WorkspaceError> {
+) -> Result<(), String> {
     let now = chrono::Utc::now();
+    let conversation_id = ConversationId::new(thread_id.to_string())
+        .map_err(|error| format!("invalid Codex thread id for conversation manifest: {error}"))?;
     let manifest = IssueConversationManifest {
         issue_id: issue.id.clone(),
         identifier: issue.identifier.clone(),
-        conversation_id: ConversationId::new(thread_id.to_string())
-            .expect("Codex thread id should not be empty"),
+        conversation_id,
         reuse_policy: "per_issue".to_string(),
         server_base_url: None,
         transport_target: Some(CODEX_APP_SERVER_KIND.to_string()),
@@ -1786,6 +1792,7 @@ async fn write_codex_conversation_manifest(
             &manifest,
         )
         .await
+        .map_err(|error| error.to_string())
 }
 
 fn codex_conversation_metadata(
@@ -2044,7 +2051,7 @@ mod tests {
         collections::{BTreeMap, HashMap},
         fs,
         future::pending,
-        path::Path,
+        path::{Path, PathBuf},
     };
 
     use crate::opensymphony_domain::{
@@ -2059,6 +2066,44 @@ mod tests {
 
     fn empty_codex_schema_cache() -> CodexSchemaValidatorCache {
         Arc::new(AsyncMutex::new(HashMap::new()))
+    }
+
+    fn sample_conversation_manifest(conversation_id: &str) -> IssueConversationManifest {
+        let now = chrono::Utc::now();
+        IssueConversationManifest {
+            issue_id: IssueId::new("issue-contract").expect("issue id should be valid"),
+            identifier: IssueIdentifier::new("COE-479").expect("identifier should be valid"),
+            conversation_id: ConversationId::new(conversation_id.to_string())
+                .expect("conversation id should be valid"),
+            reuse_policy: "per_issue".to_string(),
+            server_base_url: None,
+            transport_target: None,
+            http_auth_mode: None,
+            websocket_auth_mode: None,
+            websocket_query_param_name: None,
+            persistence_dir: PathBuf::from(".opensymphony"),
+            created_at: now,
+            updated_at: now,
+            last_attached_at: now,
+            launch_profile: None,
+            llm_config_fingerprint: None,
+            fresh_conversation: true,
+            workflow_prompt_seeded: true,
+            reset_reason: None,
+            runtime_contract_version: None,
+            last_prompt_kind: None,
+            last_prompt_at: None,
+            last_prompt_path: None,
+            last_execution_status: None,
+            last_event_id: None,
+            last_event_kind: None,
+            last_event_at: None,
+            last_event_summary: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            last_token_accumulation_at: None,
+        }
     }
 
     #[test]
@@ -2159,6 +2204,17 @@ mod tests {
         }))
         .expect_err("empty thread id should fail launch");
         assert!(empty.contains("missing non-empty threadId/thread_id"));
+    }
+
+    #[test]
+    fn codex_manifest_detection_accepts_runtime_contract_only() {
+        let manifest = IssueConversationManifest {
+            transport_target: None,
+            runtime_contract_version: Some(CODEX_APP_SERVER_CONTRACT.to_string()),
+            ..sample_conversation_manifest("thread-contract")
+        };
+
+        assert!(conversation_manifest_is_codex(&manifest));
     }
 
     #[test]

--- a/crates/opensymphony-cli/tests/debug.rs
+++ b/crates/opensymphony-cli/tests/debug.rs
@@ -15,6 +15,145 @@ use tempfile::TempDir;
 use tokio::{io::AsyncWriteExt, process::Command};
 use uuid::Uuid;
 
+#[cfg(unix)]
+#[tokio::test]
+async fn debug_codex_resume_launches_fake_codex_from_issue_workspace() {
+    let project = TempDir::new().expect("temp project should exist");
+    let workspace_root = project.path().join("var").join("workspaces");
+    write_project_files(project.path(), &workspace_root, "http://127.0.0.1:39999");
+    let (_manager, ensured) = create_workspace(&workspace_root, "COE-479").await;
+    write_codex_manifest(&ensured.handle, "019ee323-173d-7ec0-8ad2-fa4067c5651c");
+
+    let log_path = project.path().join("fake-codex.log");
+    let fake_codex = project.path().join("fake-codex");
+    write_fake_codex(&fake_codex, &log_path, true);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("debug")
+        .arg("COE-479")
+        .current_dir(project.path())
+        .env("OPENSYMPHONY_CODEX_BIN", &fake_codex)
+        .output()
+        .await
+        .expect("debug command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "debug command should succeed: stdout={stdout}, stderr={stderr}",
+    );
+
+    let log = std::fs::read_to_string(log_path).expect("fake codex should write log");
+    assert!(log.contains(&format!(
+        "PWD={}",
+        ensured.handle.workspace_path().display()
+    )));
+    assert!(log.contains("ARGS=resume --help"));
+    assert!(log.contains("ARGS=resume 019ee323-173d-7ec0-8ad2-fa4067c5651c"));
+}
+
+#[tokio::test]
+async fn debug_codex_app_prints_deep_link_without_launching_runtime() {
+    let project = TempDir::new().expect("temp project should exist");
+    let workspace_root = project.path().join("var").join("workspaces");
+    write_project_files(project.path(), &workspace_root, "http://127.0.0.1:39999");
+    let (_manager, ensured) = create_workspace(&workspace_root, "COE-480").await;
+    write_codex_manifest(&ensured.handle, "019ee323-173d-7ec0-8ad2-fa4067c5651c");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("debug")
+        .arg("COE-480")
+        .arg("--app")
+        .current_dir(project.path())
+        .env(
+            "OPENSYMPHONY_CODEX_BIN",
+            project.path().join("missing-codex"),
+        )
+        .output()
+        .await
+        .expect("debug command should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "debug --app should succeed without Codex CLI: stdout={stdout}, stderr={stderr}",
+    );
+    assert_eq!(
+        stdout.trim(),
+        "codex://threads/019ee323-173d-7ec0-8ad2-fa4067c5651c"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn debug_codex_resume_reports_unsupported_cli() {
+    let project = TempDir::new().expect("temp project should exist");
+    let workspace_root = project.path().join("var").join("workspaces");
+    write_project_files(project.path(), &workspace_root, "http://127.0.0.1:39999");
+    let (_manager, ensured) = create_workspace(&workspace_root, "COE-481").await;
+    write_codex_manifest(&ensured.handle, "thread-unsupported");
+
+    let log_path = project.path().join("fake-codex.log");
+    let fake_codex = project.path().join("fake-codex");
+    write_fake_codex(&fake_codex, &log_path, false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("debug")
+        .arg("COE-481")
+        .current_dir(project.path())
+        .env("OPENSYMPHONY_CODEX_BIN", &fake_codex)
+        .output()
+        .await
+        .expect("debug command should run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "unsupported CLI should fail");
+    assert!(
+        stderr.contains("does not expose the required `codex resume <session-id>` path"),
+        "stderr should explain unsupported resume path: {stderr}",
+    );
+}
+
+#[tokio::test]
+async fn debug_app_rejects_openhands_manifest_without_starting_openhands() {
+    let project = TempDir::new().expect("temp project should exist");
+    let workspace_root = project.path().join("var").join("workspaces");
+    write_project_files(project.path(), &workspace_root, "http://127.0.0.1:39999");
+    let (_manager, ensured) = create_workspace(&workspace_root, "COE-482").await;
+    std::fs::write(
+        ensured.handle.conversation_manifest_path(),
+        serde_json::to_vec_pretty(&json!({
+            "issue_id": "issue-482",
+            "identifier": "COE-482",
+            "conversation_id": Uuid::new_v4().to_string(),
+            "server_base_url": "http://127.0.0.1:39999",
+            "transport_target": "loopback",
+            "persistence_dir": ensured.handle.openhands_dir(),
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
+            "last_attached_at": Utc::now(),
+            "fresh_conversation": false,
+            "workflow_prompt_seeded": true,
+        }))
+        .expect("manifest JSON should render"),
+    )
+    .expect("manifest should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .arg("debug")
+        .arg("COE-482")
+        .arg("--app")
+        .current_dir(project.path())
+        .output()
+        .await
+        .expect("debug command should run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "OpenHands --app should fail");
+    assert!(
+        stderr.contains("was not run by the Codex app-server harness"),
+        "stderr should explain non-Codex issue: {stderr}",
+    );
+}
+
 #[tokio::test]
 async fn debug_resumes_existing_conversation_history_and_sends_follow_up_input() {
     let openhands = FakeOpenHandsServer::start()
@@ -188,6 +327,93 @@ async fn debug_resumes_existing_conversation_history_and_sends_follow_up_input()
             .any(|message| message == "Why did you implement it this way?"),
         "debug command should append the follow-up prompt to the resumed conversation: {user_messages:?}",
     );
+}
+
+async fn create_workspace(
+    workspace_root: &std::path::Path,
+    identifier: &str,
+) -> (
+    WorkspaceManager,
+    crate::opensymphony_workspace::EnsureWorkspaceResult,
+) {
+    let manager = WorkspaceManager::new(WorkspaceManagerConfig {
+        root: workspace_root.to_path_buf(),
+        hooks: HookConfig::default(),
+        cleanup: CleanupConfig {
+            remove_terminal_workspaces: false,
+        },
+    })
+    .expect("workspace manager should build");
+    let issue = IssueDescriptor {
+        issue_id: format!("issue-{identifier}"),
+        identifier: identifier.to_string(),
+        title: "Debuggable Codex session".to_string(),
+        current_state: "In Progress".to_string(),
+        last_seen_tracker_refresh_at: None,
+    };
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("workspace should exist");
+    (manager, ensured)
+}
+
+fn write_codex_manifest(handle: &crate::opensymphony_workspace::WorkspaceHandle, thread_id: &str) {
+    std::fs::write(
+        handle.conversation_manifest_path(),
+        serde_json::to_vec_pretty(&json!({
+            "issue_id": handle.issue_id(),
+            "identifier": handle.identifier(),
+            "conversation_id": thread_id,
+            "transport_target": "codex_app_server",
+            "persistence_dir": handle.metadata_dir(),
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
+            "last_attached_at": Utc::now(),
+            "fresh_conversation": false,
+            "workflow_prompt_seeded": true,
+            "runtime_contract_version": "codex-app-server-json-rpc-v2",
+        }))
+        .expect("Codex manifest JSON should render"),
+    )
+    .expect("Codex manifest should write");
+}
+
+#[cfg(unix)]
+fn write_fake_codex(path: &std::path::Path, log_path: &std::path::Path, supports_resume: bool) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let help = if supports_resume {
+        "Usage: codex resume [OPTIONS] [SESSION_ID] [PROMPT]"
+    } else {
+        "Usage: codex [OPTIONS] [PROMPT]"
+    };
+    std::fs::write(
+        path,
+        format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf 'PWD=%s\n' "$PWD" >> "{log}"
+printf 'ARGS=%s\n' "$*" >> "{log}"
+if [ "${{1:-}}" = "resume" ] && [ "${{2:-}}" = "--help" ]; then
+  printf '%s\n' "{help}"
+  exit 0
+fi
+if [ "${{1:-}}" = "resume" ]; then
+  exit 0
+fi
+exit 2
+"#,
+            log = log_path.display(),
+            help = help
+        ),
+    )
+    .expect("fake codex should write");
+    let mut permissions = std::fs::metadata(path)
+        .expect("fake codex metadata should exist")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("fake codex should be executable");
 }
 
 fn write_project_files(

--- a/crates/opensymphony-cli/tests/run.rs
+++ b/crates/opensymphony-cli/tests/run.rs
@@ -125,6 +125,8 @@ async fn run_routing_dry_run_selects_codex_and_emits_route_decision() {
   harness: codex_app_server
   model: gpt-5-codex-test
   model_profile: codex-chatgpt-local-keychain
+polling:
+  interval_ms: 50
 "#,
     );
     write_memory_config(project.path());
@@ -203,6 +205,9 @@ fn spawn_run_child(project_root: &std::path::Path, extra_args: &[&str]) -> Child
         .current_dir(project_root)
         .env("LINEAR_API_KEY", "test-linear-key")
         .env("OPENHANDS_API_KEY", "test-openhands-key")
+        .env_remove("OPENSYMPHONY_HARNESS")
+        .env_remove("OPENSYMPHONY_MODEL")
+        .env_remove("OPENSYMPHONY_MODEL_PROFILE")
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .kill_on_drop(true);

--- a/docs/codex-app-server-harness.md
+++ b/docs/codex-app-server-harness.md
@@ -423,6 +423,13 @@ worker errors or run manifests. JSON-RPC initialize/start waits currently use
 fixed alpha bounds of 30 seconds per response and 300 seconds for terminal
 notification wait.
 
+After `thread/start` succeeds, the worker records the Codex thread id in the
+issue workspace `.opensymphony/conversation.json` manifest with
+`transport_target: codex_app_server`. `opensymphony debug <issue-key>` uses that
+recorded thread id to run `codex resume <thread-id>` from the issue workspace.
+`opensymphony debug <issue-key> --app` prints the matching
+`codex://threads/<thread-id>` deep link.
+
 Codex approval notifications are normalized into the shared approval-center
 contract, and the Codex adapter exposes the `approval/respond` request shape
 plus matching audit records that the future action path will use. The live

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -421,6 +421,13 @@ managed server against the store containing the requested conversation. If
 another OpenHands server is already bound to the configured port with a
 different store, stop it and retry the debug command.
 
+For issues last run through the local Codex app-server harness,
+`opensymphony debug COE-123` reads the recorded Codex thread id from the issue
+workspace manifest and runs `codex resume <thread-id>` from that exact issue
+workspace. Set `OPENSYMPHONY_CODEX_BIN` to override the Codex binary. Use
+`opensymphony debug COE-123 --app` to print `codex://threads/<thread-id>`
+without starting OpenHands or launching the Codex CLI.
+
 See [Project Memory](memory.md) for the full command surface, import YAML
 schema, and troubleshooting notes.
 


### PR DESCRIPTION
## Summary

Wire `opensymphony debug` to recognize Codex app-server issue manifests and resume the recorded Codex thread instead of treating it as an OpenHands conversation.

## Changes

- Add `opensymphony debug <issue-key> --app` to print `codex://threads/<thread-id>` for Codex-backed runs.
- Route Codex-backed manifests to `codex resume <thread-id>` from the exact issue workspace, with installed CLI support validation and actionable errors.
- Persist Codex thread ids into the issue `.opensymphony/conversation.json` manifest after `thread/start`, and skip Codex manifests during OpenHands store moves using the same Codex detection rule as debug.
- Add focused fake-Codex CLI, manifest lookup, OpenHands fallback, route dry-run, and docs coverage.

## Evidence

### Test output

```text
cargo test-system-duckdb --test debug -- --nocapture
# 5 passed

cargo test-system-duckdb --test run run_routing_dry_run_selects_codex_and_emits_route_decision -- --nocapture
# 1 passed

cargo test-system-duckdb codex_manifest_detection_accepts_runtime_contract_only -- --nocapture
# 1 passed

cargo test-system-duckdb codex_debug_metadata_uses_recorded_thread_id -- --nocapture
# 1 passed

cargo test-system-duckdb codex_debug_metadata_reports_missing_thread_id -- --nocapture
# 1 passed

cargo test-system-duckdb codex_start_response_requires_real_thread_id -- --nocapture
# 1 passed

cargo clippy-system-duckdb
# finished clean

git diff --check
# clean
```

### Verification

- Reproduced the base CLI gap from `origin/main`: `DebugArgs` had no `--app` and the debug path parsed only OpenHands manifests.
- Verified installed Codex CLI compatibility: `codex-cli 0.141.0` exposes `codex resume [SESSION_ID]`.
- Fake-Codex debug test confirms the resume command runs from the issue workspace and uses the recorded thread id, not the Linear issue key.
- Full model-backed real Codex resume was not launched because no existing recorded real Codex issue workspace was present in this checkout; the installed CLI resume surface was validated live.

## Checklist

- [x] Tests pass (`cargo test` equivalent focused suites listed above)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: <!-- describe -->

## Breaking changes

None.

## Related issues

COE-479: Codex Debug Session Resume.

## Additional notes

Merged latest `origin/main`, stabilized the Codex routing dry-run integration test against host `OPENSYMPHONY_*` env overrides, and addressed inline review feedback in `5cf55f0`.
