### PR TITLE
Add OKF concept mapping for memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,14 @@ OpenHands event schemas can evolve. Implement:
 - compatibility tests against the pinned version
 - version notes in `docs/sources.md`
 
+### Keep OKF memory compatibility local to memory
+
+OKF bundle parsing, legacy capsule mapping, bundle-relative path validation, and
+unknown frontmatter preservation belong in `opensymphony-memory`. Keep the
+logical bundle layout and migration model documented in `docs/memory.md` and
+`docs/okf-memory-spec.md`. Do not move the durable `.opensymphony/memory/` store
+to the final OKF layout unless a task explicitly includes that migration.
+
 ### Separate Symphony hooks from OpenHands hooks
 
 Symphony workspace hooks:

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1139,9 +1139,15 @@ type: topic-doc
 [paren](/issues/COE-124.md?query=(ok))
 \![escaped image marker](/issues/COE-125.md)
 [reference link][runtime-ref]
+[shortcut link]
 <https://example.com/okf>
+```text
+[fenced](/ignored.md)
+```
+<!-- [commented](/ignored.md) -->
 
 [runtime-ref]: /areas/runtime.md
+[shortcut link]: /areas/shortcut.md
 "#;
 
         let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), contents)
@@ -1158,6 +1164,7 @@ type: topic-doc
                 "/issues/COE-124.md?query=(ok)",
                 "/issues/COE-125.md",
                 "/areas/runtime.md",
+                "/areas/shortcut.md",
                 "https://example.com/okf",
             ]
         );

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -737,6 +737,7 @@ struct IndexedIssue {
 }
 
 include!("config.rs");
+include!("okf.rs");
 include!("capture.rs");
 include!("query.rs");
 include!("docs_sync.rs");
@@ -774,6 +775,192 @@ mod tests {
 
         assert_eq!(second.config, MemoryInitFileChange::Unchanged);
         assert_eq!(second.gitignore, MemoryInitFileChange::Unchanged);
+    }
+
+    #[test]
+    fn okf_parses_legacy_issue_capsule_without_losing_metadata() {
+        let repo = TempDir::new().expect("temp repo");
+        let capsule = r#"---
+type: issue-capsule
+visibility: private
+issue: COE-123
+title: "COE-123: WebSocket reconnect recovery"
+milestone: "M3: Runtime"
+milestone_id: milestone-3
+linear_url: https://linear.app/example/issue/COE-123
+areas:
+  - openhands-runtime
+repository: OpenSymphony
+prs:
+  - number: 456
+    url: https://github.com/example/repo/pull/456
+    merge_sha: abcdef1234567890
+source_refs:
+  linear_issue: linear:COE-123
+  github_prs:
+    - github:pr:456
+docs_sync:
+  status: pending
+legacy_custom: keep-me
+---
+
+# COE-123: WebSocket reconnect recovery
+
+See [runtime docs](/areas/openhands-runtime.md).
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("issues/COE-123.md"), capsule)
+            .expect("legacy issue capsule should parse");
+
+        assert_eq!(concept.id, "issues/COE-123");
+        assert_eq!(concept.frontmatter.concept_type, "issue-capsule");
+        assert_eq!(
+            concept.frontmatter.extra.get("legacy_custom"),
+            Some(&serde_yaml::Value::String("keep-me".to_string()))
+        );
+        assert!(concept.frontmatter.extra.contains_key("source_refs"));
+        let metadata = concept
+            .frontmatter
+            .opensymphony
+            .as_ref()
+            .expect("legacy fields should map to OpenSymphony metadata");
+        assert_eq!(metadata.visibility, Some(MemoryVisibility::Private));
+        assert_eq!(metadata.kind.as_deref(), Some("issue_capsule"));
+        assert!(
+            metadata.scope_refs.iter().any(|scope| {
+                scope.kind == KnowledgeScopeKind::WorkItem && scope.id == "COE-123"
+            })
+        );
+        assert!(metadata.scope_refs.iter().any(|scope| {
+            scope.kind == KnowledgeScopeKind::Milestone && scope.id == "milestone-3"
+        }));
+        assert!(metadata.scope_refs.iter().any(|scope| {
+            scope.kind == KnowledgeScopeKind::Area && scope.id == "openhands-runtime"
+        }));
+        assert!(metadata.scope_refs.iter().any(|scope| {
+            scope.kind == KnowledgeScopeKind::Repository && scope.id == "OpenSymphony"
+        }));
+        assert!(
+            metadata
+                .source_refs
+                .iter()
+                .any(|source| { source.kind == "linear_issue" && source.id == "COE-123" })
+        );
+        assert!(
+            metadata
+                .source_refs
+                .iter()
+                .any(|source| { source.kind == "github_pr" && source.id == "456" })
+        );
+        assert_eq!(concept.links[0].target, "/areas/openhands-runtime.md");
+
+        let rendered = render_okf_concept(&concept).expect("concept should render");
+        assert!(rendered.contains("legacy_custom: keep-me"));
+        assert!(rendered.contains("issue: COE-123"));
+        assert!(rendered.contains("opensymphony:"));
+    }
+
+    #[test]
+    fn okf_parses_milestone_and_topic_doc_fixtures() {
+        let repo = TempDir::new().expect("temp repo");
+        let milestone = parse_okf_concept(
+            repo.path(),
+            Path::new("milestones/m3-runtime.md"),
+            r#"---
+type: milestone-memory-node
+milestone: "M3: Runtime"
+updated_at: 2026-06-13T17:00:00Z
+---
+
+# M3: Runtime
+
+- [COE-123](/issues/COE-123.md)
+"#,
+        )
+        .expect("milestone node should parse");
+        let milestone_metadata = milestone
+            .frontmatter
+            .opensymphony
+            .as_ref()
+            .expect("milestone should map legacy fields");
+        assert_eq!(
+            milestone_metadata.kind.as_deref(),
+            Some("milestone_memory_node")
+        );
+        assert!(milestone_metadata.scope_refs.iter().any(|scope| {
+            scope.kind == KnowledgeScopeKind::Milestone && scope.id == "M3: Runtime"
+        }));
+
+        let topic = parse_okf_concept(
+            repo.path(),
+            Path::new("areas/openhands-runtime.md"),
+            r#"---
+type: topic-doc
+area: openhands-runtime
+visibility: public
+last_memory_sync: 2026-06-13T17:00:00Z
+---
+
+# OpenHands Runtime
+
+See [COE-123](/issues/COE-123.md).
+"#,
+        )
+        .expect("topic doc should parse");
+        let topic_metadata = topic
+            .frontmatter
+            .opensymphony
+            .as_ref()
+            .expect("topic should map legacy fields");
+        assert_eq!(topic_metadata.visibility, Some(MemoryVisibility::Public));
+        assert!(topic_metadata.scope_refs.iter().any(|scope| {
+            scope.kind == KnowledgeScopeKind::Area && scope.id == "openhands-runtime"
+        }));
+        assert_eq!(topic.links[0].target, "/issues/COE-123.md");
+    }
+
+    #[test]
+    fn okf_rejects_empty_type_and_escaping_paths() {
+        let empty_type = OkfFrontmatter::new("");
+        assert!(matches!(empty_type, Err(MemoryError::InvalidInput(_))));
+
+        let frontmatter = OkfFrontmatter::new("topic-doc").expect("frontmatter");
+        let escaped = OkfConcept::new("../escape.md", frontmatter.clone(), "");
+        assert!(matches!(escaped, Err(MemoryError::InvalidInput(_))));
+        let absolute = OkfConcept::new("/tmp/escape.md", frontmatter.clone(), "");
+        assert!(matches!(absolute, Err(MemoryError::InvalidInput(_))));
+        let not_markdown = OkfConcept::new("areas/runtime.txt", frontmatter, "");
+        assert!(matches!(not_markdown, Err(MemoryError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn okf_unknown_fields_round_trip_through_writer() {
+        let repo = TempDir::new().expect("temp repo");
+        let original = r#"---
+type: topic-doc
+title: Runtime
+x_unknown:
+  nested: true
+legacy_number: 7
+---
+
+# Runtime
+"#;
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), original)
+            .expect("concept should parse");
+        let rendered = render_okf_concept(&concept).expect("concept should render");
+        let reparsed = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), &rendered)
+            .expect("rendered concept should parse");
+
+        assert_eq!(
+            reparsed.frontmatter.extra.get("x_unknown"),
+            concept.frontmatter.extra.get("x_unknown")
+        );
+        assert_eq!(
+            reparsed.frontmatter.extra.get("legacy_number"),
+            concept.frontmatter.extra.get("legacy_number")
+        );
+        assert_eq!(reparsed.body, "# Runtime\n");
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -964,6 +964,46 @@ legacy_number: 7
     }
 
     #[test]
+    fn okf_frontmatter_accepts_real_markdown_delimiters() {
+        let repo = TempDir::new().expect("temp repo");
+        let contents =
+            "---\r\ntype: topic-doc\r\ntitle: Runtime\r\n\r\n---   \r\n\r\n# Runtime\r\n";
+
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), contents)
+            .expect("CRLF frontmatter should parse");
+
+        assert_eq!(concept.frontmatter.concept_type, "topic-doc");
+        assert_eq!(concept.body, "# Runtime\n");
+    }
+
+    #[test]
+    fn okf_markdown_links_skip_images_code_and_escapes() {
+        let repo = TempDir::new().expect("temp repo");
+        let contents = r#"---
+type: topic-doc
+---
+
+![diagram](/images/runtime.png)
+`[code](/ignored.md)`
+\[escaped](/ignored.md)
+[text [nested]](/issues/COE-123.md)
+[paren](/issues/COE-124.md?query=(ok))
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), contents)
+            .expect("concept should parse");
+
+        assert_eq!(
+            concept
+                .links
+                .iter()
+                .map(|link| link.target.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/issues/COE-123.md", "/issues/COE-124.md?query=(ok)"]
+        );
+    }
+
+    #[test]
     fn capture_plan_matches_prs_and_infers_areas() {
         let repo = TempDir::new().expect("temp repo");
         let config = config_for(repo.path());

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -857,7 +857,58 @@ See [runtime docs](/areas/openhands-runtime.md).
         let rendered = render_okf_concept(&concept).expect("concept should render");
         assert!(rendered.contains("legacy_custom: keep-me"));
         assert!(rendered.contains("issue: COE-123"));
+        assert!(!rendered.contains("opensymphony:"));
+    }
+
+    #[test]
+    fn okf_explicit_opensymphony_metadata_round_trips() {
+        let repo = TempDir::new().expect("temp repo");
+        let original = r#"---
+type: topic-doc
+opensymphony:
+  visibility: public
+  kind: curated_topic
+  schema_version: 7
+---
+
+# Runtime
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), original)
+            .expect("concept should parse");
+        assert!(!concept.derived_opensymphony);
+
+        let rendered = render_okf_concept(&concept).expect("concept should render");
         assert!(rendered.contains("opensymphony:"));
+        assert!(rendered.contains("curated_topic"));
+    }
+
+    #[test]
+    fn okf_demo_parse_render_preserves_legacy_source_of_truth() {
+        let repo = TempDir::new().expect("temp repo");
+        let original = r#"---
+type: topic-doc
+area: openhands-runtime
+visibility: public
+docs_sync:
+  status: pending
+---
+
+# Runtime
+
+See [COE-123](/issues/COE-123.md).
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("./areas/./runtime.md"), original)
+            .expect("concept should parse");
+        let rendered = render_okf_concept(&concept).expect("concept should render");
+        println!("{rendered}");
+
+        assert_eq!(concept.path.as_path(), Path::new("areas/runtime.md"));
+        assert!(concept.derived_opensymphony);
+        assert!(rendered.contains("visibility: public"));
+        assert!(rendered.contains("docs_sync:"));
+        assert!(!rendered.contains("opensymphony:"));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -852,6 +852,11 @@ See [runtime docs](/areas/openhands-runtime.md).
                 .iter()
                 .any(|source| { source.kind == "github_pr" && source.id == "456" })
         );
+        assert!(metadata.source_refs.iter().any(|source| {
+            source.kind == "github_pr"
+                && source.id == "456"
+                && source.url.as_deref() == Some("https://github.com/example/repo/pull/456")
+        }));
         assert_eq!(concept.links[0].target, "/areas/openhands-runtime.md");
 
         let rendered = render_okf_concept(&concept).expect("concept should render");
@@ -891,6 +896,29 @@ opensymphony:
         assert!(rendered.contains("legacy_custom: keep-me"));
         assert!(!rendered.contains("legacy-area"));
         assert!(!rendered.contains("visibility: private"));
+    }
+
+    #[test]
+    fn okf_null_opensymphony_uses_legacy_source_of_truth() {
+        let repo = TempDir::new().expect("temp repo");
+        let original = r#"---
+type: topic-doc
+area: legacy-area
+visibility: public
+opensymphony: ~
+---
+
+# Runtime
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), original)
+            .expect("concept should parse");
+        assert!(concept.derived_opensymphony);
+
+        let rendered = render_okf_concept(&concept).expect("concept should render");
+        assert!(rendered.contains("area: legacy-area"));
+        assert!(rendered.contains("visibility: public"));
+        assert!(!rendered.contains("opensymphony:"));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -899,6 +899,34 @@ opensymphony:
     }
 
     #[test]
+    fn okf_partial_explicit_opensymphony_preserves_unrepresented_legacy_fields() {
+        let repo = TempDir::new().expect("temp repo");
+        let original = r#"---
+type: topic-doc
+area: legacy-area
+visibility: private
+issue: COE-123
+legacy_custom: keep-me
+opensymphony:
+  kind: curated_topic
+---
+
+# Runtime
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), original)
+            .expect("concept should parse");
+
+        let rendered = render_okf_concept(&concept).expect("concept should render");
+        assert!(rendered.contains("opensymphony:"));
+        assert!(rendered.contains("kind: curated_topic"));
+        assert!(rendered.contains("area: legacy-area"));
+        assert!(rendered.contains("visibility: private"));
+        assert!(rendered.contains("issue: COE-123"));
+        assert!(rendered.contains("legacy_custom: keep-me"));
+    }
+
+    #[test]
     fn okf_null_opensymphony_uses_legacy_source_of_truth() {
         let repo = TempDir::new().expect("temp repo");
         let original = r#"---
@@ -1021,6 +1049,12 @@ See [COE-123](/issues/COE-123.md).
         let contained = OkfConcept::new("./areas/./runtime.md", frontmatter.clone(), "")
             .expect("curdir components should normalize away");
         assert_eq!(contained.path.as_path(), Path::new("areas/runtime.md"));
+        let uppercase_markdown = OkfConcept::new("areas/runtime.MD", frontmatter.clone(), "")
+            .expect("markdown extension should be case-insensitive");
+        assert_eq!(
+            uppercase_markdown.path.as_path(),
+            Path::new("areas/runtime.MD")
+        );
         let not_markdown = OkfConcept::new("areas/runtime.txt", frontmatter, "");
         assert!(matches!(not_markdown, Err(MemoryError::InvalidInput(_))));
     }
@@ -1103,6 +1137,11 @@ type: topic-doc
 \[escaped](/ignored.md)
 [text [nested]](/issues/COE-123.md)
 [paren](/issues/COE-124.md?query=(ok))
+\![escaped image marker](/issues/COE-125.md)
+[reference link][runtime-ref]
+<https://example.com/okf>
+
+[runtime-ref]: /areas/runtime.md
 "#;
 
         let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), contents)
@@ -1114,7 +1153,13 @@ type: topic-doc
                 .iter()
                 .map(|link| link.target.as_str())
                 .collect::<Vec<_>>(),
-            vec!["/issues/COE-123.md", "/issues/COE-124.md?query=(ok)"]
+            vec![
+                "/issues/COE-123.md",
+                "/issues/COE-124.md?query=(ok)",
+                "/issues/COE-125.md",
+                "/areas/runtime.md",
+                "https://example.com/okf",
+            ]
         );
     }
 

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -865,10 +865,16 @@ See [runtime docs](/areas/openhands-runtime.md).
         let repo = TempDir::new().expect("temp repo");
         let original = r#"---
 type: topic-doc
+area: legacy-area
+visibility: private
+legacy_custom: keep-me
 opensymphony:
   visibility: public
   kind: curated_topic
   schema_version: 7
+  scope_refs:
+    - kind: area
+      id: explicit-area
 ---
 
 # Runtime
@@ -881,6 +887,10 @@ opensymphony:
         let rendered = render_okf_concept(&concept).expect("concept should render");
         assert!(rendered.contains("opensymphony:"));
         assert!(rendered.contains("curated_topic"));
+        assert!(rendered.contains("explicit-area"));
+        assert!(rendered.contains("legacy_custom: keep-me"));
+        assert!(!rendered.contains("legacy-area"));
+        assert!(!rendered.contains("visibility: private"));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -929,6 +929,9 @@ See [COE-123](/issues/COE-123.md).
         assert!(matches!(escaped, Err(MemoryError::InvalidInput(_))));
         let absolute = OkfConcept::new("/tmp/escape.md", frontmatter.clone(), "");
         assert!(matches!(absolute, Err(MemoryError::InvalidInput(_))));
+        let contained = OkfConcept::new("./areas/./runtime.md", frontmatter.clone(), "")
+            .expect("curdir components should normalize away");
+        assert_eq!(contained.path.as_path(), Path::new("areas/runtime.md"));
         let not_markdown = OkfConcept::new("areas/runtime.txt", frontmatter, "");
         assert!(matches!(not_markdown, Err(MemoryError::InvalidInput(_))));
     }
@@ -973,6 +976,29 @@ legacy_number: 7
             .expect("CRLF frontmatter should parse");
 
         assert_eq!(concept.frontmatter.concept_type, "topic-doc");
+        assert_eq!(concept.body, "# Runtime\n");
+    }
+
+    #[test]
+    fn okf_frontmatter_does_not_close_on_indented_yaml_delimiter() {
+        let repo = TempDir::new().expect("temp repo");
+        let contents = r#"---
+type: topic-doc
+description: |
+  ---
+  YAML literal content
+---
+
+# Runtime
+"#;
+
+        let concept = parse_okf_concept(repo.path(), Path::new("areas/runtime.md"), contents)
+            .expect("indented yaml delimiter should not close frontmatter");
+
+        assert_eq!(
+            concept.frontmatter.description.as_deref(),
+            Some("---\nYAML literal content\n")
+        );
         assert_eq!(concept.body, "# Runtime\n");
     }
 

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -8,10 +8,11 @@ pub struct OkfBundlePath {
 impl OkfBundlePath {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self, MemoryError> {
         let path = path.into();
-        let mut has_component = false;
+        let mut normalized = PathBuf::new();
         for component in path.components() {
             match component {
-                std::path::Component::Normal(_) => has_component = true,
+                std::path::Component::CurDir => {}
+                std::path::Component::Normal(part) => normalized.push(part),
                 _ => {
                     return Err(MemoryError::InvalidInput(format!(
                         "OKF concept path `{}` must be bundle-relative and contained",
@@ -20,13 +21,17 @@ impl OkfBundlePath {
                 }
             }
         }
-        if !has_component || path.extension().and_then(OsStr::to_str) != Some("md") {
+        if normalized.as_os_str().is_empty()
+            || normalized.extension().and_then(OsStr::to_str) != Some("md")
+        {
             return Err(MemoryError::InvalidInput(format!(
                 "OKF concept path `{}` must name a Markdown file",
                 path.display()
             )));
         }
-        Ok(Self { relative: path })
+        Ok(Self {
+            relative: normalized,
+        })
     }
 
     pub fn as_path(&self) -> &Path {
@@ -43,7 +48,6 @@ impl OkfBundlePath {
             })
             .collect::<Vec<_>>()
             .join("/")
-            .replace('\\', "/")
     }
 
     pub fn reserved_file(&self) -> Option<OkfReservedFile> {
@@ -223,7 +227,7 @@ fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String)
             .map(|index| offset + index + 1)
             .unwrap_or(normalized.len());
         let line = &normalized[offset..next_end];
-        if line.trim() == "---" {
+        if line.trim_end() == "---" {
             let body = &normalized[next_end..];
             return Ok((
                 frontmatter,

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -21,9 +21,11 @@ impl OkfBundlePath {
                 }
             }
         }
-        if normalized.as_os_str().is_empty()
-            || normalized.extension().and_then(OsStr::to_str) != Some("md")
-        {
+        let markdown_extension = normalized
+            .extension()
+            .and_then(OsStr::to_str)
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("md"));
+        if normalized.as_os_str().is_empty() || !markdown_extension {
             return Err(MemoryError::InvalidInput(format!(
                 "OKF concept path `{}` must name a Markdown file",
                 path.display()
@@ -208,8 +210,8 @@ pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
     let mut frontmatter = concept.frontmatter.clone();
     if concept.derived_opensymphony {
         frontmatter.opensymphony = None;
-    } else if frontmatter.opensymphony.is_some() {
-        remove_legacy_opensymphony_fields(&mut frontmatter.extra);
+    } else if let Some(metadata) = frontmatter.opensymphony.clone() {
+        remove_represented_legacy_opensymphony_fields(&mut frontmatter.extra, &metadata);
     }
     let frontmatter =
         serde_yaml::to_string(&frontmatter).map_err(|source| MemoryError::ParseYaml {
@@ -332,25 +334,70 @@ fn legacy_frontmatter_to_opensymphony_metadata(
     metadata
 }
 
-fn remove_legacy_opensymphony_fields(extra: &mut BTreeMap<String, serde_yaml::Value>) {
-    for key in [
-        "area",
-        "areas",
-        "docs_sync",
-        "issue",
-        "linear_url",
-        "milestone",
-        "milestone_id",
-        "project",
-        "project_id",
-        "prs",
-        "repo",
-        "repository",
-        "source_refs",
-        "visibility",
-    ] {
-        extra.remove(key);
+fn remove_represented_legacy_opensymphony_fields(
+    extra: &mut BTreeMap<String, serde_yaml::Value>,
+    metadata: &OpenSymphonyOkfMetadata,
+) {
+    if metadata.visibility.is_some() {
+        extra.remove("visibility");
     }
+    if metadata.docs_sync.is_some() {
+        extra.remove("docs_sync");
+    }
+    if has_scope_ref(metadata, &KnowledgeScopeKind::WorkItem) {
+        extra.remove("issue");
+    }
+    if has_scope_ref(metadata, &KnowledgeScopeKind::Milestone) {
+        extra.remove("milestone");
+        extra.remove("milestone_id");
+    }
+    if has_scope_ref(metadata, &KnowledgeScopeKind::Project) {
+        extra.remove("project");
+        extra.remove("project_id");
+    }
+    if has_scope_ref(metadata, &KnowledgeScopeKind::Area) {
+        extra.remove("area");
+        extra.remove("areas");
+    }
+    if has_scope_ref(metadata, &KnowledgeScopeKind::Repository) {
+        extra.remove("repo");
+        extra.remove("repository");
+    }
+    if metadata
+        .source_refs
+        .iter()
+        .any(|source_ref| source_ref.kind == "linear_issue" && source_ref.url.is_some())
+    {
+        extra.remove("linear_url");
+    }
+
+    let legacy_refs = legacy_source_refs_from_extra(extra);
+    if !legacy_refs.is_empty()
+        && legacy_refs
+            .iter()
+            .all(|legacy_ref| source_ref_is_represented(metadata, legacy_ref))
+    {
+        extra.remove("prs");
+        extra.remove("source_refs");
+    }
+}
+
+fn has_scope_ref(metadata: &OpenSymphonyOkfMetadata, kind: &KnowledgeScopeKind) -> bool {
+    metadata
+        .scope_refs
+        .iter()
+        .any(|scope_ref| &scope_ref.kind == kind)
+}
+
+fn source_ref_is_represented(
+    metadata: &OpenSymphonyOkfMetadata,
+    legacy_ref: &MemorySourceRef,
+) -> bool {
+    metadata.source_refs.iter().any(|source_ref| {
+        source_ref.kind == legacy_ref.kind
+            && source_ref.id == legacy_ref.id
+            && (legacy_ref.url.is_none() || source_ref.url == legacy_ref.url)
+    })
 }
 
 fn legacy_visibility(frontmatter: &OkfFrontmatter) -> Option<MemoryVisibility> {
@@ -405,8 +452,14 @@ fn push_scope_ref(refs: &mut Vec<KnowledgeScope>, scope_ref: KnowledgeScope) {
 }
 
 fn legacy_source_refs(frontmatter: &OkfFrontmatter) -> Vec<MemorySourceRef> {
+    legacy_source_refs_from_extra(&frontmatter.extra)
+}
+
+fn legacy_source_refs_from_extra(
+    extra: &BTreeMap<String, serde_yaml::Value>,
+) -> Vec<MemorySourceRef> {
     let mut refs = Vec::new();
-    if let Some(serde_yaml::Value::Mapping(source_refs)) = frontmatter.extra.get("source_refs") {
+    if let Some(serde_yaml::Value::Mapping(source_refs)) = extra.get("source_refs") {
         for (key, value) in source_refs {
             let Some(kind) = value_as_string(key) else {
                 continue;
@@ -427,7 +480,7 @@ fn legacy_source_refs(frontmatter: &OkfFrontmatter) -> Vec<MemorySourceRef> {
             }
         }
     }
-    if let Some(serde_yaml::Value::Sequence(prs)) = frontmatter.extra.get("prs") {
+    if let Some(serde_yaml::Value::Sequence(prs)) = extra.get("prs") {
         for pr in prs {
             let serde_yaml::Value::Mapping(pr) = pr else {
                 continue;
@@ -510,6 +563,7 @@ fn push_source_ref(refs: &mut Vec<MemorySourceRef>, source_ref: MemorySourceRef)
 
 fn extract_markdown_links(body: &str) -> Vec<OkfLink> {
     let mut links = Vec::new();
+    let references = reference_link_targets(body);
     let mut index = 0;
     while index < body.len() {
         let Some((current, next)) = char_at(body, index) else {
@@ -518,26 +572,59 @@ fn extract_markdown_links(body: &str) -> Vec<OkfLink> {
         match current {
             '`' => index = skip_code_span(body, index),
             '\\' => index = skip_escaped_char(body, next),
+            '<' => {
+                let Some((target, after_target)) = parse_autolink(body, next) else {
+                    index = next;
+                    continue;
+                };
+                links.push(OkfLink {
+                    target,
+                    label: None,
+                });
+                index = after_target;
+            }
             '[' if !is_image_marker(body, index) => {
                 let Some((label, after_label)) = parse_link_label(body, next) else {
                     index = next;
                     continue;
                 };
-                let Some(('(', after_open)) = char_at(body, after_label) else {
-                    index = after_label;
-                    continue;
-                };
-                let Some((target, after_target)) = parse_link_target(body, after_open) else {
-                    index = after_open;
-                    continue;
-                };
-                if !target.is_empty() {
-                    links.push(OkfLink {
-                        target,
-                        label: Some(label).filter(|label| !label.is_empty()),
-                    });
+                match char_at(body, after_label) {
+                    Some(('(', after_open)) => {
+                        let Some((target, after_target)) = parse_link_target(body, after_open)
+                        else {
+                            index = after_open;
+                            continue;
+                        };
+                        if !target.is_empty() {
+                            links.push(OkfLink {
+                                target,
+                                label: Some(label).filter(|label| !label.is_empty()),
+                            });
+                        }
+                        index = after_target;
+                    }
+                    Some(('[', after_ref_open)) => {
+                        let Some((reference, after_reference)) =
+                            parse_link_label(body, after_ref_open)
+                        else {
+                            index = after_ref_open;
+                            continue;
+                        };
+                        let key = if reference.is_empty() {
+                            label.as_str()
+                        } else {
+                            reference.as_str()
+                        };
+                        if let Some(target) = references.get(&normalize_reference_label(key)) {
+                            links.push(OkfLink {
+                                target: target.clone(),
+                                label: Some(label).filter(|label| !label.is_empty()),
+                            });
+                        }
+                        index = after_reference;
+                    }
+                    _ => index = after_label,
                 }
-                index = after_target;
             }
             _ => index = next,
         }
@@ -578,7 +665,20 @@ fn skip_code_span(value: &str, index: usize) -> usize {
 }
 
 fn is_image_marker(value: &str, index: usize) -> bool {
-    value[..index].ends_with('!')
+    value[..index].ends_with('!') && !is_escaped(value, index - 1)
+}
+
+fn is_escaped(value: &str, index: usize) -> bool {
+    let mut slash_count = 0;
+    let mut cursor = index;
+    while cursor > 0 {
+        cursor -= 1;
+        if value.as_bytes()[cursor] != b'\\' {
+            break;
+        }
+        slash_count += 1;
+    }
+    slash_count % 2 == 1
 }
 
 fn parse_link_label(value: &str, mut index: usize) -> Option<(String, usize)> {
@@ -642,4 +742,36 @@ fn normalize_link_target(raw: &str) -> Option<String> {
         return Some(target.to_string()).filter(|target| !target.is_empty());
     }
     raw.split_whitespace().next().map(str::to_string)
+}
+
+fn parse_autolink(value: &str, index: usize) -> Option<(String, usize)> {
+    let end = value[index..].find('>')? + index;
+    let target = &value[index..end];
+    if target.starts_with("http://") || target.starts_with("https://") {
+        Some((target.to_string(), end + 1))
+    } else {
+        None
+    }
+}
+
+fn reference_link_targets(body: &str) -> BTreeMap<String, String> {
+    let mut references = BTreeMap::new();
+    for line in body.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix('[') else {
+            continue;
+        };
+        let Some((label, target)) = rest.split_once("]:") else {
+            continue;
+        };
+        let Some(target) = normalize_link_target(target) else {
+            continue;
+        };
+        references.insert(normalize_reference_label(label), target);
+    }
+    references
+}
+
+fn normalize_reference_label(label: &str) -> String {
+    label.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
 }

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -496,10 +496,14 @@ fn source_ref_from_token(kind: &str, token: &str) -> MemorySourceRef {
 }
 
 fn push_source_ref(refs: &mut Vec<MemorySourceRef>, source_ref: MemorySourceRef) {
-    if !refs
-        .iter()
-        .any(|existing| existing.kind == source_ref.kind && existing.id == source_ref.id)
+    if let Some(existing) = refs
+        .iter_mut()
+        .find(|existing| existing.kind == source_ref.kind && existing.id == source_ref.id)
     {
+        if existing.url.is_none() {
+            existing.url = source_ref.url;
+        }
+    } else {
         refs.push(source_ref);
     }
 }

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -43,6 +43,7 @@ impl OkfBundlePath {
             })
             .collect::<Vec<_>>()
             .join("/")
+            .replace('\\', "/")
     }
 
     pub fn reserved_file(&self) -> Option<OkfReservedFile> {
@@ -180,7 +181,7 @@ pub fn parse_okf_concept(
     };
     let (frontmatter, body) = split_okf_frontmatter(document_path, contents)?;
     let mut frontmatter: OkfFrontmatter =
-        serde_yaml::from_str(frontmatter).map_err(|source| MemoryError::ParseYaml {
+        serde_yaml::from_str(&frontmatter).map_err(|source| MemoryError::ParseYaml {
             path: document_path.to_path_buf(),
             source,
         })?;
@@ -201,23 +202,42 @@ pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
     Ok(format!("---\n{frontmatter}---\n\n{}", concept.body))
 }
 
-fn split_okf_frontmatter<'a>(
-    path: &Path,
-    contents: &'a str,
-) -> Result<(&'a str, &'a str), MemoryError> {
-    let Some(after_open) = contents.strip_prefix("---\n") else {
+fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String), MemoryError> {
+    let normalized = contents.replace("\r\n", "\n").replace('\r', "\n");
+    let first_end = normalized
+        .find('\n')
+        .map(|index| index + 1)
+        .unwrap_or(normalized.len());
+    if normalized[..first_end].trim() != "---" {
         return Err(MemoryError::InvalidInput(format!(
             "{} lacks OKF YAML frontmatter",
             path.display()
         )));
     };
-    let Some((frontmatter, body)) = after_open.split_once("\n---\n") else {
-        return Err(MemoryError::InvalidInput(format!(
-            "{} has unterminated OKF YAML frontmatter",
-            path.display()
-        )));
-    };
-    Ok((frontmatter, body.strip_prefix('\n').unwrap_or(body)))
+
+    let mut offset = first_end;
+    let mut frontmatter = String::new();
+    while offset < normalized.len() {
+        let next_end = normalized[offset..]
+            .find('\n')
+            .map(|index| offset + index + 1)
+            .unwrap_or(normalized.len());
+        let line = &normalized[offset..next_end];
+        if line.trim() == "---" {
+            let body = &normalized[next_end..];
+            return Ok((
+                frontmatter,
+                body.strip_prefix('\n').unwrap_or(body).to_string(),
+            ));
+        }
+        frontmatter.push_str(line);
+        offset = next_end;
+    }
+
+    Err(MemoryError::InvalidInput(format!(
+        "{} has unterminated OKF YAML frontmatter",
+        path.display()
+    )))
 }
 
 fn require_okf_type(concept_type: &str) -> Result<(), MemoryError> {
@@ -477,25 +497,136 @@ fn push_source_ref(refs: &mut Vec<MemorySourceRef>, source_ref: MemorySourceRef)
 
 fn extract_markdown_links(body: &str) -> Vec<OkfLink> {
     let mut links = Vec::new();
-    let mut rest = body;
-    while let Some(label_start) = rest.find('[') {
-        rest = &rest[label_start + 1..];
-        let Some(label_end) = rest.find("](") else {
-            continue;
-        };
-        let label = &rest[..label_end];
-        rest = &rest[label_end + 2..];
-        let Some(target_end) = rest.find(')') else {
+    let mut index = 0;
+    while index < body.len() {
+        let Some((current, next)) = char_at(body, index) else {
             break;
         };
-        let target = &rest[..target_end];
-        if !target.trim().is_empty() {
-            links.push(OkfLink {
-                target: target.to_string(),
-                label: Some(label.to_string()).filter(|label| !label.is_empty()),
-            });
+        match current {
+            '`' => index = skip_code_span(body, index),
+            '\\' => index = skip_escaped_char(body, next),
+            '[' if !is_image_marker(body, index) => {
+                let Some((label, after_label)) = parse_link_label(body, next) else {
+                    index = next;
+                    continue;
+                };
+                let Some(('(', after_open)) = char_at(body, after_label) else {
+                    index = after_label;
+                    continue;
+                };
+                let Some((target, after_target)) = parse_link_target(body, after_open) else {
+                    index = after_open;
+                    continue;
+                };
+                if !target.is_empty() {
+                    links.push(OkfLink {
+                        target,
+                        label: Some(label).filter(|label| !label.is_empty()),
+                    });
+                }
+                index = after_target;
+            }
+            _ => index = next,
         }
-        rest = &rest[target_end + 1..];
     }
     links
+}
+
+fn char_at(value: &str, index: usize) -> Option<(char, usize)> {
+    value[index..]
+        .chars()
+        .next()
+        .map(|character| (character, index + character.len_utf8()))
+}
+
+fn skip_escaped_char(value: &str, index: usize) -> usize {
+    char_at(value, index)
+        .map(|(_, next)| next)
+        .unwrap_or(index)
+}
+
+fn skip_code_span(value: &str, index: usize) -> usize {
+    let mut tick_end = index;
+    while let Some(('`', next)) = char_at(value, tick_end) {
+        tick_end = next;
+    }
+    let tick_count = tick_end - index;
+    let mut cursor = tick_end;
+    while cursor < value.len() {
+        if value[cursor..].starts_with(&"`".repeat(tick_count)) {
+            return cursor + tick_count;
+        }
+        let Some((_, next)) = char_at(value, cursor) else {
+            break;
+        };
+        cursor = next;
+    }
+    tick_end
+}
+
+fn is_image_marker(value: &str, index: usize) -> bool {
+    value[..index].ends_with('!')
+}
+
+fn parse_link_label(value: &str, mut index: usize) -> Option<(String, usize)> {
+    let label_start = index;
+    let mut depth = 1usize;
+    while index < value.len() {
+        let (current, next) = char_at(value, index)?;
+        match current {
+            '\\' => index = skip_escaped_char(value, next),
+            '`' => index = skip_code_span(value, index),
+            '[' => {
+                depth += 1;
+                index = next;
+            }
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((value[label_start..index].to_string(), next));
+                }
+                index = next;
+            }
+            _ => index = next,
+        }
+    }
+    None
+}
+
+fn parse_link_target(value: &str, mut index: usize) -> Option<(String, usize)> {
+    let target_start = index;
+    let mut depth = 1usize;
+    while index < value.len() {
+        let (current, next) = char_at(value, index)?;
+        match current {
+            '\\' => index = skip_escaped_char(value, next),
+            '(' => {
+                depth += 1;
+                index = next;
+            }
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return normalize_link_target(&value[target_start..index])
+                        .map(|target| (target, next));
+                }
+                index = next;
+            }
+            _ => index = next,
+        }
+    }
+    None
+}
+
+fn normalize_link_target(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some(after_open) = raw.strip_prefix('<')
+        && let Some((target, _)) = after_open.split_once('>')
+    {
+        return Some(target.to_string()).filter(|target| !target.is_empty());
+    }
+    raw.split_whitespace().next().map(str::to_string)
 }

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -1,0 +1,501 @@
+pub const OKF_VERSION: &str = "0.1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OkfBundlePath {
+    relative: PathBuf,
+}
+
+impl OkfBundlePath {
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self, MemoryError> {
+        let path = path.into();
+        let mut has_component = false;
+        for component in path.components() {
+            match component {
+                std::path::Component::Normal(_) => has_component = true,
+                _ => {
+                    return Err(MemoryError::InvalidInput(format!(
+                        "OKF concept path `{}` must be bundle-relative and contained",
+                        path.display()
+                    )));
+                }
+            }
+        }
+        if !has_component || path.extension().and_then(OsStr::to_str) != Some("md") {
+            return Err(MemoryError::InvalidInput(format!(
+                "OKF concept path `{}` must name a Markdown file",
+                path.display()
+            )));
+        }
+        Ok(Self { relative: path })
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.relative
+    }
+
+    pub fn concept_id(&self) -> String {
+        let mut id = self.relative.clone();
+        id.set_extension("");
+        id.components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(part) => part.to_str(),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    pub fn reserved_file(&self) -> Option<OkfReservedFile> {
+        match self.relative.file_name().and_then(OsStr::to_str) {
+            Some("index.md") => Some(OkfReservedFile::Index),
+            Some("log.md") => Some(OkfReservedFile::Log),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OkfReservedFile {
+    Index,
+    Log,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OkfFrontmatter {
+    #[serde(rename = "type")]
+    pub concept_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opensymphony: Option<OpenSymphonyOkfMetadata>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+impl OkfFrontmatter {
+    pub fn new(concept_type: impl Into<String>) -> Result<Self, MemoryError> {
+        let concept_type = concept_type.into();
+        require_okf_type(&concept_type)?;
+        Ok(Self {
+            concept_type,
+            title: None,
+            description: None,
+            resource: None,
+            tags: Vec::new(),
+            timestamp: None,
+            opensymphony: None,
+            extra: BTreeMap::new(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OpenSymphonyOkfMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<MemoryVisibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scope_refs: Vec<KnowledgeScope>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<MemorySourceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<OkfLink>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub citations: Vec<OkfCitation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docs_sync: Option<serde_yaml::Value>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OkfLink {
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OkfCitation {
+    pub id: String,
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OkfConcept {
+    pub path: OkfBundlePath,
+    pub id: String,
+    pub frontmatter: OkfFrontmatter,
+    pub body: String,
+    pub links: Vec<OkfLink>,
+}
+
+impl OkfConcept {
+    pub fn new(
+        path: impl Into<PathBuf>,
+        frontmatter: OkfFrontmatter,
+        body: impl Into<String>,
+    ) -> Result<Self, MemoryError> {
+        require_okf_type(&frontmatter.concept_type)?;
+        let path = OkfBundlePath::new(path)?;
+        let body = body.into();
+        Ok(Self {
+            id: path.concept_id(),
+            links: extract_markdown_links(&body),
+            path,
+            frontmatter,
+            body,
+        })
+    }
+}
+
+pub fn parse_okf_concept(
+    bundle_root: &Path,
+    document_path: &Path,
+    contents: &str,
+) -> Result<OkfConcept, MemoryError> {
+    let relative_path = if document_path.is_absolute() {
+        document_path
+            .strip_prefix(bundle_root)
+            .map_err(|_| MemoryError::PathOutsideRepo {
+                path: document_path.to_path_buf(),
+                repo_root: bundle_root.to_path_buf(),
+            })?
+            .to_path_buf()
+    } else {
+        document_path.to_path_buf()
+    };
+    let (frontmatter, body) = split_okf_frontmatter(document_path, contents)?;
+    let mut frontmatter: OkfFrontmatter =
+        serde_yaml::from_str(frontmatter).map_err(|source| MemoryError::ParseYaml {
+            path: document_path.to_path_buf(),
+            source,
+        })?;
+    require_okf_type(&frontmatter.concept_type)?;
+    let legacy = legacy_frontmatter_to_opensymphony_metadata(&frontmatter);
+    merge_opensymphony_metadata(&mut frontmatter, legacy);
+    OkfConcept::new(relative_path, frontmatter, body.to_string())
+}
+
+pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
+    require_okf_type(&concept.frontmatter.concept_type)?;
+    OkfBundlePath::new(concept.path.as_path().to_path_buf())?;
+    let frontmatter =
+        serde_yaml::to_string(&concept.frontmatter).map_err(|source| MemoryError::ParseYaml {
+            path: concept.path.as_path().to_path_buf(),
+            source,
+        })?;
+    Ok(format!("---\n{frontmatter}---\n\n{}", concept.body))
+}
+
+fn split_okf_frontmatter<'a>(
+    path: &Path,
+    contents: &'a str,
+) -> Result<(&'a str, &'a str), MemoryError> {
+    let Some(after_open) = contents.strip_prefix("---\n") else {
+        return Err(MemoryError::InvalidInput(format!(
+            "{} lacks OKF YAML frontmatter",
+            path.display()
+        )));
+    };
+    let Some((frontmatter, body)) = after_open.split_once("\n---\n") else {
+        return Err(MemoryError::InvalidInput(format!(
+            "{} has unterminated OKF YAML frontmatter",
+            path.display()
+        )));
+    };
+    Ok((frontmatter, body.strip_prefix('\n').unwrap_or(body)))
+}
+
+fn require_okf_type(concept_type: &str) -> Result<(), MemoryError> {
+    if concept_type.trim().is_empty() {
+        Err(MemoryError::InvalidInput(
+            "OKF concept frontmatter requires non-empty `type`".to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn legacy_frontmatter_to_opensymphony_metadata(
+    frontmatter: &OkfFrontmatter,
+) -> OpenSymphonyOkfMetadata {
+    let mut metadata = OpenSymphonyOkfMetadata {
+        visibility: legacy_visibility(frontmatter),
+        kind: Some(frontmatter.concept_type.replace('-', "_")),
+        schema_version: Some(1),
+        scope_refs: Vec::new(),
+        source_refs: Vec::new(),
+        links: Vec::new(),
+        citations: Vec::new(),
+        docs_sync: frontmatter.extra.get("docs_sync").cloned(),
+        extra: BTreeMap::new(),
+    };
+
+    push_scope(
+        &mut metadata.scope_refs,
+        KnowledgeScopeKind::WorkItem,
+        string_extra(frontmatter, "issue"),
+        frontmatter.title.clone(),
+    );
+    push_scope(
+        &mut metadata.scope_refs,
+        KnowledgeScopeKind::Milestone,
+        string_extra(frontmatter, "milestone_id").or_else(|| string_extra(frontmatter, "milestone")),
+        string_extra(frontmatter, "milestone"),
+    );
+    push_scope(
+        &mut metadata.scope_refs,
+        KnowledgeScopeKind::Project,
+        string_extra(frontmatter, "project_id").or_else(|| string_extra(frontmatter, "project")),
+        string_extra(frontmatter, "project"),
+    );
+    for area in string_array_extra(frontmatter, "areas")
+        .into_iter()
+        .chain(string_extra(frontmatter, "area"))
+    {
+        push_scope(
+            &mut metadata.scope_refs,
+            KnowledgeScopeKind::Area,
+            Some(area.clone()),
+            Some(area),
+        );
+    }
+    push_scope(
+        &mut metadata.scope_refs,
+        KnowledgeScopeKind::Repository,
+        string_extra(frontmatter, "repository").or_else(|| string_extra(frontmatter, "repo")),
+        string_extra(frontmatter, "repository").or_else(|| string_extra(frontmatter, "repo")),
+    );
+
+    if let Some(issue) = string_extra(frontmatter, "issue") {
+        metadata.source_refs.push(MemorySourceRef {
+            kind: "linear_issue".to_string(),
+            id: issue,
+            url: string_extra(frontmatter, "linear_url"),
+        });
+    }
+    for source_ref in legacy_source_refs(frontmatter) {
+        push_source_ref(&mut metadata.source_refs, source_ref);
+    }
+
+    metadata
+}
+
+fn merge_opensymphony_metadata(
+    frontmatter: &mut OkfFrontmatter,
+    legacy: OpenSymphonyOkfMetadata,
+) {
+    match &mut frontmatter.opensymphony {
+        Some(existing) => {
+            if existing.visibility.is_none() {
+                existing.visibility = legacy.visibility;
+            }
+            if existing.kind.is_none() {
+                existing.kind = legacy.kind;
+            }
+            if existing.schema_version.is_none() {
+                existing.schema_version = legacy.schema_version;
+            }
+            for scope_ref in legacy.scope_refs {
+                push_scope_ref(&mut existing.scope_refs, scope_ref);
+            }
+            for source_ref in legacy.source_refs {
+                push_source_ref(&mut existing.source_refs, source_ref);
+            }
+            if existing.docs_sync.is_none() {
+                existing.docs_sync = legacy.docs_sync;
+            }
+        }
+        None => frontmatter.opensymphony = Some(legacy),
+    }
+}
+
+fn legacy_visibility(frontmatter: &OkfFrontmatter) -> Option<MemoryVisibility> {
+    string_extra(frontmatter, "visibility").and_then(|value| match value.as_str() {
+        "public" => Some(MemoryVisibility::Public),
+        "private" => Some(MemoryVisibility::Private),
+        _ => None,
+    })
+}
+
+fn string_extra(frontmatter: &OkfFrontmatter, key: &str) -> Option<String> {
+    frontmatter.extra.get(key).and_then(value_as_string)
+}
+
+fn string_array_extra(frontmatter: &OkfFrontmatter, key: &str) -> Vec<String> {
+    match frontmatter.extra.get(key) {
+        Some(serde_yaml::Value::Sequence(values)) => {
+            values.iter().filter_map(value_as_string).collect()
+        }
+        Some(value) => value_as_string(value).into_iter().collect(),
+        None => Vec::new(),
+    }
+}
+
+fn value_as_string(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(value) if !value.trim().is_empty() => Some(value.clone()),
+        serde_yaml::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn push_scope(
+    refs: &mut Vec<KnowledgeScope>,
+    kind: KnowledgeScopeKind,
+    id: Option<String>,
+    label: Option<String>,
+) {
+    let Some(id) = id.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    push_scope_ref(refs, KnowledgeScope { kind, id, label });
+}
+
+fn push_scope_ref(refs: &mut Vec<KnowledgeScope>, scope_ref: KnowledgeScope) {
+    if !refs
+        .iter()
+        .any(|existing| existing.kind == scope_ref.kind && existing.id == scope_ref.id)
+    {
+        refs.push(scope_ref);
+    }
+}
+
+fn legacy_source_refs(frontmatter: &OkfFrontmatter) -> Vec<MemorySourceRef> {
+    let mut refs = Vec::new();
+    if let Some(serde_yaml::Value::Mapping(source_refs)) = frontmatter.extra.get("source_refs") {
+        for (key, value) in source_refs {
+            let Some(kind) = value_as_string(key) else {
+                continue;
+            };
+            match value {
+                serde_yaml::Value::Sequence(values) => {
+                    for value in values {
+                        if let Some(token) = value_as_string(value) {
+                            push_source_ref(&mut refs, source_ref_from_token(&kind, &token));
+                        }
+                    }
+                }
+                value => {
+                    if let Some(token) = value_as_string(value) {
+                        push_source_ref(&mut refs, source_ref_from_token(&kind, &token));
+                    }
+                }
+            }
+        }
+    }
+    if let Some(serde_yaml::Value::Sequence(prs)) = frontmatter.extra.get("prs") {
+        for pr in prs {
+            let serde_yaml::Value::Mapping(pr) = pr else {
+                continue;
+            };
+            let number = pr
+                .get(serde_yaml::Value::String("number".to_string()))
+                .and_then(value_as_string);
+            if let Some(number) = number {
+                let url = pr
+                    .get(serde_yaml::Value::String("url".to_string()))
+                    .and_then(value_as_string);
+                push_source_ref(
+                    &mut refs,
+                    MemorySourceRef {
+                        kind: "github_pr".to_string(),
+                        id: number,
+                        url,
+                    },
+                );
+            }
+            if let Some(sha) = pr
+                .get(serde_yaml::Value::String("merge_sha".to_string()))
+                .and_then(value_as_string)
+            {
+                push_source_ref(
+                    &mut refs,
+                    MemorySourceRef {
+                        kind: "github_merge_sha".to_string(),
+                        id: sha,
+                        url: None,
+                    },
+                );
+            }
+        }
+    }
+    refs
+}
+
+fn source_ref_from_token(kind: &str, token: &str) -> MemorySourceRef {
+    if let Some(id) = token.strip_prefix("github:pr:") {
+        return MemorySourceRef {
+            kind: "github_pr".to_string(),
+            id: id.to_string(),
+            url: None,
+        };
+    }
+    if let Some(id) = token.strip_prefix("github:merge:") {
+        return MemorySourceRef {
+            kind: "github_merge_sha".to_string(),
+            id: id.to_string(),
+            url: None,
+        };
+    }
+    if let Some(id) = token.strip_prefix("linear:") {
+        return MemorySourceRef {
+            kind: kind.to_string(),
+            id: id.to_string(),
+            url: None,
+        };
+    }
+    MemorySourceRef {
+        kind: kind.to_string(),
+        id: token.to_string(),
+        url: None,
+    }
+}
+
+fn push_source_ref(refs: &mut Vec<MemorySourceRef>, source_ref: MemorySourceRef) {
+    if !refs
+        .iter()
+        .any(|existing| existing.kind == source_ref.kind && existing.id == source_ref.id)
+    {
+        refs.push(source_ref);
+    }
+}
+
+fn extract_markdown_links(body: &str) -> Vec<OkfLink> {
+    let mut links = Vec::new();
+    let mut rest = body;
+    while let Some(label_start) = rest.find('[') {
+        rest = &rest[label_start + 1..];
+        let Some(label_end) = rest.find("](") else {
+            continue;
+        };
+        let label = &rest[..label_end];
+        rest = &rest[label_end + 2..];
+        let Some(target_end) = rest.find(')') else {
+            break;
+        };
+        let target = &rest[..target_end];
+        if !target.trim().is_empty() {
+            links.push(OkfLink {
+                target: target.to_string(),
+                label: Some(label.to_string()).filter(|label| !label.is_empty()),
+            });
+        }
+        rest = &rest[target_end + 1..];
+    }
+    links
+}

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -146,6 +146,7 @@ pub struct OkfConcept {
     pub frontmatter: OkfFrontmatter,
     pub body: String,
     pub links: Vec<OkfLink>,
+    pub derived_opensymphony: bool,
 }
 
 impl OkfConcept {
@@ -163,6 +164,7 @@ impl OkfConcept {
             path,
             frontmatter,
             body,
+            derived_opensymphony: false,
         })
     }
 }
@@ -190,16 +192,23 @@ pub fn parse_okf_concept(
             source,
         })?;
     require_okf_type(&frontmatter.concept_type)?;
+    let derived_opensymphony = frontmatter.opensymphony.is_none();
     let legacy = legacy_frontmatter_to_opensymphony_metadata(&frontmatter);
     merge_opensymphony_metadata(&mut frontmatter, legacy);
-    OkfConcept::new(relative_path, frontmatter, body.to_string())
+    let mut concept = OkfConcept::new(relative_path, frontmatter, body.to_string())?;
+    concept.derived_opensymphony = derived_opensymphony;
+    Ok(concept)
 }
 
 pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
     require_okf_type(&concept.frontmatter.concept_type)?;
     OkfBundlePath::new(concept.path.as_path().to_path_buf())?;
+    let mut frontmatter = concept.frontmatter.clone();
+    if concept.derived_opensymphony {
+        frontmatter.opensymphony = None;
+    }
     let frontmatter =
-        serde_yaml::to_string(&concept.frontmatter).map_err(|source| MemoryError::ParseYaml {
+        serde_yaml::to_string(&frontmatter).map_err(|source| MemoryError::ParseYaml {
             path: concept.path.as_path().to_path_buf(),
             source,
         })?;

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -569,6 +569,14 @@ fn extract_markdown_links(body: &str) -> Vec<OkfLink> {
         let Some((current, next)) = char_at(body, index) else {
             break;
         };
+        if body[index..].starts_with("<!--") {
+            index = skip_html_comment(body, index);
+            continue;
+        }
+        if is_fenced_code_start(body, index) {
+            index = skip_fenced_code_block(body, index);
+            continue;
+        }
         match current {
             '`' => index = skip_code_span(body, index),
             '\\' => index = skip_escaped_char(body, next),
@@ -623,7 +631,16 @@ fn extract_markdown_links(body: &str) -> Vec<OkfLink> {
                         }
                         index = after_reference;
                     }
-                    _ => index = after_label,
+                    Some((':', _)) => index = after_label,
+                    _ => {
+                        if let Some(target) = references.get(&normalize_reference_label(&label)) {
+                            links.push(OkfLink {
+                                target: target.clone(),
+                                label: Some(label).filter(|label| !label.is_empty()),
+                            });
+                        }
+                        index = after_label;
+                    }
                 }
             }
             _ => index = next,
@@ -662,6 +679,45 @@ fn skip_code_span(value: &str, index: usize) -> usize {
         cursor = next;
     }
     tick_end
+}
+
+fn skip_html_comment(value: &str, index: usize) -> usize {
+    value[index..]
+        .find("-->")
+        .map(|end| index + end + 3)
+        .unwrap_or(value.len())
+}
+
+fn is_fenced_code_start(value: &str, index: usize) -> bool {
+    let line_start = value[..index].rfind('\n').map(|line| line + 1).unwrap_or(0);
+    if value[line_start..index]
+        .chars()
+        .any(|character| character != ' ' && character != '\t')
+    {
+        return false;
+    }
+    value[index..].starts_with("```") || value[index..].starts_with("~~~")
+}
+
+fn skip_fenced_code_block(value: &str, index: usize) -> usize {
+    let fence = &value[index..index + 3];
+    let mut cursor = value[index..]
+        .find('\n')
+        .map(|line| index + line + 1)
+        .unwrap_or(value.len());
+    while cursor < value.len() {
+        if is_fenced_code_start(value, cursor) && value[cursor..].starts_with(fence) {
+            return value[cursor..]
+                .find('\n')
+                .map(|line| cursor + line + 1)
+                .unwrap_or(value.len());
+        }
+        cursor = value[cursor..]
+            .find('\n')
+            .map(|line| cursor + line + 1)
+            .unwrap_or(value.len());
+    }
+    value.len()
 }
 
 fn is_image_marker(value: &str, index: usize) -> bool {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -193,8 +193,10 @@ pub fn parse_okf_concept(
         })?;
     require_okf_type(&frontmatter.concept_type)?;
     let derived_opensymphony = frontmatter.opensymphony.is_none();
-    let legacy = legacy_frontmatter_to_opensymphony_metadata(&frontmatter);
-    merge_opensymphony_metadata(&mut frontmatter, legacy);
+    if derived_opensymphony {
+        let legacy = legacy_frontmatter_to_opensymphony_metadata(&frontmatter);
+        frontmatter.opensymphony = Some(legacy);
+    }
     let mut concept = OkfConcept::new(relative_path, frontmatter, body.to_string())?;
     concept.derived_opensymphony = derived_opensymphony;
     Ok(concept)
@@ -206,6 +208,8 @@ pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
     let mut frontmatter = concept.frontmatter.clone();
     if concept.derived_opensymphony {
         frontmatter.opensymphony = None;
+    } else if frontmatter.opensymphony.is_some() {
+        remove_legacy_opensymphony_fields(&mut frontmatter.extra);
     }
     let frontmatter =
         serde_yaml::to_string(&frontmatter).map_err(|source| MemoryError::ParseYaml {
@@ -328,32 +332,24 @@ fn legacy_frontmatter_to_opensymphony_metadata(
     metadata
 }
 
-fn merge_opensymphony_metadata(
-    frontmatter: &mut OkfFrontmatter,
-    legacy: OpenSymphonyOkfMetadata,
-) {
-    match &mut frontmatter.opensymphony {
-        Some(existing) => {
-            if existing.visibility.is_none() {
-                existing.visibility = legacy.visibility;
-            }
-            if existing.kind.is_none() {
-                existing.kind = legacy.kind;
-            }
-            if existing.schema_version.is_none() {
-                existing.schema_version = legacy.schema_version;
-            }
-            for scope_ref in legacy.scope_refs {
-                push_scope_ref(&mut existing.scope_refs, scope_ref);
-            }
-            for source_ref in legacy.source_refs {
-                push_source_ref(&mut existing.source_refs, source_ref);
-            }
-            if existing.docs_sync.is_none() {
-                existing.docs_sync = legacy.docs_sync;
-            }
-        }
-        None => frontmatter.opensymphony = Some(legacy),
+fn remove_legacy_opensymphony_fields(extra: &mut BTreeMap<String, serde_yaml::Value>) {
+    for key in [
+        "area",
+        "areas",
+        "docs_sync",
+        "issue",
+        "linear_url",
+        "milestone",
+        "milestone_id",
+        "project",
+        "project_id",
+        "prs",
+        "repo",
+        "repository",
+        "source_refs",
+        "visibility",
+    ] {
+        extra.remove(key);
     }
 }
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -67,11 +67,12 @@ taxonomy.
 Every parsed OKF concept requires YAML frontmatter with a non-empty `type` and a
 contained bundle-relative Markdown path. Existing legacy top-level fields such
 as `issue`, `milestone`, `linear_url`, `areas`, `repository`, `prs`,
-`source_refs`, and `docs_sync` are preserved exactly during parse/render. The
+`source_refs`, and `docs_sync` are preserved as data during parse/render. The
 parser also projects those fields into `opensymphony` extension metadata:
 visibility, concept kind, scope refs, source refs, and docs-sync state. Unknown
 frontmatter is kept in the raw frontmatter map so future writers can round-trip
-documents they do not fully understand.
+documents they do not fully understand. Writers emit canonical YAML and do not
+preserve the original frontmatter field order or whitespace.
 
 Migration is intentionally incremental:
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -38,6 +38,50 @@ The memory system has two different outputs:
   current model, invariants, gotchas, and recent changes without requiring
   readers to know which issue introduced the knowledge.
 
+## OKF Bundle Compatibility
+
+OpenSymphony treats OKF as the portable Markdown contract for memory, not as a
+replacement for the current local store. The logical bundle layout follows
+`docs/okf-memory-spec.md`:
+
+```text
+bundle-root/
+  index.md
+  log.md
+  projects/
+  milestones/
+  issues/
+  areas/
+  repositories/
+  code/
+  runs/
+  references/
+```
+
+The current `.opensymphony/memory/` paths stay in place for this compatibility
+slice. Issue capsules map to `issues/<issue>.md`, milestone nodes map to
+`milestones/<slug>.md`, generated topic docs map to `areas/<slug>.md`, and
+repository memory remains a facet under `repositories/` rather than the root
+taxonomy.
+
+Every parsed OKF concept requires YAML frontmatter with a non-empty `type` and a
+contained bundle-relative Markdown path. Existing legacy top-level fields such
+as `issue`, `milestone`, `linear_url`, `areas`, `repository`, `prs`,
+`source_refs`, and `docs_sync` are preserved exactly during parse/render. The
+parser also projects those fields into `opensymphony` extension metadata:
+visibility, concept kind, scope refs, source refs, and docs-sync state. Unknown
+frontmatter is kept in the raw frontmatter map so future writers can round-trip
+documents they do not fully understand.
+
+Migration is intentionally incremental:
+
+- Phase 1 enriches and parses existing documents as OKF concepts while keeping
+  legacy paths and fields.
+- Phase 2 can mirror or move documents into the final bundle layout and rebuild
+  the catalog from OKF concepts.
+- Phase 3 can expose graph, hosted import/export, and visibility-filtered APIs
+  from the OKF-derived catalog.
+
 The default visibility posture is private memory with optional public docs.
 Private capsules may include Linear comments, review context, and source
 snapshots, while public docs should contain public source refs such as issue

--- a/examples/okf_parse_render.rs
+++ b/examples/okf_parse_render.rs
@@ -1,0 +1,25 @@
+use std::path::Path;
+
+use opensymphony::opensymphony_memory::{parse_okf_concept, render_okf_concept};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let markdown = r#"---
+type: topic-doc
+area: openhands-runtime
+visibility: public
+docs_sync:
+  status: pending
+---
+
+# Runtime
+
+See [COE-123](/issues/COE-123.md).
+"#;
+
+    let concept = parse_okf_concept(Path::new("."), Path::new("./areas/./runtime.md"), markdown)?;
+    println!("id={}", concept.id);
+    println!("path={}", concept.path.as_path().display());
+    println!("derived_opensymphony={}", concept.derived_opensymphony);
+    println!("{}", render_okf_concept(&concept)?);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds the first OKF bundle-schema surface for OpenSymphony memory: concept parsing, contained bundle paths, legacy capsule mapping, and docs for compatibility.

## Changes

- Added OKF concept/frontmatter/path/link/citation/OpenSymphony metadata types in the memory boundary.
- Added parser/render helpers that require non-empty `type`, reject escaping paths, preserve unknown frontmatter, and map legacy issue/milestone/topic metadata into derived `opensymphony` metadata for runtime consumers.
- Render legacy documents with top-level legacy fields as the source of truth, omitting only derived `opensymphony` blocks to avoid duplicate/stale YAML.
- Treat explicit `opensymphony` frontmatter as authoritative only for metadata facets it actually represents, so partial OKF migration keeps unmigrated legacy fields intact.
- Preserve richer source refs when duplicate legacy refs describe the same source, such as keeping PR URLs from structured `prs` entries over URL-less tokens.
- Added `examples/okf_parse_render.rs` as a concrete parse/render command for evidence outside unit tests.
- Hardened Markdown/frontmatter parsing for CRLF delimiters, delimiter whitespace, images, escaped image markers, code spans, fenced code blocks, HTML comments, escaped brackets, nested labels, parenthesized targets, full and shortcut reference links, autolinks, contained `./` path components, `.MD` paths, and indented YAML literal delimiters.
- Documented the logical OKF bundle layout, incremental legacy compatibility model, and canonical YAML rendering behavior in `docs/memory.md` plus repo guidance in `AGENTS.md`.

## Evidence

### Test output

```text
cargo test-system-duckdb okf_
11 passed; 0 failed

DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib cargo run --no-default-features --features duckdb-prebuilt --example okf_parse_render
id=areas/runtime
path=areas/runtime.md
derived_opensymphony=true
---
type: topic-doc
area: openhands-runtime
docs_sync:
  status: pending
visibility: public
---

# Runtime

See [COE-123](/issues/COE-123.md).

cargo test-system-duckdb --test memory
24 passed; 0 failed

cargo clippy-system-duckdb
passed

cargo fmt --check
passed

git diff --check
passed
```

### Verification

Reproduced the missing OKF parser/mapping surface with:

```text
rg -n "OkfConcept|OkfBundle|parse_okf|legacy.*okf|legacy.*capsule.*map" crates/opensymphony-memory tests || true
```

The command returned no matches before implementation. New fixture tests cover legacy issue capsules, milestone nodes, topic docs, non-empty type validation, bundle-relative path containment including `./` normalization and `.MD` paths, unknown frontmatter value round-tripping, CRLF frontmatter parsing, indented YAML delimiter preservation, Markdown link extraction edge cases including shortcut reference links and non-visible fenced/comment content, explicit `opensymphony` round-tripping, explicit-plus-legacy metadata overlap, partial explicit metadata preservation, null `opensymphony` legacy fallback, richer source-ref URL preservation, and legacy parse/render output without derived metadata duplication.

## Checklist

- [x] Focused tests pass (`cargo test-system-duckdb okf_` and `cargo test-system-duckdb --test memory`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Breaking changes

None.

## Related issues

COE-454

## Additional notes

This keeps the current durable `.opensymphony/memory/` paths in place. Moving or mirroring into the final OKF bundle layout remains out of scope for this ticket.