### PR TITLE
Add OKF memory lint fixtures and CLI support

### DIFF
--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1209,13 +1209,9 @@ fn run_lint(config: &MemoryConfig, args: LintArgs) -> Result<(), MemoryError> {
     let report = if args.okf {
         let bundle_root = args
             .bundle
-            .map(|path| {
-                if path.is_absolute() {
-                    path
-                } else {
-                    config.repo_root.join(path)
-                }
-            })
+            .as_deref()
+            .map(|path| repo_existing_path_from_path(config, path))
+            .transpose()?
             .unwrap_or_else(|| config.memory_root.clone());
         lint_okf_bundle(&bundle_root, args.public_docs)?
     } else {
@@ -1926,9 +1922,15 @@ fn paths_for_json(config: &MemoryConfig, paths: &[PathBuf]) -> Vec<String> {
 }
 
 fn repo_existing_path(config: &MemoryConfig, value: &str) -> Result<PathBuf, MemoryError> {
-    let path = PathBuf::from(value);
+    repo_existing_path_from_path(config, Path::new(value))
+}
+
+fn repo_existing_path_from_path(
+    config: &MemoryConfig,
+    path: &Path,
+) -> Result<PathBuf, MemoryError> {
     let candidate = if path.is_absolute() {
-        path
+        path.to_path_buf()
     } else {
         config.repo_root.join(path)
     };

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -22,8 +22,8 @@ use crate::{
         LintSeverity, MemoryConfig, MemoryContextOptions, MemoryError, MemoryReindexReport,
         MemoryScopeFilter, SourceFile, archive_blocking_warning_count, brief,
         context_for_issue_with_options, docs_for_area_with_scope, expand_issue_range, lint,
-        load_source_file, mark_archived, plan_archive, plan_capture, plan_docs_sync,
-        plan_memory_init, refresh_memory_index, related_by_area_with_scope,
+        lint_okf_bundle, load_source_file, mark_archived, plan_archive, plan_capture,
+        plan_docs_sync, plan_memory_init, refresh_memory_index, related_by_area_with_scope,
         related_by_issue_with_scope, related_by_paths_with_scope, render_archive_plan,
         render_capture_dry_run, search_with_scope, status_with_scope, write_capture_plan,
         write_docs_sync_plan, write_memory_init_plan,
@@ -288,6 +288,10 @@ struct ServeArgs {
 struct LintArgs {
     #[arg(long, help = "Check public docs for private memory links")]
     public_docs: bool,
+    #[arg(long, help = "Lint an OKF bundle")]
+    okf: bool,
+    #[arg(help = "OKF bundle root; defaults to the configured memory root with --okf")]
+    bundle: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -957,9 +961,14 @@ fn remote_memory_tool_request(command: &MemoryCommand) -> Option<(&'static str, 
                 "withDiagrams": args.with_diagrams
             }),
         )),
-        MemoryCommand::Lint(args) => {
-            Some(("memory.lint", json!({ "publicDocs": args.public_docs })))
-        }
+        MemoryCommand::Lint(args) => Some((
+            "memory.lint",
+            json!({
+                "publicDocs": args.public_docs,
+                "okf": args.okf,
+                "bundleRoot": args.bundle.as_ref().map(|path| path.display().to_string())
+            }),
+        )),
         MemoryCommand::Brief(args) => {
             Some(("memory.brief", json!({ "issue": args.issue.clone() })))
         }
@@ -1197,13 +1206,28 @@ fn with_scope_json(scope: &ScopeArgs, mut arguments: Value) -> Value {
 }
 
 fn run_lint(config: &MemoryConfig, args: LintArgs) -> Result<(), MemoryError> {
-    let report = lint(config, args.public_docs)?;
+    let report = if args.okf {
+        let bundle_root = args
+            .bundle
+            .map(|path| {
+                if path.is_absolute() {
+                    path
+                } else {
+                    config.repo_root.join(path)
+                }
+            })
+            .unwrap_or_else(|| config.memory_root.clone());
+        lint_okf_bundle(&bundle_root, args.public_docs)?
+    } else {
+        lint(config, args.public_docs)?
+    };
     if report.findings.is_empty() {
         println!("Memory lint passed.");
         return Ok(());
     }
     for finding in report.findings {
         let severity = match finding.severity {
+            LintSeverity::Info => "info",
             LintSeverity::Warn => "warn",
             LintSeverity::Error => "error",
         };
@@ -1721,15 +1745,23 @@ fn call_memory_sync_docs_tool(
 }
 
 fn call_memory_lint_tool(config: &MemoryConfig, arguments: &Value) -> Result<Value, MemoryError> {
-    let report = lint(
-        config,
-        bool_arg(arguments, "publicDocs") || bool_arg(arguments, "public_docs"),
-    )?;
+    let public_docs = bool_arg(arguments, "publicDocs") || bool_arg(arguments, "public_docs");
+    let report = if bool_arg(arguments, "okf") {
+        let bundle_root = optional_string_arg(arguments, "bundleRoot")
+            .or_else(|| optional_string_arg(arguments, "bundle_root"))
+            .map(|path| repo_existing_path(config, &path))
+            .transpose()?
+            .unwrap_or_else(|| config.memory_root.clone());
+        lint_okf_bundle(&bundle_root, public_docs)?
+    } else {
+        lint(config, public_docs)?
+    };
     Ok(json!({
         "findingCount": report.findings.len(),
         "findings": report.findings.into_iter().map(|finding| {
             json!({
                 "severity": match finding.severity {
+                    LintSeverity::Info => "info",
                     LintSeverity::Warn => "warn",
                     LintSeverity::Error => "error",
                 },

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -3544,12 +3544,14 @@ exit 64
     fn write_executable(path: &Path, contents: &str) {
         use std::os::unix::fs::PermissionsExt;
 
-        fs::write(path, contents).expect("fake executable should be written");
-        let mut permissions = fs::metadata(path)
+        let temp_path = path.with_extension(format!("tmp-{}", std::process::id()));
+        fs::write(&temp_path, contents).expect("fake executable should be written");
+        let mut permissions = fs::metadata(&temp_path)
             .expect("fake executable metadata should load")
             .permissions();
         permissions.set_mode(0o755);
-        fs::set_permissions(path, permissions).expect("fake executable should be executable");
+        fs::set_permissions(&temp_path, permissions).expect("fake executable should be executable");
+        fs::rename(&temp_path, path).expect("fake executable should be replaced atomically");
     }
 
     fn sample_issue_conversation_manifest(

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -262,6 +262,38 @@ fn memory_admin_commands_can_use_mcp_endpoint() {
 }
 
 #[test]
+fn memory_lint_okf_reports_fixture_diagnostics() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    let fixture = okf_fixture("okf-migration");
+    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args([
+            "memory",
+            "lint",
+            "--okf",
+            fixture.to_str().expect("fixture path should be utf-8"),
+        ])
+        .current_dir(repo.path())
+        .output()
+        .expect("command should run");
+
+    assert_success(&output, "okf lint fixture");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[error]"));
+    assert!(stdout.contains("frontmatter lacks non-empty `type`"));
+    assert!(stdout.contains("reserved log.md must use ISO date headings"));
+    assert!(stdout.contains("private export leak"));
+    assert!(stdout.contains("[warn]"));
+    assert!(stdout.contains("missing recommended field(s)"));
+    assert!(stdout.contains("broken Markdown link"));
+    assert!(stdout.contains("wiki-only link"));
+    assert!(stdout.contains("missing generated index.md"));
+    assert!(stdout.contains("citation section missing"));
+    assert!(stdout.contains("[info]"));
+    assert!(stdout.contains("legacy field(s) retained"));
+}
+
+#[test]
 fn memory_search_defaults_cross_repo_and_repo_filters_by_changed_paths() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_memory_config(repo.path());
@@ -540,6 +572,38 @@ fn memory_lint_related_paths_and_from_memory_archive_cover_private_doc_links() {
     let stdout = String::from_utf8_lossy(&archive.stdout);
     assert!(stdout.contains("COE-123"));
     assert!(stdout.contains("eligible"));
+}
+
+#[test]
+fn memory_import_generates_date_grouped_log_newest_first() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    fs::write(repo.path().join("source.yaml"), sample_two_issue_source())
+        .expect("source evidence should write");
+
+    assert_success(
+        &run(
+            repo.path(),
+            [
+                "memory",
+                "import",
+                "--issues",
+                "COE-123,COE-124",
+                "--source-file",
+                "source.yaml",
+            ],
+        ),
+        "capture two dated issues",
+    );
+
+    let log = fs::read_to_string(repo.path().join(".opensymphony/memory/indexes/log.md"))
+        .expect("log should be readable");
+    assert!(log.contains("## 2026-06-14"));
+    assert!(log.contains("## 2026-06-13"));
+    assert!(
+        log.find("## 2026-06-14").expect("newer heading")
+            < log.find("## 2026-06-13").expect("older heading")
+    );
 }
 
 #[test]
@@ -891,6 +955,12 @@ fn assert_failure(output: &std::process::Output, label: &str) {
 fn write_memory_fixture(repo: &std::path::Path) {
     write_memory_config(repo);
     fs::write(repo.join("source.yaml"), sample_source()).expect("source evidence should write");
+}
+
+fn okf_fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/opensymphony-memory/tests/fixtures")
+        .join(name)
 }
 
 fn write_memory_config(repo: &std::path::Path) {
@@ -1413,6 +1483,7 @@ issues:
     url: https://linear.app/example/issue/COE-123
     description: First completed issue.
     state: Done
+    completed_at: 2026-06-13T17:00:00Z
     labels:
       - runtime
     linked_prs:
@@ -1422,6 +1493,7 @@ issues:
     url: https://linear.app/example/issue/COE-124
     description: Second completed issue.
     state: Done
+    completed_at: 2026-06-14T17:00:00Z
     labels:
       - runtime
     linked_prs:

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -244,6 +244,7 @@ fn memory_admin_commands_can_use_mcp_endpoint() {
     let repo = TempDir::new().expect("temp repo should exist");
     let server = TinyGraphqlServer::start([
         r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"findingCount":0,"findings":[]}}"#,
+        r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"findingCount":0,"findings":[]}}"#,
     ]);
 
     let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
@@ -255,24 +256,32 @@ fn memory_admin_commands_can_use_mcp_endpoint() {
         .expect("command should run");
 
     assert_success(&output, "remote memory lint");
+    let okf_output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["memory", "lint", "--okf", "fixtures/okf-migration"])
+        .current_dir(repo.path())
+        .env("OPENSYMPHONY_MEMORY_ENDPOINT", &server.base_url)
+        .env("OPENSYMPHONY_MEMORY_ADMIN_TOKEN", "admin-token")
+        .output()
+        .expect("command should run");
+
+    assert_success(&okf_output, "remote okf memory lint");
     let requests = server.requests();
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
     assert!(requests[0].contains("\"name\":\"memory.lint\""));
     assert!(requests[0].contains("\"publicDocs\":true"));
+    assert!(requests[1].contains("\"name\":\"memory.lint\""));
+    assert!(requests[1].contains("\"okf\":true"));
+    assert!(requests[1].contains("\"bundleRoot\":\"fixtures/okf-migration\""));
 }
 
 #[test]
 fn memory_lint_okf_reports_fixture_diagnostics() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_memory_config(repo.path());
-    let fixture = okf_fixture("okf-migration");
+    let fixture = repo.path().join("fixtures/okf-migration");
+    copy_dir_recursive(&okf_fixture("okf-migration"), &fixture);
     let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
-        .args([
-            "memory",
-            "lint",
-            "--okf",
-            fixture.to_str().expect("fixture path should be utf-8"),
-        ])
+        .args(["memory", "lint", "--okf", "fixtures/okf-migration"])
         .current_dir(repo.path())
         .output()
         .expect("command should run");
@@ -961,6 +970,24 @@ fn okf_fixture(name: &str) -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("crates/opensymphony-memory/tests/fixtures")
         .join(name)
+}
+
+fn copy_dir_recursive(source: &std::path::Path, destination: &std::path::Path) {
+    fs::create_dir_all(destination).expect("destination directory should be created");
+    for entry in fs::read_dir(source).expect("source directory should be readable") {
+        let entry = entry.expect("source entry should be readable");
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry
+            .file_type()
+            .expect("source entry type should be readable")
+            .is_dir()
+        {
+            copy_dir_recursive(&source_path, &destination_path);
+        } else {
+            fs::copy(&source_path, &destination_path).expect("fixture file should copy");
+        }
+    }
 }
 
 fn write_memory_config(repo: &std::path::Path) {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -323,7 +323,7 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
 
     let mut statement = connection
         .prepare(
-            "SELECT issue_key, title, state, milestone, labels_json, capsule_path, visibility, source_hash, warning_count, docs_sync_status, body FROM issues ORDER BY issue_key",
+            "SELECT issue_key, title, state, milestone, labels_json, capsule_path, visibility, source_hash, warning_count, docs_sync_status, completion_time, captured_at, body FROM issues ORDER BY issue_key",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -347,8 +347,10 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
                 source_hash: row.get(7)?,
                 warning_count: row.get::<_, i64>(8)? as usize,
                 docs_sync_status: row.get(9)?,
+                completion_time: row.get(10)?,
+                captured_at: row.get(11)?,
                 changed_files: Vec::new(),
-                body: row.get(10)?,
+                body: row.get(12)?,
             })
         })
         .map_err(|source| MemoryError::DuckDb {
@@ -444,7 +446,22 @@ fn write_markdown_indexes(config: &MemoryConfig) -> Result<Vec<PathBuf>, MemoryE
 
     let mut log = String::new();
     log.push_str("# OpenSymphony Memory Log\n\n");
-    for issue in issues.iter().rev() {
+    let mut log_entries = issues.iter().collect::<Vec<_>>();
+    log_entries.sort_by(|left, right| {
+        issue_log_date(right)
+            .cmp(&issue_log_date(left))
+            .then_with(|| right.issue_key.cmp(&left.issue_key))
+    });
+    let mut current_date = String::new();
+    for issue in log_entries {
+        let date = issue_log_date(issue);
+        if date != current_date {
+            if !current_date.is_empty() {
+                log.push('\n');
+            }
+            log.push_str(&format!("## {date}\n\n"));
+            current_date = date;
+        }
         log.push_str(&format!(
             "- {}: {} [{}]\n",
             issue.issue_key, issue.title, issue.docs_sync_status
@@ -453,6 +470,21 @@ fn write_markdown_indexes(config: &MemoryConfig) -> Result<Vec<PathBuf>, MemoryE
     write_file(&log_path, &log)?;
 
     Ok(vec![index_path, log_path])
+}
+
+fn issue_log_date(issue: &IndexedIssue) -> String {
+    issue
+        .completion_time
+        .as_deref()
+        .and_then(iso_date_prefix)
+        .or_else(|| iso_date_prefix(&issue.captured_at))
+        .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string())
+}
+
+fn iso_date_prefix(value: &str) -> Option<String> {
+    let candidate = value.get(..10)?;
+    NaiveDate::parse_from_str(candidate, "%Y-%m-%d").ok()?;
+    Some(candidate.to_string())
 }
 
 pub fn refresh_memory_index(config: &MemoryConfig) -> Result<MemoryReindexReport, MemoryError> {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -1,3 +1,5 @@
+const UNDATED_LOG_DATE: &str = "1970-01-01";
+
 fn index_capture_plan(config: &MemoryConfig, plan: &CapturePlan) -> Result<(), MemoryError> {
     let mut connection = open_index(config)?;
     migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
@@ -478,7 +480,7 @@ fn issue_log_date(issue: &IndexedIssue) -> String {
         .as_deref()
         .and_then(iso_date_prefix)
         .or_else(|| iso_date_prefix(&issue.captured_at))
-        .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| UNDATED_LOG_DATE.to_string())
 }
 
 fn iso_date_prefix(value: &str) -> Option<String> {
@@ -851,4 +853,32 @@ fn all_known_areas(config: &MemoryConfig, issues: &[IndexedIssue]) -> Vec<AreaCo
         .into_iter()
         .map(|slug| config.area_or_default(&slug))
         .collect()
+}
+
+#[cfg(test)]
+mod index_tests {
+    use super::*;
+
+    #[test]
+    fn issue_log_date_uses_stable_sentinel_for_malformed_timestamps() {
+        let issue = IndexedIssue {
+            issue_key: "COE-999".to_string(),
+            title: "Malformed timestamps".to_string(),
+            state: None,
+            milestone: None,
+            labels: Vec::new(),
+            areas: Vec::new(),
+            capsule_path: PathBuf::from(".opensymphony/memory/issues/COE-999.md"),
+            visibility: MemoryVisibility::Private,
+            source_hash: String::new(),
+            warning_count: 0,
+            docs_sync_status: "pending".to_string(),
+            completion_time: Some("not-a-date".to_string()),
+            captured_at: "also-not-a-date".to_string(),
+            changed_files: Vec::new(),
+            body: String::new(),
+        };
+
+        assert_eq!(issue_log_date(&issue), UNDATED_LOG_DATE);
+    }
 }

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -678,6 +678,7 @@ pub struct LintFinding {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LintSeverity {
+    Info,
     Warn,
     Error,
 }
@@ -732,6 +733,8 @@ struct IndexedIssue {
     source_hash: String,
     warning_count: usize,
     docs_sync_status: String,
+    completion_time: Option<String>,
+    captured_at: String,
     changed_files: Vec<PathBuf>,
     body: String,
 }
@@ -1168,6 +1171,63 @@ type: topic-doc
                 "https://example.com/okf",
             ]
         );
+    }
+
+    #[test]
+    fn okf_lint_fixture_reports_errors_warnings_and_info() {
+        let report = lint_okf_bundle(&okf_fixture("okf-migration"), false).expect("lint");
+        let has = |severity, text: &str| {
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.severity == severity && finding.message.contains(text))
+        };
+
+        assert!(has(LintSeverity::Error, "lacks OKF YAML frontmatter"));
+        assert!(has(
+            LintSeverity::Error,
+            "frontmatter is not parseable YAML"
+        ));
+        assert!(has(
+            LintSeverity::Error,
+            "frontmatter lacks non-empty `type`"
+        ));
+        assert!(has(
+            LintSeverity::Error,
+            "reserved log.md must use ISO date headings"
+        ));
+        assert!(has(LintSeverity::Error, "private export leak"));
+        assert!(has(LintSeverity::Warn, "missing recommended field(s)"));
+        assert!(has(LintSeverity::Warn, "broken Markdown link"));
+        assert!(has(LintSeverity::Warn, "wiki-only link"));
+        assert!(has(LintSeverity::Warn, "missing generated index.md"));
+        assert!(has(LintSeverity::Warn, "citation section missing"));
+        assert!(has(LintSeverity::Warn, "unknown type"));
+        assert!(has(LintSeverity::Info, "title can be synthesized"));
+        assert!(has(LintSeverity::Info, "description can be synthesized"));
+        assert!(has(LintSeverity::Info, "legacy field(s) retained"));
+        assert!(has(
+            LintSeverity::Info,
+            "bundle contains OpenSymphony extension fields"
+        ));
+
+        let public_report =
+            lint_okf_bundle(&okf_fixture("okf-migration"), true).expect("public lint");
+        assert!(public_report.findings.iter().any(|finding| {
+            finding.severity == LintSeverity::Error
+                && finding
+                    .message
+                    .contains("public export includes a private concept")
+        }));
+
+        let fixture = okf_fixture("okf-migration");
+        let capsule_path = Path::new("issues/COE-123.md");
+        let capsule =
+            fs::read_to_string(fixture.join(capsule_path)).expect("fixture capsule should read");
+        let concept =
+            parse_okf_concept(&fixture, capsule_path, &capsule).expect("legacy fixture parses");
+        let rendered = render_okf_concept(&concept).expect("legacy fixture renders");
+        assert!(rendered.contains("legacy_custom: keep-me"));
     }
 
     #[test]
@@ -1748,6 +1808,12 @@ areas:
         )
         .expect("config");
         MemoryConfig::load(repo_root, Some(&config_path)).expect("memory config")
+    }
+
+    fn okf_fixture(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("crates/opensymphony-memory/tests/fixtures")
+            .join(name)
     }
 
     fn sample_source() -> SourceFile {

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -50,6 +50,10 @@ pub enum MemoryError {
         #[source]
         source: serde_yaml::Error,
     },
+    #[error("{path} lacks OKF YAML frontmatter")]
+    OkfMissingFrontmatter { path: PathBuf },
+    #[error("{path} has unterminated OKF YAML frontmatter")]
+    OkfUnterminatedFrontmatter { path: PathBuf },
     #[error("failed to encode JSON: {0}")]
     Json(#[from] serde_json::Error),
     #[error("failed to update DuckDB index {path}: {source}")]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -74,6 +74,8 @@ pub enum MemoryError {
     InvalidInput(String),
     #[error("{path} is outside the repository root {repo_root}")]
     PathOutsideRepo { path: PathBuf, repo_root: PathBuf },
+    #[error("{path} is outside the OKF bundle root {bundle_root}")]
+    PathOutsideBundle { path: PathBuf, bundle_root: PathBuf },
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -354,9 +354,9 @@ fn collect_okf_markdown_files(
 fn bundle_relative_path(bundle_root: &Path, path: &Path) -> Result<PathBuf, MemoryError> {
     path.strip_prefix(bundle_root)
         .map(Path::to_path_buf)
-        .map_err(|_| MemoryError::PathOutsideRepo {
+        .map_err(|_| MemoryError::PathOutsideBundle {
             path: path.to_path_buf(),
-            repo_root: bundle_root.to_path_buf(),
+            bundle_root: bundle_root.to_path_buf(),
         })
 }
 
@@ -532,7 +532,7 @@ fn lint_okf_concept(
             next_command: None,
         });
     }
-    if contains_private_memory_link(contents) {
+    if contains_private_memory_link_in_markdown(contents) {
         findings.push(LintFinding {
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
@@ -803,26 +803,48 @@ fn normalize_okf_relative_path(path: &Path) -> Option<PathBuf> {
 
 fn normalized_markdown_link_id(target: &str) -> Option<String> {
     let target = local_markdown_target(target)?;
-    Some(
-        target
-            .trim_start_matches('/')
-            .trim_end_matches(".md")
-            .trim_end_matches(".MD")
-            .to_ascii_lowercase(),
-    )
+    Some(normalize_okf_link_id(target))
 }
 
 fn normalized_wiki_link_id(target: &str) -> String {
+    normalize_okf_link_id(target.split('|').next().unwrap_or(target))
+}
+
+fn normalize_okf_link_id(target: &str) -> String {
     target
-        .split('|')
-        .next()
-        .unwrap_or(target)
         .trim()
         .trim_start_matches('/')
         .trim_end_matches(".md")
         .trim_end_matches(".MD")
         .replace(' ', "-")
         .to_ascii_lowercase()
+}
+
+fn contains_private_memory_link_in_markdown(contents: &str) -> bool {
+    let mut visible = String::with_capacity(contents.len());
+    let mut index = 0;
+    while index < contents.len() {
+        let Some((current, next)) = char_at(contents, index) else {
+            break;
+        };
+        if contents[index..].starts_with("<!--") {
+            index = skip_html_comment(contents, index);
+            continue;
+        }
+        if is_fenced_code_start(contents, index) {
+            index = skip_fenced_code_block(contents, index);
+            continue;
+        }
+        match current {
+            '`' => index = skip_code_span(contents, index),
+            '\\' => index = skip_escaped_char(contents, next),
+            _ => {
+                visible.push(current);
+                index = next;
+            }
+        }
+    }
+    contains_private_memory_link(&visible)
 }
 
 fn extract_wiki_links(body: &str) -> Vec<String> {
@@ -1425,7 +1447,26 @@ fn normalize_link_target(raw: &str) -> Option<String> {
     {
         return Some(target.to_string()).filter(|target| !target.is_empty());
     }
+    if let Some(target) = markdown_target_before_optional_title(raw) {
+        return Some(target);
+    }
     raw.split_whitespace().next().map(str::to_string)
+}
+
+fn markdown_target_before_optional_title(raw: &str) -> Option<String> {
+    let mut boundary = raw.len();
+    for (index, character) in raw.char_indices() {
+        if character.is_whitespace() && raw[..index].to_ascii_lowercase().contains(".md") {
+            boundary = index;
+            break;
+        }
+    }
+    let candidate = raw[..boundary].trim();
+    candidate
+        .to_ascii_lowercase()
+        .contains(".md")
+        .then(|| candidate.to_string())
+        .filter(|candidate| !candidate.is_empty())
 }
 
 fn parse_autolink(value: &str, index: usize) -> Option<(String, usize)> {
@@ -1482,5 +1523,48 @@ Visible [[real-target|Real Target]].
         );
 
         assert_eq!(links, vec!["real-target|Real Target"]);
+    }
+
+    #[test]
+    fn wiki_link_matches_markdown_target_with_spaces() {
+        let frontmatter = OkfFrontmatter::new("issue-capsule").expect("frontmatter should build");
+        let concept = OkfConcept::new(
+            "issues/COE-123.md",
+            frontmatter,
+            "[Some Page](Some Page.md)\n[[Some Page]]\n",
+        )
+        .expect("concept should build");
+        let mut findings = Vec::new();
+
+        lint_okf_links(
+            Path::new("."),
+            &concept,
+            Path::new("issues/COE-123.md"),
+            &mut findings,
+        );
+
+        assert!(
+            !findings
+                .iter()
+                .any(|finding| finding.message.contains("wiki-only link")),
+            "matching Markdown link should suppress wiki-only warning: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn private_memory_link_scan_ignores_code_and_comments() {
+        let visible = "See .opensymphony/memory/issues/COE-123.md";
+        let hidden = r#"
+` .opensymphony/memory/issues/COE-123.md `
+
+```text
+.opensymphony/memory/issues/COE-123.md
+```
+
+<!-- .opensymphony/memory/issues/COE-123.md -->
+"#;
+
+        assert!(contains_private_memory_link_in_markdown(visible));
+        assert!(!contains_private_memory_link_in_markdown(hidden));
     }
 }

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -1477,7 +1477,7 @@ Visible [[real-target|Real Target]].
 ```
 
 <!-- [[commented]] -->
-\[[escaped]]
+\[\[escaped\]\]
 "#,
         );
 

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -221,6 +221,66 @@ pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
     Ok(format!("---\n{frontmatter}---\n\n{}", concept.body))
 }
 
+pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintReport, MemoryError> {
+    if !bundle_root.is_dir() {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF bundle root `{}` is not a directory",
+            bundle_root.display()
+        )));
+    }
+
+    let mut files = Vec::new();
+    collect_okf_markdown_files(bundle_root, bundle_root, &mut files)?;
+
+    let mut findings = Vec::new();
+    let mut dirs_with_concepts = BTreeSet::new();
+    let mut dirs_with_index = BTreeSet::new();
+
+    for path in files {
+        let relative = bundle_relative_path(bundle_root, &path)?;
+        let bundle_path = match OkfBundlePath::new(relative.clone()) {
+            Ok(path) => path,
+            Err(error) => {
+                findings.push(LintFinding {
+                    severity: LintSeverity::Error,
+                    path: Some(path),
+                    message: error.to_string(),
+                    next_command: None,
+                });
+                continue;
+            }
+        };
+        let directory = relative.parent().unwrap_or(Path::new("")).to_path_buf();
+        if bundle_path.reserved_file() == Some(OkfReservedFile::Index) {
+            dirs_with_index.insert(directory);
+        } else if bundle_path.reserved_file().is_none() {
+            dirs_with_concepts.insert(directory);
+        }
+
+        let contents = read_to_string(&path)?;
+        match bundle_path.reserved_file() {
+            Some(OkfReservedFile::Index) => {
+                lint_okf_index(bundle_root, &path, &relative, &contents, &mut findings)
+            }
+            Some(OkfReservedFile::Log) => lint_okf_log(&path, &contents, &mut findings),
+            None => lint_okf_concept(bundle_root, &path, &contents, public_export, &mut findings),
+        }
+    }
+
+    for directory in dirs_with_concepts {
+        if !dirs_with_index.contains(&directory) {
+            findings.push(LintFinding {
+                severity: LintSeverity::Warn,
+                path: Some(bundle_root.join(&directory)),
+                message: "missing generated index.md".to_string(),
+                next_command: Some("opensymphony memory reindex".to_string()),
+            });
+        }
+    }
+
+    Ok(LintReport { findings })
+}
+
 fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String), MemoryError> {
     let normalized = contents.replace("\r\n", "\n").replace('\r', "\n");
     let first_end = normalized
@@ -257,6 +317,558 @@ fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String)
         "{} has unterminated OKF YAML frontmatter",
         path.display()
     )))
+}
+
+fn collect_okf_markdown_files(
+    bundle_root: &Path,
+    directory: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), MemoryError> {
+    for entry in fs::read_dir(directory).map_err(|source| MemoryError::ReadFile {
+        path: directory.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| MemoryError::ReadFile {
+            path: directory.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|source| MemoryError::ReadFile {
+            path: path.clone(),
+            source,
+        })?;
+        if file_type.is_dir() {
+            collect_okf_markdown_files(bundle_root, &path, files)?;
+        } else if file_type.is_file()
+            && path
+                .extension()
+                .and_then(OsStr::to_str)
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+        {
+            bundle_relative_path(bundle_root, &path)?;
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(())
+}
+
+fn bundle_relative_path(bundle_root: &Path, path: &Path) -> Result<PathBuf, MemoryError> {
+    path.strip_prefix(bundle_root)
+        .map(Path::to_path_buf)
+        .map_err(|_| MemoryError::PathOutsideRepo {
+            path: path.to_path_buf(),
+            repo_root: bundle_root.to_path_buf(),
+        })
+}
+
+fn lint_okf_index(
+    bundle_root: &Path,
+    path: &Path,
+    relative: &Path,
+    contents: &str,
+    findings: &mut Vec<LintFinding>,
+) {
+    if !has_okf_frontmatter(contents) {
+        return;
+    }
+    if !relative
+        .parent()
+        .is_none_or(|parent| parent.as_os_str().is_empty())
+    {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "reserved index.md must not contain frontmatter outside the bundle root"
+                .to_string(),
+            next_command: None,
+        });
+        return;
+    }
+    let Ok((frontmatter, _)) = split_okf_frontmatter(path, contents) else {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "reserved index.md has invalid frontmatter".to_string(),
+            next_command: None,
+        });
+        return;
+    };
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&frontmatter) else {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "reserved index.md frontmatter is not parseable YAML".to_string(),
+            next_command: None,
+        });
+        return;
+    };
+    let Some(mapping) = value.as_mapping() else {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "reserved index.md frontmatter must be a YAML mapping".to_string(),
+            next_command: None,
+        });
+        return;
+    };
+    if let Some(version) = mapping_string(mapping, "okf_version")
+        && version != OKF_VERSION
+    {
+        findings.push(LintFinding {
+            severity: LintSeverity::Warn,
+            path: Some(bundle_root.join(relative)),
+            message: format!("unknown OKF version `{version}`"),
+            next_command: None,
+        });
+    }
+}
+
+fn lint_okf_log(path: &Path, contents: &str, findings: &mut Vec<LintFinding>) {
+    if has_okf_frontmatter(contents) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "reserved log.md must not contain frontmatter".to_string(),
+            next_command: None,
+        });
+    }
+
+    let mut dates = Vec::new();
+    let mut invalid_heading = false;
+    for line in contents.lines() {
+        let Some(heading) = line.strip_prefix("## ") else {
+            continue;
+        };
+        let date = heading.split_whitespace().next().unwrap_or_default();
+        if NaiveDate::parse_from_str(date, "%Y-%m-%d").is_ok() {
+            dates.push(date.to_string());
+        } else {
+            invalid_heading = true;
+        }
+    }
+
+    if dates.is_empty() || invalid_heading || !dates.windows(2).all(|pair| pair[0] >= pair[1]) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "reserved log.md must use ISO date headings newest first".to_string(),
+            next_command: Some("opensymphony memory reindex".to_string()),
+        });
+    }
+}
+
+fn lint_okf_concept(
+    bundle_root: &Path,
+    path: &Path,
+    contents: &str,
+    public_export: bool,
+    findings: &mut Vec<LintFinding>,
+) {
+    let (frontmatter, body) = match split_okf_frontmatter(path, contents) {
+        Ok(parts) => parts,
+        Err(error) => {
+            let message = okf_frontmatter_lint_message(&error);
+            findings.push(LintFinding {
+                severity: LintSeverity::Error,
+                path: Some(path.to_path_buf()),
+                message,
+                next_command: None,
+            });
+            return;
+        }
+    };
+    let value = match serde_yaml::from_str::<serde_yaml::Value>(&frontmatter) {
+        Ok(value) => value,
+        Err(_) => {
+            findings.push(LintFinding {
+                severity: LintSeverity::Error,
+                path: Some(path.to_path_buf()),
+                message: "frontmatter is not parseable YAML".to_string(),
+                next_command: None,
+            });
+            return;
+        }
+    };
+    let Some(mapping) = value.as_mapping() else {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "frontmatter must be a YAML mapping".to_string(),
+            next_command: None,
+        });
+        return;
+    };
+    if mapping_string(mapping, "type")
+        .as_deref()
+        .is_none_or(str::is_empty)
+    {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "frontmatter lacks non-empty `type`".to_string(),
+            next_command: None,
+        });
+        return;
+    }
+
+    let concept = match parse_okf_concept(bundle_root, path, contents) {
+        Ok(concept) => concept,
+        Err(error) => {
+            findings.push(LintFinding {
+                severity: LintSeverity::Error,
+                path: Some(path.to_path_buf()),
+                message: format!("frontmatter is not parseable OKF YAML: {error}"),
+                next_command: None,
+            });
+            return;
+        }
+    };
+
+    lint_okf_recommended_fields(&concept, &body, path, findings);
+    if !known_okf_type(&concept.frontmatter.concept_type) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Warn,
+            path: Some(path.to_path_buf()),
+            message: format!("unknown type `{}`", concept.frontmatter.concept_type),
+            next_command: None,
+        });
+    }
+    if contains_private_memory_link(contents) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "private export leak: document links to a private memory path".to_string(),
+            next_command: None,
+        });
+    }
+    if public_export && concept_visibility(&concept) == Some(MemoryVisibility::Private) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: "public export includes a private concept".to_string(),
+            next_command: None,
+        });
+    }
+    lint_okf_links(bundle_root, &concept, path, findings);
+    lint_okf_citations(&concept, path, findings);
+    lint_okf_info(&concept, mapping, path, findings);
+}
+
+fn lint_okf_recommended_fields(
+    concept: &OkfConcept,
+    body: &str,
+    path: &Path,
+    findings: &mut Vec<LintFinding>,
+) {
+    let mut missing = Vec::new();
+    if concept.frontmatter.title.is_none() {
+        missing.push("title");
+        if first_heading(body).is_some() {
+            findings.push(LintFinding {
+                severity: LintSeverity::Info,
+                path: Some(path.to_path_buf()),
+                message: "title can be synthesized from the first heading".to_string(),
+                next_command: None,
+            });
+        }
+    }
+    if concept.frontmatter.description.is_none() {
+        missing.push("description");
+        if first_paragraph(body).is_some() {
+            findings.push(LintFinding {
+                severity: LintSeverity::Info,
+                path: Some(path.to_path_buf()),
+                message: "description can be synthesized from the first paragraph".to_string(),
+                next_command: None,
+            });
+        }
+    }
+    if concept.frontmatter.resource.is_none() {
+        missing.push("resource");
+    }
+    if concept.frontmatter.tags.is_empty() {
+        missing.push("tags");
+    }
+    if concept.frontmatter.timestamp.is_none() {
+        missing.push("timestamp");
+    }
+    if !missing.is_empty() {
+        findings.push(LintFinding {
+            severity: LintSeverity::Warn,
+            path: Some(path.to_path_buf()),
+            message: format!("missing recommended field(s): {}", missing.join(", ")),
+            next_command: None,
+        });
+    }
+}
+
+fn lint_okf_links(
+    bundle_root: &Path,
+    concept: &OkfConcept,
+    path: &Path,
+    findings: &mut Vec<LintFinding>,
+) {
+    for link in &concept.links {
+        let Some(resolved) = resolve_okf_markdown_link(bundle_root, concept.path.as_path(), &link.target)
+        else {
+            continue;
+        };
+        if !resolved.exists() {
+            findings.push(LintFinding {
+                severity: LintSeverity::Warn,
+                path: Some(path.to_path_buf()),
+                message: format!("broken Markdown link `{}`", link.target),
+                next_command: None,
+            });
+        }
+    }
+
+    let markdown_ids = concept
+        .links
+        .iter()
+        .filter_map(|link| normalized_markdown_link_id(&link.target))
+        .collect::<BTreeSet<_>>();
+    for wiki_link in extract_wiki_links(&concept.body) {
+        if !markdown_ids.contains(&normalized_wiki_link_id(&wiki_link)) {
+            findings.push(LintFinding {
+                severity: LintSeverity::Warn,
+                path: Some(path.to_path_buf()),
+                message: format!("wiki-only link `[[{wiki_link}]]` has no Markdown equivalent"),
+                next_command: None,
+            });
+        }
+    }
+}
+
+fn lint_okf_citations(concept: &OkfConcept, path: &Path, findings: &mut Vec<LintFinding>) {
+    let source_backed = concept
+        .frontmatter
+        .opensymphony
+        .as_ref()
+        .is_some_and(|metadata| !metadata.source_refs.is_empty())
+        || concept.frontmatter.extra.contains_key("source_refs")
+        || concept.frontmatter.extra.contains_key("prs")
+        || concept.frontmatter.extra.contains_key("linear_url");
+    if source_backed && !has_citations_section(&concept.body) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Warn,
+            path: Some(path.to_path_buf()),
+            message: "citation section missing for source-backed claims".to_string(),
+            next_command: None,
+        });
+    }
+}
+
+fn lint_okf_info(
+    concept: &OkfConcept,
+    mapping: &serde_yaml::Mapping,
+    path: &Path,
+    findings: &mut Vec<LintFinding>,
+) {
+    let retained_legacy = [
+        "issue",
+        "milestone",
+        "milestone_id",
+        "project",
+        "project_id",
+        "linear_url",
+        "areas",
+        "area",
+        "repository",
+        "repo",
+        "prs",
+        "source_refs",
+        "docs_sync",
+    ]
+    .into_iter()
+    .filter(|key| concept.frontmatter.extra.contains_key(*key))
+    .collect::<Vec<_>>();
+    if !retained_legacy.is_empty() {
+        findings.push(LintFinding {
+            severity: LintSeverity::Info,
+            path: Some(path.to_path_buf()),
+            message: format!("legacy field(s) retained: {}", retained_legacy.join(", ")),
+            next_command: None,
+        });
+    }
+    if mapping.contains_key(serde_yaml::Value::String("opensymphony".to_string())) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Info,
+            path: Some(path.to_path_buf()),
+            message: "bundle contains OpenSymphony extension fields".to_string(),
+            next_command: None,
+        });
+    }
+}
+
+fn has_okf_frontmatter(contents: &str) -> bool {
+    contents
+        .lines()
+        .next()
+        .is_some_and(|line| line.trim() == "---")
+}
+
+fn okf_frontmatter_lint_message(error: &MemoryError) -> String {
+    let message = error.to_string();
+    if message.contains("lacks OKF YAML frontmatter") {
+        "lacks OKF YAML frontmatter".to_string()
+    } else if message.contains("has unterminated OKF YAML frontmatter") {
+        "has unterminated OKF YAML frontmatter".to_string()
+    } else {
+        message
+    }
+}
+
+fn mapping_string(mapping: &serde_yaml::Mapping, key: &str) -> Option<String> {
+    mapping
+        .get(serde_yaml::Value::String(key.to_string()))
+        .and_then(value_as_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn known_okf_type(concept_type: &str) -> bool {
+    matches!(
+        concept_type,
+        "issue-capsule"
+            | "milestone-memory-node"
+            | "project-memory-node"
+            | "area-memory-node"
+            | "topic-doc"
+            | "run-summary"
+            | "code-context"
+            | "repository-memory-node"
+            | "reference"
+    )
+}
+
+fn concept_visibility(concept: &OkfConcept) -> Option<MemoryVisibility> {
+    concept
+        .frontmatter
+        .opensymphony
+        .as_ref()
+        .and_then(|metadata| metadata.visibility)
+        .or_else(|| legacy_visibility(&concept.frontmatter))
+}
+
+fn resolve_okf_markdown_link(
+    bundle_root: &Path,
+    concept_path: &Path,
+    target: &str,
+) -> Option<PathBuf> {
+    let target = local_markdown_target(target)?;
+    let relative = if let Some(stripped) = target.strip_prefix('/') {
+        PathBuf::from(stripped)
+    } else {
+        concept_path
+            .parent()
+            .unwrap_or(Path::new(""))
+            .join(target)
+    };
+    let normalized = normalize_okf_relative_path(&relative)?;
+    Some(bundle_root.join(normalized))
+}
+
+fn local_markdown_target(target: &str) -> Option<&str> {
+    let target = target.trim();
+    if target.is_empty()
+        || target.starts_with('#')
+        || target.starts_with("http://")
+        || target.starts_with("https://")
+        || target.starts_with("mailto:")
+    {
+        return None;
+    }
+    let end = target.find(['#', '?']).unwrap_or(target.len());
+    let target = &target[..end];
+    target
+        .to_ascii_lowercase()
+        .ends_with(".md")
+        .then_some(target)
+}
+
+fn normalize_okf_relative_path(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(part) => normalized.push(part),
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+    }
+    Some(normalized)
+}
+
+fn normalized_markdown_link_id(target: &str) -> Option<String> {
+    let target = local_markdown_target(target)?;
+    Some(
+        target
+            .trim_start_matches('/')
+            .trim_end_matches(".md")
+            .trim_end_matches(".MD")
+            .to_ascii_lowercase(),
+    )
+}
+
+fn normalized_wiki_link_id(target: &str) -> String {
+    target
+        .split('|')
+        .next()
+        .unwrap_or(target)
+        .trim()
+        .trim_start_matches('/')
+        .trim_end_matches(".md")
+        .trim_end_matches(".MD")
+        .replace(' ', "-")
+        .to_ascii_lowercase()
+}
+
+fn extract_wiki_links(body: &str) -> Vec<String> {
+    let mut links = Vec::new();
+    let mut offset = 0;
+    while let Some(start) = body[offset..].find("[[") {
+        let content_start = offset + start + 2;
+        let Some(end) = body[content_start..].find("]]") else {
+            break;
+        };
+        let content_end = content_start + end;
+        let link = body[content_start..content_end].trim();
+        if !link.is_empty() {
+            links.push(link.to_string());
+        }
+        offset = content_end + 2;
+    }
+    links
+}
+
+fn first_heading(body: &str) -> Option<&str> {
+    body.lines()
+        .find_map(|line| line.trim_start().strip_prefix("# "))
+        .map(str::trim)
+        .filter(|heading| !heading.is_empty())
+}
+
+fn first_paragraph(body: &str) -> Option<&str> {
+    body.lines()
+        .map(str::trim)
+        .find(|line| {
+            !line.is_empty()
+                && !line.starts_with('#')
+                && !line.starts_with('-')
+                && !line.starts_with("```")
+        })
+}
+
+fn has_citations_section(body: &str) -> bool {
+    body.lines().any(|line| {
+        let line = line.trim();
+        line == "# Citations" || line == "## Citations" || line == "### Citations"
+    })
 }
 
 fn require_okf_type(concept_type: &str) -> Result<(), MemoryError> {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -1456,15 +1456,14 @@ fn normalize_link_target(raw: &str) -> Option<String> {
 fn markdown_target_before_optional_title(raw: &str) -> Option<String> {
     let mut boundary = raw.len();
     for (index, character) in raw.char_indices() {
-        if character.is_whitespace() && raw[..index].to_ascii_lowercase().contains(".md") {
+        if character.is_whitespace() && local_markdown_target(&raw[..index]).is_some() {
             boundary = index;
             break;
         }
     }
     let candidate = raw[..boundary].trim();
-    candidate
-        .to_ascii_lowercase()
-        .contains(".md")
+    local_markdown_target(candidate)
+        .is_some()
         .then(|| candidate.to_string())
         .filter(|candidate| !candidate.is_empty())
 }
@@ -1548,6 +1547,18 @@ Visible [[real-target|Real Target]].
                 .iter()
                 .any(|finding| finding.message.contains("wiki-only link")),
             "matching Markdown link should suppress wiki-only warning: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn markdown_target_with_optional_title_requires_md_suffix() {
+        assert_eq!(
+            markdown_target_before_optional_title("Some Page.md \"Title\"").as_deref(),
+            Some("Some Page.md")
+        );
+        assert_eq!(
+            markdown_target_before_optional_title("assets/image.md.png \"Title\""),
+            None
         );
     }
 

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -288,10 +288,9 @@ fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String)
         .map(|index| index + 1)
         .unwrap_or(normalized.len());
     if normalized[..first_end].trim() != "---" {
-        return Err(MemoryError::InvalidInput(format!(
-            "{} lacks OKF YAML frontmatter",
-            path.display()
-        )));
+        return Err(MemoryError::OkfMissingFrontmatter {
+            path: path.to_path_buf(),
+        });
     };
 
     let mut offset = first_end;
@@ -313,10 +312,9 @@ fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String)
         offset = next_end;
     }
 
-    Err(MemoryError::InvalidInput(format!(
-        "{} has unterminated OKF YAML frontmatter",
-        path.display()
-    )))
+    Err(MemoryError::OkfUnterminatedFrontmatter {
+        path: path.to_path_buf(),
+    })
 }
 
 fn collect_okf_markdown_files(
@@ -710,13 +708,12 @@ fn has_okf_frontmatter(contents: &str) -> bool {
 }
 
 fn okf_frontmatter_lint_message(error: &MemoryError) -> String {
-    let message = error.to_string();
-    if message.contains("lacks OKF YAML frontmatter") {
-        "lacks OKF YAML frontmatter".to_string()
-    } else if message.contains("has unterminated OKF YAML frontmatter") {
-        "has unterminated OKF YAML frontmatter".to_string()
-    } else {
-        message
+    match error {
+        MemoryError::OkfMissingFrontmatter { .. } => "lacks OKF YAML frontmatter".to_string(),
+        MemoryError::OkfUnterminatedFrontmatter { .. } => {
+            "has unterminated OKF YAML frontmatter".to_string()
+        }
+        _ => error.to_string(),
     }
 }
 
@@ -830,18 +827,37 @@ fn normalized_wiki_link_id(target: &str) -> String {
 
 fn extract_wiki_links(body: &str) -> Vec<String> {
     let mut links = Vec::new();
-    let mut offset = 0;
-    while let Some(start) = body[offset..].find("[[") {
-        let content_start = offset + start + 2;
-        let Some(end) = body[content_start..].find("]]") else {
+    let mut index = 0;
+    while index < body.len() {
+        let Some((current, next)) = char_at(body, index) else {
             break;
         };
-        let content_end = content_start + end;
-        let link = body[content_start..content_end].trim();
-        if !link.is_empty() {
-            links.push(link.to_string());
+        if body[index..].starts_with("<!--") {
+            index = skip_html_comment(body, index);
+            continue;
         }
-        offset = content_end + 2;
+        if is_fenced_code_start(body, index) {
+            index = skip_fenced_code_block(body, index);
+            continue;
+        }
+        match current {
+            '`' => index = skip_code_span(body, index),
+            '\\' => index = skip_escaped_char(body, next),
+            '[' if body[index..].starts_with("[[") => {
+                let content_start = index + 2;
+                let Some(end) = body[content_start..].find("]]") else {
+                    index = next;
+                    continue;
+                };
+                let content_end = content_start + end;
+                let link = body[content_start..content_end].trim();
+                if !link.is_empty() {
+                    links.push(link.to_string());
+                }
+                index = content_end + 2;
+            }
+            _ => index = next,
+        }
     }
     links
 }
@@ -1442,4 +1458,29 @@ fn reference_link_targets(body: &str) -> BTreeMap<String, String> {
 
 fn normalize_reference_label(label: &str) -> String {
     label.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
+#[cfg(test)]
+mod okf_tests {
+    use super::*;
+
+    #[test]
+    fn wiki_link_extraction_ignores_code_and_comments() {
+        let links = extract_wiki_links(
+            r#"
+Visible [[real-target|Real Target]].
+
+`[[inline-code]]`
+
+```text
+[[fenced-code]]
+```
+
+<!-- [[commented]] -->
+\[[escaped]]
+"#,
+        );
+
+        assert_eq!(links, vec!["real-target|Real Target"]);
+    }
 }

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/index.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/index.md
@@ -1,0 +1,9 @@
+---
+okf_version: "0.1"
+---
+
+# OKF Migration Fixture
+
+- [Legacy capsule](issues/COE-123.md)
+- [Link warnings](issues/link-warnings.md)
+- [Missing recommended fields](issues/missing-recommended.md)

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/COE-123.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/COE-123.md
@@ -1,0 +1,26 @@
+---
+type: issue-capsule
+title: "COE-123: Legacy capsule"
+description: Legacy issue capsule with OKF metadata and retained custom data.
+resource: https://linear.app/example/issue/COE-123
+tags: [memory, okf]
+timestamp: 2026-06-13T17:00:00Z
+issue: COE-123
+legacy_custom: keep-me
+opensymphony:
+  visibility: private
+  kind: issue_capsule
+  schema_version: 1
+  source_refs:
+    - kind: linear_issue
+      id: COE-123
+      url: https://linear.app/example/issue/COE-123
+---
+
+# COE-123: Legacy capsule
+
+See [link warnings](link-warnings.md).
+
+## Citations
+
+1. [COE-123](https://linear.app/example/issue/COE-123)

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/invalid-yaml.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/invalid-yaml.md
@@ -1,0 +1,5 @@
+---
+type: [
+---
+
+# Invalid YAML

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/link-warnings.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/link-warnings.md
@@ -1,0 +1,16 @@
+---
+type: mystery-concept
+title: Link warnings
+description: Exercises wiki-only links, broken Markdown links, and missing citations.
+resource: https://linear.app/example/issue/COE-124
+tags: [memory, okf]
+timestamp: 2026-06-14T17:00:00Z
+source_refs:
+  linear_issue: linear:COE-124
+---
+
+# Link warnings
+
+This fixture keeps a wiki-only edge to [[issues/wiki-target]].
+
+It also keeps a broken Markdown edge to [missing](/issues/missing-target.md).

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/log.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/log.md
@@ -1,0 +1,3 @@
+# Flat Legacy Log
+
+- COE-123: this is intentionally not date-grouped.

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/missing-frontmatter.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/missing-frontmatter.md
@@ -1,0 +1,3 @@
+# Missing Frontmatter
+
+This file intentionally lacks OKF YAML frontmatter.

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/missing-recommended.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/missing-recommended.md
@@ -1,0 +1,7 @@
+---
+type: topic-doc
+---
+
+# Synthesized Topic
+
+This paragraph can become a synthesized description.

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/missing-type.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/missing-type.md
@@ -1,0 +1,5 @@
+---
+title: Missing Type
+---
+
+# Missing Type

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/private-leak.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/private-leak.md
@@ -9,4 +9,4 @@ timestamp: 2026-06-14T18:00:00Z
 
 # Private leak
 
-Do not publish `.opensymphony/memory/issues/COE-999.md`.
+Do not publish .opensymphony/memory/issues/COE-999.md.

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/private-leak.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/issues/private-leak.md
@@ -1,0 +1,12 @@
+---
+type: topic-doc
+title: Private leak
+description: Exercises private path leak detection.
+resource: https://example.com/private-leak
+tags: [memory, okf]
+timestamp: 2026-06-14T18:00:00Z
+---
+
+# Private leak
+
+Do not publish `.opensymphony/memory/issues/COE-999.md`.

--- a/crates/opensymphony-memory/tests/fixtures/okf-migration/log.md
+++ b/crates/opensymphony-memory/tests/fixtures/okf-migration/log.md
@@ -1,0 +1,9 @@
+# OpenSymphony Memory Log
+
+## 2026-06-14
+
+- COE-124: Link warnings [pending]
+
+## 2026-06-13
+
+- COE-123: Legacy capsule [pending]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -74,6 +74,23 @@ frontmatter is kept in the raw frontmatter map so future writers can round-trip
 documents they do not fully understand. Writers emit canonical YAML and do not
 preserve the original frontmatter field order or whitespace.
 
+`opensymphony memory lint --okf [bundle-root]` validates an OKF bundle from the
+CLI, and the memory MCP admin path accepts the equivalent `memory.lint` request
+with `okf` plus `bundleRoot` arguments. A user-supplied bundle root is
+canonicalized and must stay inside the repository root, matching the containment
+policy used by other memory admin file arguments. When no bundle root is
+provided, linting uses the configured memory root.
+
+OKF lint diagnostics are intentionally actionable. Errors cover missing or
+invalid concept frontmatter, missing `type`, malformed reserved files,
+containment failures, and public-export leaks of private memory. Warnings cover
+missing recommended fields, unknown types, broken Markdown links, wiki-only
+links without Markdown equivalents, missing generated indexes, missing
+citations for source-backed claims, and unknown OKF versions. Info diagnostics
+call out synthesized title/description data, retained legacy fields, and
+OpenSymphony extension metadata. Warning-level findings remain nonfatal;
+private-data leakage and containment breakage are reported as errors.
+
 Migration is intentionally incremental:
 
 - Phase 1 enriches and parses existing documents as OKF concepts while keeping
@@ -90,6 +107,11 @@ identifiers, PR URLs, and commit SHAs. Public docs must not link directly to
 private capsule paths. Public memory is supported only by explicit
 configuration, and generated indexes such as DuckDB should remain local unless a
 project deliberately publishes them.
+
+Generated memory `indexes/log.md` output groups entries under `## YYYY-MM-DD`
+headings with newest dates first. The date comes from indexed completion time
+when available, then capture time, and finally a stable ISO sentinel for
+malformed legacy rows so regeneration is deterministic.
 
 Areas bridge issue memory and topic docs. Area inference uses Linear narrative,
 labels, milestones, active Workpad content, PR narrative, review summaries, and

--- a/docs/okf-memory-spec.md
+++ b/docs/okf-memory-spec.md
@@ -312,6 +312,18 @@ opensymphony memory export-okf --visibility private --output memory-bundle.zip
 opensymphony memory import-okf path/to/bundle
 ```
 
+The implemented first slice supports:
+
+```bash
+opensymphony memory lint --okf [bundle-root]
+```
+
+The optional `bundle-root` is resolved with the same repository-containment
+check used by memory admin file arguments. Absolute paths are allowed only when
+their canonical path remains inside the repository root. Relative paths are
+resolved from the repository root. The memory MCP admin surface accepts the same
+operation through `memory.lint` with `okf: true` and optional `bundleRoot`.
+
 Existing commands keep their behavior:
 
 ```bash
@@ -340,8 +352,9 @@ Warnings:
 
 - Missing recommended fields.
 - Unknown type.
-- Broken Markdown link.
-- Wiki-only link with no Markdown equivalent.
+- Broken Markdown link outside code spans, code fences, and HTML comments.
+- Wiki-only link with no Markdown equivalent outside code spans, code fences,
+  and HTML comments.
 - Missing generated index.
 - Citation section missing for source-backed claims.
 - Unknown OKF version.
@@ -350,8 +363,13 @@ Info:
 
 - Synthesized title.
 - Synthesized description.
-- Legacy field retained.
-- Bundle contains implementation-specific extension fields.
+- Retained legacy fields.
+- OpenSymphony extension metadata.
+
+Generated `log.md` files must use ISO `## YYYY-MM-DD` headings in newest-first
+order. OpenSymphony derives the date from completion time, then capture time, and
+uses a stable ISO sentinel for malformed legacy timestamps so regeneration does
+not depend on wall-clock time.
 
 ## 11. Migration Plan
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -96,13 +96,24 @@ Current implementation:
 - `tests/issue_session_runner.rs` now covers continuation reuse, already-running conversation wait/retry behavior, launch reporting for reused running conversations before prior-turn drain completes, delayed `/run` conflicts that surface an active prior turn only after attach, missing-conversation recreation that stays on continuation guidance, **simplified conversation resumption that reuses conversations as-is without LLM config drift checks**, configured `persistence_dir_relative` handling, terminal-error normalization, and temp-repo smoke execution
 - `tests/supervisor.rs` now covers startup rejection when a foreign ready server is already bound to the supervised target port
 - `tests/update.rs` covers the new `opensymphony update` maintenance flow: skipping `cargo install opensymphony` when the running CLI already matches the newest published release, running the install when a newer release exists, refreshing template-managed skill files in place for an existing target repo, and skipping that skill refresh outside a repo that lacks `WORKFLOW.md` plus `config.yaml`
-- `tests/memory.rs` covers the first memory workflow: capture dry runs, capsule writes, DuckDB indexing, compact briefs, search, docs-sync dry-run diffs, public/private link handling, and Linear archive eligibility gating
+- `tests/memory.rs` covers the first memory workflow: capture dry runs, capsule writes, DuckDB indexing, compact briefs, search, docs-sync dry-run diffs, public/private link handling, OKF lint fixture diagnostics, OKF MCP admin payloads, date-grouped generated memory logs, and Linear archive eligibility gating
 - `opensymphony-gateway-schema/tests/gateway_schema.rs` and
   `opensymphony-gateway/tests/gateway.rs` cover Codex local readiness rendering
   with fake command outputs for installed, logged-out, unsupported, and
   permission-denied states. These tests assert that the gateway exposes only
   safe status metadata and `codex_cli_login` references, never raw OAuth access
   or refresh material.
+
+Focused OKF memory validation for implementation work:
+
+- `cargo test-system-duckdb okf_lint_fixture_reports_errors_warnings_and_info`
+  verifies OKF lint errors, warnings, info diagnostics, and metadata
+  preservation for the migration fixture corpus.
+- `cargo test-system-duckdb --test memory` runs the CLI-facing OKF fixture test,
+  MCP `memory.lint` argument coverage for `okf` and `bundleRoot`, generated
+  `log.md` date grouping, and the rest of the memory integration suite.
+- `opensymphony memory lint --okf <repo-contained-bundle>` is the manual CLI
+  smoke path for a generated or fixture OKF bundle.
 
 Codex ChatGPT subscription smoke testing remains opt-in on trusted local
 machines because the final exec probe can consume account quota. The supported


### PR DESCRIPTION
## Summary

Adds OKF-aware memory linting and fixture coverage for COE-456, with review-requested containment, docs, MCP coverage, link normalization, and Markdown-aware leak scanning included.

## Changes

- Add `opensymphony memory lint --okf [bundle]` and memory MCP admin support for OKF bundle linting.
- Report OKF errors, warnings, and info diagnostics for frontmatter, reserved files, links, citations, private leaks, legacy fields, and extension metadata.
- Generate memory `indexes/log.md` with ISO date headings in newest-first order and deterministic fallback handling for malformed legacy timestamps.
- Add an OKF migration fixture corpus and tests covering malformed, legacy, warning-only, and conformant documents.
- Contain local CLI OKF bundle paths inside the repository root and report OKF bundle containment failures explicitly.
- Normalize OKF Markdown and wiki link IDs consistently, including targets with spaces.
- Parse titled Markdown targets with spaces only when the candidate target actually ends in `.md`.
- Scan only visible Markdown content for private memory export leaks, ignoring code spans, fenced code, escaped text, and HTML comments.
- Stabilize the fake Codex executable cache-invalidation test by replacing the executable atomically after CI exposed a Linux `ETXTBSY` failure.
- Update OKF memory and testing docs for the implemented lint surface.

## Evidence

### Test output

```
cargo test-system-duckdb okf_lint_fixture_reports_errors_warnings_and_info
# ok: 1 passed

cargo test-system-duckdb wiki_link_extraction_ignores_code_and_comments
# ok: 1 passed

cargo test-system-duckdb wiki_link_matches_markdown_target_with_spaces
# ok: 1 passed

cargo test-system-duckdb private_memory_link_scan_ignores_code_and_comments
# ok: 1 passed

cargo test-system-duckdb markdown_target_with_optional_title_requires_md_suffix
# ok: 1 passed

cargo test-system-duckdb issue_log_date_uses_stable_sentinel_for_malformed_timestamps
# ok: 1 passed

cargo test-system-duckdb codex_schema_validator_cache_invalidates_when_binary_changes
# ok: 1 passed

cargo test-system-duckdb --test memory
# ok: 26 passed

cargo clippy-system-duckdb
# ok: Finished dev profile

cargo fmt --check
# ok: no output

git diff --check
# ok: no output
```

### Verification

Ran the CLI against the repo-contained fixture bundle:

```
DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib cargo run --no-default-features --features duckdb-prebuilt -- memory lint --okf crates/opensymphony-memory/tests/fixtures/okf-migration
```

The command emitted `[error]`, `[warn]`, and `[info]` diagnostics covering the COE-456 acceptance cases.

## Checklist

- [x] Tests pass (`cargo test-system-duckdb --test memory`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (OKF lint behavior and validation docs)
- [ ] `AGENTS.md` updated (not needed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Breaking changes

None.

## Related issues

COE-456

## Additional notes

This reuses the existing OKF parser/writer from COE-454 rather than adding a second OKF data model. Public/private export packaging remains out of scope for COE-456.
