### PR TITLE
Add OKF import and export CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,17 @@ Do not silently invent behavior when the upstream spec or chosen integration con
 - `opensymphony run` is the real local orchestrator entrypoint.
 - `opensymphony daemon` is demo-only and exists for smoke tests or UI-focused development.
 - When documenting, validating, or operating the system, prefer `opensymphony run` unless the task is specifically about the demo control-plane publisher.
+- `opensymphony memory export-okf --visibility public|private [--output DIR]`
+  exports a directory OKF bundle. Public export skips private concepts, runs
+  public redaction checks through OKF lint, stages output before promotion, and
+  requires the output directory to be new or empty.
+- `opensymphony memory import-okf <bundle-root> [--force]` imports a
+  repo-contained, non-overlapping directory OKF bundle into the configured
+  memory root while preserving unknown concept types and frontmatter fields. It
+  preflights target conflicts before copying and does not overwrite existing
+  Markdown files unless `--force` is supplied. Import is not transactional after
+  preflight: a write or reindex failure can leave already-copied Markdown files,
+  so document recovery guidance in `docs/memory.md` when changing this path.
 
 ## Design rules
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -326,6 +326,8 @@ struct ExportOkfArgs {
 struct ImportOkfArgs {
     #[arg(help = "OKF bundle directory to import")]
     bundle: PathBuf,
+    #[arg(long, help = "Overwrite existing imported OKF Markdown files")]
+    force: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -1342,7 +1344,7 @@ fn run_export_okf(config: &MemoryConfig, args: ExportOkfArgs) -> Result<(), Memo
 }
 
 fn run_import_okf(config: &MemoryConfig, args: ImportOkfArgs) -> Result<(), MemoryError> {
-    let report = import_okf_bundle(config, &args.bundle)?;
+    let report = import_okf_bundle(config, &args.bundle, args.force)?;
     println!("Imported OKF bundle: {}", report.source_path.display());
     println!("Target memory root: {}", report.target_path.display());
     println!("Copied files: {}", report.copied_files.len());

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use chrono::{NaiveDate, Utc};
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::task::JoinHandle;
@@ -20,13 +20,14 @@ use crate::{
         ArchivePlan, CodeIntelArtifact, CodeIntelIndex, CommentEvidence, DocsSyncPlan,
         IssueEvidence, IssueLinkEvidence, IssueSelection, KnowledgeScope, KnowledgeScopeKind,
         LintSeverity, MemoryConfig, MemoryContextOptions, MemoryError, MemoryReindexReport,
-        MemoryScopeFilter, SourceFile, archive_blocking_warning_count, brief,
-        context_for_issue_with_options, docs_for_area_with_scope, expand_issue_range, lint,
-        lint_okf_bundle, load_source_file, mark_archived, plan_archive, plan_capture,
-        plan_docs_sync, plan_memory_init, refresh_memory_index, refresh_memory_index_from_okf,
-        related_by_area_with_scope, related_by_issue_with_scope, related_by_paths_with_scope,
-        render_archive_plan, render_capture_dry_run, search_with_scope, status_with_scope,
-        write_capture_plan, write_docs_sync_plan, write_memory_init_plan,
+        MemoryScopeFilter, MemoryVisibility, SourceFile, archive_blocking_warning_count, brief,
+        context_for_issue_with_options, docs_for_area_with_scope, expand_issue_range,
+        export_okf_bundle, import_okf_bundle, lint, lint_okf_bundle, load_source_file,
+        mark_archived, plan_archive, plan_capture, plan_docs_sync, plan_memory_init,
+        refresh_memory_index, refresh_memory_index_from_okf, related_by_area_with_scope,
+        related_by_issue_with_scope, related_by_paths_with_scope, render_archive_plan,
+        render_capture_dry_run, search_with_scope, status_with_scope, write_capture_plan,
+        write_docs_sync_plan, write_memory_init_plan,
     },
     opensymphony_openhands::{
         ConversationMoveOutcome, ConversationStoreKind, IssueConversationManifest,
@@ -78,6 +79,10 @@ enum MemoryCommand {
     Lint(LintArgs),
     #[command(about = "Refresh memory catalog schema and generated indexes")]
     Reindex(ReindexArgs),
+    #[command(name = "export-okf", about = "Export an OKF memory bundle")]
+    ExportOkf(ExportOkfArgs),
+    #[command(name = "import-okf", about = "Import an OKF memory bundle")]
+    ImportOkf(ImportOkfArgs),
 }
 
 #[derive(Debug, Args)]
@@ -307,6 +312,35 @@ struct ReindexArgs {
     from_okf: bool,
     #[arg(help = "OKF bundle root; defaults to the configured memory root")]
     bundle: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct ExportOkfArgs {
+    #[arg(long, value_enum, help = "Bundle visibility to export")]
+    visibility: OkfVisibilityArg,
+    #[arg(long, help = "Output directory; must be empty if it already exists")]
+    output: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct ImportOkfArgs {
+    #[arg(help = "OKF bundle directory to import")]
+    bundle: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OkfVisibilityArg {
+    Public,
+    Private,
+}
+
+impl From<OkfVisibilityArg> for MemoryVisibility {
+    fn from(value: OkfVisibilityArg) -> Self {
+        match value {
+            OkfVisibilityArg::Public => MemoryVisibility::Public,
+            OkfVisibilityArg::Private => MemoryVisibility::Private,
+        }
+    }
 }
 
 #[derive(Debug, Args)]
@@ -647,6 +681,14 @@ async fn run_memory(args: MemoryArgs) -> Result<(), MemoryError> {
         MemoryCommand::Reindex(args) => {
             let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
             run_reindex(&config, args)
+        }
+        MemoryCommand::ExportOkf(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_export_okf(&config, args)
+        }
+        MemoryCommand::ImportOkf(args) => {
+            let config = MemoryConfig::load(&repo_root, config_path.as_deref())?;
+            run_import_okf(&config, args)
         }
     }
 }
@@ -1279,6 +1321,33 @@ fn run_reindex(config: &MemoryConfig, args: ReindexArgs) -> Result<(), MemoryErr
         refresh_memory_index(config)?
     };
     print_reindex_report(report);
+    Ok(())
+}
+
+fn run_export_okf(config: &MemoryConfig, args: ExportOkfArgs) -> Result<(), MemoryError> {
+    let visibility = MemoryVisibility::from(args.visibility);
+    let report = export_okf_bundle(config, visibility, args.output.as_deref())?;
+    println!("Exported OKF bundle: {}", report.output_path.display());
+    println!("Visibility: {visibility}");
+    println!("Copied files: {}", report.copied_files.len());
+    println!(
+        "Skipped private files: {}",
+        report.skipped_private_files.len()
+    );
+    println!("Lint findings: {}", report.finding_count);
+    for path in report.copied_files {
+        println!("- {}", path.display());
+    }
+    Ok(())
+}
+
+fn run_import_okf(config: &MemoryConfig, args: ImportOkfArgs) -> Result<(), MemoryError> {
+    let report = import_okf_bundle(config, &args.bundle)?;
+    println!("Imported OKF bundle: {}", report.source_path.display());
+    println!("Target memory root: {}", report.target_path.display());
+    println!("Copied files: {}", report.copied_files.len());
+    println!("Lint findings: {}", report.finding_count);
+    print_reindex_report(report.reindex);
     Ok(())
 }
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1881,6 +1881,7 @@ fn call_memory_lint_tool(config: &MemoryConfig, arguments: &Value) -> Result<Val
         "findingCount": report.findings.len(),
         "findings": report.findings.into_iter().map(|finding| {
             json!({
+                "code": finding.code.map(|code| code.as_str()),
                 "severity": match finding.severity {
                     LintSeverity::Info => "info",
                     LintSeverity::Warn => "warn",

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1881,7 +1881,6 @@ fn call_memory_lint_tool(config: &MemoryConfig, arguments: &Value) -> Result<Val
         "findingCount": report.findings.len(),
         "findings": report.findings.into_iter().map(|finding| {
             json!({
-                "code": finding.code.map(|code| code.as_str()),
                 "severity": match finding.severity {
                     LintSeverity::Info => "info",
                     LintSeverity::Warn => "warn",

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -318,7 +318,10 @@ struct ReindexArgs {
 struct ExportOkfArgs {
     #[arg(long, value_enum, help = "Bundle visibility to export")]
     visibility: OkfVisibilityArg,
-    #[arg(long, help = "Output directory; must be empty if it already exists")]
+    #[arg(
+        long,
+        help = "Output directory; defaults to okf-export-{visibility} under the repo root and must be empty if it already exists"
+    )]
     output: Option<PathBuf>,
 }
 

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -155,6 +155,12 @@ fn memory_export_okf_public_skips_private_and_private_keeps_it() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_okf_reindex_fixture(repo.path());
     write_public_okf_concept(repo.path(), "COE-200.md", "Public concept", "");
+    write_private_okf_concept(
+        repo.path(),
+        "COE-201.md",
+        "Private linked concept",
+        "See .opensymphony/memory/issues/COE-201.md for private capture details.\n",
+    );
 
     let public_export = run(
         repo.path(),
@@ -174,7 +180,7 @@ fn memory_export_okf_public_skips_private_and_private_keeps_it() {
     assert!(repo.path().join("public-okf/log.md").is_file());
     let stdout = String::from_utf8_lossy(&public_export.stdout);
     assert!(stdout.contains("Visibility: public"));
-    assert!(stdout.contains("Skipped private files: 2"));
+    assert!(stdout.contains("Skipped private files: 3"));
 
     let lint = run(
         repo.path(),
@@ -196,6 +202,9 @@ fn memory_export_okf_public_skips_private_and_private_keeps_it() {
     );
     assert_success(&private_export, "private OKF export");
     assert!(repo.path().join("private-okf/issues/COE-123.md").is_file());
+    let private_linked = fs::read_to_string(repo.path().join("private-okf/issues/COE-201.md"))
+        .expect("private linked concept should export");
+    assert!(private_linked.contains(".opensymphony/memory/issues/COE-201.md"));
     assert!(repo.path().join("private-okf/issues/COE-200.md").is_file());
 }
 
@@ -360,6 +369,7 @@ fn memory_import_okf_tolerates_warnings_and_preserves_unknown_fields() {
         .expect("imported concept should read");
     assert!(imported.contains("x_unknown: keep-me"));
     assert!(imported.contains("type: surprise-concept"));
+    assert!(imported.contains(".opensymphony/memory/issues/COE-500.md"));
 
     let search = run(repo.path(), ["memory", "search", "warning-friendly"]);
     assert_success(&search, "search imported OKF");
@@ -1509,6 +1519,7 @@ opensymphony:
 # COE-500: Warning-friendly import
 
 This warning-friendly concept has a [broken link](missing.md).
+It also preserves a private round-trip link to .opensymphony/memory/issues/COE-500.md.
 "#,
     )
     .expect("warning import fixture should write");

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -279,6 +279,37 @@ fn memory_export_okf_rejects_output_that_contains_source_bundle() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("must not overlap"));
 }
 
+#[cfg(unix)]
+#[test]
+fn memory_export_okf_rejects_output_parent_symlink() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_public_okf_concept(repo.path(), "COE-206.md", "Public concept", "");
+    fs::create_dir(repo.path().join("real-exports")).expect("real export dir should write");
+    std::os::unix::fs::symlink(
+        repo.path().join("real-exports"),
+        repo.path().join("export-link"),
+    )
+    .expect("export parent symlink should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "export-link/public-okf",
+        ],
+    );
+
+    assert_failure(&output, "symlinked parent OKF export output");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("symlink component"));
+    assert!(!repo.path().join("real-exports/public-okf").exists());
+}
+
 #[test]
 fn memory_export_okf_public_ignores_private_patterns_in_markdown_code() {
     let repo = TempDir::new().expect("temp repo should exist");

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -324,9 +324,9 @@ fn memory_export_okf_source_lint_failure_leaves_no_staging_dir() {
             "memory",
             "export-okf",
             "--visibility",
-            "public",
+            "private",
             "--output",
-            "public-okf",
+            "private-okf",
         ],
     );
 
@@ -338,7 +338,7 @@ fn memory_export_okf_source_lint_failure_leaves_no_staging_dir() {
             entry
                 .file_name()
                 .to_string_lossy()
-                .starts_with(".public-okf.tmp-")
+                .starts_with(".private-okf.tmp-")
         });
     assert!(
         !leaked_staging,
@@ -392,6 +392,16 @@ opensymphony:
 "#,
     )
     .expect("malformed private concept should write");
+    fs::write(
+        repo.path().join(".opensymphony/memory/issues/COE-214.md"),
+        r#"---
+opensymphony: [
+---
+
+# Private malformed concept with invalid YAML
+"#,
+    )
+    .expect("invalid YAML private concept should write");
 
     let output = run(
         repo.path(),
@@ -408,6 +418,7 @@ opensymphony:
     assert_success(&output, "public OKF export skips malformed private concept");
     assert!(repo.path().join("public-okf/issues/COE-212.md").is_file());
     assert!(!repo.path().join("public-okf/issues/COE-213.md").exists());
+    assert!(!repo.path().join("public-okf/issues/COE-214.md").exists());
 }
 
 #[test]

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -151,6 +151,162 @@ fn memory_reindex_from_okf_preserves_query_commands() {
 }
 
 #[test]
+fn memory_export_okf_public_skips_private_and_private_keeps_it() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_okf_reindex_fixture(repo.path());
+    write_public_okf_concept(repo.path(), "COE-200.md", "Public concept", "");
+
+    let public_export = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ],
+    );
+    assert_success(&public_export, "public OKF export");
+    assert!(repo.path().join("public-okf/issues/COE-200.md").is_file());
+    assert!(!repo.path().join("public-okf/issues/COE-123.md").exists());
+    assert!(repo.path().join("public-okf/index.md").is_file());
+    assert!(repo.path().join("public-okf/log.md").is_file());
+    let stdout = String::from_utf8_lossy(&public_export.stdout);
+    assert!(stdout.contains("Visibility: public"));
+    assert!(stdout.contains("Skipped private files: 2"));
+
+    let lint = run(
+        repo.path(),
+        ["memory", "lint", "--okf", "--public-docs", "public-okf"],
+    );
+    assert_success(&lint, "public export lint");
+    assert!(!String::from_utf8_lossy(&lint.stdout).contains("[error]"));
+
+    let private_export = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "private",
+            "--output",
+            "private-okf",
+        ],
+    );
+    assert_success(&private_export, "private OKF export");
+    assert!(repo.path().join("private-okf/issues/COE-123.md").is_file());
+    assert!(repo.path().join("private-okf/issues/COE-200.md").is_file());
+}
+
+#[test]
+fn memory_export_okf_public_fails_on_private_material_in_public_concepts() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_public_okf_concept(
+        repo.path(),
+        "COE-201.md",
+        "Leaky comment",
+        "Private comment source: linear:comment:abc123.\n",
+    );
+    write_public_okf_concept(
+        repo.path(),
+        "COE-202.md",
+        "Leaky snapshot",
+        "Private snapshot: .opensymphony/memory/source-snapshots/COE-202.md.\n",
+    );
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ],
+    );
+
+    assert_failure(&output, "public OKF export redaction");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("public export contains private comment references"));
+    assert!(stderr.contains("public export contains private source snapshots"));
+    assert!(stderr.contains("COE-201.md"));
+    assert!(stderr.contains("COE-202.md"));
+}
+
+#[test]
+fn memory_export_okf_public_skips_private_concepts_with_private_paths() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_public_okf_concept(repo.path(), "COE-210.md", "Safe public concept", "");
+    write_private_okf_concept(
+        repo.path(),
+        "COE-211.md",
+        "Private leaky concept",
+        "Private path: .opensymphony/memory/issues/COE-211.md.\n",
+    );
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ],
+    );
+
+    assert_success(&output, "public OKF export skips private leaky concept");
+    assert!(repo.path().join("public-okf/issues/COE-210.md").is_file());
+    assert!(!repo.path().join("public-okf/issues/COE-211.md").exists());
+}
+
+#[test]
+fn memory_import_okf_tolerates_warnings_and_preserves_unknown_fields() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_import_warning_bundle(repo.path());
+
+    let output = run(repo.path(), ["memory", "import-okf", "incoming-okf"]);
+
+    assert_success(&output, "OKF import with warnings");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Copied files: 1"));
+    assert!(stdout.contains("Indexed records: 1"));
+    let imported = fs::read_to_string(repo.path().join(".opensymphony/memory/issues/COE-500.md"))
+        .expect("imported concept should read");
+    assert!(imported.contains("x_unknown: keep-me"));
+    assert!(imported.contains("type: surprise-concept"));
+
+    let search = run(repo.path(), ["memory", "search", "warning-friendly"]);
+    assert_success(&search, "search imported OKF");
+    assert!(String::from_utf8_lossy(&search.stdout).contains("COE-500"));
+}
+
+#[test]
+fn memory_import_okf_reports_malformed_concept_paths() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    fs::create_dir_all(repo.path().join("incoming-okf/issues")).expect("bundle dir should write");
+    fs::write(
+        repo.path().join("incoming-okf/issues/broken.md"),
+        "---\ntype: [unterminated\n---\n\n# Broken\n",
+    )
+    .expect("broken fixture should write");
+
+    let output = run(repo.path(), ["memory", "import-okf", "incoming-okf"]);
+
+    assert_failure(&output, "malformed OKF import");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("incoming-okf/issues/broken.md"));
+    assert!(stderr.contains("frontmatter is not parseable YAML"));
+}
+
+#[test]
 fn memory_init_creates_private_config_and_gitignore_policy() {
     let repo = TempDir::new().expect("temp repo should exist");
     fs::create_dir_all(repo.path().join("docs/tasks")).expect("tasks dir should write");
@@ -1083,6 +1239,81 @@ fn write_okf_reindex_fixture(repo: &std::path::Path) {
         &okf_fixture("okf-reindex"),
         &repo.join(".opensymphony/memory"),
     );
+}
+
+fn write_public_okf_concept(repo: &std::path::Path, file_name: &str, title: &str, body: &str) {
+    fs::create_dir_all(repo.join(".opensymphony/memory/issues")).expect("issues dir should write");
+    fs::write(
+        repo.join(".opensymphony/memory/issues").join(file_name),
+        format!(
+            r#"---
+type: topic-doc
+title: "{title}"
+description: Public OKF fixture.
+resource: https://example.com/{file_name}
+tags: [memory, okf]
+timestamp: 2026-06-22T10:00:00Z
+opensymphony:
+  visibility: public
+  kind: topic_doc
+---
+
+# {title}
+
+{body}
+"#
+        ),
+    )
+    .expect("public OKF concept should write");
+}
+
+fn write_private_okf_concept(repo: &std::path::Path, file_name: &str, title: &str, body: &str) {
+    fs::create_dir_all(repo.join(".opensymphony/memory/issues")).expect("issues dir should write");
+    fs::write(
+        repo.join(".opensymphony/memory/issues").join(file_name),
+        format!(
+            r#"---
+type: issue-capsule
+title: "{title}"
+description: Private OKF fixture.
+resource: https://example.com/{file_name}
+tags: [memory, okf]
+timestamp: 2026-06-22T10:00:00Z
+opensymphony:
+  visibility: private
+  kind: issue_capsule
+---
+
+# {title}
+
+{body}
+"#
+        ),
+    )
+    .expect("private OKF concept should write");
+}
+
+fn write_import_warning_bundle(repo: &std::path::Path) {
+    fs::create_dir_all(repo.join("incoming-okf/issues")).expect("incoming dir should write");
+    fs::write(
+        repo.join("incoming-okf/issues/COE-500.md"),
+        r#"---
+type: surprise-concept
+title: "COE-500: Warning-friendly import"
+x_unknown: keep-me
+opensymphony:
+  visibility: private
+  scope_refs:
+    - kind: work_item
+      id: COE-500
+---
+
+# COE-500: Warning-friendly import
+
+This warning-friendly concept has a [broken link](missing.md).
+"#,
+    )
+    .expect("warning import fixture should write");
 }
 
 fn write_general_memory_config(repo: &std::path::Path) {

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -215,6 +215,12 @@ fn memory_export_okf_public_fails_on_private_material_in_public_concepts() {
         "Leaky snapshot",
         "Private snapshot: .opensymphony/memory/source-snapshots/COE-202.md.\n",
     );
+    write_public_okf_concept(
+        repo.path(),
+        "COE-203.md",
+        "Leaky path",
+        "Private path: .opensymphony/memory/issues/COE-203.md.\n",
+    );
 
     let output = run(
         repo.path(),
@@ -232,8 +238,10 @@ fn memory_export_okf_public_fails_on_private_material_in_public_concepts() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("public export contains private comment references"));
     assert!(stderr.contains("public export contains private source snapshots"));
+    assert!(stderr.contains("public export contains private local paths"));
     assert!(stderr.contains("COE-201.md"));
     assert!(stderr.contains("COE-202.md"));
+    assert!(stderr.contains("COE-203.md"));
 }
 
 #[test]
@@ -285,6 +293,18 @@ fn memory_import_okf_tolerates_warnings_and_preserves_unknown_fields() {
     let search = run(repo.path(), ["memory", "search", "warning-friendly"]);
     assert_success(&search, "search imported OKF");
     assert!(String::from_utf8_lossy(&search.stdout).contains("COE-500"));
+
+    let duplicate = run(repo.path(), ["memory", "import-okf", "incoming-okf"]);
+    assert_failure(&duplicate, "duplicate OKF import");
+    let stderr = String::from_utf8_lossy(&duplicate.stderr);
+    assert!(stderr.contains("already exists"));
+    assert!(stderr.contains("--force"));
+
+    let forced = run(
+        repo.path(),
+        ["memory", "import-okf", "incoming-okf", "--force"],
+    );
+    assert_success(&forced, "forced OKF import");
 }
 
 #[test]

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -222,7 +222,7 @@ fn memory_export_okf_public_fails_on_private_material_in_public_concepts() {
         repo.path(),
         "COE-202.md",
         "Leaky snapshot",
-        "Private snapshot: .opensymphony/memory/source-snapshots/COE-202.md.\n",
+        "Private snapshot: ../.opensymphony/memory/source-snapshots/COE-202.md.\n",
     );
     write_public_okf_concept(
         repo.path(),
@@ -255,6 +255,28 @@ fn memory_export_okf_public_fails_on_private_material_in_public_concepts() {
         !repo.path().join("public-okf").exists(),
         "failed public export should not leave partial output"
     );
+}
+
+#[test]
+fn memory_export_okf_rejects_output_that_contains_source_bundle() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_public_okf_concept(repo.path(), "COE-205.md", "Public concept", "");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            ".opensymphony",
+        ],
+    );
+
+    assert_failure(&output, "overlapping OKF export output");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must not overlap"));
 }
 
 #[test]

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -242,6 +242,37 @@ fn memory_export_okf_public_fails_on_private_material_in_public_concepts() {
     assert!(stderr.contains("COE-201.md"));
     assert!(stderr.contains("COE-202.md"));
     assert!(stderr.contains("COE-203.md"));
+    assert!(
+        !repo.path().join("public-okf").exists(),
+        "failed public export should not leave partial output"
+    );
+}
+
+#[test]
+fn memory_export_okf_public_ignores_private_patterns_in_markdown_code() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_public_okf_concept(
+        repo.path(),
+        "COE-204.md",
+        "Code samples are not private links",
+        "Inline sample: `.opensymphony/memory/issues/COE-204.md`.\n\n```text\nlinear:comment:abc123\n.opensymphony/memory/source-snapshots/COE-204.md\n```\n\n<!-- .opensymphony/memory/issues/COE-204.md -->\n",
+    );
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ],
+    );
+
+    assert_success(&output, "public OKF export ignores code/comment samples");
+    assert!(repo.path().join("public-okf/issues/COE-204.md").is_file());
 }
 
 #[test]
@@ -305,6 +336,66 @@ fn memory_import_okf_tolerates_warnings_and_preserves_unknown_fields() {
         ["memory", "import-okf", "incoming-okf", "--force"],
     );
     assert_success(&forced, "forced OKF import");
+}
+
+#[test]
+fn memory_import_okf_rejects_overlapping_source_and_target() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_import_warning_bundle(repo.path());
+    copy_dir_recursive(
+        &repo.path().join("incoming-okf"),
+        &repo.path().join(".opensymphony/memory/incoming-okf"),
+    );
+
+    let output = run(
+        repo.path(),
+        ["memory", "import-okf", ".opensymphony/memory/incoming-okf"],
+    );
+
+    assert_failure(&output, "overlapping OKF import source");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must not overlap"));
+}
+
+#[test]
+fn memory_import_okf_preflight_failure_leaves_no_partial_copy() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_import_warning_bundle(repo.path());
+    fs::create_dir_all(repo.path().join("incoming-okf/issues/nested"))
+        .expect("nested source dir should write");
+    fs::write(
+        repo.path().join("incoming-okf/issues/nested/COE-501.md"),
+        r#"---
+type: issue-capsule
+title: "COE-501: Nested import"
+opensymphony:
+  visibility: private
+---
+
+# COE-501: Nested import
+"#,
+    )
+    .expect("nested import fixture should write");
+    fs::create_dir_all(repo.path().join(".opensymphony/memory/issues"))
+        .expect("target issues dir should write");
+    fs::write(
+        repo.path().join(".opensymphony/memory/issues/nested"),
+        "blocking file",
+    )
+    .expect("blocking target should write");
+
+    let output = run(repo.path(), ["memory", "import-okf", "incoming-okf"]);
+
+    assert_failure(&output, "preflight OKF import failure");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("blocks OKF import"));
+    assert!(
+        !repo
+            .path()
+            .join(".opensymphony/memory/issues/COE-500.md")
+            .exists(),
+        "preflight failure should not copy earlier files"
+    );
 }
 
 #[test]

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -376,6 +376,41 @@ fn memory_export_okf_public_skips_private_concepts_with_private_paths() {
 }
 
 #[test]
+fn memory_export_okf_public_skips_malformed_private_concepts() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_public_okf_concept(repo.path(), "COE-212.md", "Public survivor", "");
+    fs::write(
+        repo.path().join(".opensymphony/memory/issues/COE-213.md"),
+        r#"---
+title: "COE-213: Private malformed concept"
+opensymphony:
+  visibility: private
+---
+
+# Private malformed concept
+"#,
+    )
+    .expect("malformed private concept should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ],
+    );
+
+    assert_success(&output, "public OKF export skips malformed private concept");
+    assert!(repo.path().join("public-okf/issues/COE-212.md").is_file());
+    assert!(!repo.path().join("public-okf/issues/COE-213.md").exists());
+}
+
+#[test]
 fn memory_import_okf_tolerates_warnings_and_preserves_unknown_fields() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_memory_config(repo.path());
@@ -457,6 +492,39 @@ fn memory_import_okf_force_rejects_target_symlink() {
     assert!(
         !outside_target.exists(),
         "force import must not follow symlink outside memory root"
+    );
+}
+
+#[test]
+fn memory_import_okf_preflights_existing_target_lint_errors() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_import_warning_bundle(repo.path());
+    fs::create_dir_all(repo.path().join(".opensymphony/memory/issues"))
+        .expect("target issues dir should write");
+    fs::write(
+        repo.path().join(".opensymphony/memory/issues/BAD.md"),
+        r#"---
+title: "Existing malformed target concept"
+---
+
+# Existing malformed target concept
+"#,
+    )
+    .expect("malformed target concept should write");
+
+    let output = run(repo.path(), ["memory", "import-okf", "incoming-okf"]);
+
+    assert_failure(&output, "OKF import should preflight target lint");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("OKF import target"));
+    assert!(stderr.contains("BAD.md"));
+    assert!(
+        !repo
+            .path()
+            .join(".opensymphony/memory/issues/COE-500.md")
+            .exists(),
+        "target lint failure must happen before copying imported files"
     );
 }
 

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -407,6 +407,35 @@ fn memory_import_okf_rejects_overlapping_source_and_target() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("must not overlap"));
 }
 
+#[cfg(unix)]
+#[test]
+fn memory_import_okf_force_rejects_target_symlink() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_import_warning_bundle(repo.path());
+    fs::create_dir_all(repo.path().join(".opensymphony/memory/issues"))
+        .expect("target issues dir should write");
+    let outside_target = repo.path().join("outside-target.md");
+    std::os::unix::fs::symlink(
+        &outside_target,
+        repo.path().join(".opensymphony/memory/issues/COE-500.md"),
+    )
+    .expect("target symlink should write");
+
+    let output = run(
+        repo.path(),
+        ["memory", "import-okf", "incoming-okf", "--force"],
+    );
+
+    assert_failure(&output, "forced OKF import should reject target symlink");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("is a symlink"));
+    assert!(
+        !outside_target.exists(),
+        "force import must not follow symlink outside memory root"
+    );
+}
+
 #[test]
 fn memory_import_okf_preflight_failure_leaves_no_partial_copy() {
     let repo = TempDir::new().expect("temp repo should exist");

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -392,6 +392,8 @@ fn memory_import_okf_tolerates_warnings_and_preserves_unknown_fields() {
     assert!(imported.contains("x_unknown: keep-me"));
     assert!(imported.contains("type: surprise-concept"));
     assert!(imported.contains(".opensymphony/memory/issues/COE-500.md"));
+    assert!(!repo.path().join(".opensymphony/memory/index.md").exists());
+    assert!(!repo.path().join(".opensymphony/memory/log.md").exists());
 
     let search = run(repo.path(), ["memory", "search", "warning-friendly"]);
     assert_success(&search, "search imported OKF");
@@ -1554,6 +1556,16 @@ opensymphony:
 
 fn write_import_warning_bundle(repo: &std::path::Path) {
     fs::create_dir_all(repo.join("incoming-okf/issues")).expect("incoming dir should write");
+    fs::write(
+        repo.join("incoming-okf/index.md"),
+        "# Imported bundle index\n\nThis generated file should not be copied.\n",
+    )
+    .expect("incoming index should write");
+    fs::write(
+        repo.join("incoming-okf/log.md"),
+        "# Imported bundle log\n\n## 2026-06-23\n\n- Generated source log.\n",
+    )
+    .expect("incoming log should write");
     fs::write(
         repo.join("incoming-okf/issues/COE-500.md"),
         r#"---

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -398,6 +398,53 @@ opensymphony:
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn memory_import_okf_mid_copy_failure_documents_partial_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    write_import_warning_bundle(repo.path());
+    fs::create_dir_all(repo.path().join("incoming-okf/readonly"))
+        .expect("readonly source dir should write");
+    fs::write(
+        repo.path().join("incoming-okf/readonly/COE-501.md"),
+        r#"---
+type: issue-capsule
+title: "COE-501: Mid-copy import"
+opensymphony:
+  visibility: private
+---
+
+# COE-501: Mid-copy import
+"#,
+    )
+    .expect("mid-copy fixture should write");
+    let readonly_target = repo.path().join(".opensymphony/memory/readonly");
+    fs::create_dir_all(&readonly_target).expect("readonly target dir should write");
+    fs::set_permissions(&readonly_target, fs::Permissions::from_mode(0o555))
+        .expect("readonly target permissions should set");
+
+    let output = run(repo.path(), ["memory", "import-okf", "incoming-okf"]);
+
+    fs::set_permissions(&readonly_target, fs::Permissions::from_mode(0o755))
+        .expect("readonly target permissions should restore");
+    assert_failure(&output, "mid-copy OKF import failure");
+    assert!(
+        repo.path()
+            .join(".opensymphony/memory/issues/COE-500.md")
+            .exists(),
+        "post-preflight copy failure documents the current partial-update behavior"
+    );
+    assert!(
+        !repo
+            .path()
+            .join(".opensymphony/memory/readonly/COE-501.md")
+            .exists()
+    );
+}
+
 #[test]
 fn memory_import_okf_reports_malformed_concept_paths() {
     let repo = TempDir::new().expect("temp repo should exist");

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -276,6 +276,46 @@ fn memory_export_okf_public_ignores_private_patterns_in_markdown_code() {
 }
 
 #[test]
+fn memory_export_okf_source_lint_failure_leaves_no_staging_dir() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    write_memory_config(repo.path());
+    fs::create_dir_all(repo.path().join(".opensymphony/memory/issues"))
+        .expect("issues dir should write");
+    fs::write(
+        repo.path().join(".opensymphony/memory/issues/broken.md"),
+        "---\ntype: [unterminated\n---\n\n# Broken\n",
+    )
+    .expect("broken source concept should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ],
+    );
+
+    assert_failure(&output, "source lint failure before OKF export staging");
+    let leaked_staging = fs::read_dir(repo.path())
+        .expect("repo should list")
+        .filter_map(Result::ok)
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".public-okf.tmp-")
+        });
+    assert!(
+        !leaked_staging,
+        "source lint failure should not leak staging dir"
+    );
+}
+
+#[test]
 fn memory_export_okf_public_skips_private_concepts_with_private_paths() {
     let repo = TempDir::new().expect("temp repo should exist");
     write_memory_config(repo.path());

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -580,6 +580,7 @@ pub fn refresh_memory_index_from_okf(
         .findings
         .iter()
         .filter(|finding| finding.severity == LintSeverity::Error)
+        .filter(|finding| !is_private_export_leak(finding))
         .map(|finding| {
             let path = finding
                 .path

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -575,7 +575,7 @@ pub fn refresh_memory_index_from_okf(
 ) -> Result<MemoryReindexReport, MemoryError> {
     ensure_repo_contained(&config.repo_root, bundle_root)?;
     let bundle_root = canonicalize_existing_path(bundle_root)?;
-    let lint = lint_okf_bundle(&bundle_root, false)?;
+    let lint = lint_okf_bundle_with_codes(&bundle_root, false)?;
     let errors = lint
         .findings
         .iter()

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -687,10 +687,24 @@ pub struct LintReport {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintFinding {
+    pub code: Option<LintCode>,
     pub severity: LintSeverity,
     pub path: Option<PathBuf>,
     pub message: String,
     pub next_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LintCode {
+    OkfPrivateMemoryLink,
+}
+
+impl LintCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OkfPrivateMemoryLink => "okf_private_memory_link",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -703,16 +703,8 @@ pub struct LintFinding {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LintCode {
+pub(crate) enum LintCode {
     OkfPrivateMemoryLink,
-}
-
-impl LintCode {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::OkfPrivateMemoryLink => "okf_private_memory_link",
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -696,7 +696,6 @@ pub struct LintReport {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintFinding {
-    pub code: Option<LintCode>,
     pub severity: LintSeverity,
     pub path: Option<PathBuf>,
     pub message: String,

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -76,6 +76,15 @@ pub enum MemoryError {
     PathOutsideRepo { path: PathBuf, repo_root: PathBuf },
     #[error("{path} is outside the OKF bundle root {bundle_root}")]
     PathOutsideBundle { path: PathBuf, bundle_root: PathBuf },
+    #[error(
+        "{source}; additionally failed to remove OKF export staging directory `{path}` after the export failure: {cleanup}; remove the staging directory manually"
+    )]
+    OkfExportStagingCleanup {
+        path: PathBuf,
+        #[source]
+        source: Box<MemoryError>,
+        cleanup: Box<MemoryError>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -168,6 +168,12 @@ pub struct OkfImportReport {
     pub reindex: MemoryReindexReport,
 }
 
+struct OkfPendingFile {
+    relative: PathBuf,
+    target: PathBuf,
+    contents: String,
+}
+
 impl OkfConcept {
     pub fn new(
         path: impl Into<PathBuf>,
@@ -263,7 +269,15 @@ pub fn export_okf_bundle(
             source_root.display()
         )));
     }
-    ensure_empty_output_dir(&output_path)?;
+    ensure_empty_output_target(&output_path)?;
+    let output_parent = output_path.parent().ok_or_else(|| {
+        MemoryError::InvalidInput(format!(
+            "OKF export output `{}` has no parent directory",
+            output_path.display()
+        ))
+    })?;
+    create_dir_all(output_parent)?;
+    let staging_path = create_staging_dir(output_parent, &output_path)?;
 
     let mut files = Vec::new();
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
@@ -277,7 +291,6 @@ pub fn export_okf_bundle(
     let mut writes = Vec::<(PathBuf, String)>::new();
     let mut copied_files = Vec::new();
     let mut skipped_private_files = Vec::new();
-    let mut redaction_errors = Vec::new();
 
     for path in files {
         let relative = bundle_relative_path(&source_root, &path)?;
@@ -285,7 +298,7 @@ pub fn export_okf_bundle(
         let contents = read_to_string(&path)?;
         if bundle_path.reserved_file().is_some() {
             if !public {
-                writes.push((output_path.join(&relative), contents));
+                writes.push((staging_path.join(&relative), contents));
                 copied_files.push(relative);
             }
             continue;
@@ -296,36 +309,26 @@ pub fn export_okf_bundle(
             skipped_private_files.push(relative);
             continue;
         }
-        if public && let Some(reason) = public_export_private_material(&contents) {
-            redaction_errors.push(format!(
-                "{}: public export contains {reason}",
-                display_path(&config.repo_root, &path)
-            ));
-            continue;
-        }
-        writes.push((output_path.join(&relative), contents));
+        writes.push((staging_path.join(&relative), contents));
         copied_files.push(relative);
     }
 
-    if !redaction_errors.is_empty() {
-        return Err(MemoryError::InvalidInput(format!(
-            "OKF public export redaction error(s): {}",
-            redaction_errors.join("; ")
-        )));
-    }
     if public {
-        writes.push((output_path.join("index.md"), public_export_index()));
-        writes.push((output_path.join("log.md"), public_export_log()));
+        writes.push((staging_path.join("index.md"), public_export_index()));
+        writes.push((staging_path.join("log.md"), public_export_log()));
         copied_files.push(PathBuf::from("index.md"));
         copied_files.push(PathBuf::from("log.md"));
     }
-    for (path, contents) in writes {
-        write_file(&path, &contents)?;
-    }
-    let exported_lint = lint_okf_bundle(&output_path, public)?;
-    let errors = lint_errors(config, "exported OKF bundle", &exported_lint);
-    if !errors.is_empty() {
-        return Err(MemoryError::InvalidInput(errors));
+    let exported_lint = match write_and_lint_staged_export(config, &staging_path, writes, public) {
+        Ok(report) => report,
+        Err(error) => {
+            let _ = cleanup_staging_dir(&staging_path);
+            return Err(error);
+        }
+    };
+    if let Err(error) = promote_staged_export(&staging_path, &output_path) {
+        let _ = cleanup_staging_dir(&staging_path);
+        return Err(error);
     }
 
     Ok(OkfExportReport {
@@ -341,15 +344,22 @@ pub fn import_okf_bundle(
     source: &Path,
     force: bool,
 ) -> Result<OkfImportReport, MemoryError> {
-    ensure_repo_contained(&config.repo_root, source)?;
+    let source_path = canonicalize_existing_path(&resolve_path(&config.repo_root, source))?;
+    ensure_repo_contained(&config.repo_root, &source_path)?;
     ensure_repo_contained(&config.repo_root, &config.memory_root)?;
     create_dir_all(&config.memory_root)?;
     let target_root = canonicalize_existing_path(&config.memory_root)?;
-    let source_path = canonicalize_existing_path(&resolve_path(&config.repo_root, source))?;
     if !source_path.is_dir() {
         return Err(MemoryError::InvalidInput(format!(
             "OKF import source `{}` is not a directory",
             source_path.display()
+        )));
+    }
+    if paths_overlap(&source_path, &target_root) {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF import source `{}` must not overlap the target memory root `{}`",
+            source_path.display(),
+            target_root.display()
         )));
     }
     let lint = lint_okf_bundle(&source_path, false)?;
@@ -360,20 +370,13 @@ pub fn import_okf_bundle(
 
     let mut files = Vec::new();
     collect_okf_markdown_files(&source_path, &source_path, &mut files)?;
-    let mut copied_files = Vec::new();
-    for path in files {
-        let relative = bundle_relative_path(&source_path, &path)?;
-        OkfBundlePath::new(relative.clone())?;
-        let contents = read_to_string(&path)?;
-        let target = target_root.join(&relative);
-        if target.exists() && !force {
-            return Err(MemoryError::InvalidInput(format!(
-                "{} already exists; rerun with --force to overwrite it",
-                display_path(&config.repo_root, &target)
-            )));
-        }
-        write_file(&target, &contents)?;
-        copied_files.push(relative);
+    let pending = pending_okf_import_files(config, &source_path, &target_root, &files, force)?;
+    let copied_files = pending
+        .iter()
+        .map(|file| file.relative.clone())
+        .collect::<Vec<_>>();
+    for file in pending {
+        write_file(&file.target, &file.contents)?;
     }
 
     let reindex = refresh_memory_index_from_okf(config, &target_root)?;
@@ -384,6 +387,49 @@ pub fn import_okf_bundle(
         finding_count: lint.findings.len(),
         reindex,
     })
+}
+
+fn pending_okf_import_files(
+    config: &MemoryConfig,
+    source_path: &Path,
+    target_root: &Path,
+    files: &[PathBuf],
+    force: bool,
+) -> Result<Vec<OkfPendingFile>, MemoryError> {
+    let mut pending = Vec::new();
+    for path in files {
+        let relative = bundle_relative_path(source_path, path)?;
+        OkfBundlePath::new(relative.clone())?;
+        let contents = read_to_string(path)?;
+        let target = target_root.join(&relative);
+        if target.is_dir() {
+            return Err(MemoryError::InvalidInput(format!(
+                "{} already exists as a directory and cannot be overwritten by OKF import",
+                display_path(&config.repo_root, &target)
+            )));
+        }
+        if let Some(parent) = target.parent()
+            && parent.exists()
+            && !parent.is_dir()
+        {
+            return Err(MemoryError::InvalidInput(format!(
+                "{} already exists and blocks OKF import",
+                display_path(&config.repo_root, parent)
+            )));
+        }
+        if target.exists() && !force {
+            return Err(MemoryError::InvalidInput(format!(
+                "{} already exists; rerun with --force to overwrite it",
+                display_path(&config.repo_root, &target)
+            )));
+        }
+        pending.push(OkfPendingFile {
+            relative,
+            target,
+            contents,
+        });
+    }
+    Ok(pending)
 }
 
 pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintReport, MemoryError> {
@@ -446,7 +492,7 @@ pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintRe
     Ok(LintReport { findings })
 }
 
-fn ensure_empty_output_dir(path: &Path) -> Result<(), MemoryError> {
+fn ensure_empty_output_target(path: &Path) -> Result<(), MemoryError> {
     if path.exists() {
         if !path.is_dir() {
             return Err(MemoryError::InvalidInput(format!(
@@ -464,10 +510,75 @@ fn ensure_empty_output_dir(path: &Path) -> Result<(), MemoryError> {
                 path.display()
             )));
         }
-    } else {
-        create_dir_all(path)?;
     }
     Ok(())
+}
+
+fn create_staging_dir(parent: &Path, output_path: &Path) -> Result<PathBuf, MemoryError> {
+    let output_name = output_path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or("okf-export");
+    for attempt in 0..100 {
+        let candidate = parent.join(format!(
+            ".{output_name}.tmp-{}-{attempt}",
+            std::process::id()
+        ));
+        if candidate.exists() {
+            continue;
+        }
+        create_dir_all(&candidate)?;
+        return Ok(candidate);
+    }
+    Err(MemoryError::InvalidInput(format!(
+        "could not allocate a staging directory for OKF export `{}`",
+        output_path.display()
+    )))
+}
+
+fn write_and_lint_staged_export(
+    config: &MemoryConfig,
+    staging_path: &Path,
+    writes: Vec<(PathBuf, String)>,
+    public: bool,
+) -> Result<LintReport, MemoryError> {
+    for (path, contents) in writes {
+        write_file(&path, &contents)?;
+    }
+    let exported_lint = lint_okf_bundle(staging_path, public)?;
+    let errors = lint_errors(config, "exported OKF bundle", &exported_lint);
+    if errors.is_empty() {
+        Ok(exported_lint)
+    } else {
+        Err(MemoryError::InvalidInput(errors))
+    }
+}
+
+fn promote_staged_export(staging_path: &Path, output_path: &Path) -> Result<(), MemoryError> {
+    if output_path.exists() {
+        fs::remove_dir(output_path).map_err(|source| MemoryError::WriteFile {
+            path: output_path.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::rename(staging_path, output_path).map_err(|source| MemoryError::WriteFile {
+        path: output_path.to_path_buf(),
+        source,
+    })
+}
+
+fn cleanup_staging_dir(path: &Path) -> Result<(), MemoryError> {
+    if path.exists() {
+        fs::remove_dir_all(path).map_err(|source| MemoryError::WriteFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left == right || left.starts_with(right) || right.starts_with(left)
 }
 
 fn lint_errors(config: &MemoryConfig, label: &str, report: &LintReport) -> String {
@@ -781,6 +892,14 @@ fn lint_okf_concept(
             next_command: None,
         });
     }
+    if public_export && let Some(reason) = public_export_private_material(contents) {
+        findings.push(LintFinding {
+            severity: LintSeverity::Error,
+            path: Some(path.to_path_buf()),
+            message: format!("public export contains {reason}"),
+            next_command: None,
+        });
+    }
     lint_okf_links(bundle_root, &concept, path, findings);
     lint_okf_citations(&concept, path, findings);
     lint_okf_info(&concept, mapping, path, findings);
@@ -1054,6 +1173,11 @@ fn normalize_okf_link_id(target: &str) -> String {
 }
 
 fn contains_private_memory_link_in_markdown(contents: &str) -> bool {
+    let visible = markdown_visible_text(contents);
+    contains_private_memory_link(&visible)
+}
+
+fn markdown_visible_text(contents: &str) -> String {
     let mut visible = String::with_capacity(contents.len());
     let mut index = 0;
     while index < contents.len() {
@@ -1077,7 +1201,7 @@ fn contains_private_memory_link_in_markdown(contents: &str) -> bool {
             }
         }
     }
-    contains_private_memory_link(&visible)
+    visible
 }
 
 const PUBLIC_PRIVATE_COMMENT_PATTERNS: &[&str] = &["linear:comment:"];
@@ -1094,13 +1218,14 @@ const PUBLIC_PRIVATE_SOURCE_PATTERNS: &[&str] = &[
 ];
 
 fn public_export_private_material(contents: &str) -> Option<&'static str> {
-    if contains_any_ascii_case_insensitive(contents, PUBLIC_PRIVATE_COMMENT_PATTERNS) {
+    let visible = markdown_visible_text(contents);
+    if contains_any_ascii_case_insensitive(&visible, PUBLIC_PRIVATE_COMMENT_PATTERNS) {
         return Some("private comment references");
     }
-    if contains_any_ascii_case_insensitive(contents, PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS) {
+    if contains_any_ascii_case_insensitive(&visible, PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS) {
         return Some("private local paths");
     }
-    if contains_any_ascii_case_insensitive(contents, PUBLIC_PRIVATE_SOURCE_PATTERNS) {
+    if contains_any_ascii_case_insensitive(&visible, PUBLIC_PRIVATE_SOURCE_PATTERNS) {
         return Some("private source snapshots");
     }
     None

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -275,7 +275,7 @@ pub fn export_okf_bundle(
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
     let public = visibility == MemoryVisibility::Public;
     let lint = lint_okf_bundle(&source_root, false)?;
-    let errors = lint_errors_for_export(config, "OKF source bundle", &lint, public);
+    let errors = lint_errors_for_export(config, "OKF source bundle", &lint, true);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
     }
@@ -363,7 +363,7 @@ pub fn import_okf_bundle(
         )));
     }
     let lint = lint_okf_bundle(&source_path, false)?;
-    let errors = lint_errors(config, "OKF import bundle", &lint);
+    let errors = lint_errors_for_export(config, "OKF import bundle", &lint, true);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
     }
@@ -546,7 +546,8 @@ fn write_and_lint_staged_export(
         write_file(&path, &contents)?;
     }
     let exported_lint = lint_okf_bundle(staging_path, public)?;
-    let errors = lint_errors(config, "exported OKF bundle", &exported_lint);
+    let errors =
+        lint_errors_for_export(config, "exported OKF bundle", &exported_lint, !public);
     if errors.is_empty() {
         Ok(exported_lint)
     } else {
@@ -581,10 +582,6 @@ fn paths_overlap(left: &Path, right: &Path) -> bool {
     left == right || left.starts_with(right) || right.starts_with(left)
 }
 
-fn lint_errors(config: &MemoryConfig, label: &str, report: &LintReport) -> String {
-    lint_errors_for_export(config, label, report, false)
-}
-
 fn lint_errors_for_export(
     config: &MemoryConfig,
     label: &str,
@@ -613,7 +610,11 @@ fn lint_errors_for_export(
 }
 
 fn ignored_private_export_leak(finding: &LintFinding, ignore_private_export_leaks: bool) -> bool {
-    ignore_private_export_leaks && finding.message.contains("private export leak")
+    ignore_private_export_leaks && is_private_export_leak(finding)
+}
+
+fn is_private_export_leak(finding: &LintFinding) -> bool {
+    finding.message.contains("private export leak")
 }
 
 fn public_export_index() -> String {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -316,10 +316,12 @@ pub fn export_okf_bundle(
     let mut files = Vec::new();
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
     let public = visibility == MemoryVisibility::Public;
-    let lint = lint_okf_bundle_with_codes(&source_root, false)?;
-    let errors = filtered_lint_errors(config, "OKF source bundle", &lint, true);
-    if !errors.is_empty() {
-        return Err(MemoryError::InvalidInput(errors));
+    if !public {
+        let lint = lint_okf_bundle_with_codes(&source_root, false)?;
+        let errors = filtered_lint_errors(config, "OKF source bundle", &lint, true);
+        if !errors.is_empty() {
+            return Err(MemoryError::InvalidInput(errors));
+        }
     }
     let output_parent = output_path.parent().ok_or_else(|| {
         MemoryError::InvalidInput(format!(
@@ -327,8 +329,6 @@ pub fn export_okf_bundle(
             output_path.display()
         ))
     })?;
-    create_dir_all(output_parent)?;
-    let staging_path = create_staging_dir(output_parent, &output_path)?;
 
     let mut writes = Vec::<(PathBuf, String)>::new();
     let mut copied_files = Vec::new();
@@ -340,9 +340,14 @@ pub fn export_okf_bundle(
         let contents = read_to_string(&path)?;
         if bundle_path.reserved_file().is_some() {
             if !public {
-                writes.push((staging_path.join(&relative), contents));
+                writes.push((relative.clone(), contents));
                 copied_files.push(relative);
             }
+            continue;
+        }
+
+        if public && raw_okf_visibility(&contents) == Some(MemoryVisibility::Private) {
+            skipped_private_files.push(relative);
             continue;
         }
 
@@ -351,16 +356,22 @@ pub fn export_okf_bundle(
             skipped_private_files.push(relative);
             continue;
         }
-        writes.push((staging_path.join(&relative), contents));
+        writes.push((relative.clone(), contents));
         copied_files.push(relative);
     }
 
     if public {
-        writes.push((staging_path.join("index.md"), public_export_index()));
-        writes.push((staging_path.join("log.md"), public_export_log()));
+        writes.push((PathBuf::from("index.md"), public_export_index()));
+        writes.push((PathBuf::from("log.md"), public_export_log()));
         copied_files.push(PathBuf::from("index.md"));
         copied_files.push(PathBuf::from("log.md"));
     }
+    create_dir_all(output_parent)?;
+    let staging_path = create_staging_dir(output_parent, &output_path)?;
+    let writes = writes
+        .into_iter()
+        .map(|(relative, contents)| (staging_path.join(relative), contents))
+        .collect::<Vec<_>>();
     let exported_lint = match write_and_lint_staged_export(config, &staging_path, writes, public) {
         Ok(report) => report,
         Err(error) => return Err(cleanup_staging_after_export_failure(&staging_path, error)),
@@ -397,6 +408,11 @@ pub fn import_okf_bundle(
             source_path.display(),
             target_root.display()
         )));
+    }
+    let target_lint = lint_okf_bundle_with_codes(&target_root, false)?;
+    let target_errors = filtered_lint_errors(config, "OKF import target", &target_lint, true);
+    if !target_errors.is_empty() {
+        return Err(MemoryError::InvalidInput(target_errors));
     }
     let lint = lint_okf_bundle_with_codes(&source_path, false)?;
     let errors = filtered_lint_errors(config, "OKF import bundle", &lint, true);
@@ -1347,6 +1363,26 @@ fn mapping_string(mapping: &serde_yaml::Mapping, key: &str) -> Option<String> {
         .get(serde_yaml::Value::String(key.to_string()))
         .and_then(value_as_string)
         .filter(|value| !value.trim().is_empty())
+}
+
+fn raw_okf_visibility(contents: &str) -> Option<MemoryVisibility> {
+    let (frontmatter, _) = split_okf_frontmatter(Path::new("okf-concept.md"), contents).ok()?;
+    let value = serde_yaml::from_str::<serde_yaml::Value>(&frontmatter).ok()?;
+    let mapping = value.as_mapping()?;
+    mapping_visibility(mapping).or_else(|| {
+        mapping
+            .get(serde_yaml::Value::String("opensymphony".to_string()))
+            .and_then(|value| value.as_mapping())
+            .and_then(mapping_visibility)
+    })
+}
+
+fn mapping_visibility(mapping: &serde_yaml::Mapping) -> Option<MemoryVisibility> {
+    match mapping_string(mapping, "visibility")?.as_str() {
+        "private" => Some(MemoryVisibility::Private),
+        "public" => Some(MemoryVisibility::Public),
+        _ => None,
+    }
 }
 
 fn known_okf_type(concept_type: &str) -> bool {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -151,6 +151,23 @@ pub struct OkfConcept {
     pub derived_opensymphony: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OkfExportReport {
+    pub output_path: PathBuf,
+    pub copied_files: Vec<PathBuf>,
+    pub skipped_private_files: Vec<PathBuf>,
+    pub finding_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OkfImportReport {
+    pub source_path: PathBuf,
+    pub target_path: PathBuf,
+    pub copied_files: Vec<PathBuf>,
+    pub finding_count: usize,
+    pub reindex: MemoryReindexReport,
+}
+
 impl OkfConcept {
     pub fn new(
         path: impl Into<PathBuf>,
@@ -221,6 +238,148 @@ pub fn render_okf_concept(concept: &OkfConcept) -> Result<String, MemoryError> {
     Ok(format!("---\n{frontmatter}---\n\n{}", concept.body))
 }
 
+pub fn export_okf_bundle(
+    config: &MemoryConfig,
+    visibility: MemoryVisibility,
+    output: Option<&Path>,
+) -> Result<OkfExportReport, MemoryError> {
+    ensure_repo_contained(&config.repo_root, &config.memory_root)?;
+    let source_root = canonicalize_existing_path(&config.memory_root)?;
+    if !source_root.is_dir() {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF source bundle `{}` is not a directory",
+            source_root.display()
+        )));
+    }
+    let output_path = output
+        .map(|path| resolve_path(&config.repo_root, path))
+        .unwrap_or_else(|| config.repo_root.join(format!("okf-export-{visibility}")));
+    ensure_repo_contained(&config.repo_root, &output_path)?;
+    let output_path = canonicalize_existing_prefix(&output_path)?;
+    if output_path == source_root || output_path.starts_with(&source_root) {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF export output `{}` must not be inside the source bundle `{}`",
+            output_path.display(),
+            source_root.display()
+        )));
+    }
+    ensure_empty_output_dir(&output_path)?;
+
+    let mut files = Vec::new();
+    collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
+    let public = visibility == MemoryVisibility::Public;
+    let private_source_paths = if public {
+        private_okf_concept_paths(&source_root, &files)?
+    } else {
+        BTreeSet::new()
+    };
+    let lint = lint_okf_bundle(&source_root, false)?;
+    let errors = lint_errors_for_export(config, "OKF source bundle", &lint, &private_source_paths);
+    if !errors.is_empty() {
+        return Err(MemoryError::InvalidInput(errors));
+    }
+
+    let mut writes = Vec::<(PathBuf, String)>::new();
+    let mut copied_files = Vec::new();
+    let mut skipped_private_files = Vec::new();
+    let mut redaction_errors = Vec::new();
+
+    for path in files {
+        let relative = bundle_relative_path(&source_root, &path)?;
+        let bundle_path = OkfBundlePath::new(relative.clone())?;
+        let contents = read_to_string(&path)?;
+        if bundle_path.reserved_file().is_some() {
+            if !public {
+                writes.push((output_path.join(&relative), contents));
+                copied_files.push(relative);
+            }
+            continue;
+        }
+
+        let concept = parse_okf_concept(&source_root, &path, &contents)?;
+        if public && concept_visibility(&concept) == Some(MemoryVisibility::Private) {
+            skipped_private_files.push(relative);
+            continue;
+        }
+        if public && let Some(reason) = public_export_private_material(&contents) {
+            redaction_errors.push(format!(
+                "{}: public export contains {reason}",
+                display_path(&config.repo_root, &path)
+            ));
+            continue;
+        }
+        writes.push((output_path.join(&relative), contents));
+        copied_files.push(relative);
+    }
+
+    if !redaction_errors.is_empty() {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF public export redaction error(s): {}",
+            redaction_errors.join("; ")
+        )));
+    }
+    if public {
+        writes.push((output_path.join("index.md"), public_export_index()));
+        writes.push((output_path.join("log.md"), public_export_log()));
+        copied_files.push(PathBuf::from("index.md"));
+        copied_files.push(PathBuf::from("log.md"));
+    }
+    for (path, contents) in writes {
+        write_file(&path, &contents)?;
+    }
+    let exported_lint = lint_okf_bundle(&output_path, public)?;
+    let errors = lint_errors(config, "exported OKF bundle", &exported_lint);
+    if !errors.is_empty() {
+        return Err(MemoryError::InvalidInput(errors));
+    }
+
+    Ok(OkfExportReport {
+        output_path,
+        copied_files,
+        skipped_private_files,
+        finding_count: exported_lint.findings.len(),
+    })
+}
+
+pub fn import_okf_bundle(
+    config: &MemoryConfig,
+    source: &Path,
+) -> Result<OkfImportReport, MemoryError> {
+    ensure_repo_contained(&config.repo_root, source)?;
+    let source_path = canonicalize_existing_path(&resolve_path(&config.repo_root, source))?;
+    if !source_path.is_dir() {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF import source `{}` is not a directory",
+            source_path.display()
+        )));
+    }
+    let lint = lint_okf_bundle(&source_path, false)?;
+    let errors = lint_errors(config, "OKF import bundle", &lint);
+    if !errors.is_empty() {
+        return Err(MemoryError::InvalidInput(errors));
+    }
+
+    let mut files = Vec::new();
+    collect_okf_markdown_files(&source_path, &source_path, &mut files)?;
+    let mut copied_files = Vec::new();
+    for path in files {
+        let relative = bundle_relative_path(&source_path, &path)?;
+        OkfBundlePath::new(relative.clone())?;
+        let contents = read_to_string(&path)?;
+        write_file(&config.memory_root.join(&relative), &contents)?;
+        copied_files.push(relative);
+    }
+
+    let reindex = refresh_memory_index_from_okf(config, &config.memory_root)?;
+    Ok(OkfImportReport {
+        source_path,
+        target_path: config.memory_root.clone(),
+        copied_files,
+        finding_count: lint.findings.len(),
+        reindex,
+    })
+}
+
 pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintReport, MemoryError> {
     if !bundle_root.is_dir() {
         return Err(MemoryError::InvalidInput(format!(
@@ -279,6 +438,102 @@ pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintRe
     }
 
     Ok(LintReport { findings })
+}
+
+fn ensure_empty_output_dir(path: &Path) -> Result<(), MemoryError> {
+    if path.exists() {
+        if !path.is_dir() {
+            return Err(MemoryError::InvalidInput(format!(
+                "OKF export output `{}` exists and is not a directory",
+                path.display()
+            )));
+        }
+        let mut entries = fs::read_dir(path).map_err(|source| MemoryError::ReadFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        if entries.next().is_some() {
+            return Err(MemoryError::InvalidInput(format!(
+                "OKF export output `{}` must be empty",
+                path.display()
+            )));
+        }
+    } else {
+        create_dir_all(path)?;
+    }
+    Ok(())
+}
+
+fn lint_errors(config: &MemoryConfig, label: &str, report: &LintReport) -> String {
+    lint_errors_for_export(config, label, report, &BTreeSet::new())
+}
+
+fn lint_errors_for_export(
+    config: &MemoryConfig,
+    label: &str,
+    report: &LintReport,
+    ignored_private_paths: &BTreeSet<PathBuf>,
+) -> String {
+    let errors = report
+        .findings
+        .iter()
+        .filter(|finding| finding.severity == LintSeverity::Error)
+        .filter(|finding| !ignored_private_export_leak(finding, ignored_private_paths))
+        .map(|finding| {
+            let path = finding
+                .path
+                .as_ref()
+                .map(|path| display_path(&config.repo_root, path))
+                .unwrap_or_else(|| "bundle".to_string());
+            format!("{path}: {}", finding.message)
+        })
+        .collect::<Vec<_>>();
+    if errors.is_empty() {
+        String::new()
+    } else {
+        format!("{label} has error(s): {}", errors.join("; "))
+    }
+}
+
+fn ignored_private_export_leak(
+    finding: &LintFinding,
+    ignored_private_paths: &BTreeSet<PathBuf>,
+) -> bool {
+    finding.message.contains("private export leak")
+        && finding
+            .path
+            .as_ref()
+            .is_some_and(|path| ignored_private_paths.contains(path))
+}
+
+fn private_okf_concept_paths(
+    bundle_root: &Path,
+    files: &[PathBuf],
+) -> Result<BTreeSet<PathBuf>, MemoryError> {
+    let mut private = BTreeSet::new();
+    for path in files {
+        let relative = bundle_relative_path(bundle_root, path)?;
+        let bundle_path = OkfBundlePath::new(relative)?;
+        if bundle_path.reserved_file().is_some() {
+            continue;
+        }
+        let contents = read_to_string(path)?;
+        if let Ok(concept) = parse_okf_concept(bundle_root, path, &contents)
+            && concept_visibility(&concept) == Some(MemoryVisibility::Private)
+        {
+            private.insert(path.clone());
+        }
+    }
+    Ok(private)
+}
+
+fn public_export_index() -> String {
+    "---\nokf_version: \"0.1\"\n---\n\n# OpenSymphony Public Memory Export\n".to_string()
+}
+
+fn public_export_log() -> String {
+    "# OpenSymphony Public Memory Export Log\n\n## 1970-01-01\n\n- Public export generated.\n"
+        .to_string()
 }
 
 fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String), MemoryError> {
@@ -845,6 +1100,27 @@ fn contains_private_memory_link_in_markdown(contents: &str) -> bool {
         }
     }
     contains_private_memory_link(&visible)
+}
+
+fn public_export_private_material(contents: &str) -> Option<&'static str> {
+    let contents = contents.to_ascii_lowercase();
+    if contents.contains("linear:comment:") {
+        return Some("private comment references");
+    }
+    if contents.contains(".opensymphony/memory/issues")
+        || contents.contains(".opensymphony\\memory\\issues")
+        || contents.contains("../.opensymphony/memory/issues")
+    {
+        return Some("private local paths");
+    }
+    if contents.contains(".opensymphony/memory/source")
+        || contents.contains(".opensymphony\\memory\\source")
+        || contents.contains(".opensymphony/memory/snapshot")
+        || contents.contains(".opensymphony\\memory\\snapshot")
+    {
+        return Some("private source snapshots");
+    }
+    None
 }
 
 fn extract_wiki_links(body: &str) -> Vec<String> {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -268,13 +268,8 @@ pub fn export_okf_bundle(
     let mut files = Vec::new();
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
     let public = visibility == MemoryVisibility::Public;
-    let private_source_paths = if public {
-        private_okf_concept_paths(&source_root, &files)?
-    } else {
-        BTreeSet::new()
-    };
     let lint = lint_okf_bundle(&source_root, false)?;
-    let errors = lint_errors_for_export(config, "OKF source bundle", &lint, &private_source_paths);
+    let errors = lint_errors_for_export(config, "OKF source bundle", &lint, public);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
     }
@@ -344,8 +339,12 @@ pub fn export_okf_bundle(
 pub fn import_okf_bundle(
     config: &MemoryConfig,
     source: &Path,
+    force: bool,
 ) -> Result<OkfImportReport, MemoryError> {
     ensure_repo_contained(&config.repo_root, source)?;
+    ensure_repo_contained(&config.repo_root, &config.memory_root)?;
+    create_dir_all(&config.memory_root)?;
+    let target_root = canonicalize_existing_path(&config.memory_root)?;
     let source_path = canonicalize_existing_path(&resolve_path(&config.repo_root, source))?;
     if !source_path.is_dir() {
         return Err(MemoryError::InvalidInput(format!(
@@ -366,14 +365,21 @@ pub fn import_okf_bundle(
         let relative = bundle_relative_path(&source_path, &path)?;
         OkfBundlePath::new(relative.clone())?;
         let contents = read_to_string(&path)?;
-        write_file(&config.memory_root.join(&relative), &contents)?;
+        let target = target_root.join(&relative);
+        if target.exists() && !force {
+            return Err(MemoryError::InvalidInput(format!(
+                "{} already exists; rerun with --force to overwrite it",
+                display_path(&config.repo_root, &target)
+            )));
+        }
+        write_file(&target, &contents)?;
         copied_files.push(relative);
     }
 
-    let reindex = refresh_memory_index_from_okf(config, &config.memory_root)?;
+    let reindex = refresh_memory_index_from_okf(config, &target_root)?;
     Ok(OkfImportReport {
         source_path,
-        target_path: config.memory_root.clone(),
+        target_path: target_root,
         copied_files,
         finding_count: lint.findings.len(),
         reindex,
@@ -465,20 +471,20 @@ fn ensure_empty_output_dir(path: &Path) -> Result<(), MemoryError> {
 }
 
 fn lint_errors(config: &MemoryConfig, label: &str, report: &LintReport) -> String {
-    lint_errors_for_export(config, label, report, &BTreeSet::new())
+    lint_errors_for_export(config, label, report, false)
 }
 
 fn lint_errors_for_export(
     config: &MemoryConfig,
     label: &str,
     report: &LintReport,
-    ignored_private_paths: &BTreeSet<PathBuf>,
+    ignore_private_export_leaks: bool,
 ) -> String {
     let errors = report
         .findings
         .iter()
         .filter(|finding| finding.severity == LintSeverity::Error)
-        .filter(|finding| !ignored_private_export_leak(finding, ignored_private_paths))
+        .filter(|finding| !ignored_private_export_leak(finding, ignore_private_export_leaks))
         .map(|finding| {
             let path = finding
                 .path
@@ -495,36 +501,8 @@ fn lint_errors_for_export(
     }
 }
 
-fn ignored_private_export_leak(
-    finding: &LintFinding,
-    ignored_private_paths: &BTreeSet<PathBuf>,
-) -> bool {
-    finding.message.contains("private export leak")
-        && finding
-            .path
-            .as_ref()
-            .is_some_and(|path| ignored_private_paths.contains(path))
-}
-
-fn private_okf_concept_paths(
-    bundle_root: &Path,
-    files: &[PathBuf],
-) -> Result<BTreeSet<PathBuf>, MemoryError> {
-    let mut private = BTreeSet::new();
-    for path in files {
-        let relative = bundle_relative_path(bundle_root, path)?;
-        let bundle_path = OkfBundlePath::new(relative)?;
-        if bundle_path.reserved_file().is_some() {
-            continue;
-        }
-        let contents = read_to_string(path)?;
-        if let Ok(concept) = parse_okf_concept(bundle_root, path, &contents)
-            && concept_visibility(&concept) == Some(MemoryVisibility::Private)
-        {
-            private.insert(path.clone());
-        }
-    }
-    Ok(private)
+fn ignored_private_export_leak(finding: &LintFinding, ignore_private_export_leaks: bool) -> bool {
+    ignore_private_export_leaks && finding.message.contains("private export leak")
 }
 
 fn public_export_index() -> String {
@@ -1102,25 +1080,45 @@ fn contains_private_memory_link_in_markdown(contents: &str) -> bool {
     contains_private_memory_link(&visible)
 }
 
+const PUBLIC_PRIVATE_COMMENT_PATTERNS: &[&str] = &["linear:comment:"];
+const PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS: &[&str] = &[
+    ".opensymphony/memory/issues",
+    ".opensymphony\\memory\\issues",
+    "../.opensymphony/memory/issues",
+];
+const PUBLIC_PRIVATE_SOURCE_PATTERNS: &[&str] = &[
+    ".opensymphony/memory/source",
+    ".opensymphony\\memory\\source",
+    ".opensymphony/memory/snapshot",
+    ".opensymphony\\memory\\snapshot",
+];
+
 fn public_export_private_material(contents: &str) -> Option<&'static str> {
-    let contents = contents.to_ascii_lowercase();
-    if contents.contains("linear:comment:") {
+    if contains_any_ascii_case_insensitive(contents, PUBLIC_PRIVATE_COMMENT_PATTERNS) {
         return Some("private comment references");
     }
-    if contents.contains(".opensymphony/memory/issues")
-        || contents.contains(".opensymphony\\memory\\issues")
-        || contents.contains("../.opensymphony/memory/issues")
-    {
+    if contains_any_ascii_case_insensitive(contents, PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS) {
         return Some("private local paths");
     }
-    if contents.contains(".opensymphony/memory/source")
-        || contents.contains(".opensymphony\\memory\\source")
-        || contents.contains(".opensymphony/memory/snapshot")
-        || contents.contains(".opensymphony\\memory\\snapshot")
-    {
+    if contains_any_ascii_case_insensitive(contents, PUBLIC_PRIVATE_SOURCE_PATTERNS) {
         return Some("private source snapshots");
     }
     None
+}
+
+fn contains_any_ascii_case_insensitive(contents: &str, patterns: &[&str]) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| contains_ascii_case_insensitive(contents, pattern))
+}
+
+fn contains_ascii_case_insensitive(contents: &str, pattern: &str) -> bool {
+    let pattern = pattern.as_bytes();
+    !pattern.is_empty()
+        && contents
+            .as_bytes()
+            .windows(pattern.len())
+            .any(|window| window.eq_ignore_ascii_case(pattern))
 }
 
 fn extract_wiki_links(body: &str) -> Vec<String> {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -322,10 +322,7 @@ pub fn export_okf_bundle(
     }
     let exported_lint = match write_and_lint_staged_export(config, &staging_path, writes, public) {
         Ok(report) => report,
-        Err(error) => {
-            let _ = cleanup_staging_dir(&staging_path);
-            return Err(error);
-        }
+        Err(error) => return Err(cleanup_staging_after_export_failure(&staging_path, error)),
     };
     promote_staged_export(&staging_path, &output_path)?;
 
@@ -732,6 +729,28 @@ fn cleanup_staging_dir(path: &Path) -> Result<(), MemoryError> {
     Ok(())
 }
 
+fn cleanup_staging_after_export_failure(path: &Path, error: MemoryError) -> MemoryError {
+    cleanup_staging_after_export_failure_with(path, error, cleanup_staging_dir)
+}
+
+fn cleanup_staging_after_export_failure_with<D>(
+    path: &Path,
+    error: MemoryError,
+    mut cleanup: D,
+) -> MemoryError
+where
+    D: FnMut(&Path) -> Result<(), MemoryError>,
+{
+    match cleanup(path) {
+        Ok(()) => error,
+        Err(cleanup_error) => MemoryError::InvalidInput(format!(
+            "{error}; additionally failed to remove OKF export staging directory `{}` after the export failure: {}; remove the staging directory manually",
+            path.display(),
+            cleanup_error
+        )),
+    }
+}
+
 fn paths_overlap(left: &Path, right: &Path) -> bool {
     left == right || left.starts_with(right) || right.starts_with(left)
 }
@@ -1046,7 +1065,8 @@ fn lint_okf_concept(
             next_command: None,
         });
     }
-    if contains_private_memory_link_in_markdown(contents) {
+    let visible_text = markdown_visible_text(contents);
+    if contains_private_memory_link(&visible_text) {
         findings.push(LintFinding {
             code: Some(LintCode::OkfPrivateMemoryLink),
             severity: LintSeverity::Error,
@@ -1064,7 +1084,7 @@ fn lint_okf_concept(
             next_command: None,
         });
     }
-    if public_export && let Some(reason) = public_export_private_material(contents) {
+    if public_export && let Some(reason) = public_export_private_material(&visible_text) {
         findings.push(LintFinding {
             code: None,
             severity: LintSeverity::Error,
@@ -1353,6 +1373,7 @@ fn normalize_okf_link_id(target: &str) -> String {
         .to_ascii_lowercase()
 }
 
+#[cfg(test)]
 fn contains_private_memory_link_in_markdown(contents: &str) -> bool {
     let visible = markdown_visible_text(contents);
     contains_private_memory_link(&visible)
@@ -1400,15 +1421,14 @@ const PUBLIC_PRIVATE_SOURCE_PATTERNS: &[&str] = &[
     "../.opensymphony/memory/snapshot",
 ];
 
-fn public_export_private_material(contents: &str) -> Option<&'static str> {
-    let visible = markdown_visible_text(contents);
-    if contains_any_ascii_case_insensitive(&visible, PUBLIC_PRIVATE_COMMENT_PATTERNS) {
+fn public_export_private_material(visible: &str) -> Option<&'static str> {
+    if contains_any_ascii_case_insensitive(visible, PUBLIC_PRIVATE_COMMENT_PATTERNS) {
         return Some("private comment references");
     }
-    if contains_any_ascii_case_insensitive(&visible, PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS) {
+    if contains_any_ascii_case_insensitive(visible, PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS) {
         return Some("private local paths");
     }
-    if contains_any_ascii_case_insensitive(&visible, PUBLIC_PRIVATE_SOURCE_PATTERNS) {
+    if contains_any_ascii_case_insensitive(visible, PUBLIC_PRIVATE_SOURCE_PATTERNS) {
         return Some("private source snapshots");
     }
     None
@@ -2222,6 +2242,34 @@ Visible [[real-target|Real Target]].
         assert!(
             leaked_backup,
             "failed cleanup should leave backup for manual operator cleanup"
+        );
+    }
+
+    #[test]
+    fn export_failure_reports_staging_cleanup_failure() {
+        let repo = tempfile::TempDir::new().expect("temp repo should exist");
+        let staging = repo.path().join(".okf-export.tmp");
+        let original = MemoryError::InvalidInput("exported OKF bundle has error(s)".to_string());
+
+        let error = cleanup_staging_after_export_failure_with(&staging, original, |path| {
+            Err(MemoryError::WriteFile {
+                path: path.to_path_buf(),
+                source: io::Error::other("injected cleanup failure"),
+            })
+        });
+
+        let message = error.to_string();
+        assert!(
+            message.contains("exported OKF bundle has error(s)"),
+            "error should preserve the original export failure: {message}"
+        );
+        assert!(
+            message.contains("failed to remove OKF export staging directory"),
+            "error should report the failed staging cleanup: {message}"
+        );
+        assert!(
+            message.contains(staging.to_string_lossy().as_ref()),
+            "error should include the recoverable staging path: {message}"
         );
     }
 

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -262,6 +262,7 @@ pub fn export_okf_bundle(
         .unwrap_or_else(|| config.repo_root.join(format!("okf-export-{visibility}")));
     ensure_repo_contained(&config.repo_root, &output_path)?;
     let output_path = canonicalize_existing_prefix(&output_path)?;
+    ensure_output_target_not_symlink(&output_path)?;
     if output_path == source_root || output_path.starts_with(&source_root) {
         return Err(MemoryError::InvalidInput(format!(
             "OKF export output `{}` must not be inside the source bundle `{}`",
@@ -275,7 +276,7 @@ pub fn export_okf_bundle(
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
     let public = visibility == MemoryVisibility::Public;
     let lint = lint_okf_bundle(&source_root, false)?;
-    let errors = lint_errors_for_export(config, "OKF source bundle", &lint, true);
+    let errors = filtered_lint_errors(config, "OKF source bundle", &lint, true);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
     }
@@ -326,10 +327,7 @@ pub fn export_okf_bundle(
             return Err(error);
         }
     };
-    if let Err(error) = promote_staged_export(&staging_path, &output_path) {
-        let _ = cleanup_staging_dir(&staging_path);
-        return Err(error);
-    }
+    promote_staged_export(&staging_path, &output_path)?;
 
     Ok(OkfExportReport {
         output_path,
@@ -363,7 +361,7 @@ pub fn import_okf_bundle(
         )));
     }
     let lint = lint_okf_bundle(&source_path, false)?;
-    let errors = lint_errors_for_export(config, "OKF import bundle", &lint, true);
+    let errors = filtered_lint_errors(config, "OKF import bundle", &lint, true);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
     }
@@ -514,6 +512,18 @@ fn ensure_empty_output_target(path: &Path) -> Result<(), MemoryError> {
     Ok(())
 }
 
+fn ensure_output_target_not_symlink(path: &Path) -> Result<(), MemoryError> {
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && metadata.file_type().is_symlink()
+    {
+        return Err(MemoryError::InvalidInput(format!(
+            "OKF export output `{}` must not be a symlink",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
 fn create_staging_dir(parent: &Path, output_path: &Path) -> Result<PathBuf, MemoryError> {
     let output_name = output_path
         .file_name()
@@ -546,8 +556,7 @@ fn write_and_lint_staged_export(
         write_file(&path, &contents)?;
     }
     let exported_lint = lint_okf_bundle(staging_path, public)?;
-    let errors =
-        lint_errors_for_export(config, "exported OKF bundle", &exported_lint, !public);
+    let errors = filtered_lint_errors(config, "exported OKF bundle", &exported_lint, !public);
     if errors.is_empty() {
         Ok(exported_lint)
     } else {
@@ -556,16 +565,110 @@ fn write_and_lint_staged_export(
 }
 
 fn promote_staged_export(staging_path: &Path, output_path: &Path) -> Result<(), MemoryError> {
-    if output_path.exists() {
-        fs::remove_dir(output_path).map_err(|source| MemoryError::WriteFile {
-            path: output_path.to_path_buf(),
-            source,
+    promote_staged_export_with(
+        staging_path,
+        output_path,
+        |from, to| fs::rename(from, to),
+        |path| fs::remove_dir_all(path),
+    )
+}
+
+fn promote_staged_export_with<R, D>(
+    staging_path: &Path,
+    output_path: &Path,
+    mut rename: R,
+    mut remove_dir_all: D,
+) -> Result<(), MemoryError>
+where
+    R: FnMut(&Path, &Path) -> io::Result<()>,
+    D: FnMut(&Path) -> io::Result<()>,
+{
+    let backup_path = if output_path.exists() {
+        let backup_path = create_promotion_backup_path(output_path)?;
+        rename(output_path, &backup_path).map_err(|source| {
+            promotion_failure(output_path, staging_path, None, source, "backing up existing output")
         })?;
+        Some(backup_path)
+    } else {
+        None
+    };
+
+    if let Err(source) = rename(staging_path, output_path) {
+        let rollback = if let Some(backup_path) = backup_path.as_ref() {
+            match rename(backup_path, output_path) {
+                Ok(()) => format!(
+                    "previous output was restored from `{}`",
+                    backup_path.display()
+                ),
+                Err(rollback_source) => format!(
+                    "previous output remains at `{}` because rollback failed: {}",
+                    backup_path.display(),
+                    rollback_source
+                ),
+            }
+        } else {
+            "no previous output existed".to_string()
+        };
+        return Err(promotion_failure(
+            output_path,
+            staging_path,
+            Some(rollback),
+            source,
+            "moving staged bundle into place",
+        ));
     }
-    fs::rename(staging_path, output_path).map_err(|source| MemoryError::WriteFile {
-        path: output_path.to_path_buf(),
+
+    if let Some(backup_path) = backup_path
+        && backup_path.exists()
+    {
+        let _ = remove_dir_all(&backup_path);
+    }
+    Ok(())
+}
+
+fn create_promotion_backup_path(output_path: &Path) -> Result<PathBuf, MemoryError> {
+    let parent = output_path.parent().ok_or_else(|| {
+        MemoryError::InvalidInput(format!(
+            "OKF export output `{}` has no parent directory",
+            output_path.display()
+        ))
+    })?;
+    let output_name = output_path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or("okf-export");
+    for attempt in 0..100 {
+        let candidate = parent.join(format!(
+            ".{output_name}.backup-{}-{attempt}",
+            std::process::id()
+        ));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(MemoryError::InvalidInput(format!(
+        "could not allocate a backup directory for OKF export `{}`",
+        output_path.display()
+    )))
+}
+
+fn promotion_failure(
+    output_path: &Path,
+    staging_path: &Path,
+    recovery_detail: Option<String>,
+    source: io::Error,
+    action: &str,
+) -> MemoryError {
+    let recovery_detail = recovery_detail
+        .map(|detail| format!("; {detail}"))
+        .unwrap_or_default();
+    MemoryError::InvalidInput(format!(
+        "failed to promote OKF export to `{}` while {action}: {}; staged bundle preserved at `{}`{}",
+        output_path.display(),
         source,
-    })
+        staging_path.display(),
+        recovery_detail
+    ))
 }
 
 fn cleanup_staging_dir(path: &Path) -> Result<(), MemoryError> {
@@ -582,17 +685,17 @@ fn paths_overlap(left: &Path, right: &Path) -> bool {
     left == right || left.starts_with(right) || right.starts_with(left)
 }
 
-fn lint_errors_for_export(
+fn filtered_lint_errors(
     config: &MemoryConfig,
     label: &str,
     report: &LintReport,
-    ignore_private_export_leaks: bool,
+    ignore_private_memory_links: bool,
 ) -> String {
     let errors = report
         .findings
         .iter()
         .filter(|finding| finding.severity == LintSeverity::Error)
-        .filter(|finding| !ignored_private_export_leak(finding, ignore_private_export_leaks))
+        .filter(|finding| !ignored_private_export_leak(finding, ignore_private_memory_links))
         .map(|finding| {
             let path = finding
                 .path
@@ -609,8 +712,8 @@ fn lint_errors_for_export(
     }
 }
 
-fn ignored_private_export_leak(finding: &LintFinding, ignore_private_export_leaks: bool) -> bool {
-    ignore_private_export_leaks && is_private_export_leak(finding)
+fn ignored_private_export_leak(finding: &LintFinding, ignore_private_memory_links: bool) -> bool {
+    ignore_private_memory_links && is_private_export_leak(finding)
 }
 
 fn is_private_export_leak(finding: &LintFinding) -> bool {
@@ -622,8 +725,10 @@ fn public_export_index() -> String {
 }
 
 fn public_export_log() -> String {
-    "# OpenSymphony Public Memory Export Log\n\n## 1970-01-01\n\n- Public export generated.\n"
-        .to_string()
+    format!(
+        "# OpenSymphony Public Memory Export Log\n\n## {}\n\n- Public export generated.\n",
+        Utc::now().date_naive()
+    )
 }
 
 fn split_okf_frontmatter(path: &Path, contents: &str) -> Result<(String, String), MemoryError> {
@@ -1960,6 +2065,64 @@ Visible [[real-target|Real Target]].
             markdown_target_before_optional_title("assets/image.md.png \"Title\""),
             None
         );
+    }
+
+    #[test]
+    fn export_promotion_failure_restores_output_and_preserves_staging() {
+        let repo = tempfile::TempDir::new().expect("temp repo should exist");
+        let staging = repo.path().join(".okf-export.tmp");
+        let output = repo.path().join("okf-export-private");
+        fs::create_dir_all(&staging).expect("staging should write");
+        fs::write(staging.join("bundle.md"), "staged bundle")
+            .expect("staged file should write");
+        fs::create_dir_all(&output).expect("existing output should write");
+
+        let staging_for_failure = staging.clone();
+        let output_for_failure = output.clone();
+        let result = promote_staged_export_with(
+            &staging,
+            &output,
+            |from, to| {
+                if from == staging_for_failure.as_path() && to == output_for_failure.as_path() {
+                    Err(io::Error::other("injected rename failure"))
+                } else {
+                    fs::rename(from, to)
+                }
+            },
+            |path| fs::remove_dir_all(path),
+        );
+
+        let error = result.expect_err("promotion should fail");
+        assert!(
+            error.to_string().contains("staged bundle preserved"),
+            "error should explain recovery path: {error}"
+        );
+        assert!(
+            staging.join("bundle.md").is_file(),
+            "failed promotion should preserve staged bundle"
+        );
+        assert!(
+            output.is_dir(),
+            "failed promotion should restore previous output directory"
+        );
+        let leaked_backup = fs::read_dir(repo.path())
+            .expect("repo should list")
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().contains(".backup-"));
+        assert!(!leaked_backup, "successful rollback should consume backup dir");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_output_target_rejects_final_symlink() {
+        let repo = tempfile::TempDir::new().expect("temp repo should exist");
+        let output = repo.path().join("public-okf");
+        std::os::unix::fs::symlink(repo.path().join("missing-target"), &output)
+            .expect("symlink should write");
+
+        let result = ensure_output_target_not_symlink(&output);
+
+        assert!(matches!(result, Err(MemoryError::InvalidInput(_))));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -270,14 +270,6 @@ pub fn export_okf_bundle(
         )));
     }
     ensure_empty_output_target(&output_path)?;
-    let output_parent = output_path.parent().ok_or_else(|| {
-        MemoryError::InvalidInput(format!(
-            "OKF export output `{}` has no parent directory",
-            output_path.display()
-        ))
-    })?;
-    create_dir_all(output_parent)?;
-    let staging_path = create_staging_dir(output_parent, &output_path)?;
 
     let mut files = Vec::new();
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
@@ -287,6 +279,14 @@ pub fn export_okf_bundle(
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
     }
+    let output_parent = output_path.parent().ok_or_else(|| {
+        MemoryError::InvalidInput(format!(
+            "OKF export output `{}` has no parent directory",
+            output_path.display()
+        ))
+    })?;
+    create_dir_all(output_parent)?;
+    let staging_path = create_staging_dir(output_parent, &output_path)?;
 
     let mut writes = Vec::<(PathBuf, String)>::new();
     let mut copied_files = Vec::new();

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -302,6 +302,7 @@ pub fn export_okf_bundle(
         .map(|path| resolve_path(&config.repo_root, path))
         .unwrap_or_else(|| config.repo_root.join(format!("okf-export-{visibility}")));
     ensure_repo_contained(&config.repo_root, &output_path)?;
+    ensure_export_output_has_no_symlink_components(config, &output_path)?;
     let output_path = canonicalize_existing_prefix(&output_path)?;
     ensure_output_target_not_symlink(&output_path)?;
     if paths_overlap(&output_path, &source_root) {
@@ -640,6 +641,62 @@ fn ensure_output_target_not_symlink(path: &Path) -> Result<(), MemoryError> {
             "OKF export output `{}` must not be a symlink",
             path.display()
         )));
+    }
+    Ok(())
+}
+
+fn ensure_export_output_has_no_symlink_components(
+    config: &MemoryConfig,
+    path: &Path,
+) -> Result<(), MemoryError> {
+    let repo_root = canonicalize_existing_path(&config.repo_root)?;
+    let output_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo_root.join(path)
+    };
+    let relative = output_path
+        .strip_prefix(&repo_root)
+        .map_err(|_| MemoryError::PathOutsideRepo {
+            path: output_path.clone(),
+            repo_root: repo_root.clone(),
+        })?;
+    let mut cursor = repo_root;
+    for component in relative.components() {
+        match component {
+            std::path::Component::CurDir => continue,
+            std::path::Component::Normal(part) => cursor.push(part),
+            _ => {
+                return Err(MemoryError::PathOutsideRepo {
+                    path: output_path,
+                    repo_root: config.repo_root.clone(),
+                });
+            }
+        }
+        match fs::symlink_metadata(&cursor) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(MemoryError::InvalidInput(format!(
+                    "OKF export output `{}` must not include symlink component `{}`",
+                    display_path(&config.repo_root, path),
+                    display_path(&config.repo_root, &cursor)
+                )));
+            }
+            Ok(_) => {}
+            Err(source)
+                if matches!(
+                    source.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+                ) =>
+            {
+                break;
+            }
+            Err(source) => {
+                return Err(MemoryError::ReadFile {
+                    path: cursor,
+                    source,
+                });
+            }
+        }
     }
     Ok(())
 }

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -575,11 +575,16 @@ fn create_staging_dir(parent: &Path, output_path: &Path) -> Result<PathBuf, Memo
             ".{output_name}.tmp-{}-{attempt}",
             std::process::id()
         ));
-        if candidate.exists() {
-            continue;
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(source) if source.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(source) => {
+                return Err(MemoryError::CreateDir {
+                    path: candidate,
+                    source,
+                });
+            }
         }
-        create_dir_all(&candidate)?;
-        return Ok(candidate);
     }
     Err(MemoryError::InvalidInput(format!(
         "could not allocate a staging directory for OKF export `{}`",
@@ -743,11 +748,11 @@ where
 {
     match cleanup(path) {
         Ok(()) => error,
-        Err(cleanup_error) => MemoryError::InvalidInput(format!(
-            "{error}; additionally failed to remove OKF export staging directory `{}` after the export failure: {}; remove the staging directory manually",
-            path.display(),
-            cleanup_error
-        )),
+        Err(cleanup) => MemoryError::OkfExportStagingCleanup {
+            path: path.to_path_buf(),
+            source: Box::new(error),
+            cleanup: Box::new(cleanup),
+        },
     }
 }
 
@@ -2270,6 +2275,39 @@ Visible [[real-target|Real Target]].
         assert!(
             message.contains(staging.to_string_lossy().as_ref()),
             "error should include the recoverable staging path: {message}"
+        );
+        let MemoryError::OkfExportStagingCleanup { source, cleanup, .. } = error else {
+            panic!("error should preserve structured export and cleanup failures");
+        };
+        assert!(
+            matches!(*source, MemoryError::InvalidInput(_)),
+            "source error should preserve the original variant"
+        );
+        assert!(
+            matches!(*cleanup, MemoryError::WriteFile { .. }),
+            "cleanup error should preserve the cleanup variant"
+        );
+    }
+
+    #[test]
+    fn create_staging_dir_retries_existing_candidate() {
+        let repo = tempfile::TempDir::new().expect("temp repo should exist");
+        let output = repo.path().join("okf-export-public");
+        let first_candidate = repo.path().join(format!(
+            ".okf-export-public.tmp-{}-0",
+            std::process::id()
+        ));
+        fs::create_dir(&first_candidate).expect("first candidate should exist");
+
+        let staging = create_staging_dir(repo.path(), &output).expect("staging should allocate");
+
+        assert_ne!(
+            staging, first_candidate,
+            "allocator should retry after an existing candidate"
+        );
+        assert!(
+            staging.is_dir(),
+            "allocator should create the retried candidate atomically"
         );
     }
 

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -67,6 +67,47 @@ pub enum OkfReservedFile {
     Log,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OkfLintReport {
+    findings: Vec<OkfLintFinding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OkfLintFinding {
+    code: Option<LintCode>,
+    severity: LintSeverity,
+    path: Option<PathBuf>,
+    message: String,
+    next_command: Option<String>,
+}
+
+impl OkfLintFinding {
+    fn into_public(self) -> LintFinding {
+        LintFinding {
+            severity: self.severity,
+            path: self.path,
+            message: self.message,
+            next_command: self.next_command,
+        }
+    }
+}
+
+fn okf_lint_finding(
+    code: Option<LintCode>,
+    severity: LintSeverity,
+    path: Option<PathBuf>,
+    message: impl Into<String>,
+    next_command: Option<String>,
+) -> OkfLintFinding {
+    OkfLintFinding {
+        code,
+        severity,
+        path,
+        message: message.into(),
+        next_command,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OkfFrontmatter {
     #[serde(rename = "type")]
@@ -275,7 +316,7 @@ pub fn export_okf_bundle(
     let mut files = Vec::new();
     collect_okf_markdown_files(&source_root, &source_root, &mut files)?;
     let public = visibility == MemoryVisibility::Public;
-    let lint = lint_okf_bundle(&source_root, false)?;
+    let lint = lint_okf_bundle_with_codes(&source_root, false)?;
     let errors = filtered_lint_errors(config, "OKF source bundle", &lint, true);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
@@ -357,7 +398,7 @@ pub fn import_okf_bundle(
             target_root.display()
         )));
     }
-    let lint = lint_okf_bundle(&source_path, false)?;
+    let lint = lint_okf_bundle_with_codes(&source_path, false)?;
     let errors = filtered_lint_errors(config, "OKF import bundle", &lint, true);
     if !errors.is_empty() {
         return Err(MemoryError::InvalidInput(errors));
@@ -394,7 +435,10 @@ fn pending_okf_import_files(
     let mut pending = Vec::new();
     for path in files {
         let relative = bundle_relative_path(source_path, path)?;
-        OkfBundlePath::new(relative.clone())?;
+        let bundle_path = OkfBundlePath::new(relative.clone())?;
+        if bundle_path.reserved_file().is_some() {
+            continue;
+        }
         let contents = read_to_string(path)?;
         let target = target_root.join(&relative);
         ensure_import_target_has_no_symlink_components(config, target_root, &target)?;
@@ -470,6 +514,20 @@ fn ensure_import_target_has_no_symlink_components(
 }
 
 pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintReport, MemoryError> {
+    let report = lint_okf_bundle_with_codes(bundle_root, public_export)?;
+    Ok(LintReport {
+        findings: report
+            .findings
+            .into_iter()
+            .map(OkfLintFinding::into_public)
+            .collect(),
+    })
+}
+
+fn lint_okf_bundle_with_codes(
+    bundle_root: &Path,
+    public_export: bool,
+) -> Result<OkfLintReport, MemoryError> {
     if !bundle_root.is_dir() {
         return Err(MemoryError::InvalidInput(format!(
             "OKF bundle root `{}` is not a directory",
@@ -489,13 +547,13 @@ pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintRe
         let bundle_path = match OkfBundlePath::new(relative.clone()) {
             Ok(path) => path,
             Err(error) => {
-                findings.push(LintFinding {
-                    code: None,
-                    severity: LintSeverity::Error,
-                    path: Some(path),
-                    message: error.to_string(),
-                    next_command: None,
-                });
+                findings.push(okf_lint_finding(
+                    None,
+                    LintSeverity::Error,
+                    Some(path),
+                    error.to_string(),
+                    None,
+                ));
                 continue;
             }
         };
@@ -518,17 +576,17 @@ pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintRe
 
     for directory in dirs_with_concepts {
         if !dirs_with_index.contains(&directory) {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Warn,
-                path: Some(bundle_root.join(&directory)),
-                message: "missing generated index.md".to_string(),
-                next_command: Some("opensymphony memory reindex".to_string()),
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Warn,
+                Some(bundle_root.join(&directory)),
+                "missing generated index.md".to_string(),
+                Some("opensymphony memory reindex".to_string()),
+            ));
         }
     }
 
-    Ok(LintReport { findings })
+    Ok(OkfLintReport { findings })
 }
 
 fn ensure_empty_output_target(path: &Path) -> Result<(), MemoryError> {
@@ -597,11 +655,11 @@ fn write_and_lint_staged_export(
     staging_path: &Path,
     writes: Vec<(PathBuf, String)>,
     public: bool,
-) -> Result<LintReport, MemoryError> {
+) -> Result<OkfLintReport, MemoryError> {
     for (path, contents) in writes {
         write_file(&path, &contents)?;
     }
-    let exported_lint = lint_okf_bundle(staging_path, public)?;
+    let exported_lint = lint_okf_bundle_with_codes(staging_path, public)?;
     let errors = filtered_lint_errors(config, "exported OKF bundle", &exported_lint, !public);
     if errors.is_empty() {
         Ok(exported_lint)
@@ -632,7 +690,13 @@ where
     let backup_path = if output_path.exists() {
         let backup_path = create_promotion_backup_path(output_path)?;
         rename(output_path, &backup_path).map_err(|source| {
-            promotion_failure(output_path, staging_path, None, source, "backing up existing output")
+            promotion_failure(
+                output_path,
+                staging_path,
+                None,
+                source,
+                "backing up existing output",
+            )
         })?;
         Some(backup_path)
     } else {
@@ -763,7 +827,7 @@ fn paths_overlap(left: &Path, right: &Path) -> bool {
 fn filtered_lint_errors(
     config: &MemoryConfig,
     label: &str,
-    report: &LintReport,
+    report: &OkfLintReport,
     ignore_private_memory_links: bool,
 ) -> String {
     let errors = report
@@ -787,11 +851,14 @@ fn filtered_lint_errors(
     }
 }
 
-fn ignored_private_export_leak(finding: &LintFinding, ignore_private_memory_links: bool) -> bool {
+fn ignored_private_export_leak(
+    finding: &OkfLintFinding,
+    ignore_private_memory_links: bool,
+) -> bool {
     ignore_private_memory_links && is_private_export_leak(finding)
 }
 
-fn is_private_export_leak(finding: &LintFinding) -> bool {
+fn is_private_export_leak(finding: &OkfLintFinding) -> bool {
     finding.code == Some(LintCode::OkfPrivateMemoryLink)
 }
 
@@ -890,7 +957,7 @@ fn lint_okf_index(
     path: &Path,
     relative: &Path,
     contents: &str,
-    findings: &mut Vec<LintFinding>,
+    findings: &mut Vec<OkfLintFinding>,
 ) {
     if !has_okf_frontmatter(contents) {
         return;
@@ -899,68 +966,67 @@ fn lint_okf_index(
         .parent()
         .is_none_or(|parent| parent.as_os_str().is_empty())
     {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "reserved index.md must not contain frontmatter outside the bundle root"
-                .to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "reserved index.md must not contain frontmatter outside the bundle root".to_string(),
+            None,
+        ));
         return;
     }
     let Ok((frontmatter, _)) = split_okf_frontmatter(path, contents) else {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "reserved index.md has invalid frontmatter".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "reserved index.md has invalid frontmatter".to_string(),
+            None,
+        ));
         return;
     };
     let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&frontmatter) else {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "reserved index.md frontmatter is not parseable YAML".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "reserved index.md frontmatter is not parseable YAML".to_string(),
+            None,
+        ));
         return;
     };
     let Some(mapping) = value.as_mapping() else {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "reserved index.md frontmatter must be a YAML mapping".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "reserved index.md frontmatter must be a YAML mapping".to_string(),
+            None,
+        ));
         return;
     };
     if let Some(version) = mapping_string(mapping, "okf_version")
         && version != OKF_VERSION
     {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Warn,
-            path: Some(bundle_root.join(relative)),
-            message: format!("unknown OKF version `{version}`"),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Warn,
+            Some(bundle_root.join(relative)),
+            format!("unknown OKF version `{version}`"),
+            None,
+        ));
     }
 }
 
-fn lint_okf_log(path: &Path, contents: &str, findings: &mut Vec<LintFinding>) {
+fn lint_okf_log(path: &Path, contents: &str, findings: &mut Vec<OkfLintFinding>) {
     if has_okf_frontmatter(contents) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "reserved log.md must not contain frontmatter".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "reserved log.md must not contain frontmatter".to_string(),
+            None,
+        ));
     }
 
     let mut dates = Vec::new();
@@ -978,13 +1044,13 @@ fn lint_okf_log(path: &Path, contents: &str, findings: &mut Vec<LintFinding>) {
     }
 
     if dates.is_empty() || invalid_heading || !dates.windows(2).all(|pair| pair[0] >= pair[1]) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "reserved log.md must use ISO date headings newest first".to_string(),
-            next_command: Some("opensymphony memory reindex".to_string()),
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "reserved log.md must use ISO date headings newest first".to_string(),
+            Some("opensymphony memory reindex".to_string()),
+        ));
     }
 }
 
@@ -993,110 +1059,110 @@ fn lint_okf_concept(
     path: &Path,
     contents: &str,
     public_export: bool,
-    findings: &mut Vec<LintFinding>,
+    findings: &mut Vec<OkfLintFinding>,
 ) {
     let (frontmatter, body) = match split_okf_frontmatter(path, contents) {
         Ok(parts) => parts,
         Err(error) => {
             let message = okf_frontmatter_lint_message(&error);
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Error,
-                path: Some(path.to_path_buf()),
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Error,
+                Some(path.to_path_buf()),
                 message,
-                next_command: None,
-            });
+                None,
+            ));
             return;
         }
     };
     let value = match serde_yaml::from_str::<serde_yaml::Value>(&frontmatter) {
         Ok(value) => value,
         Err(_) => {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Error,
-                path: Some(path.to_path_buf()),
-                message: "frontmatter is not parseable YAML".to_string(),
-                next_command: None,
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Error,
+                Some(path.to_path_buf()),
+                "frontmatter is not parseable YAML".to_string(),
+                None,
+            ));
             return;
         }
     };
     let Some(mapping) = value.as_mapping() else {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "frontmatter must be a YAML mapping".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "frontmatter must be a YAML mapping".to_string(),
+            None,
+        ));
         return;
     };
     if mapping_string(mapping, "type")
         .as_deref()
         .is_none_or(str::is_empty)
     {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "frontmatter lacks non-empty `type`".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "frontmatter lacks non-empty `type`".to_string(),
+            None,
+        ));
         return;
     }
 
     let concept = match parse_okf_concept(bundle_root, path, contents) {
         Ok(concept) => concept,
         Err(error) => {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Error,
-                path: Some(path.to_path_buf()),
-                message: format!("frontmatter is not parseable OKF YAML: {error}"),
-                next_command: None,
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Error,
+                Some(path.to_path_buf()),
+                format!("frontmatter is not parseable OKF YAML: {error}"),
+                None,
+            ));
             return;
         }
     };
 
     lint_okf_recommended_fields(&concept, &body, path, findings);
     if !known_okf_type(&concept.frontmatter.concept_type) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Warn,
-            path: Some(path.to_path_buf()),
-            message: format!("unknown type `{}`", concept.frontmatter.concept_type),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Warn,
+            Some(path.to_path_buf()),
+            format!("unknown type `{}`", concept.frontmatter.concept_type),
+            None,
+        ));
     }
     let visible_text = markdown_visible_text(contents);
     if contains_private_memory_link(&visible_text) {
-        findings.push(LintFinding {
-            code: Some(LintCode::OkfPrivateMemoryLink),
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "private export leak: document links to a private memory path".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            Some(LintCode::OkfPrivateMemoryLink),
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "private export leak: document links to a private memory path".to_string(),
+            None,
+        ));
     }
     if public_export && concept_visibility(&concept) == Some(MemoryVisibility::Private) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: "public export includes a private concept".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            "public export includes a private concept".to_string(),
+            None,
+        ));
     }
     if public_export && let Some(reason) = public_export_private_material(&visible_text) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Error,
-            path: Some(path.to_path_buf()),
-            message: format!("public export contains {reason}"),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Error,
+            Some(path.to_path_buf()),
+            format!("public export contains {reason}"),
+            None,
+        ));
     }
     lint_okf_links(bundle_root, &concept, path, findings);
     lint_okf_citations(&concept, path, findings);
@@ -1107,31 +1173,31 @@ fn lint_okf_recommended_fields(
     concept: &OkfConcept,
     body: &str,
     path: &Path,
-    findings: &mut Vec<LintFinding>,
+    findings: &mut Vec<OkfLintFinding>,
 ) {
     let mut missing = Vec::new();
     if concept.frontmatter.title.is_none() {
         missing.push("title");
         if first_heading(body).is_some() {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Info,
-                path: Some(path.to_path_buf()),
-                message: "title can be synthesized from the first heading".to_string(),
-                next_command: None,
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Info,
+                Some(path.to_path_buf()),
+                "title can be synthesized from the first heading".to_string(),
+                None,
+            ));
         }
     }
     if concept.frontmatter.description.is_none() {
         missing.push("description");
         if first_paragraph(body).is_some() {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Info,
-                path: Some(path.to_path_buf()),
-                message: "description can be synthesized from the first paragraph".to_string(),
-                next_command: None,
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Info,
+                Some(path.to_path_buf()),
+                "description can be synthesized from the first paragraph".to_string(),
+                None,
+            ));
         }
     }
     if concept.frontmatter.resource.is_none() {
@@ -1144,13 +1210,13 @@ fn lint_okf_recommended_fields(
         missing.push("timestamp");
     }
     if !missing.is_empty() {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Warn,
-            path: Some(path.to_path_buf()),
-            message: format!("missing recommended field(s): {}", missing.join(", ")),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Warn,
+            Some(path.to_path_buf()),
+            format!("missing recommended field(s): {}", missing.join(", ")),
+            None,
+        ));
     }
 }
 
@@ -1158,21 +1224,22 @@ fn lint_okf_links(
     bundle_root: &Path,
     concept: &OkfConcept,
     path: &Path,
-    findings: &mut Vec<LintFinding>,
+    findings: &mut Vec<OkfLintFinding>,
 ) {
     for link in &concept.links {
-        let Some(resolved) = resolve_okf_markdown_link(bundle_root, concept.path.as_path(), &link.target)
+        let Some(resolved) =
+            resolve_okf_markdown_link(bundle_root, concept.path.as_path(), &link.target)
         else {
             continue;
         };
         if !resolved.exists() {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Warn,
-                path: Some(path.to_path_buf()),
-                message: format!("broken Markdown link `{}`", link.target),
-                next_command: None,
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Warn,
+                Some(path.to_path_buf()),
+                format!("broken Markdown link `{}`", link.target),
+                None,
+            ));
         }
     }
 
@@ -1183,18 +1250,18 @@ fn lint_okf_links(
         .collect::<BTreeSet<_>>();
     for wiki_link in extract_wiki_links(&concept.body) {
         if !markdown_ids.contains(&normalized_wiki_link_id(&wiki_link)) {
-            findings.push(LintFinding {
-                code: None,
-                severity: LintSeverity::Warn,
-                path: Some(path.to_path_buf()),
-                message: format!("wiki-only link `[[{wiki_link}]]` has no Markdown equivalent"),
-                next_command: None,
-            });
+            findings.push(okf_lint_finding(
+                None,
+                LintSeverity::Warn,
+                Some(path.to_path_buf()),
+                format!("wiki-only link `[[{wiki_link}]]` has no Markdown equivalent"),
+                None,
+            ));
         }
     }
 }
 
-fn lint_okf_citations(concept: &OkfConcept, path: &Path, findings: &mut Vec<LintFinding>) {
+fn lint_okf_citations(concept: &OkfConcept, path: &Path, findings: &mut Vec<OkfLintFinding>) {
     let source_backed = concept
         .frontmatter
         .opensymphony
@@ -1204,13 +1271,13 @@ fn lint_okf_citations(concept: &OkfConcept, path: &Path, findings: &mut Vec<Lint
         || concept.frontmatter.extra.contains_key("prs")
         || concept.frontmatter.extra.contains_key("linear_url");
     if source_backed && !has_citations_section(&concept.body) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Warn,
-            path: Some(path.to_path_buf()),
-            message: "citation section missing for source-backed claims".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Warn,
+            Some(path.to_path_buf()),
+            "citation section missing for source-backed claims".to_string(),
+            None,
+        ));
     }
 }
 
@@ -1218,7 +1285,7 @@ fn lint_okf_info(
     concept: &OkfConcept,
     mapping: &serde_yaml::Mapping,
     path: &Path,
-    findings: &mut Vec<LintFinding>,
+    findings: &mut Vec<OkfLintFinding>,
 ) {
     let retained_legacy = [
         "issue",
@@ -1239,22 +1306,22 @@ fn lint_okf_info(
     .filter(|key| concept.frontmatter.extra.contains_key(*key))
     .collect::<Vec<_>>();
     if !retained_legacy.is_empty() {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Info,
-            path: Some(path.to_path_buf()),
-            message: format!("legacy field(s) retained: {}", retained_legacy.join(", ")),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Info,
+            Some(path.to_path_buf()),
+            format!("legacy field(s) retained: {}", retained_legacy.join(", ")),
+            None,
+        ));
     }
     if mapping.contains_key(serde_yaml::Value::String("opensymphony".to_string())) {
-        findings.push(LintFinding {
-            code: None,
-            severity: LintSeverity::Info,
-            path: Some(path.to_path_buf()),
-            message: "bundle contains OpenSymphony extension fields".to_string(),
-            next_command: None,
-        });
+        findings.push(okf_lint_finding(
+            None,
+            LintSeverity::Info,
+            Some(path.to_path_buf()),
+            "bundle contains OpenSymphony extension fields".to_string(),
+            None,
+        ));
     }
 }
 
@@ -1315,10 +1382,7 @@ fn resolve_okf_markdown_link(
     let relative = if let Some(stripped) = target.strip_prefix('/') {
         PathBuf::from(stripped)
     } else {
-        concept_path
-            .parent()
-            .unwrap_or(Path::new(""))
-            .join(target)
+        concept_path.parent().unwrap_or(Path::new("")).join(target)
     };
     let normalized = normalize_okf_relative_path(&relative)?;
     Some(bundle_root.join(normalized))
@@ -1499,14 +1563,12 @@ fn first_heading(body: &str) -> Option<&str> {
 }
 
 fn first_paragraph(body: &str) -> Option<&str> {
-    body.lines()
-        .map(str::trim)
-        .find(|line| {
-            !line.is_empty()
-                && !line.starts_with('#')
-                && !line.starts_with('-')
-                && !line.starts_with("```")
-        })
+    body.lines().map(str::trim).find(|line| {
+        !line.is_empty()
+            && !line.starts_with('#')
+            && !line.starts_with('-')
+            && !line.starts_with("```")
+    })
 }
 
 fn has_citations_section(body: &str) -> bool {
@@ -1550,7 +1612,8 @@ fn legacy_frontmatter_to_opensymphony_metadata(
     push_scope(
         &mut metadata.scope_refs,
         KnowledgeScopeKind::Milestone,
-        string_extra(frontmatter, "milestone_id").or_else(|| string_extra(frontmatter, "milestone")),
+        string_extra(frontmatter, "milestone_id")
+            .or_else(|| string_extra(frontmatter, "milestone")),
         string_extra(frontmatter, "milestone"),
     );
     push_scope(
@@ -1914,9 +1977,7 @@ fn char_at(value: &str, index: usize) -> Option<(char, usize)> {
 }
 
 fn skip_escaped_char(value: &str, index: usize) -> usize {
-    char_at(value, index)
-        .map(|(_, next)| next)
-        .unwrap_or(index)
+    char_at(value, index).map(|(_, next)| next).unwrap_or(index)
 }
 
 fn skip_code_span(value: &str, index: usize) -> usize {
@@ -2104,7 +2165,11 @@ fn reference_link_targets(body: &str) -> BTreeMap<String, String> {
 }
 
 fn normalize_reference_label(label: &str) -> String {
-    label.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+    label
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 #[cfg(test)]
@@ -2175,8 +2240,7 @@ Visible [[real-target|Real Target]].
         let staging = repo.path().join(".okf-export.tmp");
         let output = repo.path().join("okf-export-private");
         fs::create_dir_all(&staging).expect("staging should write");
-        fs::write(staging.join("bundle.md"), "staged bundle")
-            .expect("staged file should write");
+        fs::write(staging.join("bundle.md"), "staged bundle").expect("staged file should write");
         fs::create_dir_all(&output).expect("existing output should write");
 
         let staging_for_failure = staging.clone();
@@ -2211,7 +2275,10 @@ Visible [[real-target|Real Target]].
             .expect("repo should list")
             .filter_map(Result::ok)
             .any(|entry| entry.file_name().to_string_lossy().contains(".backup-"));
-        assert!(!leaked_backup, "successful rollback should consume backup dir");
+        assert!(
+            !leaked_backup,
+            "successful rollback should consume backup dir"
+        );
     }
 
     #[test]
@@ -2220,8 +2287,7 @@ Visible [[real-target|Real Target]].
         let staging = repo.path().join(".okf-export.tmp");
         let output = repo.path().join("okf-export-private");
         fs::create_dir_all(&staging).expect("staging should write");
-        fs::write(staging.join("bundle.md"), "staged bundle")
-            .expect("staged file should write");
+        fs::write(staging.join("bundle.md"), "staged bundle").expect("staged file should write");
         fs::create_dir_all(&output).expect("existing output should write");
 
         let result = promote_staged_export_with(
@@ -2276,7 +2342,10 @@ Visible [[real-target|Real Target]].
             message.contains(staging.to_string_lossy().as_ref()),
             "error should include the recoverable staging path: {message}"
         );
-        let MemoryError::OkfExportStagingCleanup { source, cleanup, .. } = error else {
+        let MemoryError::OkfExportStagingCleanup {
+            source, cleanup, ..
+        } = error
+        else {
             panic!("error should preserve structured export and cleanup failures");
         };
         assert!(
@@ -2293,10 +2362,9 @@ Visible [[real-target|Real Target]].
     fn create_staging_dir_retries_existing_candidate() {
         let repo = tempfile::TempDir::new().expect("temp repo should exist");
         let output = repo.path().join("okf-export-public");
-        let first_candidate = repo.path().join(format!(
-            ".okf-export-public.tmp-{}-0",
-            std::process::id()
-        ));
+        let first_candidate = repo
+            .path()
+            .join(format!(".okf-export-public.tmp-{}-0", std::process::id()));
         fs::create_dir(&first_candidate).expect("first candidate should exist");
 
         let staging = create_staging_dir(repo.path(), &output).expect("staging should allocate");

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -346,9 +346,14 @@ pub fn export_okf_bundle(
             continue;
         }
 
-        if public && raw_okf_visibility(&contents) == Some(MemoryVisibility::Private) {
-            skipped_private_files.push(relative);
-            continue;
+        if public {
+            match raw_okf_visibility(&contents) {
+                Some(MemoryVisibility::Public) => {}
+                Some(MemoryVisibility::Private) | None => {
+                    skipped_private_files.push(relative);
+                    continue;
+                }
+            }
         }
 
         let concept = parse_okf_concept(&source_root, &path, &contents)?;

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -263,9 +263,9 @@ pub fn export_okf_bundle(
     ensure_repo_contained(&config.repo_root, &output_path)?;
     let output_path = canonicalize_existing_prefix(&output_path)?;
     ensure_output_target_not_symlink(&output_path)?;
-    if output_path == source_root || output_path.starts_with(&source_root) {
+    if paths_overlap(&output_path, &source_root) {
         return Err(MemoryError::InvalidInput(format!(
-            "OKF export output `{}` must not be inside the source bundle `{}`",
+            "OKF export output `{}` must not overlap the source bundle `{}`",
             output_path.display(),
             source_root.display()
         )));
@@ -440,7 +440,7 @@ fn ensure_import_target_has_no_symlink_components(
         .strip_prefix(target_root)
         .map_err(|_| MemoryError::PathOutsideRepo {
             path: target.to_path_buf(),
-            repo_root: target_root.to_path_buf(),
+            repo_root: config.repo_root.clone(),
         })?;
     let mut cursor = target_root.to_path_buf();
     for component in relative.components() {
@@ -1394,8 +1394,10 @@ const PUBLIC_PRIVATE_LOCAL_PATH_PATTERNS: &[&str] = &[
 const PUBLIC_PRIVATE_SOURCE_PATTERNS: &[&str] = &[
     ".opensymphony/memory/source",
     ".opensymphony\\memory\\source",
+    "../.opensymphony/memory/source",
     ".opensymphony/memory/snapshot",
     ".opensymphony\\memory\\snapshot",
+    "../.opensymphony/memory/snapshot",
 ];
 
 fn public_export_private_material(contents: &str) -> Option<&'static str> {

--- a/crates/opensymphony-memory/src/okf.rs
+++ b/crates/opensymphony-memory/src/okf.rs
@@ -400,6 +400,7 @@ fn pending_okf_import_files(
         OkfBundlePath::new(relative.clone())?;
         let contents = read_to_string(path)?;
         let target = target_root.join(&relative);
+        ensure_import_target_has_no_symlink_components(config, target_root, &target)?;
         if target.is_dir() {
             return Err(MemoryError::InvalidInput(format!(
                 "{} already exists as a directory and cannot be overwritten by OKF import",
@@ -430,6 +431,47 @@ fn pending_okf_import_files(
     Ok(pending)
 }
 
+fn ensure_import_target_has_no_symlink_components(
+    config: &MemoryConfig,
+    target_root: &Path,
+    target: &Path,
+) -> Result<(), MemoryError> {
+    let relative = target
+        .strip_prefix(target_root)
+        .map_err(|_| MemoryError::PathOutsideRepo {
+            path: target.to_path_buf(),
+            repo_root: target_root.to_path_buf(),
+        })?;
+    let mut cursor = target_root.to_path_buf();
+    for component in relative.components() {
+        cursor.push(component.as_os_str());
+        match fs::symlink_metadata(&cursor) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(MemoryError::InvalidInput(format!(
+                    "{} is a symlink and cannot be overwritten by OKF import",
+                    display_path(&config.repo_root, &cursor)
+                )));
+            }
+            Ok(_) => {}
+            Err(source)
+                if matches!(
+                    source.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+                ) =>
+            {
+                break;
+            }
+            Err(source) => {
+                return Err(MemoryError::ReadFile {
+                    path: cursor,
+                    source,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintReport, MemoryError> {
     if !bundle_root.is_dir() {
         return Err(MemoryError::InvalidInput(format!(
@@ -451,6 +493,7 @@ pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintRe
             Ok(path) => path,
             Err(error) => {
                 findings.push(LintFinding {
+                    code: None,
                     severity: LintSeverity::Error,
                     path: Some(path),
                     message: error.to_string(),
@@ -479,6 +522,7 @@ pub fn lint_okf_bundle(bundle_root: &Path, public_export: bool) -> Result<LintRe
     for directory in dirs_with_concepts {
         if !dirs_with_index.contains(&directory) {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Warn,
                 path: Some(bundle_root.join(&directory)),
                 message: "missing generated index.md".to_string(),
@@ -621,7 +665,14 @@ where
     if let Some(backup_path) = backup_path
         && backup_path.exists()
     {
-        let _ = remove_dir_all(&backup_path);
+        remove_dir_all(&backup_path).map_err(|source| {
+            MemoryError::InvalidInput(format!(
+                "OKF export promoted to `{}` but failed to remove backup `{}`: {}; remove the backup manually",
+                output_path.display(),
+                backup_path.display(),
+                source
+            ))
+        })?;
     }
     Ok(())
 }
@@ -717,11 +768,11 @@ fn ignored_private_export_leak(finding: &LintFinding, ignore_private_memory_link
 }
 
 fn is_private_export_leak(finding: &LintFinding) -> bool {
-    finding.message.contains("private export leak")
+    finding.code == Some(LintCode::OkfPrivateMemoryLink)
 }
 
 fn public_export_index() -> String {
-    "---\nokf_version: \"0.1\"\n---\n\n# OpenSymphony Public Memory Export\n".to_string()
+    format!("---\nokf_version: \"{OKF_VERSION}\"\n---\n\n# OpenSymphony Public Memory Export\n")
 }
 
 fn public_export_log() -> String {
@@ -825,6 +876,7 @@ fn lint_okf_index(
         .is_none_or(|parent| parent.as_os_str().is_empty())
     {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "reserved index.md must not contain frontmatter outside the bundle root"
@@ -835,6 +887,7 @@ fn lint_okf_index(
     }
     let Ok((frontmatter, _)) = split_okf_frontmatter(path, contents) else {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "reserved index.md has invalid frontmatter".to_string(),
@@ -844,6 +897,7 @@ fn lint_okf_index(
     };
     let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&frontmatter) else {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "reserved index.md frontmatter is not parseable YAML".to_string(),
@@ -853,6 +907,7 @@ fn lint_okf_index(
     };
     let Some(mapping) = value.as_mapping() else {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "reserved index.md frontmatter must be a YAML mapping".to_string(),
@@ -864,6 +919,7 @@ fn lint_okf_index(
         && version != OKF_VERSION
     {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Warn,
             path: Some(bundle_root.join(relative)),
             message: format!("unknown OKF version `{version}`"),
@@ -875,6 +931,7 @@ fn lint_okf_index(
 fn lint_okf_log(path: &Path, contents: &str, findings: &mut Vec<LintFinding>) {
     if has_okf_frontmatter(contents) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "reserved log.md must not contain frontmatter".to_string(),
@@ -898,6 +955,7 @@ fn lint_okf_log(path: &Path, contents: &str, findings: &mut Vec<LintFinding>) {
 
     if dates.is_empty() || invalid_heading || !dates.windows(2).all(|pair| pair[0] >= pair[1]) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "reserved log.md must use ISO date headings newest first".to_string(),
@@ -918,6 +976,7 @@ fn lint_okf_concept(
         Err(error) => {
             let message = okf_frontmatter_lint_message(&error);
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Error,
                 path: Some(path.to_path_buf()),
                 message,
@@ -930,6 +989,7 @@ fn lint_okf_concept(
         Ok(value) => value,
         Err(_) => {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Error,
                 path: Some(path.to_path_buf()),
                 message: "frontmatter is not parseable YAML".to_string(),
@@ -940,6 +1000,7 @@ fn lint_okf_concept(
     };
     let Some(mapping) = value.as_mapping() else {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "frontmatter must be a YAML mapping".to_string(),
@@ -952,6 +1013,7 @@ fn lint_okf_concept(
         .is_none_or(str::is_empty)
     {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "frontmatter lacks non-empty `type`".to_string(),
@@ -964,6 +1026,7 @@ fn lint_okf_concept(
         Ok(concept) => concept,
         Err(error) => {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Error,
                 path: Some(path.to_path_buf()),
                 message: format!("frontmatter is not parseable OKF YAML: {error}"),
@@ -976,6 +1039,7 @@ fn lint_okf_concept(
     lint_okf_recommended_fields(&concept, &body, path, findings);
     if !known_okf_type(&concept.frontmatter.concept_type) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Warn,
             path: Some(path.to_path_buf()),
             message: format!("unknown type `{}`", concept.frontmatter.concept_type),
@@ -984,6 +1048,7 @@ fn lint_okf_concept(
     }
     if contains_private_memory_link_in_markdown(contents) {
         findings.push(LintFinding {
+            code: Some(LintCode::OkfPrivateMemoryLink),
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "private export leak: document links to a private memory path".to_string(),
@@ -992,6 +1057,7 @@ fn lint_okf_concept(
     }
     if public_export && concept_visibility(&concept) == Some(MemoryVisibility::Private) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: "public export includes a private concept".to_string(),
@@ -1000,6 +1066,7 @@ fn lint_okf_concept(
     }
     if public_export && let Some(reason) = public_export_private_material(contents) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Error,
             path: Some(path.to_path_buf()),
             message: format!("public export contains {reason}"),
@@ -1022,6 +1089,7 @@ fn lint_okf_recommended_fields(
         missing.push("title");
         if first_heading(body).is_some() {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Info,
                 path: Some(path.to_path_buf()),
                 message: "title can be synthesized from the first heading".to_string(),
@@ -1033,6 +1101,7 @@ fn lint_okf_recommended_fields(
         missing.push("description");
         if first_paragraph(body).is_some() {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Info,
                 path: Some(path.to_path_buf()),
                 message: "description can be synthesized from the first paragraph".to_string(),
@@ -1051,6 +1120,7 @@ fn lint_okf_recommended_fields(
     }
     if !missing.is_empty() {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Warn,
             path: Some(path.to_path_buf()),
             message: format!("missing recommended field(s): {}", missing.join(", ")),
@@ -1072,6 +1142,7 @@ fn lint_okf_links(
         };
         if !resolved.exists() {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Warn,
                 path: Some(path.to_path_buf()),
                 message: format!("broken Markdown link `{}`", link.target),
@@ -1088,6 +1159,7 @@ fn lint_okf_links(
     for wiki_link in extract_wiki_links(&concept.body) {
         if !markdown_ids.contains(&normalized_wiki_link_id(&wiki_link)) {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Warn,
                 path: Some(path.to_path_buf()),
                 message: format!("wiki-only link `[[{wiki_link}]]` has no Markdown equivalent"),
@@ -1108,6 +1180,7 @@ fn lint_okf_citations(concept: &OkfConcept, path: &Path, findings: &mut Vec<Lint
         || concept.frontmatter.extra.contains_key("linear_url");
     if source_backed && !has_citations_section(&concept.body) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Warn,
             path: Some(path.to_path_buf()),
             message: "citation section missing for source-backed claims".to_string(),
@@ -1142,6 +1215,7 @@ fn lint_okf_info(
     .collect::<Vec<_>>();
     if !retained_legacy.is_empty() {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Info,
             path: Some(path.to_path_buf()),
             message: format!("legacy field(s) retained: {}", retained_legacy.join(", ")),
@@ -1150,6 +1224,7 @@ fn lint_okf_info(
     }
     if mapping.contains_key(serde_yaml::Value::String("opensymphony".to_string())) {
         findings.push(LintFinding {
+            code: None,
             severity: LintSeverity::Info,
             path: Some(path.to_path_buf()),
             message: "bundle contains OpenSymphony extension fields".to_string(),
@@ -2110,6 +2185,42 @@ Visible [[real-target|Real Target]].
             .filter_map(Result::ok)
             .any(|entry| entry.file_name().to_string_lossy().contains(".backup-"));
         assert!(!leaked_backup, "successful rollback should consume backup dir");
+    }
+
+    #[test]
+    fn export_promotion_reports_backup_cleanup_failure() {
+        let repo = tempfile::TempDir::new().expect("temp repo should exist");
+        let staging = repo.path().join(".okf-export.tmp");
+        let output = repo.path().join("okf-export-private");
+        fs::create_dir_all(&staging).expect("staging should write");
+        fs::write(staging.join("bundle.md"), "staged bundle")
+            .expect("staged file should write");
+        fs::create_dir_all(&output).expect("existing output should write");
+
+        let result = promote_staged_export_with(
+            &staging,
+            &output,
+            |from, to| fs::rename(from, to),
+            |_path| Err(io::Error::other("injected cleanup failure")),
+        );
+
+        let error = result.expect_err("cleanup failure should be reported");
+        assert!(
+            error.to_string().contains("failed to remove backup"),
+            "error should explain backup cleanup failure: {error}"
+        );
+        assert!(
+            output.join("bundle.md").is_file(),
+            "successful promotion should leave staged bundle at output"
+        );
+        let leaked_backup = fs::read_dir(repo.path())
+            .expect("repo should list")
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().contains(".backup-"));
+        assert!(
+            leaked_backup,
+            "failed cleanup should leave backup for manual operator cleanup"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/opensymphony-memory/src/query.rs
+++ b/crates/opensymphony-memory/src/query.rs
@@ -791,6 +791,7 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
     for issue in &issues {
         if issue.warning_count > 0 {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Warn,
                 path: Some(issue.capsule_path.clone()),
                 message: format!(
@@ -802,6 +803,7 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
         }
         if issue.areas().is_empty() {
             findings.push(LintFinding {
+                code: None,
                 severity: LintSeverity::Error,
                 path: Some(issue.capsule_path.clone()),
                 message: format!("{} has no learned memory area", issue.issue_key),
@@ -822,6 +824,7 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
             let contents = read_to_string(&path)?;
             if contains_private_memory_link(&contents) {
                 findings.push(LintFinding {
+                    code: None,
                     severity: LintSeverity::Error,
                     path: Some(path),
                     message: "public docs contain a private memory path".to_string(),

--- a/crates/opensymphony-memory/src/query.rs
+++ b/crates/opensymphony-memory/src/query.rs
@@ -791,7 +791,6 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
     for issue in &issues {
         if issue.warning_count > 0 {
             findings.push(LintFinding {
-                code: None,
                 severity: LintSeverity::Warn,
                 path: Some(issue.capsule_path.clone()),
                 message: format!(
@@ -803,7 +802,6 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
         }
         if issue.areas().is_empty() {
             findings.push(LintFinding {
-                code: None,
                 severity: LintSeverity::Error,
                 path: Some(issue.capsule_path.clone()),
                 message: format!("{} has no learned memory area", issue.issue_key),
@@ -824,7 +822,6 @@ pub fn lint(config: &MemoryConfig, public_docs: bool) -> Result<LintReport, Memo
             let contents = read_to_string(&path)?;
             if contains_private_memory_link(&contents) {
                 findings.push(LintFinding {
-                    code: None,
                     severity: LintSeverity::Error,
                     path: Some(path),
                     message: "public docs contain a private memory path".to_string(),

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -111,6 +111,11 @@ types, unknown frontmatter fields, missing optional fields, broken links, and
 missing generated indexes are warning-level import inputs; malformed concepts
 remain errors with file paths in the diagnostic.
 
+Import is not transactional after the preflight succeeds. A filesystem write or
+DuckDB reindex failure can leave already-copied Markdown files in the memory
+root. Fix the underlying failure, inspect the partially copied files, and rerun
+with `--force` only when replacing those files is intentional.
+
 OKF lint diagnostics are intentionally actionable. Errors cover missing or
 invalid concept frontmatter, missing `type`, malformed reserved files,
 containment failures, and public-export leaks of private memory. Warnings cover

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -89,12 +89,21 @@ still references private comments, private memory paths, or private source
 snapshots. Private export can include private concepts but still keeps normal
 OKF lint errors fatal.
 
-`opensymphony memory import-okf <bundle-root>` validates an OKF directory bundle,
-copies its Markdown concepts into the configured memory root without rewriting
-frontmatter, and rebuilds the derived DuckDB catalog from the imported bundle.
-Unknown concept types, unknown frontmatter fields, missing optional fields,
-broken links, and missing generated indexes are warning-level import inputs;
-malformed concepts remain errors with file paths in the diagnostic.
+The public export redaction scan is deliberately narrow and explicit: it treats
+`linear:comment:`, `.opensymphony/memory/issues`,
+`.opensymphony/memory/source*`, `.opensymphony/memory/snapshot*`, and their
+Windows-path variants as private material when they appear in exported public
+concepts.
+
+`opensymphony memory import-okf <bundle-root> [--force]` validates an OKF
+directory bundle, copies its Markdown concepts into the configured memory root
+without rewriting frontmatter, and rebuilds the derived DuckDB catalog from the
+imported bundle. The target memory root is checked against the repository
+containment policy, and existing Markdown files are not overwritten unless
+`--force` is supplied. Unknown concept types, unknown frontmatter fields,
+missing optional fields, broken links, and missing generated indexes are
+warning-level import inputs; malformed concepts remain errors with file paths
+in the diagnostic.
 
 OKF lint diagnostics are intentionally actionable. Errors cover missing or
 invalid concept frontmatter, missing `type`, malformed reserved files,

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -84,26 +84,32 @@ provided, linting uses the configured memory root.
 `opensymphony memory export-okf --visibility public|private [--output DIR]`
 exports the configured memory root as a directory bundle. The output directory
 must be new or empty so stale private files cannot survive a public export.
-Public export skips private concepts and fails if any remaining public concept
-still references private comments, private memory paths, or private source
-snapshots. Private export can include private concepts but still keeps normal
-OKF lint errors fatal.
+Export writes into a repository-contained staging directory first, runs OKF
+lint on the staged bundle, and only then promotes the completed bundle to the
+requested output path. Public export skips private concepts and fails if any
+remaining public concept still references private comments, private memory
+paths, or private source snapshots. Private export can include private concepts
+but still keeps normal OKF lint errors fatal.
 
 The public export redaction scan is deliberately narrow and explicit: it treats
 `linear:comment:`, `.opensymphony/memory/issues`,
 `.opensymphony/memory/source*`, `.opensymphony/memory/snapshot*`, and their
 Windows-path variants as private material when they appear in exported public
-concepts.
+concepts. The scan uses the same markdown-visible text extraction as private
+memory link linting, so fenced code blocks, inline code spans, escaped text, and
+HTML comments do not create public export false positives.
 
 `opensymphony memory import-okf <bundle-root> [--force]` validates an OKF
 directory bundle, copies its Markdown concepts into the configured memory root
 without rewriting frontmatter, and rebuilds the derived DuckDB catalog from the
-imported bundle. The target memory root is checked against the repository
-containment policy, and existing Markdown files are not overwritten unless
-`--force` is supplied. Unknown concept types, unknown frontmatter fields,
-missing optional fields, broken links, and missing generated indexes are
-warning-level import inputs; malformed concepts remain errors with file paths
-in the diagnostic.
+imported bundle. The import source and target memory root are canonicalized,
+checked against the repository containment policy, and rejected when they
+overlap. Import preflights the full copy set before writing so predictable
+target conflicts do not leave partially imported Markdown files. Existing
+Markdown files are not overwritten unless `--force` is supplied. Unknown concept
+types, unknown frontmatter fields, missing optional fields, broken links, and
+missing generated indexes are warning-level import inputs; malformed concepts
+remain errors with file paths in the diagnostic.
 
 OKF lint diagnostics are intentionally actionable. Errors cover missing or
 invalid concept frontmatter, missing `type`, malformed reserved files,

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -90,7 +90,8 @@ on the staged bundle, and only then promotes the completed bundle to the
 requested output path. Public export skips private concepts and fails if any
 remaining public concept still references private comments, private memory paths,
 or private source snapshots. Private export can include private concepts but
-still keeps normal OKF lint errors fatal.
+still keeps normal OKF lint errors fatal except for visible links back into the
+private memory store, which are expected in private round-trip bundles.
 
 The public export redaction scan is deliberately narrow and explicit: it treats
 `linear:comment:`, `.opensymphony/memory/issues`,
@@ -107,10 +108,12 @@ imported bundle. The import source and target memory root are canonicalized,
 checked against the repository containment policy, and rejected when they
 overlap. Import preflights the full copy set before writing so predictable
 target conflicts do not leave partially imported Markdown files. Existing
-Markdown files are not overwritten unless `--force` is supplied. Unknown concept
-types, unknown frontmatter fields, missing optional fields, broken links, and
-missing generated indexes are warning-level import inputs; malformed concepts
-remain errors with file paths in the diagnostic.
+Markdown files are not overwritten unless `--force` is supplied. Because
+`import-okf` restores both public and private bundles, visible private memory
+links are allowed during import and preserved in the copied Markdown. Unknown
+concept types, unknown frontmatter fields, missing optional fields, broken
+links, and missing generated indexes are warning-level import inputs; malformed
+concepts remain errors with file paths in the diagnostic.
 
 Import is not transactional after the preflight succeeds. A filesystem write or
 DuckDB reindex failure can leave already-copied Markdown files in the memory

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -83,13 +83,14 @@ provided, linting uses the configured memory root.
 
 `opensymphony memory export-okf --visibility public|private [--output DIR]`
 exports the configured memory root as a directory bundle. The output directory
+defaults to `okf-export-{visibility}` under the repository root when omitted and
 must be new or empty so stale private files cannot survive a public export.
-Export writes into a repository-contained staging directory first, runs OKF
-lint on the staged bundle, and only then promotes the completed bundle to the
+Export writes into a repository-contained staging directory first, runs OKF lint
+on the staged bundle, and only then promotes the completed bundle to the
 requested output path. Public export skips private concepts and fails if any
-remaining public concept still references private comments, private memory
-paths, or private source snapshots. Private export can include private concepts
-but still keeps normal OKF lint errors fatal.
+remaining public concept still references private comments, private memory paths,
+or private source snapshots. Private export can include private concepts but
+still keeps normal OKF lint errors fatal.
 
 The public export redaction scan is deliberately narrow and explicit: it treats
 `linear:comment:`, `.opensymphony/memory/issues`,

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -81,6 +81,21 @@ canonicalized and must stay inside the repository root, matching the containment
 policy used by other memory admin file arguments. When no bundle root is
 provided, linting uses the configured memory root.
 
+`opensymphony memory export-okf --visibility public|private [--output DIR]`
+exports the configured memory root as a directory bundle. The output directory
+must be new or empty so stale private files cannot survive a public export.
+Public export skips private concepts and fails if any remaining public concept
+still references private comments, private memory paths, or private source
+snapshots. Private export can include private concepts but still keeps normal
+OKF lint errors fatal.
+
+`opensymphony memory import-okf <bundle-root>` validates an OKF directory bundle,
+copies its Markdown concepts into the configured memory root without rewriting
+frontmatter, and rebuilds the derived DuckDB catalog from the imported bundle.
+Unknown concept types, unknown frontmatter fields, missing optional fields,
+broken links, and missing generated indexes are warning-level import inputs;
+malformed concepts remain errors with file paths in the diagnostic.
+
 OKF lint diagnostics are intentionally actionable. Errors cover missing or
 invalid concept frontmatter, missing `type`, malformed reserved files,
 containment failures, and public-export leaks of private memory. Warnings cover
@@ -131,6 +146,8 @@ opensymphony memory brief COE-123
 opensymphony memory related --area openhands-runtime
 opensymphony memory sync-docs --since-last-sync
 opensymphony memory serve --addr 127.0.0.1:8765
+opensymphony memory export-okf --visibility public --output public-okf
+opensymphony memory import-okf public-okf
 opensymphony linear archive --issues COE-123
 ```
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -87,11 +87,13 @@ defaults to `okf-export-{visibility}` under the repository root when omitted and
 must be new or empty so stale private files cannot survive a public export.
 Export writes into a repository-contained staging directory first, runs OKF lint
 on the staged bundle, and only then promotes the completed bundle to the
-requested output path. Public export skips private concepts and fails if any
-remaining public concept still references private comments, private memory paths,
-or private source snapshots. Private export can include private concepts but
-still keeps normal OKF lint errors fatal except for visible links back into the
-private memory store, which are expected in private round-trip bundles.
+requested output path. If final promotion fails, OpenSymphony preserves the
+lint-clean staged bundle for recovery and restores the previous empty output
+directory when possible. Public export skips private concepts and fails if any
+remaining public concept still references private comments, private memory
+paths, or private source snapshots. Private export can include private concepts
+but still keeps normal OKF lint errors fatal except for visible links back into
+the private memory store, which are expected in private round-trip bundles.
 
 The public export redaction scan is deliberately narrow and explicit: it treats
 `linear:comment:`, `.opensymphony/memory/issues`,

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -111,15 +111,17 @@ Focused OKF memory validation for implementation work:
   preservation for the migration fixture corpus.
 - `cargo test-system-duckdb --test memory` runs the CLI-facing OKF fixture test,
   MCP `memory.lint` argument coverage for `okf` and `bundleRoot`, generated
-  `log.md` date grouping, OKF import/export redaction checks, and the rest of
-  the memory integration suite.
+  `log.md` date grouping, OKF import/export redaction checks, import preflight
+  failure coverage, source/target overlap rejection, and the rest of the memory
+  integration suite.
 - `opensymphony memory lint --okf <repo-contained-bundle>` is the manual CLI
   smoke path for a generated or fixture OKF bundle.
 - `opensymphony memory export-okf --visibility public --output <empty-dir>`
   followed by `opensymphony memory lint --okf --public-docs <empty-dir>` is the
   public export redaction smoke path.
 - `opensymphony memory import-okf <repo-contained-bundle>` is the import smoke
-  path for warning-tolerant OKF bundles with actionable malformed-file errors.
+  path for warning-tolerant OKF bundles with actionable malformed-file errors,
+  repository-contained sources, non-overlapping targets, and preflighted writes.
 
 Codex ChatGPT subscription smoke testing remains opt-in on trusted local
 machines because the final exec probe can consume account quota. The supported

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -111,9 +111,15 @@ Focused OKF memory validation for implementation work:
   preservation for the migration fixture corpus.
 - `cargo test-system-duckdb --test memory` runs the CLI-facing OKF fixture test,
   MCP `memory.lint` argument coverage for `okf` and `bundleRoot`, generated
-  `log.md` date grouping, and the rest of the memory integration suite.
+  `log.md` date grouping, OKF import/export redaction checks, and the rest of
+  the memory integration suite.
 - `opensymphony memory lint --okf <repo-contained-bundle>` is the manual CLI
   smoke path for a generated or fixture OKF bundle.
+- `opensymphony memory export-okf --visibility public --output <empty-dir>`
+  followed by `opensymphony memory lint --okf --public-docs <empty-dir>` is the
+  public export redaction smoke path.
+- `opensymphony memory import-okf <repo-contained-bundle>` is the import smoke
+  path for warning-tolerant OKF bundles with actionable malformed-file errors.
 
 Codex ChatGPT subscription smoke testing remains opt-in on trusted local
 machines because the final exec probe can consume account quota. The supported

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -123,6 +123,10 @@ Focused OKF memory validation for implementation work:
 - `opensymphony memory import-okf <repo-contained-bundle>` is the import smoke
   path for warning-tolerant OKF bundles with actionable malformed-file errors,
   repository-contained sources, non-overlapping targets, and preflighted writes.
+  The documented post-preflight partial-write regression is Unix-gated because
+  it uses POSIX directory permissions to induce a deterministic mid-copy write
+  failure; add a separate Windows-native failure injection before treating that
+  path as covered on Windows.
 
 Codex ChatGPT subscription smoke testing remains opt-in on trusted local
 machines because the final exec probe can consume account quota. The supported

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -112,8 +112,9 @@ Focused OKF memory validation for implementation work:
 - `cargo test-system-duckdb --test memory` runs the CLI-facing OKF fixture test,
   MCP `memory.lint` argument coverage for `okf` and `bundleRoot`, generated
   `log.md` date grouping, OKF import/export redaction checks, import preflight
-  failure coverage, source/target overlap rejection, and the rest of the memory
-  integration suite.
+  failure coverage, documented non-transactional mid-copy import behavior,
+  source/target overlap rejection, and the rest of the memory integration
+  suite.
 - `opensymphony memory lint --okf <repo-contained-bundle>` is the manual CLI
   smoke path for a generated or fixture OKF bundle.
 - `opensymphony memory export-okf --visibility public --output <empty-dir>`


### PR DESCRIPTION
## Summary

Adds OKF directory import/export CLI flows with explicit public/private visibility boundaries and validation that treats public redaction failures as errors.

## Changes

- Added `opensymphony memory export-okf --visibility public|private [--output DIR]` using existing OKF parsing, linting, and repo containment rules.
- Added `opensymphony memory import-okf <bundle-root> [--force]` that validates warning-tolerant bundles, preflights target conflicts, copies Markdown unchanged, and rebuilds the derived catalog.
- Added public/private export tests, public redaction failure tests, import warning/malformed-path tests, and docs for operator usage.

## Evidence

### Test output

```text
cargo test-system-duckdb --test memory
result: ok. 37 passed; 0 failed

cargo test-system-duckdb okf
result: ok. 18 OKF unit tests passed; 7 focused CLI OKF tests passed

cargo clippy-system-duckdb
result: finished cleanly with -D warnings

git diff --check
result: passed
```

### Verification

Reproduced the missing CLI paths before implementation: `memory export-okf --visibility public` and `memory import-okf <bundle>` both failed as unrecognized subcommands.

Ran an exported-fixture smoke using the compiled CLI:

```text
memory export-okf --visibility public --output public-okf
result: copied 2 generated public bundle files, skipped 2 private files, lint findings 0

memory lint --okf --public-docs public-okf
result: Memory lint passed.

memory export-okf --visibility private --output private-okf
result: copied 4 files, skipped 0 private files, lint findings 4 warning/info findings

memory lint --okf private-okf
result: warnings/info only for unknown fixture type, broken fixture link, and extension metadata
```

## Checklist

- [x] Tests pass (`cargo test` equivalent: focused DuckDB system test suite)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy` equivalent: `cargo clippy-system-duckdb`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

COE-460

## Additional notes

Directory bundle support follows the existing OKF CLI convention. ZIP output was not added because it would require extra archive handling that is not needed for the current acceptance criteria. Import is documented as non-transactional after preflight; recovery guidance and regression coverage are included.

