### PR TITLE
Add OKF memory admin MCP parity

### DIFF
--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1946,8 +1946,6 @@ fn call_memory_import_okf_tool(
     arguments: &Value,
 ) -> Result<Value, MemoryError> {
     let bundle = optional_string_arg(arguments, "bundleRoot")
-        .or_else(|| optional_string_arg(arguments, "bundle_root"))
-        .or_else(|| optional_string_arg(arguments, "bundle"))
         .map(PathBuf::from)
         .ok_or_else(|| {
             MemoryError::InvalidInput("missing string argument `bundleRoot`".to_string())

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1042,6 +1042,20 @@ fn remote_memory_tool_request(command: &MemoryCommand) -> Option<(&'static str, 
                 "bundleRoot": args.bundle.as_ref().map(|path| path.display().to_string())
             }),
         )),
+        MemoryCommand::ExportOkf(args) => Some((
+            "memory.export_okf",
+            json!({
+                "visibility": MemoryVisibility::from(args.visibility).as_str(),
+                "output": args.output.as_ref().map(|path| path.display().to_string())
+            }),
+        )),
+        MemoryCommand::ImportOkf(args) => Some((
+            "memory.import_okf",
+            json!({
+                "bundleRoot": args.bundle.display().to_string(),
+                "force": args.force
+            }),
+        )),
         MemoryCommand::Brief(args) => {
             Some(("memory.brief", json!({ "issue": args.issue.clone() })))
         }
@@ -1577,6 +1591,8 @@ fn memory_tool_descriptors() -> Vec<Value> {
         json!({ "name": "memory.sync_docs", "description": "Sync captured memory into topic docs", "access": "admin" }),
         json!({ "name": "memory.lint", "description": "Lint memory and docs", "access": "admin" }),
         json!({ "name": "memory.reindex", "description": "Refresh memory catalog schema and generated indexes", "access": "admin" }),
+        json!({ "name": "memory.export_okf", "description": "Export an OKF memory bundle", "access": "admin" }),
+        json!({ "name": "memory.import_okf", "description": "Import an OKF memory bundle", "access": "admin" }),
         json!({ "name": "memory.ingest_code_intel", "description": "Generate code-intelligence artifacts for future ingestion", "access": "admin" }),
     ]
 }
@@ -1588,6 +1604,8 @@ fn is_admin_memory_tool(name: &str) -> bool {
             | "memory.sync_docs"
             | "memory.lint"
             | "memory.reindex"
+            | "memory.export_okf"
+            | "memory.import_okf"
             | "memory.ingest_code_intel"
     )
 }
@@ -1781,6 +1799,8 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
         "memory.sync_docs" => call_memory_sync_docs_tool(config, &arguments),
         "memory.lint" => call_memory_lint_tool(config, &arguments),
         "memory.reindex" => call_memory_reindex_tool(config, &arguments),
+        "memory.export_okf" => call_memory_export_okf_tool(config, &arguments),
+        "memory.import_okf" => call_memory_import_okf_tool(config, &arguments),
         "memory.ingest_code_intel" => call_memory_ingest_code_intel_tool(config, &arguments).await,
         other => Err(MemoryError::InvalidInput(format!(
             "unsupported memory tool `{other}`"
@@ -1911,6 +1931,31 @@ fn call_memory_reindex_tool(
     Ok(memory_reindex_report_json(config, report))
 }
 
+fn call_memory_export_okf_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let visibility = memory_visibility_arg(arguments)?;
+    let output = optional_string_arg(arguments, "output").map(PathBuf::from);
+    let report = export_okf_bundle(config, visibility, output.as_deref())?;
+    Ok(okf_export_report_json(config, visibility, report))
+}
+
+fn call_memory_import_okf_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let bundle = optional_string_arg(arguments, "bundleRoot")
+        .or_else(|| optional_string_arg(arguments, "bundle_root"))
+        .or_else(|| optional_string_arg(arguments, "bundle"))
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            MemoryError::InvalidInput("missing string argument `bundleRoot`".to_string())
+        })?;
+    let report = import_okf_bundle(config, &bundle, bool_arg(arguments, "force"))?;
+    Ok(okf_import_report_json(config, report))
+}
+
 async fn call_memory_ingest_code_intel_tool(
     config: &MemoryConfig,
     arguments: &Value,
@@ -2021,6 +2066,33 @@ fn memory_reindex_report_json(config: &MemoryConfig, report: MemoryReindexReport
         "warningCount": report.warning_count,
         "indexPath": path_for_json(config, &report.index_path),
         "markdownIndexes": paths_for_json(config, &report.markdown_indexes)
+    })
+}
+
+fn okf_export_report_json(
+    config: &MemoryConfig,
+    visibility: MemoryVisibility,
+    report: crate::opensymphony_memory::OkfExportReport,
+) -> Value {
+    json!({
+        "outputPath": path_for_json(config, &report.output_path),
+        "visibility": visibility.as_str(),
+        "copiedFiles": paths_for_json(config, &report.copied_files),
+        "skippedPrivateFiles": paths_for_json(config, &report.skipped_private_files),
+        "findingCount": report.finding_count
+    })
+}
+
+fn okf_import_report_json(
+    config: &MemoryConfig,
+    report: crate::opensymphony_memory::OkfImportReport,
+) -> Value {
+    json!({
+        "sourcePath": path_for_json(config, &report.source_path),
+        "targetPath": path_for_json(config, &report.target_path),
+        "copiedFiles": paths_for_json(config, &report.copied_files),
+        "findingCount": report.finding_count,
+        "reindex": memory_reindex_report_json(config, report.reindex)
     })
 }
 
@@ -2336,6 +2408,19 @@ fn path_for_json(config: &MemoryConfig, path: &Path) -> String {
 fn required_string_arg(arguments: &Value, key: &str) -> Result<String, MemoryError> {
     optional_string_arg(arguments, key)
         .ok_or_else(|| MemoryError::InvalidInput(format!("missing string argument `{key}`")))
+}
+
+fn memory_visibility_arg(arguments: &Value) -> Result<MemoryVisibility, MemoryError> {
+    match required_string_arg(arguments, "visibility")?
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "public" => Ok(MemoryVisibility::Public),
+        "private" => Ok(MemoryVisibility::Private),
+        value => Err(MemoryError::InvalidInput(format!(
+            "invalid visibility `{value}`; expected public or private"
+        ))),
+    }
 }
 
 fn optional_string_arg(arguments: &Value, key: &str) -> Option<String> {
@@ -3437,7 +3522,7 @@ fn print_search_results(
 mod tests {
     use super::{
         LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, MemoryMcpRequest, MemoryServerAccess,
-        MemoryServerAuth, authorize_memory_request, context_source_from_mcp,
+        MemoryServerAuth, authorize_memory_request, call_memory_tool, context_source_from_mcp,
         memory_server_health_payload, memory_tool_descriptors, origin_is_localhost,
         parse_remote_memory_response, remote_memory_tool_token, replace_or_append_managed_section,
         required_access_for_request, resolve_code_intel_repo, trim_auto_memory_status_log,
@@ -3462,6 +3547,8 @@ mod tests {
         assert!(names.contains(&"memory.capture".to_string()));
         assert!(names.contains(&"memory.sync_docs".to_string()));
         assert!(names.contains(&"memory.reindex".to_string()));
+        assert!(names.contains(&"memory.export_okf".to_string()));
+        assert!(names.contains(&"memory.import_okf".to_string()));
         assert!(!names.iter().any(|name| name.contains("code_context")));
         assert!(!names.iter().any(|name| name.contains("code-context")));
     }
@@ -3478,6 +3565,11 @@ mod tests {
             method: "tools/call".to_string(),
             params: json!({ "name": "memory.capture" }),
         };
+        let okf_export_request = MemoryMcpRequest {
+            id: json!("test"),
+            method: "tools/call".to_string(),
+            params: json!({ "name": "memory.export_okf" }),
+        };
 
         assert_eq!(
             required_access_for_request(&read_request),
@@ -3486,6 +3578,86 @@ mod tests {
         assert_eq!(
             required_access_for_request(&admin_request),
             MemoryServerAccess::Admin
+        );
+        assert_eq!(
+            required_access_for_request(&okf_export_request),
+            MemoryServerAccess::Admin
+        );
+    }
+
+    #[tokio::test]
+    async fn okf_export_import_tools_dispatch_through_mcp() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        let memory_dir = repo_root.join(".opensymphony/memory/issues");
+        std::fs::create_dir_all(&memory_dir).expect("memory dir");
+        std::fs::write(
+            memory_dir.join("COE-1.md"),
+            r#"---
+type: topic-doc
+title: "COE-1: Public OKF concept"
+description: Public concept.
+tags: [memory, okf]
+timestamp: 2026-06-23T10:00:00Z
+opensymphony:
+  visibility: public
+  scope_refs:
+    - kind: work_item
+      id: COE-1
+---
+
+# COE-1: Public OKF concept
+
+Public memory concept.
+"#,
+        )
+        .expect("concept");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let export = call_memory_tool(
+            &config,
+            json!({
+                "name": "memory.export_okf",
+                "arguments": {
+                    "visibility": "public",
+                    "output": "public-okf"
+                }
+            }),
+        )
+        .await
+        .expect("export okf tool");
+
+        assert_eq!(export["outputPath"], "public-okf");
+        assert_eq!(export["visibility"], "public");
+        assert!(
+            export["copiedFiles"]
+                .as_array()
+                .expect("copied files")
+                .iter()
+                .any(|path| path == "issues/COE-1.md")
+        );
+
+        let import = call_memory_tool(
+            &config,
+            json!({
+                "name": "memory.import_okf",
+                "arguments": {
+                    "bundleRoot": "public-okf",
+                    "force": true
+                }
+            }),
+        )
+        .await
+        .expect("import okf tool");
+
+        assert_eq!(import["sourcePath"], "public-okf");
+        assert_eq!(import["targetPath"], ".opensymphony/memory");
+        assert!(
+            import["copiedFiles"]
+                .as_array()
+                .expect("copied files")
+                .iter()
+                .any(|path| path == "issues/COE-1.md")
         );
     }
 
@@ -3582,7 +3754,7 @@ mod tests {
 
     #[test]
     fn remote_admin_tool_requires_admin_token_without_read_fallback() {
-        let error = remote_memory_tool_token("memory.capture", |name| match name {
+        let error = remote_memory_tool_token("memory.export_okf", |name| match name {
             "OPENSYMPHONY_MEMORY_TOKEN" => Some("read-token".to_string()),
             _ => None,
         })

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -143,6 +143,13 @@ fn memory_reindex_from_okf_preserves_query_commands() {
     assert_success(&docs, "docs after OKF reindex");
     assert!(String::from_utf8_lossy(&docs.stdout).contains("Runtime docs from OKF"));
 
+    let sync_docs = run(repo.path(), ["memory", "sync-docs", "--issues", "COE-123"]);
+    assert_success(&sync_docs, "sync-docs after OKF reindex");
+    let synced_docs =
+        fs::read_to_string(repo.path().join("docs/openhands-runtime.md")).expect("synced docs");
+    assert!(synced_docs.contains("OKF catalog rebuild"));
+    assert!(!synced_docs.contains(".opensymphony/memory/issues"));
+
     let help = run(repo.path(), ["memory", "reindex", "--help"]);
     assert_success(&help, "reindex help");
     assert!(
@@ -832,6 +839,8 @@ fn memory_admin_commands_can_use_mcp_endpoint() {
     let server = TinyGraphqlServer::start([
         r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"findingCount":0,"findings":[]}}"#,
         r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"findingCount":0,"findings":[]}}"#,
+        r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"outputPath":"public-okf","visibility":"public","copiedFiles":["issues/COE-123.md"],"skippedPrivateFiles":[],"findingCount":0}}"#,
+        r#"{"jsonrpc":"2.0","id":"opensymphony-cli","result":{"sourcePath":"incoming-okf","targetPath":".opensymphony/memory","copiedFiles":["issues/COE-500.md"],"findingCount":0,"reindex":{"issueCount":1,"warningCount":0,"indexPath":".opensymphony/memory/memory.duckdb","markdownIndexes":[]}}}"#,
     ]);
 
     let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
@@ -852,13 +861,44 @@ fn memory_admin_commands_can_use_mcp_endpoint() {
         .expect("command should run");
 
     assert_success(&okf_output, "remote okf memory lint");
+    let export_output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args([
+            "memory",
+            "export-okf",
+            "--visibility",
+            "public",
+            "--output",
+            "public-okf",
+        ])
+        .current_dir(repo.path())
+        .env("OPENSYMPHONY_MEMORY_ENDPOINT", &server.base_url)
+        .env("OPENSYMPHONY_MEMORY_ADMIN_TOKEN", "admin-token")
+        .output()
+        .expect("command should run");
+
+    assert_success(&export_output, "remote okf memory export");
+    let import_output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
+        .args(["memory", "import-okf", "incoming-okf", "--force"])
+        .current_dir(repo.path())
+        .env("OPENSYMPHONY_MEMORY_ENDPOINT", &server.base_url)
+        .env("OPENSYMPHONY_MEMORY_ADMIN_TOKEN", "admin-token")
+        .output()
+        .expect("command should run");
+
+    assert_success(&import_output, "remote okf memory import");
     let requests = server.requests();
-    assert_eq!(requests.len(), 2);
+    assert_eq!(requests.len(), 4);
     assert!(requests[0].contains("\"name\":\"memory.lint\""));
     assert!(requests[0].contains("\"publicDocs\":true"));
     assert!(requests[1].contains("\"name\":\"memory.lint\""));
     assert!(requests[1].contains("\"okf\":true"));
     assert!(requests[1].contains("\"bundleRoot\":\"fixtures/okf-migration\""));
+    assert!(requests[2].contains("\"name\":\"memory.export_okf\""));
+    assert!(requests[2].contains("\"visibility\":\"public\""));
+    assert!(requests[2].contains("\"output\":\"public-okf\""));
+    assert!(requests[3].contains("\"name\":\"memory.import_okf\""));
+    assert!(requests[3].contains("\"bundleRoot\":\"incoming-okf\""));
+    assert!(requests[3].contains("\"force\":true"));
 }
 
 #[test]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -103,6 +103,11 @@ concepts. The scan uses the same markdown-visible text extraction as private
 memory link linting, so fenced code blocks, inline code spans, escaped text, and
 HTML comments do not create public export false positives.
 
+The memory MCP admin surface exposes the same export operation as
+`memory.export_okf` with `visibility` (`public` or `private`) and optional
+`output` arguments. It uses the same repository containment, staging, lint, and
+public redaction checks as the CLI command.
+
 `opensymphony memory import-okf <bundle-root> [--force]` validates an OKF
 directory bundle, copies its Markdown concepts into the configured memory root
 without rewriting frontmatter, and rebuilds the derived DuckDB catalog from the
@@ -121,6 +126,11 @@ Import is not transactional after the preflight succeeds. A filesystem write or
 DuckDB reindex failure can leave already-copied Markdown files in the memory
 root. Fix the underlying failure, inspect the partially copied files, and rerun
 with `--force` only when replacing those files is intentional.
+
+The memory MCP admin surface exposes the same import operation as
+`memory.import_okf` with `bundleRoot` and optional `force` arguments. Prefer the
+CLI or MCP admin tools for normal maintenance; direct file or DuckDB inspection
+is an offline fallback for recovery and diagnostics only.
 
 OKF lint diagnostics are intentionally actionable. Errors cover missing or
 invalid concept frontmatter, missing `type`, malformed reserved files,
@@ -378,10 +388,11 @@ Streamable HTTP JSON-RPC endpoint at `/mcp`. CLI commands call that endpoint
 when `OPENSYMPHONY_MEMORY_ENDPOINT` is set; otherwise they use offline direct
 mode. Read tools are `memory.context`, `memory.search`, `memory.related`,
 `memory.brief`, `memory.docs`, and `memory.status`. Admin tools are
-`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`, and
-`memory.ingest_code_intel`; these require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or
-`--admin-token` on `opensymphony memory serve`. If an admin token is configured
-without a separate read token, the admin token also protects read tools.
+`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`,
+`memory.export_okf`, `memory.import_okf`, and `memory.ingest_code_intel`; these
+require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or `--admin-token` on
+`opensymphony memory serve`. If an admin token is configured without a separate
+read token, the admin token also protects read tools.
 `memory.context` builds the agent kickoff bundle. Add `--include-code-intel`
 to include available codebase-analysis artifacts alongside selected memory.
 `opensymphony memory reindex --from-okf [bundle-root]` rebuilds the derived

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -358,6 +358,10 @@ opensymphony memory brief COE-123
 opensymphony memory related --paths crates/opensymphony-openhands
 opensymphony memory sync-docs --since-last-sync
 opensymphony memory lint --public-docs
+opensymphony memory lint --okf
+opensymphony memory reindex --from-okf
+opensymphony memory export-okf --visibility public --output public-okf
+opensymphony memory import-okf public-okf
 ```
 
 Add `--dry-run` to write commands when an operator wants a non-writing preview.
@@ -380,8 +384,10 @@ Memory capture does not archive Linear issues.
 
 Read commands such as `memory status`, `memory brief`, `memory related`, and
 `memory context` open the DuckDB index in read-only mode and do not run schema
-migrations. Run capture, import, docs sync, or reindex-style admin operations
-serially if a local DuckDB writer is active.
+migrations. Run capture, import, OKF import/export, docs sync, or reindex-style
+admin operations serially if a local DuckDB writer is active. Prefer the CLI or
+MCP admin surface for maintenance; direct file or DuckDB access is an offline
+recovery and diagnostics fallback only.
 
 For worker or tool access, `opensymphony run` starts the read-only memory server
 when memory is initialized and `memory.serve` is not disabled. The supervised
@@ -392,10 +398,11 @@ operation is also available with `opensymphony memory serve --addr
 127.0.0.1:8765`, which exposes MCP-style `initialize`, `tools/list`, and
 `tools/call` JSON-RPC methods at `/mcp`. Set `OPENSYMPHONY_MEMORY_TOKEN` or
 pass `--token` to require bearer-token access for read tools. Admin tools
-(`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`, and
-`memory.ingest_code_intel`) require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or
-`--admin-token`. When only the admin token is configured, it also gates read
-tools; do not inject that token into ordinary worker environments.
+(`memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`,
+`memory.export_okf`, `memory.import_okf`, and `memory.ingest_code_intel`)
+require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or `--admin-token`. When only the
+admin token is configured, it also gates read tools; do not inject that token
+into ordinary worker environments.
 
 Linear archival is a separate command and is guarded by captured memory:
 


### PR DESCRIPTION
## Summary

Adds memory MCP/admin parity for OKF export and import, matching the existing OKF lint, reindex, and sync-docs admin paths.

## Changes

- Routes `opensymphony memory export-okf` and `opensymphony memory import-okf` through `OPENSYMPHONY_MEMORY_ENDPOINT` when configured.
- Advertises, authorizes, and dispatches `memory.export_okf` and `memory.import_okf` as admin MCP tools.
- Keeps the `memory.import_okf` tool contract narrow: `bundleRoot` plus optional `force`.
- Adds coverage for docs sync after OKF reindex, OKF export/import MCP dispatch, remote admin forwarding, and private-path redaction.
- Updates operator docs for OKF lint, reindex, export, import, sync-docs, and the offline direct file/DB fallback boundary.

## Evidence

### Test output

```text
PASS cargo test-system-duckdb memory_admin_commands_can_use_mcp_endpoint
PASS cargo test-system-duckdb okf_export_import_tools_dispatch_through_mcp
PASS cargo test-system-duckdb memory_reindex_from_okf_preserves_query_commands
PASS cargo test-system-duckdb mcp_tool_list_exposes_context_and_admin_tools_without_code_context
PASS cargo test-system-duckdb mcp_admin_tools_require_admin_access
PASS cargo test-system-duckdb remote_admin_tool_requires_admin_token_without_read_fallback
PASS cargo test-system-duckdb sync_docs_writes_only_configured_areas_and_dry_run_writes_nothing
PASS cargo test-system-duckdb memory_lint_related_paths_and_from_memory_archive_cover_private_doc_links
PASS cargo test-system-duckdb memory_lint_okf_reports_fixture_diagnostics
PASS target/debug/opensymphony memory lint --okf crates/opensymphony-memory/tests/fixtures/okf-reindex
PASS cargo clippy-system-duckdb
PASS cargo fmt --check
PASS git diff --check
```

### Verification

Reproduced the missing parity by confirming `export-okf` and `import-okf` existed as local CLI commands while no `memory.export_okf` or `memory.import_okf` MCP routes/descriptors existed. Verified the new tools are advertised, require admin auth, dispatch through the MCP server, and are used by the CLI remote endpoint path.

Live memory-server proof against a disposable repo-local OKF fixture:

```text
endpoint=http://127.0.0.1:55536/mcp
tools/list export/import:
memory.export_okf:admin
memory.import_okf:admin
remote export-okf:
{
  "copiedFiles": [
    "issues/COE-900.md",
    "index.md",
    "log.md"
  ],
  "findingCount": 3,
  "outputPath": "public-okf",
  "skippedPrivateFiles": [],
  "visibility": "public"
}
remote import-okf:
{
  "copiedFiles": [
    "issues/COE-900.md"
  ],
  "findingCount": 3,
  "reindex": {
    "indexPath": ".opensymphony/memory/memory.duckdb",
    "issueCount": 1,
    "markdownIndexes": [
      ".opensymphony/memory/indexes/index.md",
      ".opensymphony/memory/indexes/log.md"
    ],
    "warningCount": 1
  },
  "sourcePath": "public-okf",
  "targetPath": ".opensymphony/memory"
}
```

## Checklist

- [x] Focused tests pass (`cargo test-system-duckdb ...`)
- [x] Code is formatted (`cargo fmt` / `cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` update not needed (repo guidance unchanged)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: Not applicable

## Breaking changes

None.

## Related issues

COE-463: https://linear.app/trilogy-ai-coe/issue/COE-463/docs-sync-and-mcp-admin-parity-for-okf

## Additional notes

Direct file or DuckDB inspection remains documented as an offline recovery and diagnostics fallback only. The first clippy attempt hit a local generated-artifact disk limit while writing Cargo incremental cache; after clearing `target/debug/incremental` in this workspace and rerunning with incremental disabled, `cargo clippy-system-duckdb` passed.