### PR TITLE
test(tui): add shared project grouping fixture coverage

### DIFF
--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -4226,6 +4226,7 @@ mod tests {
         prelude::Model,
         text::text::{Line, Span},
     };
+    use serde::Deserialize;
     use std::{
         fs,
         path::Path,
@@ -4244,6 +4245,19 @@ mod tests {
         span::{Attributes, Record},
     };
     use url::Url;
+
+    #[derive(Deserialize)]
+    struct ProjectGroupingFixtureIssue {
+        id: String,
+        title: String,
+        runtime_state: String,
+        tracker_state: String,
+        project_id: Option<String>,
+        project_slug: Option<String>,
+        project_name: Option<String>,
+        workspace_label: Option<String>,
+        blocked_by: Vec<String>,
+    }
 
     struct EventCounter {
         events: Arc<AtomicUsize>,
@@ -4383,6 +4397,33 @@ mod tests {
                 }],
             },
         }
+    }
+
+    fn project_grouping_fixture() -> SnapshotEnvelope {
+        let cases: Vec<ProjectGroupingFixtureIssue> = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/project_grouping_cases.json"
+        ))
+        .expect("project grouping fixture should decode");
+        let mut snapshot = fixture(8, cases.len());
+
+        for (issue, case) in snapshot.snapshot.issues.iter_mut().zip(cases) {
+            issue.identifier = case.id;
+            issue.title = case.title;
+            issue.runtime_state = match case.runtime_state.as_str() {
+                "running" => IssueRuntimeState::Running,
+                "completed" => IssueRuntimeState::Completed,
+                "failed" => IssueRuntimeState::Failed,
+                _ => IssueRuntimeState::Idle,
+            };
+            issue.tracker_state = case.tracker_state;
+            issue.project_id = case.project_id;
+            issue.project_slug = case.project_slug;
+            issue.project_name = case.project_name;
+            issue.workspace_label = case.workspace_label;
+            issue.blocked_by = case.blocked_by;
+        }
+
+        snapshot
     }
 
     fn run_git(repo: &Path, args: &[&str]) {
@@ -4922,6 +4963,38 @@ mod tests {
         assert!(rendered.contains(">    COE-255"));
         assert!(!rendered.contains("->"));
         assert!(!rendered.contains("<-"));
+    }
+
+    #[test]
+    fn shared_project_grouping_fixture_covers_tui_group_and_dependency_cases() {
+        let mut state = TuiState::default();
+        state.reduce(TuiAction::SnapshotReceived(Box::new(
+            project_grouping_fixture(),
+        )));
+
+        let rendered = state.issue_lines(140, 12).join("\n");
+        assert!(rendered.contains(
+            "== proj-alpha | alpha-project | Alpha Project | OpenSymphony | issues=2 running=1 todo=1 =="
+        ));
+        assert!(rendered.contains(
+            "== proj-beta | beta-project | Beta Project | OpenSymphony | issues=3 running=0 todo=2 =="
+        ));
+        assert!(
+            rendered.contains("== unknown-project | OpenSymphony | issues=1 running=0 todo=1 ==")
+        );
+        assert!(rendered.contains("+-- COE-700"));
+        assert!(rendered.contains("-> COE-701"));
+        assert!(rendered.contains("|   COE-701"));
+        assert!(rendered.contains("<- COE-700"));
+        assert!(rendered.contains("COE-702"));
+        assert!(rendered.contains("<- 1 hidden"));
+        assert!(
+            !rendered.contains("COE-703 [idle / Todo] Beta completed blocker target <- COE-704")
+        );
+
+        state.selected_issue = 3;
+        let detail = state.detail_lines(140, 8).join("\n");
+        assert!(detail.contains("completed blockers COE-704"));
     }
 
     #[test]

--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -4992,7 +4992,17 @@ mod tests {
             !rendered.contains("COE-703 [idle / Todo] Beta completed blocker target <- COE-704")
         );
 
-        state.selected_issue = 3;
+        state.selected_issue = state
+            .latest_snapshot
+            .as_ref()
+            .and_then(|snapshot| {
+                snapshot
+                    .snapshot
+                    .issues
+                    .iter()
+                    .position(|issue| issue.identifier == "COE-703")
+            })
+            .expect("COE-703 fixture issue should exist");
         let detail = state.detail_lines(140, 8).join("\n");
         assert!(detail.contains("completed blockers COE-704"));
     }

--- a/docs/ui-frankentui.md
+++ b/docs/ui-frankentui.md
@@ -141,6 +141,11 @@ Issue rows are rendered as compact single-line summaries so the default inline v
 When issue snapshots include project metadata, the issue pane renders compact non-selectable
 project headers and a fixed dependency gutter; dependency suffixes are kept width-gated so
 narrow panes drop the suffix before corrupting titles or separators.
+Snapshots that contain only one visible project still show that header when project-set metadata is
+present. Missing project metadata falls back to an `unknown-project` header only when other visible
+issues carry project metadata. Hidden unfinished blockers are summarized as hidden dependency counts
+in the compact list, while completed blockers stay out of issue rows and appear in the selected
+issue detail pane.
 The detail pane now shows a git-backed changed-file summary for the selected workspace, including
 per-file `+/-` counts. In wide layouts the lower-right pane stays on conversation activity until an
 operator expands a changed file, at which point it becomes a diff viewer for that file while the

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -41,7 +41,7 @@ interface ProjectGroupingFixtureIssue {
 }
 
 const projectGroupingFixture = JSON.parse(readFileSync(
-  join(process.cwd(), "tests/fixtures/project_grouping_cases.json"),
+  join(__dirname, "../../../tests/fixtures/project_grouping_cases.json"),
   "utf8",
 )) as ProjectGroupingFixtureIssue[];
 

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -7,6 +7,8 @@
 import { renderOpenSymphonyApp } from "../src/app-shell.js";
 import { MockGatewayTransport } from "@opensymphony/api-client";
 import { schemaVersionV1 } from "@opensymphony/gateway-schema";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type {
   EditableProfileInput,
   ModelProfileController,
@@ -25,6 +27,23 @@ import type {
   TaskGraphSnapshot,
 } from "@opensymphony/gateway-schema";
 import { defaultModelProfiles } from "@opensymphony/gateway-schema";
+
+interface ProjectGroupingFixtureIssue {
+  id: string;
+  title: string;
+  runtime_state: string;
+  tracker_state: string;
+  project_id: string | null;
+  project_slug: string | null;
+  project_name: string | null;
+  workspace_label: string | null;
+  blocked_by: string[];
+}
+
+const projectGroupingFixture = JSON.parse(readFileSync(
+  join(process.cwd(), "tests/fixtures/project_grouping_cases.json"),
+  "utf8",
+)) as ProjectGroupingFixtureIssue[];
 
 const capabilities: GatewayCapabilities = {
   schema_version: schemaVersionV1(),
@@ -211,6 +230,33 @@ const projectSetTaskGraph: TaskGraphSnapshot = {
   }),
 };
 
+const sharedProjectGroupingTaskGraph: TaskGraphSnapshot = {
+  schema_version: schemaVersionV1(),
+  project_id: "project-set",
+  generated_at: "2025-09-01T00:00:00Z",
+  root_ids: [],
+  nodes: projectGroupingFixture.map((item) => ({
+    schema_version: schemaVersionV1(),
+    node_id: item.id,
+    kind: "issue",
+    identifier: item.id,
+    title: item.title,
+    state: item.tracker_state,
+    state_category: item.tracker_state === "Done"
+      ? "done"
+      : item.tracker_state === "In Progress"
+        ? "in_progress"
+        : "todo",
+    project_id: item.project_id ?? undefined,
+    project_slug: item.project_slug ?? undefined,
+    project_name: item.project_name ?? undefined,
+    children: [],
+    blocked_by: item.blocked_by,
+    run_id: item.id,
+    labels: item.workspace_label ? [item.workspace_label] : [],
+  })),
+};
+
 const runEvents: RunEventPage = {
   schema_version: schemaVersionV1(),
   run_id: "COE-449",
@@ -288,6 +334,7 @@ function buildTransport(opts?: {
   failHealth?: boolean;
   failTaskGraphStructured?: boolean;
   taskGraph?: TaskGraphSnapshot;
+  runDetails?: RunDetail[];
 }): MockGatewayTransport {
   if (opts?.failHealth) {
     class AlwaysFailHealthTransport extends MockGatewayTransport {
@@ -327,6 +374,7 @@ function buildTransport(opts?: {
     runDetails: [
       runDetail,
       { ...runDetail, run_id: "desktop-alpha", issue_id: "desktop-alpha" },
+      ...(opts?.runDetails ?? []),
     ],
     runFiles: [
       { runId: "COE-449", files: changedFiles },
@@ -817,6 +865,58 @@ describe("OpenSymphonyApp mount", () => {
     ).map((node) => node.getAttribute("data-node-id"));
     expect(restoredAlphaNodes).toEqual(["m7-milestone", "app-shell", "desktop-alpha", "follow-up", "completed-prereq"]);
     expect(root.querySelector(".os-run-head strong")?.textContent).toBe("COE-449");
+
+    await handle.destroy();
+  });
+
+  it("uses the shared project grouping fixture for desktop groups and dependency signals", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({
+        taskGraph: sharedProjectGroupingTaskGraph,
+        runDetails: [
+          { ...runDetail, run_id: "COE-703", issue_id: "COE-703", issue_identifier: "COE-703" },
+        ],
+      }),
+    });
+
+    await flushUntil(
+      () => root.querySelector("[data-project-group='alpha-project']") !== null,
+    );
+
+    const headings = Array.from(root.querySelectorAll(".os-project-group-header"))
+      .map((heading) => heading.textContent ?? "");
+    expect(headings).toEqual([
+      expect.stringContaining("alpha-project | Alpha Project"),
+      expect.stringContaining("beta-project | Beta Project"),
+      expect.stringContaining("unassigned"),
+    ]);
+    expect(headings[0]).toContain("issues=2 running=1 todo=1 blocked=1");
+    expect(headings[1]).toContain("issues=3 running=0 todo=2 blocked=1");
+    expect(headings[2]).toContain("issues=1 running=0 todo=1 blocked=0");
+    expect(root.querySelector("[data-project-group='__opensymphony_unassigned__'] [data-node-id='COE-705']")).not.toBeNull();
+    expect(root.querySelector("[data-node-id='COE-700'] .os-node-line")?.textContent).toContain("blocks COE-701");
+    expect(root.querySelector("[data-node-id='COE-701'] .os-node-line")?.textContent).toContain("blocked by COE-700");
+    expect(root.querySelector("[data-node-id='COE-702'] .os-node-line")?.textContent).toContain("blocked by 1 hidden");
+    expect(root.querySelector("[data-node-id='COE-703'] .os-node-line")?.textContent).not.toContain("blocked by COE-704");
+
+    (root.querySelector("[data-project-group-toggle='beta-project']") as HTMLButtonElement).click();
+    await flushUntil(
+      () => root.querySelector("[data-project-group='beta-project'] [data-node-id='COE-702']") === null,
+    );
+    expect(root.querySelector("[data-project-group-toggle='beta-project']")?.getAttribute("aria-expanded")).toBe("false");
+
+    (root.querySelector("[data-project-group-toggle='beta-project']") as HTMLButtonElement).click();
+    await flushUntil(
+      () => root.querySelector("[data-project-group='beta-project'] [data-node-id='COE-703']") !== null,
+    );
+    (root.querySelector("[data-node-id='COE-703']") as HTMLElement).click();
+    await flushUntil(
+      () => root.querySelector("[data-testid='dependency-detail']")?.textContent?.includes("completed blockers COE-704") ?? false,
+    );
 
     await handle.destroy();
   });

--- a/tests/fixtures/project_grouping_cases.json
+++ b/tests/fixtures/project_grouping_cases.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "COE-700",
+    "title": "Alpha active root",
+    "runtime_state": "running",
+    "tracker_state": "In Progress",
+    "project_id": "proj-alpha",
+    "project_slug": "alpha-project",
+    "project_name": "Alpha Project",
+    "workspace_label": "OpenSymphony",
+    "blocked_by": []
+  },
+  {
+    "id": "COE-701",
+    "title": "Alpha visible blocker target",
+    "runtime_state": "idle",
+    "tracker_state": "Todo",
+    "project_id": "proj-alpha",
+    "project_slug": "alpha-project",
+    "project_name": "Alpha Project",
+    "workspace_label": "OpenSymphony",
+    "blocked_by": ["COE-700"]
+  },
+  {
+    "id": "COE-702",
+    "title": "Beta hidden blocker target",
+    "runtime_state": "idle",
+    "tracker_state": "Todo",
+    "project_id": "proj-beta",
+    "project_slug": "beta-project",
+    "project_name": "Beta Project",
+    "workspace_label": "OpenSymphony",
+    "blocked_by": ["COE-999"]
+  },
+  {
+    "id": "COE-703",
+    "title": "Beta completed blocker target",
+    "runtime_state": "idle",
+    "tracker_state": "Todo",
+    "project_id": "proj-beta",
+    "project_slug": "beta-project",
+    "project_name": "Beta Project",
+    "workspace_label": "OpenSymphony",
+    "blocked_by": ["COE-704"]
+  },
+  {
+    "id": "COE-704",
+    "title": "Beta completed prerequisite",
+    "runtime_state": "completed",
+    "tracker_state": "Done",
+    "project_id": "proj-beta",
+    "project_slug": "beta-project",
+    "project_name": "Beta Project",
+    "workspace_label": "OpenSymphony",
+    "blocked_by": []
+  },
+  {
+    "id": "COE-705",
+    "title": "Missing project fallback",
+    "runtime_state": "idle",
+    "tracker_state": "Todo",
+    "project_id": null,
+    "project_slug": null,
+    "project_name": null,
+    "workspace_label": "OpenSymphony",
+    "blocked_by": []
+  }
+]


### PR DESCRIPTION
## Summary

Adds shared cross-client project grouping fixture coverage for COE-497.

## Changes

- Added one shared fixture for project metadata and dependency cases used by both TUI and desktop tests.
- Added TUI coverage for grouped headers, missing project fallback, hidden blockers, and completed blockers from that fixture.
- Added desktop coverage for the same fixture, including group counts, collapse/expand behavior, hidden blockers, and completed blocker detail.
- Updated FrankenTUI docs for operator-visible project fallback and dependency detail behavior.

## Evidence

### Test output

```
cargo test-system-duckdb project --lib
# 11 passed; 0 failed

cargo test-system-duckdb dependency --lib
# 17 passed; 0 failed

npx jest --config jest.config.js packages/ui-core/__tests__/app-shell.test.ts --runInBand -t "groups desktop task graph rows|sorts desktop project groups|renders a project heading|collapses and expands|shared project grouping fixture"
# 5 passed; 0 failed

npm run type-check
# tsc --build tsconfig.projects.json passed

cargo fmt --check && git diff --check
# passed
```

### Verification

The shared fixture covers multi-project, single-project existing coverage, missing-project fallback, visible blockers, hidden blockers, and completed blockers. TUI and desktop tests now both consume the same project/dependency metadata shape for the grouped snapshot cases.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [x] Other: Test coverage hardening

## Breaking changes

None.

## Related issues

Linear: COE-497

## Additional notes

This stays within the verification slice: no scheduling behavior, dependency sorting, or new test harness was added.

