### PR TITLE
Add harness interrupt diagnostics contract

### DIFF
--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1876,8 +1876,12 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 0,
             total_tokens: 1536,
             detached: false,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
         },
         IssueSnapshot {
             identifier: "OSYM-401".to_owned(),
@@ -1913,8 +1917,12 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 512,
             total_tokens: 3072,
             detached: false,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
         },
         IssueSnapshot {
             identifier: "OSYM-402".to_owned(),
@@ -1958,8 +1966,12 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 0,
             total_tokens: 768,
             detached: false,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
         },
     ];
     let running_issues = issues

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1877,7 +1877,6 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             total_tokens: 1536,
             detached: false,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,
@@ -1918,7 +1917,6 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             total_tokens: 3072,
             detached: false,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,
@@ -1967,7 +1965,6 @@ fn sample_snapshot(step: u64) -> DaemonSnapshot {
             total_tokens: 768,
             detached: false,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
@@ -282,12 +282,7 @@ fn map_issue(
             interrupt.map(|interrupt| interrupt.status),
             Some(HarnessInterruptStatus::TimedOut)
         ),
-        cancel_reason: interrupt.map(|interrupt| {
-            serde_json::to_value(interrupt.command.reason)
-                .ok()
-                .and_then(|value| value.as_str().map(ToOwned::to_owned))
-                .unwrap_or_else(|| format!("{:?}", interrupt.command.reason))
-        }),
+        cancel_reason: interrupt.map(|interrupt| interrupt.command.reason.as_str().to_string()),
     }
 }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
@@ -11,7 +11,8 @@ use crate::opensymphony_control::{
     RecentEventKind, WorkerOutcome,
 };
 use crate::opensymphony_domain::{
-    HealthStatus, IssueIdentifier, OrchestratorSnapshot, SchedulerStatus, WorkerOutcomeKind,
+    HarnessInterruptStatus, HealthStatus, IssueIdentifier, OrchestratorSnapshot, SchedulerStatus,
+    WorkerOutcomeKind,
 };
 use crate::opensymphony_openhands::LocalServerSupervisor;
 use crate::opensymphony_workflow::ResolvedWorkflow;
@@ -124,6 +125,7 @@ fn map_issue(
         .unwrap_or(generated_at);
     let worker = issue.runtime.worker.as_ref();
     let last_worker_outcome = issue.last_worker_outcome.as_ref();
+    let interrupt = issue.runtime.interrupt.as_ref();
     let started_at = issue
         .runtime
         .started_at
@@ -264,8 +266,28 @@ fn map_issue(
             .map(|conversation| conversation.effective_total_tokens())
             .unwrap_or(0),
         detached: false,
-        cancel_acknowledged: false,
-        cancel_failed: false,
+        cancel_requested: matches!(
+            interrupt.map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Requested)
+        ),
+        cancel_acknowledged: matches!(
+            interrupt.map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Acknowledged)
+        ),
+        cancel_failed: matches!(
+            interrupt.map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Failed)
+        ),
+        cancel_timed_out: matches!(
+            interrupt.map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::TimedOut)
+        ),
+        cancel_reason: interrupt.map(|interrupt| {
+            serde_json::to_value(interrupt.command.reason)
+                .ok()
+                .and_then(|value| value.as_str().map(ToOwned::to_owned))
+                .unwrap_or_else(|| format!("{:?}", interrupt.command.reason))
+        }),
     }
 }
 
@@ -534,6 +556,7 @@ tracker:
                     }),
                     last_event_at: Some(ts(1_011)),
                     stalled_at: None,
+                    interrupt: None,
                 },
                 workspace: Some(WorkspaceRecord {
                     path: PathBuf::from("/tmp/workspaces/COE-352"),

--- a/crates/opensymphony-cli/tests/tui.rs
+++ b/crates/opensymphony-cli/tests/tui.rs
@@ -93,7 +93,6 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 256,
             total_tokens: 2048,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/crates/opensymphony-cli/tests/tui.rs
+++ b/crates/opensymphony-cli/tests/tui.rs
@@ -92,8 +92,12 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             output_tokens: 512,
             cache_read_tokens: 256,
             total_tokens: 2048,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
             detached: false,
         }],
         recent_events: vec![RecentEvent {

--- a/crates/opensymphony-control/src/lib.rs
+++ b/crates/opensymphony-control/src/lib.rs
@@ -470,8 +470,12 @@ mod tests {
                 output_tokens: 512,
                 cache_read_tokens: 256,
                 total_tokens: 0,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             }],
             recent_events: vec![RecentEvent {

--- a/crates/opensymphony-control/src/lib.rs
+++ b/crates/opensymphony-control/src/lib.rs
@@ -471,7 +471,6 @@ mod tests {
                 cache_read_tokens: 256,
                 total_tokens: 0,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,

--- a/crates/opensymphony-control/tests/control_plane.rs
+++ b/crates/opensymphony-control/tests/control_plane.rs
@@ -78,7 +78,6 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 256,
             total_tokens: 0,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/crates/opensymphony-control/tests/control_plane.rs
+++ b/crates/opensymphony-control/tests/control_plane.rs
@@ -77,8 +77,12 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             output_tokens: 512,
             cache_read_tokens: 256,
             total_tokens: 0,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
             detached: false,
         }],
         recent_events: vec![RecentEvent {

--- a/crates/opensymphony-domain/src/control_plane.rs
+++ b/crates/opensymphony-domain/src/control_plane.rs
@@ -143,6 +143,8 @@ pub struct ControlPlaneIssueSnapshot {
     /// host requested disconnect without a clean terminal state).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub detached: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cancel_requested: bool,
     /// True when the harness acknowledged a cancel/force-stop request.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cancel_acknowledged: bool,
@@ -150,6 +152,10 @@ pub struct ControlPlaneIssueSnapshot {
     /// ended in a cancel-failed state.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cancel_failed: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cancel_timed_out: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancel_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -379,30 +379,45 @@ mod tests {
 
     #[test]
     fn interrupt_status_records_acknowledged_failed_and_timeout() {
-        let mut execution = running_execution();
-        must(execution.request_interrupt(
+        let mut acknowledged = running_execution();
+        must(acknowledged.request_interrupt(
             "openhands_agent_server",
             None,
             HarnessInterruptReason::OperatorCancel,
             HarnessInterruptExpectedNextState::Paused,
             ts(60),
         ));
-
-        must(execution.acknowledge_interrupt(ts(61)));
+        must(acknowledged.acknowledge_interrupt(ts(61)));
         assert_eq!(
-            execution.interrupt().map(|interrupt| interrupt.status),
+            acknowledged.interrupt().map(|interrupt| interrupt.status),
             Some(HarnessInterruptStatus::Acknowledged)
         );
 
-        must(execution.fail_interrupt(ts(62), "adapter refused interrupt"));
+        let mut failed = running_execution();
+        must(failed.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        must(failed.fail_interrupt(ts(62), "adapter refused interrupt"));
         assert_eq!(
-            execution.interrupt().map(|interrupt| interrupt.status),
+            failed.interrupt().map(|interrupt| interrupt.status),
             Some(HarnessInterruptStatus::Failed)
         );
 
-        must(execution.timeout_interrupt(ts(63), "ack timeout"));
+        let mut timed_out = running_execution();
+        must(timed_out.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        must(timed_out.timeout_interrupt(ts(63), "ack timeout"));
         assert_eq!(
-            execution.interrupt().map(|interrupt| interrupt.status),
+            timed_out.interrupt().map(|interrupt| interrupt.status),
             Some(HarnessInterruptStatus::TimedOut)
         );
     }

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -387,6 +387,58 @@ mod tests {
     }
 
     #[test]
+    fn interrupt_idempotency_does_not_cross_reopened_runs() {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let mut execution = IssueExecution::new(issue.clone(), ts(30));
+        must(execution.attach_workspace(workspace.clone()));
+
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let execution = must(execution.claim(run));
+        let mut execution = must(execution.start_running(
+            ts(50),
+            super::DurationMs::new(10_000),
+            Some(sample_conversation(true)),
+        ));
+
+        let (first_command, queued) = must(execution.request_interrupt(
+            "openhands_agent_server",
+            Some("turn-1".to_string()),
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        assert!(queued);
+
+        let execution = must(execution.release(ts(70), ReleaseReason::TrackerInactive, None));
+        let execution = must(execution.reopen(ts(80)));
+
+        let run = sample_run(&issue, &workspace, None, ts(90));
+        let execution = must(execution.claim(run));
+        assert!(execution.interrupt().is_none());
+
+        let mut conversation = sample_conversation(false);
+        conversation.conversation_id = must(super::ConversationId::new("conv_261"));
+        let mut execution = must(execution.start_running(
+            ts(100),
+            super::DurationMs::new(10_000),
+            Some(conversation),
+        ));
+        let (second_command, queued) = must(execution.request_interrupt(
+            "openhands_agent_server",
+            Some("turn-2".to_string()),
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(110),
+        ));
+
+        assert!(queued);
+        assert_ne!(second_command, first_command);
+        assert_eq!(second_command.conversation_id.as_str(), "conv_261");
+        assert_eq!(second_command.turn_id.as_deref(), Some("turn-2"));
+    }
+
+    #[test]
     fn interrupt_status_records_acknowledged_failed_and_timeout() {
         let mut acknowledged = running_execution();
         must(acknowledged.request_interrupt(

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -457,7 +457,34 @@ mod tests {
         assert_eq!(interrupt.status, HarnessInterruptStatus::Failed);
         assert_eq!(
             interrupt.detail.as_deref(),
-            Some("worker reported cancel_failed")
+            Some("adapter refused interrupt")
+        );
+    }
+
+    #[test]
+    fn non_cancel_outcome_does_not_infer_interrupt_terminal_status() {
+        let mut execution = running_execution();
+        must(execution.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        let run = execution.current_run().expect("active run").clone();
+        let outcome = WorkerOutcomeRecord::from_run(
+            &run,
+            WorkerOutcomeKind::Succeeded,
+            ts(70),
+            Some("worker completed before interrupt acknowledgement".to_owned()),
+            None,
+        );
+
+        let execution = must(execution.release(ts(71), ReleaseReason::Completed, Some(outcome)));
+
+        assert_eq!(
+            execution.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Requested)
         );
     }
 

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -220,6 +220,15 @@ mod tests {
         }))
     }
 
+    fn claimed_execution() -> IssueExecution {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let mut execution = IssueExecution::new(issue, ts(30));
+        must(execution.attach_workspace(workspace));
+        must(execution.claim(run))
+    }
+
     #[test]
     fn state_transitions_are_explicit_and_testable() {
         let issue = sample_issue();
@@ -416,6 +425,163 @@ mod tests {
             ts(60),
         ));
         must(timed_out.timeout_interrupt(ts(63), "ack timeout"));
+        assert_eq!(
+            timed_out.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::TimedOut)
+        );
+    }
+
+    #[test]
+    fn cancel_failed_outcome_marks_requested_interrupt_failed() {
+        let mut execution = running_execution();
+        must(execution.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        let run = execution.current_run().expect("active run").clone();
+        let outcome = WorkerOutcomeRecord::from_run(
+            &run,
+            WorkerOutcomeKind::CancelFailed,
+            ts(70),
+            Some("cancel failed".to_owned()),
+            Some("adapter refused interrupt".to_owned()),
+        );
+
+        let execution =
+            must(execution.release(ts(71), ReleaseReason::TrackerInactive, Some(outcome)));
+
+        let interrupt = execution.interrupt().expect("interrupt state");
+        assert_eq!(interrupt.status, HarnessInterruptStatus::Failed);
+        assert_eq!(
+            interrupt.detail.as_deref(),
+            Some("worker reported cancel_failed")
+        );
+    }
+
+    #[test]
+    fn request_interrupt_rejects_inactive_states_and_missing_conversation() {
+        let mut unclaimed = IssueExecution::new(sample_issue(), ts(30));
+        assert!(matches!(
+            unclaimed.request_interrupt(
+                "openhands_agent_server",
+                None,
+                HarnessInterruptReason::OperatorCancel,
+                HarnessInterruptExpectedNextState::Paused,
+                ts(60),
+            ),
+            Err(StateTransitionError::InvalidTransition {
+                from: SchedulerStatus::Unclaimed,
+                ..
+            })
+        ));
+
+        let mut claimed = claimed_execution();
+        assert!(matches!(
+            claimed.request_interrupt(
+                "openhands_agent_server",
+                None,
+                HarnessInterruptReason::OperatorCancel,
+                HarnessInterruptExpectedNextState::Paused,
+                ts(60),
+            ),
+            Err(StateTransitionError::ConversationNotAttached)
+        ));
+
+        let retry_issue = sample_issue();
+        let retry = RetryEntry::failure(
+            &retry_issue,
+            None,
+            1,
+            ts(80),
+            RetryReason::Failure,
+            Some("failed".to_owned()),
+            RetryPolicy::default(),
+        )
+        .expect("retry entry");
+        let outcome = WorkerOutcomeRecord::from_run(
+            claimed.current_run().expect("claimed run"),
+            WorkerOutcomeKind::Failed,
+            ts(70),
+            None,
+            Some("failed".to_owned()),
+        );
+        let mut retry_queued = must(claimed.queue_retry(retry, outcome));
+        assert!(matches!(
+            retry_queued.request_interrupt(
+                "openhands_agent_server",
+                None,
+                HarnessInterruptReason::OperatorCancel,
+                HarnessInterruptExpectedNextState::Paused,
+                ts(90),
+            ),
+            Err(StateTransitionError::InvalidTransition {
+                from: SchedulerStatus::RetryQueued,
+                ..
+            })
+        ));
+
+        let mut released =
+            must(running_execution().release(ts(90), ReleaseReason::Cancelled, None));
+        assert!(matches!(
+            released.request_interrupt(
+                "openhands_agent_server",
+                None,
+                HarnessInterruptReason::OperatorCancel,
+                HarnessInterruptExpectedNextState::Paused,
+                ts(91),
+            ),
+            Err(StateTransitionError::InvalidTransition {
+                from: SchedulerStatus::Released,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn terminal_interrupt_status_updates_are_noops() {
+        let mut acknowledged = running_execution();
+        must(acknowledged.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        must(acknowledged.acknowledge_interrupt(ts(61)));
+        must(acknowledged.fail_interrupt(ts(62), "late failure"));
+        assert_eq!(
+            acknowledged.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Acknowledged)
+        );
+
+        let mut failed = running_execution();
+        must(failed.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        must(failed.fail_interrupt(ts(62), "adapter refused interrupt"));
+        must(failed.timeout_interrupt(ts(63), "late timeout"));
+        assert_eq!(
+            failed.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Failed)
+        );
+
+        let mut timed_out = running_execution();
+        must(timed_out.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+        must(timed_out.timeout_interrupt(ts(63), "ack timeout"));
+        must(timed_out.acknowledge_interrupt(ts(64)));
         assert_eq!(
             timed_out.interrupt().map(|interrupt| interrupt.status),
             Some(HarnessInterruptStatus::TimedOut)

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -362,7 +362,7 @@ mod tests {
                 ts(60),
             ));
             assert!(queued);
-            command.clone()
+            command
         };
 
         let (second_command, queued) = must(execution.request_interrupt(
@@ -374,7 +374,7 @@ mod tests {
         ));
 
         assert!(!queued);
-        assert_eq!(*second_command, first_command);
+        assert_eq!(second_command, first_command);
     }
 
     #[test]

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -29,10 +29,11 @@ pub use issue::{BlockerRef, IssueRef, IssueState, IssueStateCategory, Normalized
 pub use journal::{EventJournalBackend, EventStream, InMemoryEventJournal, StreamBroker};
 pub use runtime::{
     ConversationActivityEvent, ConversationMetadata, DetachMetadata, DetachReason,
-    HistorySyncStatus, LivenessState, ReconnectStatus, ReleaseReason, RetryAttempt,
-    RetryCalculationError, RetryEntry, RetryPolicy, RetryReason, RunAttempt, RuntimeLivenessPhase,
-    RuntimeProgressSnapshot, RuntimeStreamState, StallMetadata, StreamHealth, WorkerOutcomeKind,
-    WorkerOutcomeRecord, WorkspaceRecord,
+    HarnessInterruptCommand, HarnessInterruptExpectedNextState, HarnessInterruptReason,
+    HarnessInterruptState, HarnessInterruptStatus, HistorySyncStatus, LivenessState,
+    ReconnectStatus, ReleaseReason, RetryAttempt, RetryCalculationError, RetryEntry, RetryPolicy,
+    RetryReason, RunAttempt, RuntimeLivenessPhase, RuntimeProgressSnapshot, RuntimeStreamState,
+    StallMetadata, StreamHealth, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceRecord,
 };
 pub use snapshot::{
     ComponentHealthSnapshot, DaemonSnapshot, HealthStatus, IssueSnapshot, OrchestratorSnapshot,
@@ -63,7 +64,8 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        ComponentHealthSnapshot, ConversationMetadata, HealthStatus, IssueExecution, IssueId,
+        ComponentHealthSnapshot, ConversationMetadata, HarnessInterruptExpectedNextState,
+        HarnessInterruptReason, HarnessInterruptStatus, HealthStatus, IssueExecution, IssueId,
         IssueIdentifier, IssueRef, IssueSnapshot, IssueState, IssueStateCategory, NormalizedIssue,
         OrchestratorSnapshot, ReleaseReason, RetryAttempt, RetryEntry, RetryPolicy, RetryReason,
         RunAttempt, RuntimeStreamState, RuntimeUsageTotals, SchedulerStatus, StateTransitionError,
@@ -203,6 +205,21 @@ mod tests {
         }
     }
 
+    fn running_execution() -> IssueExecution {
+        let issue = sample_issue();
+        let workspace = sample_workspace();
+        let run = sample_run(&issue, &workspace, None, ts(40));
+        let mut execution = IssueExecution::new(issue, ts(30));
+        must(execution.attach_workspace(workspace));
+        must(execution.claim(run).and_then(|execution| {
+            execution.start_running(
+                ts(50),
+                super::DurationMs::new(10_000),
+                Some(sample_conversation(true)),
+            )
+        }))
+    }
+
     #[test]
     fn state_transitions_are_explicit_and_testable() {
         let issue = sample_issue();
@@ -291,6 +308,103 @@ mod tests {
             Some(ReleaseReason::TrackerInactive)
         );
         assert_eq!(snapshot.recent_worker_outcomes.len(), 1);
+    }
+
+    #[test]
+    fn records_operator_cancel_interrupt_request() {
+        let mut execution = running_execution();
+        let (command, queued) = must(execution.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+
+        assert!(queued);
+        assert_eq!(command.run_id, "COE-260");
+        assert_eq!(command.harness_kind, "openhands_agent_server");
+        assert_eq!(command.reason, HarnessInterruptReason::OperatorCancel);
+        assert_eq!(
+            execution.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Requested)
+        );
+    }
+
+    #[test]
+    fn records_tracker_merging_interrupt_request() {
+        let mut execution = running_execution();
+        let (command, queued) = must(execution.request_interrupt(
+            "codex_app_server",
+            Some("turn-1".to_string()),
+            HarnessInterruptReason::TrackerMergingSupersedesHumanReview,
+            HarnessInterruptExpectedNextState::CloseoutPending,
+            ts(60),
+        ));
+
+        assert!(queued);
+        assert_eq!(command.turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(
+            command.reason,
+            HarnessInterruptReason::TrackerMergingSupersedesHumanReview
+        );
+    }
+
+    #[test]
+    fn repeated_interrupt_request_is_idempotent_for_active_run() {
+        let mut execution = running_execution();
+        let first_command = {
+            let (command, queued) = must(execution.request_interrupt(
+                "openhands_agent_server",
+                None,
+                HarnessInterruptReason::OperatorCancel,
+                HarnessInterruptExpectedNextState::Paused,
+                ts(60),
+            ));
+            assert!(queued);
+            command.clone()
+        };
+
+        let (second_command, queued) = must(execution.request_interrupt(
+            "openhands_agent_server",
+            Some("ignored".to_string()),
+            HarnessInterruptReason::TrackerMergingSupersedesHumanReview,
+            HarnessInterruptExpectedNextState::CloseoutPending,
+            ts(61),
+        ));
+
+        assert!(!queued);
+        assert_eq!(*second_command, first_command);
+    }
+
+    #[test]
+    fn interrupt_status_records_acknowledged_failed_and_timeout() {
+        let mut execution = running_execution();
+        must(execution.request_interrupt(
+            "openhands_agent_server",
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            ts(60),
+        ));
+
+        must(execution.acknowledge_interrupt(ts(61)));
+        assert_eq!(
+            execution.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Acknowledged)
+        );
+
+        must(execution.fail_interrupt(ts(62), "adapter refused interrupt"));
+        assert_eq!(
+            execution.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::Failed)
+        );
+
+        must(execution.timeout_interrupt(ts(63), "ack timeout"));
+        assert_eq!(
+            execution.interrupt().map(|interrupt| interrupt.status),
+            Some(HarnessInterruptStatus::TimedOut)
+        );
     }
 
     #[test]

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -942,6 +942,84 @@ pub enum WorkerOutcomeKind {
     CancelFailed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessInterruptReason {
+    OperatorCancel,
+    TrackerMergingSupersedesHumanReview,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessInterruptExpectedNextState {
+    Paused,
+    Interrupted,
+    Released,
+    CloseoutPending,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessInterruptStatus {
+    Requested,
+    Acknowledged,
+    Failed,
+    TimedOut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessInterruptCommand {
+    pub run_id: String,
+    pub issue_id: IssueId,
+    pub harness_kind: String,
+    pub conversation_id: ConversationId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub reason: HarnessInterruptReason,
+    pub expected_next_state: HarnessInterruptExpectedNextState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessInterruptState {
+    pub command: HarnessInterruptCommand,
+    pub status: HarnessInterruptStatus,
+    pub requested_at: TimestampMs,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<TimestampMs>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl HarnessInterruptState {
+    pub fn requested(command: HarnessInterruptCommand, requested_at: TimestampMs) -> Self {
+        Self {
+            command,
+            status: HarnessInterruptStatus::Requested,
+            requested_at,
+            updated_at: None,
+            detail: None,
+        }
+    }
+
+    pub fn acknowledge(&mut self, observed_at: TimestampMs) {
+        self.status = HarnessInterruptStatus::Acknowledged;
+        self.updated_at = Some(observed_at);
+        self.detail = None;
+    }
+
+    pub fn fail(&mut self, observed_at: TimestampMs, detail: impl Into<String>) {
+        self.status = HarnessInterruptStatus::Failed;
+        self.updated_at = Some(observed_at);
+        self.detail = Some(detail.into());
+    }
+
+    pub fn timeout(&mut self, observed_at: TimestampMs, detail: impl Into<String>) {
+        self.status = HarnessInterruptStatus::TimedOut;
+        self.updated_at = Some(observed_at);
+        self.detail = Some(detail.into());
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkerOutcomeRecord {
     pub worker_id: WorkerId,

--- a/crates/opensymphony-domain/src/runtime.rs
+++ b/crates/opensymphony-domain/src/runtime.rs
@@ -949,6 +949,21 @@ pub enum HarnessInterruptReason {
     TrackerMergingSupersedesHumanReview,
 }
 
+impl HarnessInterruptReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OperatorCancel => "operator_cancel",
+            Self::TrackerMergingSupersedesHumanReview => "tracker_merging_supersedes_human_review",
+        }
+    }
+}
+
+impl fmt::Display for HarnessInterruptReason {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HarnessInterruptExpectedNextState {
@@ -1002,18 +1017,27 @@ impl HarnessInterruptState {
     }
 
     pub fn acknowledge(&mut self, observed_at: TimestampMs) {
+        if self.status != HarnessInterruptStatus::Requested {
+            return;
+        }
         self.status = HarnessInterruptStatus::Acknowledged;
         self.updated_at = Some(observed_at);
         self.detail = None;
     }
 
     pub fn fail(&mut self, observed_at: TimestampMs, detail: impl Into<String>) {
+        if self.status != HarnessInterruptStatus::Requested {
+            return;
+        }
         self.status = HarnessInterruptStatus::Failed;
         self.updated_at = Some(observed_at);
         self.detail = Some(detail.into());
     }
 
     pub fn timeout(&mut self, observed_at: TimestampMs, detail: impl Into<String>) {
+        if self.status != HarnessInterruptStatus::Requested {
+            return;
+        }
         self.status = HarnessInterruptStatus::TimedOut;
         self.updated_at = Some(observed_at);
         self.detail = Some(detail.into());

--- a/crates/opensymphony-domain/src/snapshot.rs
+++ b/crates/opensymphony-domain/src/snapshot.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::{
-    ConversationMetadata, IssueExecution, NormalizedIssue, ReleaseReason, RetryEntry,
-    SchedulerState, SchedulerStatus, TimestampMs, WorkerOutcomeRecord, WorkspaceRecord,
+    ConversationMetadata, HarnessInterruptState, IssueExecution, NormalizedIssue, ReleaseReason,
+    RetryEntry, SchedulerState, SchedulerStatus, TimestampMs, WorkerOutcomeRecord, WorkspaceRecord,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -121,6 +121,8 @@ pub struct RuntimeStateSnapshot {
     pub worker: Option<WorkerAttemptSnapshot>,
     pub last_event_at: Option<TimestampMs>,
     pub stalled_at: Option<TimestampMs>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interrupt: Option<HarnessInterruptState>,
 }
 
 impl RuntimeStateSnapshot {
@@ -137,6 +139,7 @@ impl RuntimeStateSnapshot {
                 worker: None,
                 last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
+                interrupt: execution.interrupt().cloned(),
             },
             SchedulerState::Claimed { run } => Self {
                 state: SchedulerStatus::Claimed,
@@ -147,6 +150,7 @@ impl RuntimeStateSnapshot {
                 worker: Some(WorkerAttemptSnapshot::from(run)),
                 last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
+                interrupt: execution.interrupt().cloned(),
             },
             SchedulerState::Running { run, stall } => Self {
                 state: SchedulerStatus::Running,
@@ -157,6 +161,7 @@ impl RuntimeStateSnapshot {
                 worker: Some(WorkerAttemptSnapshot::from(run)),
                 last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: Some(stall.stalled_at),
+                interrupt: execution.interrupt().cloned(),
             },
             SchedulerState::RetryQueued { .. } => Self {
                 state: SchedulerStatus::RetryQueued,
@@ -167,6 +172,7 @@ impl RuntimeStateSnapshot {
                 worker: None,
                 last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
+                interrupt: execution.interrupt().cloned(),
             },
             SchedulerState::Released {
                 released_at,
@@ -180,6 +186,7 @@ impl RuntimeStateSnapshot {
                 worker: None,
                 last_event_at: conversation.and_then(|conversation| conversation.last_event_at),
                 stalled_at: None,
+                interrupt: execution.interrupt().cloned(),
             },
         }
     }

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -554,7 +554,12 @@ impl IssueExecution {
             && let Some(interrupt) = &mut self.interrupt
             && interrupt.status == HarnessInterruptStatus::Requested
         {
-            interrupt.fail(outcome.finished_at, "worker reported cancel_failed");
+            let detail = outcome
+                .error
+                .clone()
+                .or_else(|| outcome.summary.clone())
+                .unwrap_or_else(|| "worker reported cancel_failed".to_string());
+            interrupt.fail(outcome.finished_at, detail);
         }
         self.last_worker_outcome = Some(outcome.clone());
         if self.recent_worker_outcomes.len() == MAX_RECENT_WORKER_OUTCOMES {

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -7,9 +7,10 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
-    ConversationMetadata, DurationMs, IssueId, NormalizedIssue, ReleaseReason, RetryAttempt,
-    RetryEntry, RunAttempt, StallMetadata, TimestampMs, WorkerId, WorkerOutcomeRecord,
-    WorkspaceKey, WorkspaceRecord,
+    ConversationMetadata, DurationMs, HarnessInterruptCommand, HarnessInterruptExpectedNextState,
+    HarnessInterruptReason, HarnessInterruptState, HarnessInterruptStatus, IssueId,
+    NormalizedIssue, ReleaseReason, RetryAttempt, RetryEntry, RunAttempt, StallMetadata,
+    TimestampMs, WorkerId, WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
 };
 
 const MAX_RECENT_WORKER_OUTCOMES: usize = 10;
@@ -52,6 +53,7 @@ pub enum TransitionAction {
     QueueRetry,
     Release,
     Reopen,
+    RequestInterrupt,
 }
 
 impl TransitionAction {
@@ -64,6 +66,7 @@ impl TransitionAction {
             Self::QueueRetry => "queue_retry",
             Self::Release => "release",
             Self::Reopen => "reopen",
+            Self::RequestInterrupt => "request_interrupt",
         }
     }
 }
@@ -157,6 +160,7 @@ pub struct IssueExecution {
     issue: NormalizedIssue,
     workspace: Option<WorkspaceRecord>,
     conversation: Option<ConversationMetadata>,
+    interrupt: Option<HarnessInterruptState>,
     state: SchedulerState,
     last_worker_outcome: Option<WorkerOutcomeRecord>,
     recent_worker_outcomes: Vec<WorkerOutcomeRecord>,
@@ -168,6 +172,7 @@ impl IssueExecution {
             issue,
             workspace: None,
             conversation: None,
+            interrupt: None,
             state: SchedulerState::Unclaimed { since: observed_at },
             last_worker_outcome: None,
             recent_worker_outcomes: Vec::new(),
@@ -221,6 +226,10 @@ impl IssueExecution {
         self.conversation.as_ref()
     }
 
+    pub fn interrupt(&self) -> Option<&HarnessInterruptState> {
+        self.interrupt.as_ref()
+    }
+
     /// Update the conversation metadata with new values (e.g., token counts after accumulation)
     pub fn update_conversation(&mut self, conversation: ConversationMetadata) {
         self.conversation = Some(conversation);
@@ -241,6 +250,83 @@ impl IssueExecution {
                 total_tokens,
             );
         }
+    }
+
+    pub fn request_interrupt(
+        &mut self,
+        harness_kind: impl Into<String>,
+        turn_id: Option<String>,
+        reason: HarnessInterruptReason,
+        expected_next_state: HarnessInterruptExpectedNextState,
+        requested_at: TimestampMs,
+    ) -> Result<(&HarnessInterruptCommand, bool), StateTransitionError> {
+        if self.interrupt.is_some() {
+            let command = &self
+                .interrupt
+                .as_ref()
+                .expect("checked interrupt presence")
+                .command;
+            return Ok((command, false));
+        }
+
+        let run = match &self.state {
+            SchedulerState::Claimed { run } | SchedulerState::Running { run, .. } => run,
+            _ => {
+                return Err(StateTransitionError::InvalidTransition {
+                    from: self.status(),
+                    action: TransitionAction::RequestInterrupt,
+                });
+            }
+        };
+        let Some(conversation) = &self.conversation else {
+            return Err(StateTransitionError::ConversationNotAttached);
+        };
+
+        self.interrupt = Some(HarnessInterruptState::requested(
+            HarnessInterruptCommand {
+                run_id: run.issue_identifier.to_string(),
+                issue_id: self.issue.id.clone(),
+                harness_kind: harness_kind.into(),
+                conversation_id: conversation.conversation_id.clone(),
+                turn_id,
+                reason,
+                expected_next_state,
+            },
+            requested_at,
+        ));
+        let interrupt = self.interrupt.as_ref().expect("interrupt was just set");
+        Ok((&interrupt.command, true))
+    }
+
+    pub fn acknowledge_interrupt(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<(), StateTransitionError> {
+        self.update_interrupt(observed_at, |interrupt, observed_at| {
+            interrupt.acknowledge(observed_at)
+        })
+    }
+
+    pub fn fail_interrupt(
+        &mut self,
+        observed_at: TimestampMs,
+        detail: impl Into<String>,
+    ) -> Result<(), StateTransitionError> {
+        let detail = detail.into();
+        self.update_interrupt(observed_at, |interrupt, observed_at| {
+            interrupt.fail(observed_at, detail)
+        })
+    }
+
+    pub fn timeout_interrupt(
+        &mut self,
+        observed_at: TimestampMs,
+        detail: impl Into<String>,
+    ) -> Result<(), StateTransitionError> {
+        let detail = detail.into();
+        self.update_interrupt(observed_at, |interrupt, observed_at| {
+            interrupt.timeout(observed_at, detail)
+        })
     }
 
     pub fn retry(&self) -> Option<&RetryEntry> {
@@ -450,6 +536,7 @@ impl IssueExecution {
                 if !reason.preserves_reactivation_state() {
                     self.workspace = None;
                     self.conversation = None;
+                    self.interrupt = None;
                 }
                 self.state = SchedulerState::Unclaimed { since: observed_at };
                 Ok(self)
@@ -466,11 +553,33 @@ impl IssueExecution {
     }
 
     fn record_outcome(&mut self, outcome: WorkerOutcomeRecord) {
+        if outcome.outcome == super::WorkerOutcomeKind::CancelFailed {
+            if let Some(interrupt) = &mut self.interrupt {
+                if interrupt.status == HarnessInterruptStatus::Requested {
+                    interrupt.fail(outcome.finished_at, "worker reported cancel_failed");
+                }
+            }
+        }
         self.last_worker_outcome = Some(outcome.clone());
         if self.recent_worker_outcomes.len() == MAX_RECENT_WORKER_OUTCOMES {
             self.recent_worker_outcomes.remove(0);
         }
         self.recent_worker_outcomes.push(outcome);
+    }
+
+    fn update_interrupt(
+        &mut self,
+        observed_at: TimestampMs,
+        update: impl FnOnce(&mut HarnessInterruptState, TimestampMs),
+    ) -> Result<(), StateTransitionError> {
+        let Some(interrupt) = &mut self.interrupt else {
+            return Err(StateTransitionError::InvalidTransition {
+                from: self.status(),
+                action: TransitionAction::RequestInterrupt,
+            });
+        };
+        update(interrupt, observed_at);
+        Ok(())
     }
 
     fn validate_run_binding(&self, run: &RunAttempt) -> Result<(), StateTransitionError> {

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -54,6 +54,7 @@ pub enum TransitionAction {
     Release,
     Reopen,
     RequestInterrupt,
+    UpdateInterrupt,
 }
 
 impl TransitionAction {
@@ -67,6 +68,7 @@ impl TransitionAction {
             Self::Release => "release",
             Self::Reopen => "reopen",
             Self::RequestInterrupt => "request_interrupt",
+            Self::UpdateInterrupt => "update_interrupt",
         }
     }
 }
@@ -569,7 +571,7 @@ impl IssueExecution {
         let Some(interrupt) = &mut self.interrupt else {
             return Err(StateTransitionError::InvalidTransition {
                 from: self.status(),
-                action: TransitionAction::RequestInterrupt,
+                action: TransitionAction::UpdateInterrupt,
             });
         };
         update(interrupt, observed_at);

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -262,10 +262,6 @@ impl IssueExecution {
         expected_next_state: HarnessInterruptExpectedNextState,
         requested_at: TimestampMs,
     ) -> Result<(HarnessInterruptCommand, bool), StateTransitionError> {
-        if let Some(interrupt) = &self.interrupt {
-            return Ok((interrupt.command.clone(), false));
-        }
-
         let run = match &self.state {
             SchedulerState::Claimed { run } | SchedulerState::Running { run, .. } => run,
             _ => {
@@ -278,6 +274,9 @@ impl IssueExecution {
         let Some(conversation) = &self.conversation else {
             return Err(StateTransitionError::ConversationNotAttached);
         };
+        if let Some(interrupt) = &self.interrupt {
+            return Ok((interrupt.command.clone(), false));
+        }
 
         self.interrupt = Some(HarnessInterruptState::requested(
             HarnessInterruptCommand {
@@ -401,6 +400,7 @@ impl IssueExecution {
         self.state = SchedulerState::Claimed {
             run: run.with_normal_retry_count(normal_retry_count),
         };
+        self.interrupt = None;
         Ok(self)
     }
 

--- a/crates/opensymphony-domain/src/state_machine.rs
+++ b/crates/opensymphony-domain/src/state_machine.rs
@@ -259,14 +259,9 @@ impl IssueExecution {
         reason: HarnessInterruptReason,
         expected_next_state: HarnessInterruptExpectedNextState,
         requested_at: TimestampMs,
-    ) -> Result<(&HarnessInterruptCommand, bool), StateTransitionError> {
-        if self.interrupt.is_some() {
-            let command = &self
-                .interrupt
-                .as_ref()
-                .expect("checked interrupt presence")
-                .command;
-            return Ok((command, false));
+    ) -> Result<(HarnessInterruptCommand, bool), StateTransitionError> {
+        if let Some(interrupt) = &self.interrupt {
+            return Ok((interrupt.command.clone(), false));
         }
 
         let run = match &self.state {
@@ -295,7 +290,7 @@ impl IssueExecution {
             requested_at,
         ));
         let interrupt = self.interrupt.as_ref().expect("interrupt was just set");
-        Ok((&interrupt.command, true))
+        Ok((interrupt.command.clone(), true))
     }
 
     pub fn acknowledge_interrupt(
@@ -553,12 +548,11 @@ impl IssueExecution {
     }
 
     fn record_outcome(&mut self, outcome: WorkerOutcomeRecord) {
-        if outcome.outcome == super::WorkerOutcomeKind::CancelFailed {
-            if let Some(interrupt) = &mut self.interrupt {
-                if interrupt.status == HarnessInterruptStatus::Requested {
-                    interrupt.fail(outcome.finished_at, "worker reported cancel_failed");
-                }
-            }
+        if outcome.outcome == super::WorkerOutcomeKind::CancelFailed
+            && let Some(interrupt) = &mut self.interrupt
+            && interrupt.status == HarnessInterruptStatus::Requested
+        {
+            interrupt.fail(outcome.finished_at, "worker reported cancel_failed");
         }
         self.last_worker_outcome = Some(outcome.clone());
         if self.recent_worker_outcomes.len() == MAX_RECENT_WORKER_OUTCOMES {

--- a/crates/opensymphony-domain/tests/snapshot_serialization.rs
+++ b/crates/opensymphony-domain/tests/snapshot_serialization.rs
@@ -73,8 +73,12 @@ fn fixture() -> SnapshotEnvelope {
                 output_tokens: 1024,
                 cache_read_tokens: 512,
                 total_tokens: 3072,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             }],
             recent_events: vec![RecentEvent {

--- a/crates/opensymphony-domain/tests/snapshot_serialization.rs
+++ b/crates/opensymphony-domain/tests/snapshot_serialization.rs
@@ -74,7 +74,6 @@ fn fixture() -> SnapshotEnvelope {
                 cache_read_tokens: 512,
                 total_tokens: 3072,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,

--- a/crates/opensymphony-gateway-schema/src/run.rs
+++ b/crates/opensymphony-gateway-schema/src/run.rs
@@ -81,6 +81,12 @@ pub struct RunDetail {
     /// True when a cancel/force-stop request was not acknowledged.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cancel_failed: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cancel_requested: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cancel_timed_out: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancel_reason: Option<String>,
 }
 
 /// Action a client may dispatch on a run.
@@ -162,6 +168,15 @@ pub struct RunDiagnostics {
     /// True when a cancel/force-stop request was not acknowledged.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cancel_failed: bool,
+    /// True while a cancel/force-stop request is pending acknowledgement.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cancel_requested: bool,
+    /// True when a cancel/force-stop request timed out before acknowledgement.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cancel_timed_out: bool,
+    /// Machine-readable cancel reason supplied by the orchestrator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancel_reason: Option<String>,
 }
 
 /// Details of a harness/scheduler disagreement.

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -442,7 +442,6 @@ fn run_detail_roundtrips() {
         safe_actions: SafeActions::default(),
         detached: false,
         cancel_requested: false,
-
         cancel_acknowledged: false,
         cancel_failed: false,
         cancel_timed_out: false,

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -18,8 +18,8 @@ use opensymphony::opensymphony_gateway_schema::{
         TaskPackageProjection, TurnRole,
     },
     run::{
-        HarnessSchedulerDisagreement, ReleaseReason, RunDetail, RunEvent, RunEventPage,
-        RunLifecycleState, RunLivenessEnvelope, RunPhase, RunProgress, RunStatus,
+        HarnessSchedulerDisagreement, ReleaseReason, RunDetail, RunDiagnostics, RunEvent,
+        RunEventPage, RunLifecycleState, RunLivenessEnvelope, RunPhase, RunProgress, RunStatus,
         RunStreamLiveness, SafeActions,
     },
     snapshot::{
@@ -431,17 +431,34 @@ fn run_detail_roundtrips() {
         error: None,
         allowed_actions: vec![],
         liveness: None,
-        diagnostics: None,
+        diagnostics: Some(RunDiagnostics {
+            harness_scheduler_disagreement: None,
+            cancel_requested: true,
+            cancel_acknowledged: false,
+            cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: Some("operator_cancel".into()),
+        }),
         safe_actions: SafeActions::default(),
         detached: false,
+        cancel_requested: false,
+
         cancel_acknowledged: false,
         cancel_failed: false,
+        cancel_timed_out: false,
+        cancel_reason: None,
     };
     let json = must_serialize(&run);
     let back: RunDetail = must_deserialize(&json);
     assert_eq!(back.status, RunStatus::Running);
     assert_eq!(back.issue_identifier, "COE-390");
     assert_eq!(back.turn_count, 3);
+    let diagnostics = back.diagnostics.expect("diagnostics should roundtrip");
+    assert!(diagnostics.cancel_requested);
+    assert_eq!(
+        diagnostics.cancel_reason.as_deref(),
+        Some("operator_cancel")
+    );
 }
 
 #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2610,8 +2610,11 @@ async fn get_run_detail(
                     diagnostics: None,
                     safe_actions: SafeActions::default(),
                     detached: false,
+                    cancel_requested: false,
                     cancel_acknowledged: false,
                     cancel_failed: false,
+                    cancel_timed_out: false,
+                    cancel_reason: None,
                 }),
             );
         }
@@ -2689,13 +2692,19 @@ async fn get_run_detail(
             liveness: Some(build_liveness(issue)),
             diagnostics: Some(RunDiagnostics {
                 harness_scheduler_disagreement: None,
+                cancel_requested: issue.cancel_requested,
                 cancel_acknowledged: issue.cancel_acknowledged,
                 cancel_failed: issue.cancel_failed,
+                cancel_timed_out: issue.cancel_timed_out,
+                cancel_reason: issue.cancel_reason.clone(),
             }),
             safe_actions: safe_actions_for_issue(issue),
             detached: issue.detached,
+            cancel_requested: issue.cancel_requested,
             cancel_acknowledged: issue.cancel_acknowledged,
             cancel_failed: issue.cancel_failed,
+            cancel_timed_out: issue.cancel_timed_out,
+            cancel_reason: issue.cancel_reason.clone(),
         }),
     )
 }
@@ -4063,8 +4072,12 @@ exit 2
             cache_read_tokens: 0,
             total_tokens: 0,
             detached: flags.detached,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
         }
     }
 

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -4073,7 +4073,6 @@ exit 2
             total_tokens: 0,
             detached: flags.detached,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -238,8 +238,12 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             output_tokens: 512,
             cache_read_tokens: 256,
             total_tokens: 0,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
             detached: false,
         }],
         recent_events: vec![RecentEvent {
@@ -323,8 +327,12 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 0,
                 cache_read_tokens: 0,
                 total_tokens: 0,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             },
             // Completed issue with events and modified files
@@ -412,8 +420,12 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 1024,
                 cache_read_tokens: 256,
                 total_tokens: 0,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             },
             // Failed issue, first attempt (no retries exhausted)
@@ -450,8 +462,12 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 128,
                 cache_read_tokens: 0,
                 total_tokens: 0,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             },
             // RetryQueued issue: queued but NOT eligible (not idle)
@@ -488,8 +504,12 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 64,
                 cache_read_tokens: 0,
                 total_tokens: 0,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             },
             // Blocked Idle issue: NOT eligible AND NOT queued
@@ -526,8 +546,12 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 output_tokens: 0,
                 cache_read_tokens: 0,
                 total_tokens: 0,
+                cancel_requested: false,
+
                 cancel_acknowledged: false,
                 cancel_failed: false,
+                cancel_timed_out: false,
+                cancel_reason: None,
                 detached: false,
             },
         ],

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -239,7 +239,6 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 256,
             total_tokens: 0,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,
@@ -328,7 +327,6 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 cache_read_tokens: 0,
                 total_tokens: 0,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,
@@ -421,7 +419,6 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 cache_read_tokens: 256,
                 total_tokens: 0,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,
@@ -463,7 +460,6 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 cache_read_tokens: 0,
                 total_tokens: 0,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,
@@ -505,7 +501,6 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 cache_read_tokens: 0,
                 total_tokens: 0,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,
@@ -547,7 +542,6 @@ fn fixture_snapshot_rich(step: u64) -> DaemonSnapshot {
                 cache_read_tokens: 0,
                 total_tokens: 0,
                 cancel_requested: false,
-
                 cancel_acknowledged: false,
                 cancel_failed: false,
                 cancel_timed_out: false,
@@ -1734,6 +1728,45 @@ async fn gateway_serves_run_detail() {
         response.status,
         opensymphony::opensymphony_gateway_schema::run::RunStatus::Running
     );
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_run_detail_cancel_diagnostics() {
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].cancel_requested = true;
+    snapshot.issues[0].cancel_reason = Some("operator_cancel".to_owned());
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{address}/api/v1/runs/COE-255"))
+        .send()
+        .await
+        .expect("fetch run detail")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunDetail>()
+        .await
+        .expect("decode run detail");
+
+    let diagnostics = response.diagnostics.expect("diagnostics");
+    assert!(diagnostics.cancel_requested);
+    assert_eq!(
+        diagnostics.cancel_reason.as_deref(),
+        Some("operator_cancel")
+    );
+    assert!(response.cancel_requested);
+    assert_eq!(response.cancel_reason.as_deref(), Some("operator_cancel"));
 
     server_task.abort();
 }

--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -4385,7 +4385,6 @@ mod tests {
                         cache_read_tokens: 256 + (index as u64 * 25),
                         total_tokens: 0,
                         cancel_requested: false,
-
                         cancel_acknowledged: false,
                         cancel_failed: false,
                         cancel_timed_out: false,

--- a/crates/opensymphony-tui/src/lib.rs
+++ b/crates/opensymphony-tui/src/lib.rs
@@ -4384,8 +4384,12 @@ mod tests {
                         output_tokens: 512 + (index as u64 * 50),
                         cache_read_tokens: 256 + (index as u64 * 25),
                         total_tokens: 0,
+                        cancel_requested: false,
+
                         cancel_acknowledged: false,
                         cancel_failed: false,
+                        cancel_timed_out: false,
+                        cancel_reason: None,
                         detached: false,
                     })
                     .collect(),

--- a/crates/opensymphony-tui/tests/reducer.rs
+++ b/crates/opensymphony-tui/tests/reducer.rs
@@ -89,8 +89,12 @@ fn fixture_with_identifiers(sequence: u64, identifiers: &[String]) -> SnapshotEn
                     output_tokens: 512 + (index as u64 * 50),
                     cache_read_tokens: 256 + (index as u64 * 25),
                     total_tokens: 0,
+                    cancel_requested: false,
+
                     cancel_acknowledged: false,
                     cancel_failed: false,
+                    cancel_timed_out: false,
+                    cancel_reason: None,
                     detached: false,
                 })
                 .collect(),
@@ -142,8 +146,12 @@ fn reordered_fixture(sequence: u64, identifiers: &[&str]) -> SnapshotEnvelope {
             output_tokens: 512 + (index as u64 * 50),
             cache_read_tokens: 256 + (index as u64 * 25),
             total_tokens: 0,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
             detached: false,
         })
         .collect();

--- a/crates/opensymphony-tui/tests/reducer.rs
+++ b/crates/opensymphony-tui/tests/reducer.rs
@@ -90,7 +90,6 @@ fn fixture_with_identifiers(sequence: u64, identifiers: &[String]) -> SnapshotEn
                     cache_read_tokens: 256 + (index as u64 * 25),
                     total_tokens: 0,
                     cancel_requested: false,
-
                     cancel_acknowledged: false,
                     cancel_failed: false,
                     cancel_timed_out: false,
@@ -147,7 +146,6 @@ fn reordered_fixture(sequence: u64, identifiers: &[&str]) -> SnapshotEnvelope {
             cache_read_tokens: 256 + (index as u64 * 25),
             total_tokens: 0,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,7 +228,26 @@ silently treated as the first page.
 - a missing `LINEAR_API_KEY` blocks Linear operations but should fail clearly
 - UI failures must not affect daemon execution
 
-## 7. Migration boundary
+## 7. Interrupt diagnostics
+
+Interrupt requests are recorded in orchestrator-owned issue execution state
+before any harness-specific protocol call is attempted. The shared command
+captures the run id, Linear issue id, harness kind, conversation or thread id,
+optional turn id, reason, and expected next state. Current reasons are
+`operator_cancel` and `tracker_merging_supersedes_human_review`.
+
+The command is idempotent for the active run: repeated operator clicks or
+tracker observations return the existing command instead of enqueueing another
+harness interrupt. Harness adapters later translate that command to their
+native protocol, but scheduler state does not depend on desktop-local state or
+adapter-private DTOs.
+
+Run Detail diagnostics surface the orchestrator-owned cancel state as
+requested, acknowledged, failed, timed out, and reason fields. Terminal cancel
+states are sticky: late acknowledgements, failures, or timeouts do not overwrite
+an already terminal interrupt status.
+
+## 8. Migration boundary
 
 OpenSymphony 1.0.0 is the compatibility boundary for the GraphQL-only Linear
 rewrite and the provider-agnostic AI review configuration changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,7 +245,9 @@ adapter-private DTOs.
 Run Detail diagnostics surface the orchestrator-owned cancel state as
 requested, acknowledged, failed, timed out, and reason fields. Terminal cancel
 states are sticky: late acknowledgements, failures, or timeouts do not overwrite
-an already terminal interrupt status.
+an already terminal interrupt status. Non-cancel worker outcomes do not infer a
+harness interrupt acknowledgement or timeout; adapters must still report the
+actual acknowledgement, failure, or timeout path.
 
 ## 8. Migration boundary
 

--- a/packages/gateway-schema/src/run.ts
+++ b/packages/gateway-schema/src/run.ts
@@ -66,10 +66,16 @@ export interface HarnessSchedulerDisagreement {
 /** Diagnostic hints surfaced when multiple subsystems disagree. */
 export interface RunDiagnostics {
   harness_scheduler_disagreement?: HarnessSchedulerDisagreement | null;
+  /** True while a cancel/force-stop request is pending acknowledgement. */
+  cancel_requested?: boolean;
   /** True when the harness acknowledged a cancel/force-stop request. */
   cancel_acknowledged?: boolean;
   /** True when a cancel/force-stop request was not acknowledged. */
   cancel_failed?: boolean;
+  /** True when a cancel/force-stop request timed out before acknowledgement. */
+  cancel_timed_out?: boolean;
+  /** Machine-readable cancel reason supplied by the orchestrator. */
+  cancel_reason?: string | null;
 }
 
 /** Actions the client may safely invoke in the current run state. */
@@ -158,6 +164,12 @@ export interface RunDetail {
   cancel_acknowledged?: boolean;
   /** True when a cancel/force-stop request was not acknowledged. */
   cancel_failed?: boolean;
+  /** True while a cancel/force-stop request is pending acknowledgement. */
+  cancel_requested?: boolean;
+  /** True when a cancel/force-stop request timed out before acknowledgement. */
+  cancel_timed_out?: boolean;
+  /** Machine-readable cancel reason supplied by the orchestrator. */
+  cancel_reason?: string | null;
 }
 
 /** Paged run events. */

--- a/tests/action_handler.rs
+++ b/tests/action_handler.rs
@@ -78,7 +78,6 @@ fn fixture_snapshot(
             cache_read_tokens: 0,
             total_tokens: 0,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/tests/action_handler.rs
+++ b/tests/action_handler.rs
@@ -77,8 +77,12 @@ fn fixture_snapshot(
             output_tokens: 0,
             cache_read_tokens: 0,
             total_tokens: 0,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
             detached: false,
         }],
         recent_events: Vec::new(),

--- a/tests/task_graph_mutations_routes.rs
+++ b/tests/task_graph_mutations_routes.rs
@@ -106,7 +106,6 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             cache_read_tokens: 0,
             total_tokens: 0,
             cancel_requested: false,
-
             cancel_acknowledged: false,
             cancel_failed: false,
             cancel_timed_out: false,

--- a/tests/task_graph_mutations_routes.rs
+++ b/tests/task_graph_mutations_routes.rs
@@ -105,8 +105,12 @@ fn fixture_snapshot(step: u64) -> DaemonSnapshot {
             output_tokens: 0,
             cache_read_tokens: 0,
             total_tokens: 0,
+            cancel_requested: false,
+
             cancel_acknowledged: false,
             cancel_failed: false,
+            cancel_timed_out: false,
+            cancel_reason: None,
             detached: false,
         }],
         recent_events: vec![RecentEvent {


### PR DESCRIPTION
## Summary

Adds the shared orchestrator-owned interrupt contract and Run Detail cancel diagnostics for COE-486.

## Changes

- Add harness-neutral interrupt command, reason, expected next state, and status models in the domain state machine.
- Record active-run interrupt requests idempotently so repeated observations/button clicks reuse the existing command.
- Thread cancel requested, acknowledged, failed, timed out, and reason diagnostics through control-plane snapshots and Rust/TypeScript gateway Run Detail schemas.
- Add endpoint-level Run Detail evidence for cancel diagnostics and document the shared interrupt contract.

## Evidence

### Test output

```
cargo test-system-duckdb -p opensymphony --lib interrupt
running 9 tests
9 passed; 0 failed

cargo test-system-duckdb -p opensymphony --test gateway_schema run_detail_roundtrips
running 1 test
1 passed; 0 failed

cargo test-system-duckdb -p opensymphony --test gateway gateway_serves_run_detail_cancel_diagnostics
running 1 test
1 passed; 0 failed

cargo clippy --workspace --all-targets -- -D warnings
Finished dev profile

cargo check-system-duckdb
Finished dev profile

cargo fmt --check
passed

git diff --check
passed
```

### Verification

Verified the domain can record `operator_cancel` and `tracker_merging_supersedes_human_review`, expose acknowledged/failed/timeout transitions, reject inactive or missing-conversation interrupt requests, keep terminal interrupt states sticky, preserve adapter failure detail, avoid inferring interrupt terminal status from non-cancel outcomes, and return the original command for repeated active-run interrupt requests, and clear retained interrupt state across reopen/reclaim so a new run queues a new command. Verified Run Detail schema round-trips the new cancel diagnostics and the gateway endpoint returns cancel diagnostics in a real `/api/v1/runs/{run_id}` response via `gateway_serves_run_detail_cancel_diagnostics`.

## Checklist

- [x] Tests pass (`cargo test` focused commands above)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (`docs/architecture.md`)
- [x] `AGENTS.md` updated (not required)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None. New snapshot and diagnostics fields are serde-defaulted/optional for compatibility.

## Related issues

COE-486

## Additional notes

Adapter-specific OpenHands and Codex interrupt calls are intentionally out of scope for this PR.

