### PR TITLE
feat(cli): add lazy desktop launcher command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ Do not silently invent behavior when the upstream spec or chosen integration con
 - `opensymphony run` is the real local orchestrator entrypoint.
 - `opensymphony daemon` is demo-only and exists for smoke tests or UI-focused development.
 - When documenting, validating, or operating the system, prefer `opensymphony run` unless the task is specifically about the demo control-plane publisher.
+- `opensymphony app` and the visible alias `opensymphony desktop` are the
+  lazy desktop bundle installer/launcher path. They must remain separate from
+  the execution-plane `opensymphony run` entrypoint.
+- The desktop launcher caches verified bundles under
+  `~/.opensymphony/desktop/<version>/` and uses a bundle manifest containing
+  version, platform, architecture, relative executable path, and executable
+  SHA-256 checksum. Local materialization must not add Tauri, npm, or platform
+  desktop build dependencies to the default Cargo install.
 - `opensymphony memory export-okf --visibility public|private [--output DIR]`
   exports a directory OKF bundle. Public export skips private concepts, runs
   public redaction checks through OKF lint, stages output before promotion, and

--- a/README.md
+++ b/README.md
@@ -175,6 +175,22 @@ For real-time monitoring while the orchestrator is running, run the TUI in a sep
 opensymphony tui
 ```
 
+To launch the alpha desktop shell without adding Tauri or npm dependencies to
+the normal Cargo install path, use the lazy desktop launcher:
+
+```bash
+opensymphony app
+# or
+opensymphony desktop
+```
+
+The launcher verifies a versioned desktop bundle under
+`~/.opensymphony/desktop/<version>/` before starting it. Early local bundles can
+be materialized with `--bundle-dir <path>` or
+`OPENSYMPHONY_DESKTOP_BUNDLE_DIR`; the bundle must include
+`opensymphony-desktop-manifest.json` with `version`, `platform`, `arch`,
+relative `executable`, and `sha256` fields.
+
 ### Further Details
 
 For generated files, environment variables, `config.yaml`, and the template

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -1,0 +1,369 @@
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::{Command, ExitCode},
+};
+
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+const MANIFEST_FILE: &str = "opensymphony-desktop-manifest.json";
+const DEFAULT_CACHE_RELATIVE: &str = ".opensymphony/desktop";
+
+#[derive(Debug, Args)]
+pub struct AppArgs {
+    #[arg(
+        long,
+        env = "OPENSYMPHONY_DESKTOP_BUNDLE_DIR",
+        help = "Local desktop bundle directory to install into the versioned cache"
+    )]
+    bundle_dir: Option<PathBuf>,
+    #[arg(
+        long,
+        env = "OPENSYMPHONY_DESKTOP_CACHE_ROOT",
+        hide = true,
+        help = "Override the desktop cache root; primarily for smoke tests"
+    )]
+    cache_root: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Verify the bundle and print the launch target without starting it"
+    )]
+    dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DesktopBundleManifest {
+    version: String,
+    platform: String,
+    arch: String,
+    executable: PathBuf,
+    sha256: String,
+}
+
+#[derive(Debug)]
+struct VerifiedBundle {
+    executable: PathBuf,
+}
+
+pub async fn run_command(args: AppArgs) -> ExitCode {
+    match run_app(args) {
+        Ok(executable) => {
+            println!("OpenSymphony desktop ready: {}", executable.display());
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
+    let cache_root = args.cache_root.unwrap_or(default_cache_root()?);
+    let cache_dir = cache_root.join(desktop_version());
+    let bundle_dir = args.bundle_dir.as_deref();
+    let verified = ensure_verified_bundle(&cache_dir, bundle_dir)?;
+
+    if args.dry_run {
+        println!(
+            "Dry run: would launch cached OpenSymphony desktop at {}",
+            verified.executable.display()
+        );
+        return Ok(verified.executable);
+    }
+
+    Command::new(&verified.executable)
+        .spawn()
+        .map_err(|source| DesktopLauncherError::Launch {
+            path: verified.executable.clone(),
+            source,
+        })?;
+    Ok(verified.executable)
+}
+
+fn ensure_verified_bundle(
+    cache_dir: &Path,
+    bundle_dir: Option<&Path>,
+) -> Result<VerifiedBundle, DesktopLauncherError> {
+    match verify_bundle(cache_dir) {
+        Ok(bundle) => Ok(bundle),
+        Err(first_error) => {
+            if let Some(bundle_dir) = bundle_dir {
+                if cache_dir.exists() {
+                    fs::remove_dir_all(cache_dir).map_err(|source| {
+                        DesktopLauncherError::Repair {
+                            path: cache_dir.to_path_buf(),
+                            source,
+                        }
+                    })?;
+                }
+                copy_dir_all(bundle_dir, cache_dir)?;
+                verify_bundle(cache_dir)
+            } else {
+                Err(first_error)
+            }
+        }
+    }
+}
+
+fn verify_bundle(cache_dir: &Path) -> Result<VerifiedBundle, DesktopLauncherError> {
+    let manifest_path = cache_dir.join(MANIFEST_FILE);
+    let manifest = read_manifest(&manifest_path)?;
+
+    if manifest.version != desktop_version() {
+        return Err(DesktopLauncherError::WrongVersion {
+            path: manifest_path,
+            expected: desktop_version().to_string(),
+            actual: manifest.version,
+        });
+    }
+    if manifest.platform != current_platform() {
+        return Err(DesktopLauncherError::WrongPlatform {
+            path: manifest_path,
+            expected: current_platform().to_string(),
+            actual: manifest.platform,
+        });
+    }
+    if manifest.arch != current_arch() {
+        return Err(DesktopLauncherError::WrongArch {
+            path: manifest_path,
+            expected: current_arch().to_string(),
+            actual: manifest.arch,
+        });
+    }
+
+    let executable = cache_dir.join(&manifest.executable);
+    let actual = file_sha256(&executable)?;
+    if actual != manifest.sha256 {
+        return Err(DesktopLauncherError::BadChecksum {
+            path: executable,
+            expected: manifest.sha256,
+            actual,
+        });
+    }
+
+    Ok(VerifiedBundle { executable })
+}
+
+fn read_manifest(path: &Path) -> Result<DesktopBundleManifest, DesktopLauncherError> {
+    let contents =
+        fs::read_to_string(path).map_err(|source| DesktopLauncherError::MissingBundle {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    serde_json::from_str(&contents).map_err(|source| DesktopLauncherError::InvalidManifest {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> Result<(), DesktopLauncherError> {
+    fs::create_dir_all(to).map_err(|source| DesktopLauncherError::Repair {
+        path: to.to_path_buf(),
+        source,
+    })?;
+    for entry in fs::read_dir(from).map_err(|source| DesktopLauncherError::MissingBundle {
+        path: from.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| DesktopLauncherError::Repair {
+            path: to.to_path_buf(),
+            source,
+        })?;
+        let target = to.join(entry.file_name());
+        if entry
+            .file_type()
+            .map_err(|source| DesktopLauncherError::Repair {
+                path: entry.path(),
+                source,
+            })?
+            .is_dir()
+        {
+            copy_dir_all(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), &target).map_err(|source| DesktopLauncherError::Repair {
+                path: target,
+                source,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn file_sha256(path: &Path) -> Result<String, DesktopLauncherError> {
+    let bytes = fs::read(path).map_err(|source| DesktopLauncherError::MissingExecutable {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+fn default_cache_root() -> Result<PathBuf, DesktopLauncherError> {
+    let home = env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or(DesktopLauncherError::MissingHome)?;
+    Ok(home.join(DEFAULT_CACHE_RELATIVE))
+}
+
+fn desktop_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+fn current_platform() -> &'static str {
+    env::consts::OS
+}
+
+fn current_arch() -> &'static str {
+    env::consts::ARCH
+}
+
+#[derive(Debug, Error)]
+enum DesktopLauncherError {
+    #[error(
+        "could not find HOME; set OPENSYMPHONY_DESKTOP_CACHE_ROOT to choose a desktop cache directory"
+    )]
+    MissingHome,
+    #[error(
+        "desktop bundle is not installed at {path}: {source}\nRepair: rerun with --bundle-dir <path> or set OPENSYMPHONY_DESKTOP_BUNDLE_DIR to a verified OpenSymphony desktop bundle."
+    )]
+    MissingBundle { path: PathBuf, source: io::Error },
+    #[error(
+        "desktop executable is missing at {path}: {source}\nRepair: remove the cached version directory and rerun with --bundle-dir <path>."
+    )]
+    MissingExecutable { path: PathBuf, source: io::Error },
+    #[error(
+        "desktop manifest {path} is invalid: {source}\nRepair: rerun with a freshly built desktop bundle."
+    )]
+    InvalidManifest {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error(
+        "cached desktop bundle has version {actual}, expected {expected} in {path}\nRepair: remove the cached version directory and rerun with a matching bundle."
+    )]
+    WrongVersion {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    #[error(
+        "cached desktop bundle has platform {actual}, expected {expected} in {path}\nRepair: install a bundle built for this platform."
+    )]
+    WrongPlatform {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    #[error(
+        "cached desktop bundle has architecture {actual}, expected {expected} in {path}\nRepair: install a bundle built for this CPU architecture."
+    )]
+    WrongArch {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    #[error(
+        "cached desktop checksum mismatch for {path}: expected {expected}, got {actual}\nRepair: remove the cached version directory and rerun with --bundle-dir <path>."
+    )]
+    BadChecksum {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    #[error("failed to repair desktop cache at {path}: {source}")]
+    Repair { path: PathBuf, source: io::Error },
+    #[error("failed to launch desktop app at {path}: {source}")]
+    Launch { path: PathBuf, source: io::Error },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use tempfile::TempDir;
+
+    use super::super::{Cli, Command as CliCommand};
+
+    #[test]
+    fn app_and_desktop_alias_parse_to_same_command() {
+        let app = Cli::try_parse_from(["opensymphony", "app", "--dry-run"])
+            .expect("app command should parse");
+        let desktop = Cli::try_parse_from(["opensymphony", "desktop", "--dry-run"])
+            .expect("desktop alias should parse");
+
+        assert!(matches!(app.command, CliCommand::App(_)));
+        assert!(matches!(desktop.command, CliCommand::App(_)));
+    }
+
+    #[test]
+    fn cache_path_is_versioned_under_opensymphony_desktop() {
+        let home = Path::new("/tmp/example-home");
+        let cache = home.join(DEFAULT_CACHE_RELATIVE).join(desktop_version());
+
+        assert_eq!(
+            cache,
+            PathBuf::from(format!(
+                "/tmp/example-home/.opensymphony/desktop/{}",
+                desktop_version()
+            ))
+        );
+    }
+
+    #[test]
+    fn platform_selection_uses_current_target() {
+        assert_eq!(current_platform(), env::consts::OS);
+        assert_eq!(current_arch(), env::consts::ARCH);
+    }
+
+    #[test]
+    fn local_bundle_materializes_and_verifies_from_manifest() {
+        let source = TempDir::new().expect("source tempdir");
+        let cache = TempDir::new().expect("cache tempdir");
+        let executable = source.path().join("OpenSymphony");
+        fs::write(&executable, b"fake desktop").expect("write fake executable");
+        let manifest = DesktopBundleManifest {
+            version: desktop_version().to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            executable: PathBuf::from("OpenSymphony"),
+            sha256: file_sha256(&executable).expect("hash fake executable"),
+        };
+        fs::write(
+            source.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let cache_dir = cache.path().join(desktop_version());
+        let verified = ensure_verified_bundle(&cache_dir, Some(source.path()))
+            .expect("bundle should materialize and verify");
+
+        assert_eq!(verified.executable, cache_dir.join("OpenSymphony"));
+    }
+
+    #[test]
+    fn checksum_mismatch_reports_repair_guidance() {
+        let cache = TempDir::new().expect("cache tempdir");
+        let executable = cache.path().join("OpenSymphony");
+        fs::write(&executable, b"fake desktop").expect("write fake executable");
+        let manifest = DesktopBundleManifest {
+            version: desktop_version().to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            executable: PathBuf::from("OpenSymphony"),
+            sha256: "bad".into(),
+        };
+        fs::write(
+            cache.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let error = verify_bundle(cache.path()).expect_err("checksum should fail");
+
+        assert!(error.to_string().contains("Repair:"));
+    }
+}

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -298,6 +298,13 @@ fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> 
 fn validate_cache_dir(cache_root: &Path, cache_dir: &Path) -> Result<(), DesktopLauncherError> {
     reject_parent_components(cache_root)?;
     reject_parent_components(cache_dir)?;
+    if let Ok(metadata) = fs::symlink_metadata(cache_dir)
+        && metadata.file_type().is_symlink()
+    {
+        return Err(DesktopLauncherError::DangerousCacheRoot {
+            path: cache_dir.to_path_buf(),
+        });
+    }
     if cache_root.parent().is_none()
         || !cache_dir.starts_with(cache_root)
         || cache_dir.file_name().and_then(|name| name.to_str()) != Some(desktop_version())
@@ -623,6 +630,29 @@ mod tests {
             error,
             DesktopLauncherError::DangerousCacheRoot { .. }
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_delete_rejects_versioned_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let cache_root = TempDir::new().expect("cache root");
+        let outside = TempDir::new().expect("outside target");
+        let cache_dir = cache_root.path().join(desktop_version());
+        symlink(outside.path(), &cache_dir).expect("create versioned cache symlink");
+
+        let error = validate_cache_dir(cache_root.path(), &cache_dir)
+            .expect_err("versioned cache symlink should fail");
+
+        assert!(matches!(
+            error,
+            DesktopLauncherError::DangerousCacheRoot { .. }
+        ));
+        assert!(
+            outside.path().exists(),
+            "validation must not remove symlink target"
+        );
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -192,11 +192,30 @@ fn copy_dir_all(from: &Path, to: &Path) -> Result<(), DesktopLauncherError> {
         if metadata.is_dir() {
             copy_dir_all(&entry.path(), &target)?;
         } else {
+            let permissions = metadata.permissions();
             fs::copy(entry.path(), &target).map_err(|source| DesktopLauncherError::Repair {
-                path: target,
+                path: target.clone(),
                 source,
             })?;
+            fs::set_permissions(&target, permissions).map_err(|source| {
+                DesktopLauncherError::Repair {
+                    path: target,
+                    source,
+                }
+            })?;
         }
+    }
+    Ok(())
+}
+
+fn reject_parent_components(path: &Path) -> Result<(), DesktopLauncherError> {
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(DesktopLauncherError::DangerousCacheRoot {
+            path: path.to_path_buf(),
+        });
     }
     Ok(())
 }
@@ -231,6 +250,7 @@ fn default_cache_root() -> Result<PathBuf, DesktopLauncherError> {
 }
 
 fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> {
+    reject_parent_components(&path)?;
     let absolute = if path.is_absolute() {
         path
     } else {
@@ -238,6 +258,7 @@ fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> 
             .map_err(DesktopLauncherError::CurrentDir)?
             .join(path)
     };
+    reject_parent_components(&absolute)?;
     if absolute.parent().is_none() {
         return Err(DesktopLauncherError::DangerousCacheRoot { path: absolute });
     }
@@ -245,6 +266,8 @@ fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> 
 }
 
 fn validate_cache_dir(cache_root: &Path, cache_dir: &Path) -> Result<(), DesktopLauncherError> {
+    reject_parent_components(cache_root)?;
+    reject_parent_components(cache_dir)?;
     if cache_root.parent().is_none()
         || !cache_dir.starts_with(cache_root)
         || cache_dir.file_name().and_then(|name| name.to_str()) != Some(desktop_version())
@@ -536,5 +559,51 @@ mod tests {
             error,
             DesktopLauncherError::DangerousCacheRoot { .. }
         ));
+    }
+
+    #[test]
+    fn cache_root_rejects_parent_directory_components() {
+        let error = normalize_cache_root(PathBuf::from("cache/../outside"))
+            .expect_err("parent-directory cache roots should fail");
+
+        assert!(matches!(
+            error,
+            DesktopLauncherError::DangerousCacheRoot { .. }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_bundle_copy_preserves_executable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = TempDir::new().expect("source tempdir");
+        let cache = TempDir::new().expect("cache tempdir");
+        let executable = source.path().join("OpenSymphony");
+        fs::write(&executable, b"fake desktop").expect("write fake executable");
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
+            .expect("set executable mode");
+        let manifest = DesktopBundleManifest {
+            version: desktop_version().to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            executable: PathBuf::from("OpenSymphony"),
+            sha256: file_sha256(&executable).expect("hash fake executable"),
+        };
+        fs::write(
+            source.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let cache_dir = cache.path().join(desktop_version());
+        let verified = ensure_verified_bundle(cache.path(), &cache_dir, Some(source.path()))
+            .expect("bundle should materialize and verify");
+        let mode = fs::metadata(&verified.executable)
+            .expect("copied executable metadata")
+            .permissions()
+            .mode();
+
+        assert_ne!(mode & 0o111, 0);
     }
 }

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -143,7 +143,7 @@ fn verify_bundle(cache_dir: &Path) -> Result<VerifiedBundle, DesktopLauncherErro
 
     let executable = resolve_manifest_executable(cache_dir, &manifest.executable)?;
     let actual = file_sha256(&executable)?;
-    if actual != manifest.sha256 {
+    if !actual.eq_ignore_ascii_case(&manifest.sha256) {
         return Err(DesktopLauncherError::BadChecksum {
             path: executable,
             expected: manifest.sha256,
@@ -473,6 +473,29 @@ mod tests {
         let error = verify_bundle(cache.path()).expect_err("checksum should fail");
 
         assert!(error.to_string().contains("Repair:"));
+    }
+
+    #[test]
+    fn checksum_accepts_uppercase_manifest_hex() {
+        let cache = TempDir::new().expect("cache tempdir");
+        let executable = cache.path().join("OpenSymphony");
+        fs::write(&executable, b"fake desktop").expect("write fake executable");
+        let manifest = DesktopBundleManifest {
+            version: desktop_version().to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            executable: PathBuf::from("OpenSymphony"),
+            sha256: file_sha256(&executable)
+                .expect("hash fake executable")
+                .to_uppercase(),
+        };
+        fs::write(
+            cache.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        verify_bundle(cache.path()).expect("uppercase checksum should verify");
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -85,6 +85,7 @@ fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
     }
 
     Command::new(&verified.executable)
+        .current_dir(&cache_dir)
         .spawn()
         .map_err(|source| DesktopLauncherError::Launch {
             path: verified.executable.clone(),
@@ -102,7 +103,6 @@ fn ensure_verified_bundle(
         Ok(bundle) => Ok(bundle),
         Err(first_error) => {
             if let Some(bundle_dir) = bundle_dir {
-                validate_cache_dir(cache_root, cache_dir)?;
                 if cache_dir.exists() {
                     validate_cache_dir(cache_root, cache_dir)?;
                     fs::remove_dir_all(cache_dir).map_err(|source| {

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -54,9 +54,12 @@ struct VerifiedBundle {
 }
 
 pub async fn run_command(args: AppArgs) -> ExitCode {
+    let dry_run = args.dry_run;
     match run_app(args) {
         Ok(executable) => {
-            println!("OpenSymphony desktop ready: {}", executable.display());
+            if !dry_run {
+                println!("OpenSymphony desktop ready: {}", executable.display());
+            }
             ExitCode::SUCCESS
         }
         Err(error) => {
@@ -101,6 +104,7 @@ fn ensure_verified_bundle(
             if let Some(bundle_dir) = bundle_dir {
                 validate_cache_dir(cache_root, cache_dir)?;
                 if cache_dir.exists() {
+                    validate_cache_dir(cache_root, cache_dir)?;
                     fs::remove_dir_all(cache_dir).map_err(|source| {
                         DesktopLauncherError::Repair {
                             path: cache_dir.to_path_buf(),
@@ -298,19 +302,25 @@ fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> 
 fn validate_cache_dir(cache_root: &Path, cache_dir: &Path) -> Result<(), DesktopLauncherError> {
     reject_parent_components(cache_root)?;
     reject_parent_components(cache_dir)?;
-    if let Ok(metadata) = fs::symlink_metadata(cache_dir)
-        && metadata.file_type().is_symlink()
-    {
-        return Err(DesktopLauncherError::DangerousCacheRoot {
-            path: cache_dir.to_path_buf(),
-        });
-    }
+    reject_symlink(cache_root)?;
+    reject_symlink(cache_dir)?;
     if cache_root.parent().is_none()
         || !cache_dir.starts_with(cache_root)
         || cache_dir.file_name().and_then(|name| name.to_str()) != Some(desktop_version())
     {
         return Err(DesktopLauncherError::DangerousCacheRoot {
             path: cache_root.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> Result<(), DesktopLauncherError> {
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && metadata.file_type().is_symlink()
+    {
+        return Err(DesktopLauncherError::DangerousCacheRoot {
+            path: path.to_path_buf(),
         });
     }
     Ok(())
@@ -644,6 +654,30 @@ mod tests {
 
         let error = validate_cache_dir(cache_root.path(), &cache_dir)
             .expect_err("versioned cache symlink should fail");
+
+        assert!(matches!(
+            error,
+            DesktopLauncherError::DangerousCacheRoot { .. }
+        ));
+        assert!(
+            outside.path().exists(),
+            "validation must not remove symlink target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_delete_rejects_cache_root_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let outside = TempDir::new().expect("outside target");
+        let link_parent = TempDir::new().expect("link parent");
+        let cache_root = link_parent.path().join("desktop");
+        let cache_dir = cache_root.join(desktop_version());
+        symlink(outside.path(), &cache_root).expect("create cache root symlink");
+
+        let error = validate_cache_dir(&cache_root, &cache_dir)
+            .expect_err("cache root symlink should fail");
 
         assert!(matches!(
             error,

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -1,5 +1,8 @@
 use std::{
-    env, fs, io,
+    env, fs,
+    fs::File,
+    io,
+    io::Read,
     path::{Path, PathBuf},
     process::{Command, ExitCode},
 };
@@ -62,10 +65,11 @@ pub async fn run_command(args: AppArgs) -> ExitCode {
 }
 
 fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
-    let cache_root = args.cache_root.unwrap_or(default_cache_root()?);
+    let cache_root = normalize_cache_root(args.cache_root.unwrap_or(default_cache_root()?))?;
     let cache_dir = cache_root.join(desktop_version());
+    validate_cache_dir(&cache_root, &cache_dir)?;
     let bundle_dir = args.bundle_dir.as_deref();
-    let verified = ensure_verified_bundle(&cache_dir, bundle_dir)?;
+    let verified = ensure_verified_bundle(&cache_root, &cache_dir, bundle_dir)?;
 
     if args.dry_run {
         println!(
@@ -85,6 +89,7 @@ fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
 }
 
 fn ensure_verified_bundle(
+    cache_root: &Path,
     cache_dir: &Path,
     bundle_dir: Option<&Path>,
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
@@ -92,6 +97,7 @@ fn ensure_verified_bundle(
         Ok(bundle) => Ok(bundle),
         Err(first_error) => {
             if let Some(bundle_dir) = bundle_dir {
+                validate_cache_dir(cache_root, cache_dir)?;
                 if cache_dir.exists() {
                     fs::remove_dir_all(cache_dir).map_err(|source| {
                         DesktopLauncherError::Repair {
@@ -135,7 +141,7 @@ fn verify_bundle(cache_dir: &Path) -> Result<VerifiedBundle, DesktopLauncherErro
         });
     }
 
-    let executable = cache_dir.join(&manifest.executable);
+    let executable = resolve_manifest_executable(cache_dir, &manifest.executable)?;
     let actual = file_sha256(&executable)?;
     if actual != manifest.sha256 {
         return Err(DesktopLauncherError::BadChecksum {
@@ -173,15 +179,17 @@ fn copy_dir_all(from: &Path, to: &Path) -> Result<(), DesktopLauncherError> {
             path: to.to_path_buf(),
             source,
         })?;
+        let source_path = entry.path();
         let target = to.join(entry.file_name());
-        if entry
-            .file_type()
-            .map_err(|source| DesktopLauncherError::Repair {
-                path: entry.path(),
+        let metadata =
+            fs::symlink_metadata(&source_path).map_err(|source| DesktopLauncherError::Repair {
+                path: source_path.clone(),
                 source,
-            })?
-            .is_dir()
-        {
+            })?;
+        if metadata.file_type().is_symlink() {
+            return Err(DesktopLauncherError::UnsupportedBundleEntry { path: source_path });
+        }
+        if metadata.is_dir() {
             copy_dir_all(&entry.path(), &target)?;
         } else {
             fs::copy(entry.path(), &target).map_err(|source| DesktopLauncherError::Repair {
@@ -194,11 +202,25 @@ fn copy_dir_all(from: &Path, to: &Path) -> Result<(), DesktopLauncherError> {
 }
 
 fn file_sha256(path: &Path) -> Result<String, DesktopLauncherError> {
-    let bytes = fs::read(path).map_err(|source| DesktopLauncherError::MissingExecutable {
+    let mut file = File::open(path).map_err(|source| DesktopLauncherError::MissingExecutable {
         path: path.to_path_buf(),
         source,
     })?;
-    Ok(format!("{:x}", Sha256::digest(bytes)))
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let read =
+            file.read(&mut buffer)
+                .map_err(|source| DesktopLauncherError::MissingExecutable {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn default_cache_root() -> Result<PathBuf, DesktopLauncherError> {
@@ -206,6 +228,72 @@ fn default_cache_root() -> Result<PathBuf, DesktopLauncherError> {
         .map(PathBuf::from)
         .ok_or(DesktopLauncherError::MissingHome)?;
     Ok(home.join(DEFAULT_CACHE_RELATIVE))
+}
+
+fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> {
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        env::current_dir()
+            .map_err(DesktopLauncherError::CurrentDir)?
+            .join(path)
+    };
+    if absolute.parent().is_none() {
+        return Err(DesktopLauncherError::DangerousCacheRoot { path: absolute });
+    }
+    Ok(absolute)
+}
+
+fn validate_cache_dir(cache_root: &Path, cache_dir: &Path) -> Result<(), DesktopLauncherError> {
+    if cache_root.parent().is_none()
+        || !cache_dir.starts_with(cache_root)
+        || cache_dir.file_name().and_then(|name| name.to_str()) != Some(desktop_version())
+    {
+        return Err(DesktopLauncherError::DangerousCacheRoot {
+            path: cache_root.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+fn resolve_manifest_executable(
+    cache_dir: &Path,
+    executable: &Path,
+) -> Result<PathBuf, DesktopLauncherError> {
+    if executable.is_absolute()
+        || executable.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(DesktopLauncherError::UnsafeExecutablePath {
+            path: executable.to_path_buf(),
+        });
+    }
+
+    let candidate = cache_dir.join(executable);
+    let canonical_cache =
+        cache_dir
+            .canonicalize()
+            .map_err(|source| DesktopLauncherError::Repair {
+                path: cache_dir.to_path_buf(),
+                source,
+            })?;
+    let canonical_executable =
+        candidate
+            .canonicalize()
+            .map_err(|source| DesktopLauncherError::MissingExecutable {
+                path: candidate.clone(),
+                source,
+            })?;
+    if !canonical_executable.starts_with(&canonical_cache) {
+        return Err(DesktopLauncherError::UnsafeExecutablePath { path: candidate });
+    }
+    Ok(canonical_executable)
 }
 
 fn desktop_version() -> &'static str {
@@ -226,6 +314,12 @@ enum DesktopLauncherError {
         "could not find HOME; set OPENSYMPHONY_DESKTOP_CACHE_ROOT to choose a desktop cache directory"
     )]
     MissingHome,
+    #[error("failed to determine current directory for desktop cache root: {0}")]
+    CurrentDir(io::Error),
+    #[error(
+        "refusing unsafe desktop cache root {path}\nRepair: choose a non-root cache directory under ~/.opensymphony/desktop or another app-owned directory."
+    )]
+    DangerousCacheRoot { path: PathBuf },
     #[error(
         "desktop bundle is not installed at {path}: {source}\nRepair: rerun with --bundle-dir <path> or set OPENSYMPHONY_DESKTOP_BUNDLE_DIR to a verified OpenSymphony desktop bundle."
     )]
@@ -241,6 +335,14 @@ enum DesktopLauncherError {
         path: PathBuf,
         source: serde_json::Error,
     },
+    #[error(
+        "desktop manifest executable path {path} is unsafe\nRepair: use a relative executable path that stays inside the cached bundle."
+    )]
+    UnsafeExecutablePath { path: PathBuf },
+    #[error(
+        "desktop bundle entry {path} is a symlink, which local bundle materialization does not yet preserve\nRepair: pass an expanded bundle without symlinks or use a future signed/downloaded bundle format."
+    )]
+    UnsupportedBundleEntry { path: PathBuf },
     #[error(
         "cached desktop bundle has version {actual}, expected {expected} in {path}\nRepair: remove the cached version directory and rerun with a matching bundle."
     )]
@@ -338,10 +440,16 @@ mod tests {
         .expect("write manifest");
 
         let cache_dir = cache.path().join(desktop_version());
-        let verified = ensure_verified_bundle(&cache_dir, Some(source.path()))
+        let verified = ensure_verified_bundle(cache.path(), &cache_dir, Some(source.path()))
             .expect("bundle should materialize and verify");
 
-        assert_eq!(verified.executable, cache_dir.join("OpenSymphony"));
+        assert_eq!(
+            verified.executable,
+            cache_dir
+                .join("OpenSymphony")
+                .canonicalize()
+                .expect("canonical fake executable")
+        );
     }
 
     #[test]
@@ -365,5 +473,45 @@ mod tests {
         let error = verify_bundle(cache.path()).expect_err("checksum should fail");
 
         assert!(error.to_string().contains("Repair:"));
+    }
+
+    #[test]
+    fn manifest_executable_must_stay_inside_cache() {
+        let cache = TempDir::new().expect("cache tempdir");
+        let executable = cache.path().join("OpenSymphony");
+        fs::write(&executable, b"fake desktop").expect("write fake executable");
+        let manifest = DesktopBundleManifest {
+            version: desktop_version().to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            executable: PathBuf::from("../OpenSymphony"),
+            sha256: file_sha256(&executable).expect("hash fake executable"),
+        };
+        fs::write(
+            cache.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let error = verify_bundle(cache.path()).expect_err("traversal should fail");
+
+        assert!(matches!(
+            error,
+            DesktopLauncherError::UnsafeExecutablePath { .. }
+        ));
+    }
+
+    #[test]
+    fn cache_delete_requires_versioned_child_of_cache_root() {
+        let cache_root = TempDir::new().expect("cache root");
+        let wrong_dir = TempDir::new().expect("wrong dir");
+
+        let error = validate_cache_dir(cache_root.path(), wrong_dir.path())
+            .expect_err("wrong cache dir should fail");
+
+        assert!(matches!(
+            error,
+            DesktopLauncherError::DangerousCacheRoot { .. }
+        ));
     }
 }

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -1,5 +1,7 @@
 use std::{
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
     fs::File,
     io,
     io::Read,
@@ -243,10 +245,37 @@ fn file_sha256(path: &Path) -> Result<String, DesktopLauncherError> {
 }
 
 fn default_cache_root() -> Result<PathBuf, DesktopLauncherError> {
-    let home = env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or(DesktopLauncherError::MissingHome)?;
+    let home = home_dir().ok_or(DesktopLauncherError::MissingHome)?;
     Ok(home.join(DEFAULT_CACHE_RELATIVE))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    home_dir_from_vars(
+        env::var_os("HOME"),
+        env::var_os("USERPROFILE"),
+        env::var_os("HOMEDRIVE"),
+        env::var_os("HOMEPATH"),
+    )
+}
+
+fn home_dir_from_vars(
+    home: Option<OsString>,
+    userprofile: Option<OsString>,
+    homedrive: Option<OsString>,
+    homepath: Option<OsString>,
+) -> Option<PathBuf> {
+    home.filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            userprofile
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(|| {
+            let drive = homedrive.filter(|value| !value.is_empty())?;
+            let path = homepath.filter(|value| !value.is_empty())?;
+            Some(PathBuf::from(drive).join(path))
+        })
 }
 
 fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> {
@@ -441,6 +470,40 @@ mod tests {
     fn platform_selection_uses_current_target() {
         assert_eq!(current_platform(), env::consts::OS);
         assert_eq!(current_arch(), env::consts::ARCH);
+    }
+
+    #[test]
+    fn home_dir_uses_unix_home_first() {
+        let home = home_dir_from_vars(
+            Some(OsString::from("/home/alice")),
+            Some(OsString::from("C:\\Users\\alice")),
+            None,
+            None,
+        )
+        .expect("home should resolve");
+
+        assert_eq!(home, PathBuf::from("/home/alice"));
+    }
+
+    #[test]
+    fn home_dir_falls_back_to_windows_userprofile() {
+        let home = home_dir_from_vars(None, Some(OsString::from("C:\\Users\\alice")), None, None)
+            .expect("home should resolve");
+
+        assert_eq!(home, PathBuf::from("C:\\Users\\alice"));
+    }
+
+    #[test]
+    fn home_dir_falls_back_to_windows_drive_and_path() {
+        let home = home_dir_from_vars(
+            None,
+            None,
+            Some(OsString::from("C:")),
+            Some(OsString::from("\\Users\\alice")),
+        )
+        .expect("home should resolve");
+
+        assert_eq!(home, PathBuf::from("C:").join("\\Users\\alice"));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -272,9 +272,10 @@ fn home_dir_from_vars(
                 .map(PathBuf::from)
         })
         .or_else(|| {
-            let drive = homedrive.filter(|value| !value.is_empty())?;
+            let mut drive = homedrive.filter(|value| !value.is_empty())?;
             let path = homepath.filter(|value| !value.is_empty())?;
-            Some(PathBuf::from(drive).join(path))
+            drive.push(path);
+            Some(PathBuf::from(drive))
         })
 }
 
@@ -503,7 +504,7 @@ mod tests {
         )
         .expect("home should resolve");
 
-        assert_eq!(home, PathBuf::from("C:").join("\\Users\\alice"));
+        assert_eq!(home, PathBuf::from("C:\\Users\\alice"));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/lib.rs
+++ b/crates/opensymphony-cli/src/lib.rs
@@ -1,4 +1,5 @@
 mod debug_session;
+mod desktop_launcher;
 mod init_repo;
 mod install_tooling;
 mod memory;
@@ -61,6 +62,11 @@ enum Command {
     Update(update_repo::UpdateArgs),
     #[command(about = "Install app-managed runtimes and integrations")]
     Install(InstallArgs),
+    #[command(
+        about = "Install or launch the cached desktop app bundle",
+        visible_alias = "desktop"
+    )]
+    App(desktop_launcher::AppArgs),
     #[command(about = "Run the real orchestrator against the current project workflow")]
     Run(orchestrator_run::RunArgs),
     #[command(about = "Resume an issue conversation for interactive debugging")]
@@ -312,6 +318,7 @@ pub async fn run() -> ExitCode {
         Command::Init(args) => init_repo::run_command(args).await,
         Command::Update(args) => update_repo::run_command(args).await,
         Command::Install(args) => run_install(args).await,
+        Command::App(args) => desktop_launcher::run_command(args).await,
         Command::Run(args) => orchestrator_run::run_command(args).await,
         Command::Debug(args) => debug_session::run_command(args).await,
         Command::Memory(args) => memory::run_command(args).await,
@@ -2405,6 +2412,7 @@ mod tests {
         match cli.command {
             Command::Init(_) => panic!("expected daemon command"),
             Command::Daemon(args) => assert_eq!(args.sample_interval_ms.get(), 250),
+            Command::App(_) => panic!("expected daemon command"),
             Command::Run(_)
             | Command::Debug(_)
             | Command::Tui(_)

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -19,6 +19,7 @@ fn top_level_help_describes_commands_and_safety_posture() {
         "Initialize the current target repository with OpenSymphony files",
         "Update the installed CLI and refresh template-managed skills",
         "Install app-managed runtimes and integrations",
+        "Install or launch the cached desktop app bundle",
         "Run the real orchestrator against the current project workflow",
         "Resume an issue conversation for interactive debugging",
         "Capture, query, and sync project memory",

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -28,6 +28,14 @@ Keep system-linked or downloaded DuckDB as an optimization path:
   do not have the expected system library.
 - Release-sensitive validation still includes the default bundled path.
 
+The CLI also exposes `opensymphony app`, with visible alias
+`opensymphony desktop`, as a lazy desktop launcher. It verifies a cached desktop
+bundle under `~/.opensymphony/desktop/<version>/` and can materialize an early
+local bundle from `--bundle-dir` or `OPENSYMPHONY_DESKTOP_BUNDLE_DIR`. This
+launcher does not make `cargo install opensymphony` compile Tauri, npm, or
+platform desktop dependencies; signed/downloaded desktop bundle distribution is
+still future installer work.
+
 Do not make downloaded prebuilt DuckDB the default `cargo install` path until a
 managed installer or equivalent runtime-library strategy owns native library
 placement, loader configuration, health checks, and rollback.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -13,6 +13,7 @@ Recommended CLI commands:
 - `opensymphony init`
 - `opensymphony update`
 - `opensymphony run`
+- `opensymphony app` or `opensymphony desktop`
 - `opensymphony debug <issue-id>`
 - `opensymphony tui`
 - `opensymphony doctor`
@@ -33,6 +34,17 @@ opensymphony run
 
 If you already run an external OpenHands agent-server, you can skip
 `opensymphony install openhands`.
+
+The desktop launcher is intentionally lazy. `opensymphony app` and its visible
+alias `opensymphony desktop` verify and launch a cached desktop bundle from
+`~/.opensymphony/desktop/<version>/` without making the normal Cargo install
+compile Tauri, npm, or platform desktop dependencies. For early local testing,
+pass `--bundle-dir <path>` or set `OPENSYMPHONY_DESKTOP_BUNDLE_DIR` to a bundle
+directory containing `opensymphony-desktop-manifest.json`. The manifest records
+the OpenSymphony version, platform, architecture, relative executable path, and
+executable SHA-256. Local bundle materialization copies regular files and
+directories; symlinked bundle entries should be packaged by a future signed or
+downloaded bundle format instead of this local smoke path.
 
 Important `init` behavior:
 


### PR DESCRIPTION
## Summary

Adds a lazy desktop launcher command to the root CLI: `opensymphony app`, with visible alias `opensymphony desktop`.

## Changes

- Adds CLI routing for `app` and visible alias `desktop` into one launcher flow.
- Adds manifest-based local bundle materialization into `~/.opensymphony/desktop/<version>/`.
- Verifies cached bundle version, platform, architecture, relative executable containment, and executable SHA-256 before launch.
- Validates cache repair deletion stays under the versioned desktop cache path.
- Adds clear repair guidance for missing, invalid, mismatched, unsafe, or corrupt cached bundles.
- Documents the lazy launcher and local bundle manifest shape in README, operations, and installer strategy docs.
- Adds focused parser/cache/platform/materialization/path-safety tests and help coverage.

## Evidence

### Test output

```text
cargo test-system-duckdb desktop_launcher -- --nocapture
Result: 7 passed; 0 failed

cargo test-system-duckdb --test help -- --nocapture
Result: 11 passed; 0 failed

DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib cargo clippy --no-default-features --features duckdb-prebuilt -- -D warnings
Result: finished clean

cargo fmt --check
Result: passed

git diff --check
Result: passed
```

### Verification

Before the change, both commands failed:

```text
cargo run --quiet -- app --help
error: unrecognized subcommand 'app'

cargo run --quiet -- desktop --help
error: unrecognized subcommand 'desktop'
```

Fake bundle smoke with a manifest and checksum:

```text
./target/debug/opensymphony app --bundle-dir <fake> --cache-root <tmp> --dry-run
Dry run: would launch cached OpenSymphony desktop at <tmp>/cache/2.2.0/OpenSymphony
OpenSymphony desktop ready: <tmp>/cache/2.2.0/OpenSymphony

./target/debug/opensymphony desktop --cache-root <tmp> --dry-run
Dry run: would launch cached OpenSymphony desktop at <tmp>/cache/2.2.0/OpenSymphony
OpenSymphony desktop ready: <tmp>/cache/2.2.0/OpenSymphony
```

Root dependency check:

```text
cargo tree --no-default-features --features duckdb-prebuilt -i tauri
error: package ID specification `tauri` did not match any packages

cargo tree --no-default-features --features duckdb-prebuilt -i tauri-build
error: package ID specification `tauri-build` did not match any packages
```

## Checklist

- [x] Tests pass (`cargo test` equivalent focused checks above)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

COE-488

## Additional notes

This intentionally keeps desktop/Tauri build dependencies out of the root Cargo install path. The launcher currently materializes from a verified local bundle path (`--bundle-dir` or `OPENSYMPHONY_DESKTOP_BUNDLE_DIR`); signed/downloaded distribution can plug into the same manifest/cache shape later. Local materialization rejects symlinked entries rather than following them.
