### PR TITLE
COE-504: Reduce Linear polling under rate limits

### DIFF
--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -16,8 +16,8 @@ use crate::opensymphony_codex::{
 };
 use crate::opensymphony_domain::{
     ConversationId, ConversationMetadata, IssueId, IssueIdentifier, IssueState, IssueStateCategory,
-    NormalizedIssue, RuntimeStreamState, TimestampMs, TrackerIssue, WorkerOutcomeKind,
-    WorkerOutcomeRecord, WorkspaceKey,
+    NormalizedIssue, RuntimeStreamState, TimestampMs, TrackerErrorCategory, TrackerIssue,
+    TrackerIssueSummary, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey,
 };
 use crate::opensymphony_linear::{LinearClient, LinearConfig, LinearError, WorkpadComment};
 use crate::opensymphony_openhands::{
@@ -541,8 +541,19 @@ impl TrackerBackend for RuntimeTrackerBackend {
         self.client.candidate_issues().await
     }
 
+    async fn candidate_issue_summaries(&mut self) -> Result<Vec<TrackerIssueSummary>, Self::Error> {
+        self.client.candidate_issue_summaries().await
+    }
+
     async fn terminal_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error> {
         self.client.terminal_issues().await
+    }
+
+    async fn issues_by_identifiers(
+        &mut self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, Self::Error> {
+        self.client.project_issues_by_identifiers(identifiers).await
     }
 
     async fn issue_states_by_ids(
@@ -550,6 +561,14 @@ impl TrackerBackend for RuntimeTrackerBackend {
         issue_ids: &[String],
     ) -> Result<Vec<crate::opensymphony_domain::TrackerIssueStateSnapshot>, Self::Error> {
         self.client.issue_states_by_ids(issue_ids).await
+    }
+
+    fn error_category(error: &Self::Error) -> Option<TrackerErrorCategory> {
+        Some(error.category())
+    }
+
+    fn retry_after(error: &Self::Error) -> Option<Duration> {
+        error.retry_after()
     }
 }
 

--- a/crates/opensymphony-domain/src/lib.rs
+++ b/crates/opensymphony-domain/src/lib.rs
@@ -46,7 +46,7 @@ pub use time::{DurationMs, TimestampMs};
 pub use timeline::{TimelineBuilder, belongs_to_run, payload_run_id};
 pub use tracker::{
     TrackerErrorCategory, TrackerIssue, TrackerIssueBlocker, TrackerIssueRef, TrackerIssueState,
-    TrackerIssueStateKind, TrackerIssueStateSnapshot, TrackerProjectMilestone,
+    TrackerIssueStateKind, TrackerIssueStateSnapshot, TrackerIssueSummary, TrackerProjectMilestone,
 };
 
 #[cfg(test)]

--- a/crates/opensymphony-domain/src/tracker.rs
+++ b/crates/opensymphony-domain/src/tracker.rs
@@ -34,6 +34,23 @@ pub struct TrackerIssue {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackerIssueSummary {
+    pub id: String,
+    pub identifier: String,
+    pub url: String,
+    pub title: String,
+    pub priority: Option<u8>,
+    pub state: String,
+    #[serde(default = "unknown_tracker_state_kind")]
+    pub state_kind: TrackerIssueStateKind,
+    pub blocked_by: Vec<TrackerIssueBlocker>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sub_issues: Vec<TrackerIssueRef>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 fn unknown_tracker_state_kind() -> TrackerIssueStateKind {
     TrackerIssueStateKind::Unknown("unknown".to_owned())
 }

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::opensymphony_domain::{TrackerIssue, TrackerIssueStateSnapshot};
+use crate::opensymphony_domain::{TrackerIssue, TrackerIssueStateSnapshot, TrackerIssueSummary};
 use reqwest::{
     Client, StatusCode,
     header::{ACCEPT, AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, RETRY_AFTER},
@@ -18,26 +18,28 @@ use super::graphql::{
     COMMENT_CREATE_MUTATION, CommentCreateData, CommentCreateInput, CommentCreateVariables,
     GraphqlEnvelope, GraphqlErrorPayload, ISSUE_ARCHIVE_MUTATION, ISSUE_BY_IDENTIFIER_QUERY,
     ISSUE_COMMENTS_QUERY, ISSUE_CREATE_MUTATION, ISSUE_INVERSE_RELATIONS_QUERY, ISSUE_LABELS_QUERY,
-    ISSUE_RELATION_CREATE_MUTATION, ISSUE_STATES_BY_IDS_QUERY, ISSUE_UPDATE_MUTATION,
-    ISSUES_BY_STATE_QUERY, IssueArchiveData, IssueArchiveVariables, IssueByIdentifierData,
-    IssueByIdentifierVariables, IssueCommentsData, IssueCommentsVariables, IssueCreateData,
-    IssueCreateInput, IssueCreateVariables, IssueInverseRelationsData,
+    ISSUE_RELATION_CREATE_MUTATION, ISSUE_STATES_BY_IDS_QUERY, ISSUE_SUMMARIES_BY_STATE_QUERY,
+    ISSUE_UPDATE_MUTATION, ISSUES_BY_STATE_QUERY, IssueArchiveData, IssueArchiveVariables,
+    IssueByIdentifierData, IssueByIdentifierVariables, IssueCommentsData, IssueCommentsVariables,
+    IssueCreateData, IssueCreateInput, IssueCreateVariables, IssueInverseRelationsData,
     IssueInverseRelationsVariables, IssueLabelsData, IssueLabelsVariables, IssueRelationCreateData,
     IssueRelationCreateInput, IssueRelationCreateVariables, IssueRelationMutationNode,
-    IssueStatesByIdsData, IssueStatesByIdsVariables, IssueUpdateData, IssueUpdateInput,
-    IssueUpdateVariables, IssuesByStateData, IssuesByStateVariables, LinearIssueNode,
-    LinearLabelConnection, LinearProjectNode, LinearRelationConnection, PROJECT_BY_SLUG_QUERY,
-    PROJECT_ISSUES_QUERY, PROJECT_MILESTONE_CREATE_MUTATION, PROJECT_MILESTONE_UPDATE_MUTATION,
+    IssueStatesByIdsData, IssueStatesByIdsVariables, IssueSummariesByStateData,
+    IssueSummariesByStateVariables, IssueUpdateData, IssueUpdateInput, IssueUpdateVariables,
+    IssuesByStateData, IssuesByStateVariables, LinearIssueNode, LinearLabelConnection,
+    LinearProjectNode, LinearRelationConnection, PROJECT_BY_SLUG_QUERY, PROJECT_ISSUES_QUERY,
+    PROJECT_MILESTONE_CREATE_MUTATION, PROJECT_MILESTONE_UPDATE_MUTATION,
     PROJECT_UPDATE_CONTENT_MUTATION, ProjectBySlugData, ProjectBySlugVariables, ProjectIssuesData,
     ProjectIssuesVariables, ProjectMilestoneCreateData, ProjectMilestoneCreateInput,
     ProjectMilestoneCreateVariables, ProjectMilestoneUpdateData, ProjectMilestoneUpdateInput,
     ProjectMilestoneUpdateVariables, ProjectUpdateContentData, ProjectUpdateContentVariables,
 };
-use super::normalize::{normalize_issue, normalize_issue_state};
+use super::normalize::{normalize_issue, normalize_issue_state, normalize_issue_summary};
 
 const DEFAULT_BASE_URL: &str = "https://api.linear.app/graphql";
 const DEFAULT_PAGE_SIZE: usize = 50;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_INLINE_RATE_LIMIT_RETRY: Duration = Duration::from_secs(30);
 const MAX_INITIAL_RELATION_PAGE_SIZE: usize = 10;
 const MAX_INITIAL_LABEL_PAGE_SIZE: usize = 10;
 
@@ -282,6 +284,11 @@ impl LinearClient {
         self.issues_by_state_names(&self.config.active_states).await
     }
 
+    pub async fn candidate_issue_summaries(&self) -> Result<Vec<TrackerIssueSummary>, LinearError> {
+        self.issue_summaries_by_state_names(&self.config.active_states)
+            .await
+    }
+
     pub async fn terminal_issues(&self) -> Result<Vec<TrackerIssue>, LinearError> {
         self.issues_by_state_names_with_archived(&self.config.terminal_states, true)
             .await
@@ -470,6 +477,52 @@ impl LinearClient {
             after = Some(page_info.end_cursor.ok_or_else(|| {
                 LinearError::InvalidResponse(
                     "Linear issues page indicated a next page without an end cursor".to_string(),
+                )
+            })?);
+        }
+    }
+
+    async fn issue_summaries_by_state_names<S>(
+        &self,
+        state_names: &[S],
+    ) -> Result<Vec<TrackerIssueSummary>, LinearError>
+    where
+        S: AsRef<str>,
+    {
+        let state_names = normalize_strings(state_names);
+        if state_names.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut after = None;
+        let mut issues = Vec::new();
+
+        loop {
+            let variables = IssueSummariesByStateVariables {
+                project_slug: self.config.project_slug.clone(),
+                state_names: state_names.clone(),
+                include_archived: false,
+                first: self.config.page_size,
+                after: after.clone(),
+                relation_first: self.config.page_size.min(MAX_INITIAL_RELATION_PAGE_SIZE),
+            };
+            let response: IssueSummariesByStateData = self
+                .execute_graphql(ISSUE_SUMMARIES_BY_STATE_QUERY, json!(variables))
+                .await?;
+
+            let page_info = response.issues.page_info;
+            for node in response.issues.nodes {
+                issues.push(normalize_issue_summary(node)?);
+            }
+
+            if !page_info.has_next_page {
+                return Ok(issues);
+            }
+
+            after = Some(page_info.end_cursor.ok_or_else(|| {
+                LinearError::InvalidResponse(
+                    "Linear issue summaries page indicated a next page without an end cursor"
+                        .to_string(),
                 )
             })?);
         }
@@ -1018,6 +1071,18 @@ impl LinearClient {
 
     fn should_retry(&self, error: &LinearError, attempt: usize) -> bool {
         if attempt >= self.config.retry_policy.max_attempts {
+            return false;
+        }
+
+        let max_inline_rate_limit_retry = std::cmp::min(
+            self.config.retry_policy.max_backoff,
+            MAX_INLINE_RATE_LIMIT_RETRY,
+        );
+        if error.is_rate_limited()
+            && error
+                .retry_after()
+                .is_some_and(|delay| delay > max_inline_rate_limit_retry)
+        {
             return false;
         }
 

--- a/crates/opensymphony-linear/src/graphql.rs
+++ b/crates/opensymphony-linear/src/graphql.rs
@@ -92,6 +92,69 @@ query IssuesByState($projectSlug: String!, $stateNames: [String!], $includeArchi
 }
 "#;
 
+pub(super) const ISSUE_SUMMARIES_BY_STATE_QUERY: &str = r#"
+query IssueSummariesByState($projectSlug: String!, $stateNames: [String!], $includeArchived: Boolean!, $first: Int!, $after: String, $relationFirst: Int!) {
+  issues(
+    filter: {
+      project: { slugId: { eq: $projectSlug } }
+      state: { name: { in: $stateNames } }
+    }
+    includeArchived: $includeArchived
+    first: $first
+    after: $after
+  ) {
+    nodes {
+      id
+      identifier
+      url
+      title
+      priority
+      createdAt
+      updatedAt
+      state {
+        id
+        name
+        type
+      }
+      children(includeArchived: true, first: 100) {
+        nodes {
+          id
+          identifier
+          url
+          title
+          state {
+            name
+          }
+        }
+      }
+      inverseRelations(first: $relationFirst) {
+        nodes {
+          type
+          issue {
+            id
+            identifier
+            title
+            state {
+              id
+              name
+              type
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+"#;
+
 pub(super) const PROJECT_ISSUES_QUERY: &str = r#"
 query ProjectIssues($projectSlug: String!, $includeArchived: Boolean!, $first: Int!, $after: String, $relationFirst: Int!, $labelFirst: Int!) {
   issues(
@@ -595,6 +658,17 @@ pub(super) struct IssuesByStateVariables {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub(super) struct IssueSummariesByStateVariables {
+    pub project_slug: String,
+    pub state_names: Vec<String>,
+    pub include_archived: bool,
+    pub first: usize,
+    pub after: Option<String>,
+    pub relation_first: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub(super) struct IssueStatesByIdsVariables {
     pub project_slug: String,
     pub issue_ids: Vec<String>,
@@ -707,6 +781,11 @@ pub(super) struct IssuesByStateData {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct IssueSummariesByStateData {
+    pub issues: IssuesConnection<LinearIssueNode>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct ProjectIssuesData {
     pub issues: IssuesConnection<LinearIssueNode>,
 }
@@ -815,7 +894,9 @@ pub(super) struct LinearIssueNode {
     pub project_milestone: Option<LinearProjectMilestoneNode>,
     #[serde(default)]
     pub children: LinearChildConnection,
+    #[serde(default)]
     pub labels: LinearLabelConnection,
+    #[serde(default)]
     pub inverse_relations: LinearRelationConnection,
 }
 
@@ -897,7 +978,7 @@ pub(super) struct LinearIssueRefState {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub(super) struct LinearLabelConnection {
     pub nodes: Vec<LinearLabelNode>,
     #[serde(default, rename = "pageInfo")]
@@ -926,7 +1007,7 @@ pub(super) struct LinearCommentNode {
     pub resolved_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct LinearRelationConnection {
     pub nodes: Vec<LinearRelationNode>,

--- a/crates/opensymphony-linear/src/normalize.rs
+++ b/crates/opensymphony-linear/src/normalize.rs
@@ -1,6 +1,6 @@
 use crate::opensymphony_domain::{
     TrackerIssue, TrackerIssueBlocker, TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind,
-    TrackerIssueStateSnapshot, TrackerProjectMilestone,
+    TrackerIssueStateSnapshot, TrackerIssueSummary, TrackerProjectMilestone,
 };
 
 use super::error::LinearError;
@@ -27,6 +27,25 @@ pub(super) fn normalize_issue(node: LinearIssueNode) -> Result<TrackerIssue, Lin
         parent_id: normalize_parent_id(node.parent.as_ref()),
         parent: normalize_parent(node.parent),
         project_milestone: normalize_project_milestone(node.project_milestone),
+        blocked_by: normalize_blockers(node.inverse_relations.nodes),
+        sub_issues: normalize_sub_issues(node.children.nodes),
+        created_at: node.created_at,
+        updated_at: node.updated_at,
+    })
+}
+
+pub(super) fn normalize_issue_summary(
+    node: LinearIssueNode,
+) -> Result<TrackerIssueSummary, LinearError> {
+    let state = normalize_state(node.state);
+    Ok(TrackerIssueSummary {
+        id: node.id,
+        identifier: node.identifier,
+        url: node.url,
+        title: node.title,
+        priority: normalize_priority(node.priority)?,
+        state: state.name,
+        state_kind: state.kind,
         blocked_by: normalize_blockers(node.inverse_relations.nodes),
         sub_issues: normalize_sub_issues(node.children.nodes),
         created_at: node.created_at,

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -134,6 +134,63 @@ async fn candidate_issues_normalize_fixture_payloads() {
 }
 
 #[tokio::test]
+async fn candidate_issue_summaries_use_lightweight_dispatch_query() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(include_str!(
+        "fixtures/candidate_issues_page.json"
+    ))])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issue_summaries()
+        .await
+        .expect("candidate summary query should succeed");
+
+    assert_eq!(issues.len(), 2);
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].body["query"]
+            .as_str()
+            .expect("query should be a string")
+            .contains("query IssueSummariesByState")
+    );
+    assert!(
+        !requests[0].body["query"]
+            .as_str()
+            .expect("query should be a string")
+            .contains("labels(first:")
+    );
+    assert!(
+        !requests[0].body["query"]
+            .as_str()
+            .expect("query should be a string")
+            .contains("projectMilestone")
+    );
+    assert!(requests[0].body["variables"].get("labelFirst").is_none());
+}
+
+#[tokio::test]
+async fn candidate_issue_summaries_do_not_expand_relation_pages() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(include_str!(
+        "fixtures/candidate_issues_with_relation_paging.json"
+    ))])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should be valid");
+
+    let issues = client
+        .candidate_issue_summaries()
+        .await
+        .expect("candidate summary query should succeed without relation expansion");
+
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].identifier, "COE-264");
+    assert_eq!(server.recorded_requests().await.len(), 1);
+}
+
+#[tokio::test]
 async fn candidate_issues_fetch_all_inverse_relation_pages() {
     let server = MockGraphqlServer::start(vec![
         QueuedResponse::json(include_str!(
@@ -700,6 +757,64 @@ async fn rate_limited_requests_retry_using_retry_after() {
 }
 
 #[tokio::test]
+async fn rate_limited_429_with_long_retry_after_returns_immediately() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::TOO_MANY_REQUESTS,
+            "{\"error\":\"rate limited\"}",
+        )
+        .with_header("retry-after", "3600"),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let mut config = test_config(server.base_url());
+    config.retry_policy.max_backoff = Duration::from_secs(5);
+    let client = LinearClient::new(config).expect("client configuration should be valid");
+    let start = tokio::time::Instant::now();
+
+    let error = client
+        .candidate_issues()
+        .await
+        .expect_err("long retry-after should return without sleeping");
+
+    assert!(error.is_rate_limited());
+    assert_eq!(server.recorded_requests().await.len(), 1);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "long retry-after should not be slept inside the Linear client"
+    );
+}
+
+#[tokio::test]
+async fn rate_limited_429_above_inline_cap_returns_immediately() {
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::TOO_MANY_REQUESTS,
+            "{\"error\":\"rate limited\"}",
+        )
+        .with_header("retry-after", "60"),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let mut config = test_config(server.base_url());
+    config.retry_policy.max_backoff = Duration::from_secs(120);
+    let client = LinearClient::new(config).expect("client configuration should be valid");
+    let start = tokio::time::Instant::now();
+
+    let error = client
+        .candidate_issues()
+        .await
+        .expect_err("retry-after above inline cap should return without sleeping");
+
+    assert!(error.is_rate_limited());
+    assert_eq!(server.recorded_requests().await.len(), 1);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "retry-after above inline cap should not be slept inside the Linear client"
+    );
+}
+
+#[tokio::test]
 async fn graphql_rate_limited_bad_request_retries() {
     let server = MockGraphqlServer::start(vec![
         QueuedResponse::new(
@@ -783,6 +898,48 @@ async fn graphql_rate_limited_bad_request_retries_using_reset_header() {
 }
 
 #[tokio::test]
+async fn graphql_rate_limited_bad_request_with_long_reset_returns_immediately() {
+    let reset_ms = (SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("current time should be after epoch")
+        + Duration::from_secs(60 * 60))
+    .as_millis()
+    .to_string();
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::new(
+            StatusCode::BAD_REQUEST,
+            r#"{"errors":[{"message":"rate limit exceeded","extensions":{"code":"RATELIMITED"}}]}"#,
+        )
+        .with_header("content-type", "application/json")
+        .with_header("x-ratelimit-requests-reset", &reset_ms),
+        QueuedResponse::json(include_str!("fixtures/candidate_issues_page.json")),
+    ])
+    .await;
+    let mut config = test_config(server.base_url());
+    config.retry_policy.initial_backoff = Duration::from_secs(5);
+    config.retry_policy.max_backoff = Duration::from_secs(5);
+    let client = LinearClient::new(config).expect("client configuration should be valid");
+    let start = tokio::time::Instant::now();
+
+    let error = client
+        .candidate_issues()
+        .await
+        .expect_err("long reset should return a rate-limit error without sleeping");
+
+    assert!(error.is_rate_limited());
+    assert!(
+        error
+            .retry_after()
+            .is_some_and(|delay| delay > Duration::from_secs(5))
+    );
+    assert_eq!(server.recorded_requests().await.len(), 1);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "long reset header should not be slept inside the Linear client"
+    );
+}
+
+#[tokio::test]
 async fn graphql_internal_server_error_retries_even_with_graphql_envelope() {
     let server = MockGraphqlServer::start(vec![
         QueuedResponse::new(
@@ -803,6 +960,42 @@ async fn graphql_internal_server_error_retries_even_with_graphql_envelope() {
 
     assert_eq!(issues.len(), 2);
     assert_eq!(server.recorded_requests().await.len(), 2);
+}
+
+#[tokio::test]
+#[ignore = "requires LINEAR_API_KEY and live Linear access"]
+async fn live_linear_client_reads_opensymphony_project() {
+    let api_key = std::env::var("LINEAR_API_KEY").expect("LINEAR_API_KEY must be set");
+    let mut config = LinearConfig::new(api_key, "e7b957855cb7");
+    config.active_states = vec![
+        "Todo".to_string(),
+        "In Progress".to_string(),
+        "Human Review".to_string(),
+        "Rework".to_string(),
+    ];
+    config.terminal_states = vec!["Done".to_string(), "Canceled".to_string()];
+    let client = LinearClient::new(config).expect("live client configuration should be valid");
+
+    let summaries = client
+        .candidate_issue_summaries()
+        .await
+        .expect("live summary query should succeed");
+    println!("live candidate summaries fetched: {}", summaries.len());
+
+    let issues = client
+        .project_issues_by_identifiers(&["COE-504"])
+        .await
+        .expect("live project-scoped identifier lookup should succeed");
+    let issue = issues
+        .iter()
+        .find(|issue| issue.identifier == "COE-504")
+        .expect("COE-504 should be visible through the live project detail path");
+    println!(
+        "live issue detail: {} {} {}",
+        issue.identifier, issue.state, issue.title
+    );
+    assert_eq!(issue.identifier, "COE-504");
+    assert_eq!(issue.state, "Done");
 }
 
 #[tokio::test]

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -11,8 +11,8 @@ pub use crate::opensymphony_domain::{
     RunAttempt, RuntimeStreamState, RuntimeUsageTotals, SchedulerState, SchedulerStatus,
     StallMetadata, StateTransitionError, TimestampMs, TrackerIssue, TrackerIssueBlocker,
     TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind, TrackerIssueStateSnapshot,
-    TrackerStateId, TransitionAction, WorkerAttemptSnapshot, WorkerId, WorkerOutcomeKind,
-    WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
+    TrackerIssueSummary, TrackerStateId, TransitionAction, WorkerAttemptSnapshot, WorkerId,
+    WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceKey, WorkspaceRecord,
 };
 pub use scheduler::{
     HarnessRouteDecision, RecoveryRecord, Scheduler, SchedulerConfig, SchedulerError,

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     future::Future,
+    time::Duration,
 };
 
 use crate::opensymphony_domain::{
@@ -8,8 +9,10 @@ use crate::opensymphony_domain::{
     IdentifierError, IssueExecution, IssueId, IssueIdentifier, IssueRef, IssueSnapshot, IssueState,
     IssueStateCategory, NormalizedIssue, OrchestratorSnapshot, ReleaseReason,
     RetryCalculationError, RetryEntry, RetryPolicy, RetryReason, RunAttempt, RuntimeUsageTotals,
-    SchedulerStatus, StateTransitionError, TimestampMs, TrackerIssue, TrackerIssueStateSnapshot,
-    TrackerStateId, WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord, WorkspaceRecord,
+    SchedulerStatus, StateTransitionError, TimestampMs, TrackerErrorCategory, TrackerIssue,
+    TrackerIssueBlocker, TrackerIssueRef, TrackerIssueState, TrackerIssueStateKind,
+    TrackerIssueStateSnapshot, TrackerIssueSummary, TrackerStateId, WorkerId, WorkerOutcomeKind,
+    WorkerOutcomeRecord, WorkspaceRecord,
 };
 use crate::opensymphony_gateway_schema::capability::{HarnessCapability, HarnessKind};
 use crate::opensymphony_workflow::{ResolvedWorkflow, RoutingConfig};
@@ -25,6 +28,10 @@ use super::filter_issues_for_dispatch;
 
 const DISABLED_STALL_TIMEOUT_MS: u64 = u64::MAX / 4;
 const ROUTING_TASK_ISSUE_EXECUTION: &str = "issue_execution";
+const RUNNING_STATE_REFRESH_INTERVAL_MS: u64 = 30_000;
+const DISPATCH_DISCOVERY_INTERVAL_MS: u64 = 60_000;
+const TERMINAL_REFRESH_INTERVAL_MS: u64 = 300_000;
+const FULL_DETAIL_REFRESH_INTERVAL_MS: u64 = 3_600_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchedulerConfig {
@@ -179,11 +186,40 @@ pub trait TrackerBackend {
     type Error: std::fmt::Display + Send + Sync + 'static;
 
     async fn candidate_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error>;
+    async fn candidate_issue_summaries(&mut self) -> Result<Vec<TrackerIssueSummary>, Self::Error> {
+        Ok(self
+            .candidate_issues()
+            .await?
+            .into_iter()
+            .map(tracker_issue_summary_from_issue)
+            .collect())
+    }
     async fn terminal_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error>;
+    async fn issues_by_identifiers(
+        &mut self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, Self::Error> {
+        let requested = identifiers
+            .iter()
+            .map(|identifier| identifier.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        Ok(self
+            .candidate_issues()
+            .await?
+            .into_iter()
+            .filter(|issue| requested.contains(&issue.identifier.to_ascii_uppercase()))
+            .collect())
+    }
     async fn issue_states_by_ids(
         &mut self,
         issue_ids: &[String],
     ) -> Result<Vec<TrackerIssueStateSnapshot>, Self::Error>;
+    fn error_category(_error: &Self::Error) -> Option<TrackerErrorCategory> {
+        None
+    }
+    fn retry_after(_error: &Self::Error) -> Option<Duration> {
+        None
+    }
 }
 
 #[allow(async_fn_in_trait)]
@@ -264,7 +300,17 @@ pub struct Scheduler<T, W, M> {
     recovered: bool,
     next_worker_ordinal: u64,
     last_poll_at: Option<TimestampMs>,
+    last_running_state_refresh_at: Option<TimestampMs>,
+    last_dispatch_discovery_at: Option<TimestampMs>,
+    last_terminal_refresh_at: Option<TimestampMs>,
+    last_full_detail_refresh_at: Option<TimestampMs>,
+    linear_blocked_until: Option<TimestampMs>,
     health: HealthStatus,
+}
+
+enum DispatchCandidates {
+    Full(Vec<TrackerIssue>),
+    Summary(Vec<TrackerIssueSummary>),
 }
 
 impl<T, W, M> Scheduler<T, W, M>
@@ -286,6 +332,11 @@ where
             recovered: false,
             next_worker_ordinal: 0,
             last_poll_at: None,
+            last_running_state_refresh_at: None,
+            last_dispatch_discovery_at: None,
+            last_terminal_refresh_at: None,
+            last_full_detail_refresh_at: None,
+            linear_blocked_until: None,
             health: HealthStatus::Starting,
         }
     }
@@ -388,13 +439,16 @@ where
                 })?);
         }
 
-        let tracker_snapshot = self.load_tracker_snapshot().await?;
-        self.bootstrap_recovery(&tracker_snapshot, observed_at)
-            .await?;
-        self.reconcile_tracker_state(&tracker_snapshot, observed_at)
-            .await?;
+        if let Some(tracker_snapshot) = self.load_tracker_snapshot(observed_at).await? {
+            self.record_full_detail_refresh(observed_at);
+            self.bootstrap_recovery(&tracker_snapshot, observed_at)
+                .await?;
+            self.reconcile_tracker_state(&tracker_snapshot, observed_at)
+                .await?;
+        }
 
         self.last_poll_at = Some(observed_at);
+        self.refresh_health_from_linear_cooldown(observed_at);
         Ok(self.snapshot(observed_at))
     }
 
@@ -420,17 +474,69 @@ where
             })?;
         self.apply_worker_updates(updates).await?;
 
-        let tracker_snapshot = self.load_tracker_snapshot().await?;
-        self.bootstrap_recovery(&tracker_snapshot, observed_at)
-            .await?;
-        self.reconcile_tracker_state(&tracker_snapshot, observed_at)
-            .await?;
+        self.expire_linear_cooldown(observed_at);
+        let mut dispatch_candidates = None;
+        if !self.linear_cooldown_active(observed_at) {
+            if due(
+                self.last_full_detail_refresh_at,
+                FULL_DETAIL_REFRESH_INTERVAL_MS,
+                observed_at,
+            ) {
+                if let Some(tracker_snapshot) = self.load_tracker_snapshot(observed_at).await? {
+                    self.record_full_detail_refresh(observed_at);
+                    self.bootstrap_recovery(&tracker_snapshot, observed_at)
+                        .await?;
+                    self.reconcile_tracker_state(&tracker_snapshot, observed_at)
+                        .await?;
+                    dispatch_candidates = Some(DispatchCandidates::Full(tracker_snapshot.active));
+                }
+            } else if due(
+                self.last_terminal_refresh_at,
+                TERMINAL_REFRESH_INTERVAL_MS,
+                observed_at,
+            ) {
+                self.refresh_terminal_issues(observed_at).await?;
+            } else if due(
+                self.last_running_state_refresh_at,
+                RUNNING_STATE_REFRESH_INTERVAL_MS,
+                observed_at,
+            ) && self.has_running_executions()
+            {
+                self.refresh_running_issue_states(observed_at).await?;
+            } else if due(
+                self.last_dispatch_discovery_at,
+                DISPATCH_DISCOVERY_INTERVAL_MS,
+                observed_at,
+            ) {
+                dispatch_candidates = self
+                    .load_dispatch_candidates(observed_at)
+                    .await?
+                    .map(DispatchCandidates::Summary);
+            }
+        }
+
+        if let Some(candidates) = dispatch_candidates {
+            match candidates {
+                DispatchCandidates::Full(candidates) => {
+                    self.dispatch_ready_issues(&candidates, observed_at).await?;
+                }
+                DispatchCandidates::Summary(candidates) => {
+                    self.dispatch_summary_candidates(&candidates, observed_at)
+                        .await?;
+                }
+            }
+        }
+
         self.handle_stalls(observed_at).await?;
-        self.dispatch_ready_issues(&tracker_snapshot.active, observed_at)
-            .await?;
+
+        let known_candidates = self.known_dispatch_candidates(observed_at);
+        if !known_candidates.is_empty() {
+            self.dispatch_ready_issues(&known_candidates, observed_at)
+                .await?;
+        }
 
         self.last_poll_at = Some(observed_at);
-        self.health = HealthStatus::Healthy;
+        self.refresh_health_from_linear_cooldown(observed_at);
         Ok(self.snapshot(observed_at))
     }
 
@@ -439,9 +545,7 @@ where
         F: Future<Output = ()>,
     {
         let mut shutdown = std::pin::pin!(shutdown);
-        let mut ticker = interval(std::time::Duration::from_millis(
-            self.config.poll_interval_ms,
-        ));
+        let mut ticker = interval(Duration::from_millis(self.config.poll_interval_ms));
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
@@ -460,21 +564,32 @@ where
         Ok(())
     }
 
-    async fn load_tracker_snapshot(&mut self) -> Result<TrackerSnapshot, SchedulerError> {
-        let active =
-            self.tracker
-                .candidate_issues()
-                .await
-                .map_err(|error| SchedulerError::Tracker {
+    async fn load_tracker_snapshot(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<Option<TrackerSnapshot>, SchedulerError> {
+        let active = match self.tracker.candidate_issues().await {
+            Ok(active) => active,
+            Err(error) => {
+                if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                    return Ok(None);
+                }
+                return Err(SchedulerError::Tracker {
                     detail: error.to_string(),
-                })?;
-        let terminal =
-            self.tracker
-                .terminal_issues()
-                .await
-                .map_err(|error| SchedulerError::Tracker {
+                });
+            }
+        };
+        let terminal = match self.tracker.terminal_issues().await {
+            Ok(terminal) => terminal,
+            Err(error) => {
+                if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                    return Ok(None);
+                }
+                return Err(SchedulerError::Tracker {
                     detail: error.to_string(),
-                })?;
+                });
+            }
+        };
 
         let active_ids = active
             .iter()
@@ -513,23 +628,185 @@ where
         let state_by_id = if lookup_ids.is_empty() {
             HashMap::new()
         } else {
-            self.tracker
+            let snapshots = self
+                .tracker
                 .issue_states_by_ids(&lookup_ids.into_iter().collect::<Vec<_>>())
-                .await
-                .map_err(|error| SchedulerError::Tracker {
-                    detail: error.to_string(),
-                })?
-                .into_iter()
-                .map(|snapshot| (snapshot.id.clone(), snapshot))
-                .collect()
+                .await;
+            match snapshots {
+                Ok(snapshots) => snapshots
+                    .into_iter()
+                    .map(|snapshot| (snapshot.id.clone(), snapshot))
+                    .collect(),
+                Err(error) => {
+                    if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                        return Ok(None);
+                    }
+                    return Err(SchedulerError::Tracker {
+                        detail: error.to_string(),
+                    });
+                }
+            }
         };
 
-        Ok(TrackerSnapshot {
+        Ok(Some(TrackerSnapshot {
             active_index,
             terminal_state_by_id,
             state_by_id,
             active,
-        })
+        }))
+    }
+
+    async fn refresh_running_issue_states(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        let issue_ids = self
+            .executions
+            .iter()
+            .filter(|(_, execution)| {
+                matches!(
+                    execution.status(),
+                    SchedulerStatus::Claimed | SchedulerStatus::Running
+                )
+            })
+            .map(|(id, _)| id.as_str().to_string())
+            .collect::<Vec<_>>();
+        if issue_ids.is_empty() {
+            self.last_running_state_refresh_at = Some(observed_at);
+            return Ok(());
+        }
+
+        let snapshots = match self.tracker.issue_states_by_ids(&issue_ids).await {
+            Ok(snapshots) => snapshots,
+            Err(error) => {
+                if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                    return Ok(());
+                }
+                return Err(SchedulerError::Tracker {
+                    detail: error.to_string(),
+                });
+            }
+        };
+        self.last_running_state_refresh_at = Some(observed_at);
+        let tracker_snapshot = TrackerSnapshot {
+            active: Vec::new(),
+            active_index: HashMap::new(),
+            terminal_state_by_id: HashMap::new(),
+            state_by_id: snapshots
+                .into_iter()
+                .map(|snapshot| (snapshot.id.clone(), snapshot))
+                .collect(),
+        };
+        self.reconcile_tracker_state(&tracker_snapshot, observed_at)
+            .await
+    }
+
+    async fn refresh_terminal_issues(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        let terminal = match self.tracker.terminal_issues().await {
+            Ok(terminal) => terminal,
+            Err(error) => {
+                if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                    return Ok(());
+                }
+                return Err(SchedulerError::Tracker {
+                    detail: error.to_string(),
+                });
+            }
+        };
+        self.last_terminal_refresh_at = Some(observed_at);
+        let tracker_snapshot = TrackerSnapshot {
+            active: Vec::new(),
+            active_index: HashMap::new(),
+            terminal_state_by_id: terminal
+                .into_iter()
+                .map(|issue| (issue.id, issue.state))
+                .collect(),
+            state_by_id: HashMap::new(),
+        };
+        self.reconcile_tracker_state(&tracker_snapshot, observed_at)
+            .await
+    }
+
+    async fn load_dispatch_candidates(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<Option<Vec<TrackerIssueSummary>>, SchedulerError> {
+        match self.tracker.candidate_issue_summaries().await {
+            Ok(active) => {
+                self.last_dispatch_discovery_at = Some(observed_at);
+                Ok(Some(active))
+            }
+            Err(error) => {
+                if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                    Ok(None)
+                } else {
+                    Err(SchedulerError::Tracker {
+                        detail: error.to_string(),
+                    })
+                }
+            }
+        }
+    }
+
+    fn record_full_detail_refresh(&mut self, observed_at: TimestampMs) {
+        self.last_running_state_refresh_at = Some(observed_at);
+        self.last_dispatch_discovery_at = Some(observed_at);
+        self.last_terminal_refresh_at = Some(observed_at);
+        self.last_full_detail_refresh_at = Some(observed_at);
+    }
+
+    fn expire_linear_cooldown(&mut self, observed_at: TimestampMs) {
+        if self
+            .linear_blocked_until
+            .is_some_and(|blocked_until| blocked_until <= observed_at)
+        {
+            self.linear_blocked_until = None;
+        }
+    }
+
+    fn linear_cooldown_active(&self, observed_at: TimestampMs) -> bool {
+        match self.linear_blocked_until {
+            Some(blocked_until) if blocked_until > observed_at => true,
+            Some(_) | None => false,
+        }
+    }
+
+    fn refresh_health_from_linear_cooldown(&mut self, observed_at: TimestampMs) {
+        self.health = if self.linear_cooldown_active(observed_at) {
+            HealthStatus::Degraded
+        } else {
+            HealthStatus::Healthy
+        };
+    }
+
+    fn set_linear_cooldown_from_tracker_error(
+        &mut self,
+        error: &T::Error,
+        observed_at: TimestampMs,
+    ) -> bool {
+        if T::error_category(error) != Some(TrackerErrorCategory::RateLimited) {
+            return false;
+        }
+
+        let delay_ms = T::retry_after(error)
+            .map(duration_millis_saturating)
+            .unwrap_or(self.config.poll_interval_ms)
+            .max(self.config.poll_interval_ms);
+        let blocked_until = observed_at.saturating_add(DurationMs::new(delay_ms));
+        self.linear_blocked_until = Some(
+            self.linear_blocked_until
+                .map_or(blocked_until, |existing| existing.max(blocked_until)),
+        );
+        self.health = HealthStatus::Degraded;
+        warn!(
+            delay_ms,
+            blocked_until_ms = blocked_until.as_u64(),
+            "Linear tracker is rate limited; deferring Linear reads"
+        );
+        true
     }
 
     async fn bootstrap_recovery(
@@ -618,6 +895,11 @@ where
             if let Some(snapshot) = tracker_snapshot.state_by_id.get(issue_id.as_str()) {
                 let category = state_category_from_name(&snapshot.state.name, &self.config);
                 if category == IssueStateCategory::Active {
+                    if let Some(existing) = self.executions.get(&issue_id) {
+                        let mut issue = existing.issue().clone();
+                        issue.state = issue_state_from_name(&snapshot.state.name, &self.config);
+                        self.refresh_execution_issue(&issue_id, issue)?;
+                    }
                     continue;
                 }
 
@@ -655,6 +937,122 @@ where
         }
 
         Ok(())
+    }
+
+    fn known_dispatch_candidates(&self, observed_at: TimestampMs) -> Vec<TrackerIssue> {
+        self.executions
+            .values()
+            .filter(|execution| {
+                if execution.issue().state.category != IssueStateCategory::Active {
+                    return false;
+                }
+                match execution.status() {
+                    SchedulerStatus::Unclaimed => true,
+                    SchedulerStatus::RetryQueued => execution
+                        .retry()
+                        .is_some_and(|retry| retry.due_at <= observed_at),
+                    SchedulerStatus::Released
+                    | SchedulerStatus::Claimed
+                    | SchedulerStatus::Running => false,
+                }
+            })
+            .map(|execution| tracker_issue_from_normalized(execution.issue()))
+            .collect()
+    }
+
+    fn refresh_execution_issue(
+        &mut self,
+        issue_id: &IssueId,
+        issue: NormalizedIssue,
+    ) -> Result<(), SchedulerError> {
+        if let Some(mut execution) = self.remove_execution(issue_id) {
+            execution.refresh_issue(issue)?;
+            self.insert_execution(issue_id.clone(), execution);
+        }
+        Ok(())
+    }
+
+    fn has_running_executions(&self) -> bool {
+        self.executions.values().any(|execution| {
+            matches!(
+                execution.status(),
+                SchedulerStatus::Claimed | SchedulerStatus::Running
+            )
+        })
+    }
+
+    async fn dispatch_summary_candidates(
+        &mut self,
+        summaries: &[TrackerIssueSummary],
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        let ready = filter_issue_summaries_for_dispatch(
+            summaries.to_vec(),
+            &self.config.terminal_state_set(),
+        );
+        let available_capacity = usize::try_from(self.config.max_concurrent_agents)
+            .unwrap_or(usize::MAX)
+            .saturating_sub(self.worker_index.len());
+        if available_capacity == 0 {
+            return Ok(());
+        }
+
+        let identifiers = ready
+            .iter()
+            .take(available_capacity)
+            .map(|issue| issue.identifier.clone())
+            .collect::<Vec<_>>();
+        if identifiers.is_empty() {
+            return Ok(());
+        }
+        let mut detailed_by_identifier = match self
+            .tracker
+            .issues_by_identifiers(&identifiers)
+            .await
+        {
+            Ok(issues) => issues
+                .into_iter()
+                .map(|issue| (issue.identifier.to_ascii_uppercase(), issue))
+                .collect::<HashMap<_, _>>(),
+            Err(error) => {
+                if self.set_linear_cooldown_from_tracker_error(&error, observed_at) {
+                    return Ok(());
+                }
+                if T::error_category(&error) == Some(TrackerErrorCategory::NotFound) {
+                    warn!(
+                        "skipping dispatch discovery because selected issue details were not found"
+                    );
+                    return Ok(());
+                }
+                return Err(SchedulerError::Tracker {
+                    detail: error.to_string(),
+                });
+            }
+        };
+
+        let mut detailed = Vec::new();
+        for summary in ready.into_iter().take(available_capacity) {
+            let key = summary.identifier.to_ascii_uppercase();
+            let Some(detailed_issue) = detailed_by_identifier.remove(&key) else {
+                warn!(
+                    identifier = %summary.identifier,
+                    "skipping stale dispatch candidate missing from detail refresh"
+                );
+                continue;
+            };
+            let normalized = normalize_tracker_issue(&detailed_issue, &self.config)?;
+            if normalized.state.category != IssueStateCategory::Active {
+                warn!(
+                    identifier = %normalized.identifier,
+                    state = %normalized.state.name,
+                    "skipping dispatch candidate no longer in an active state"
+                );
+                continue;
+            }
+            detailed.push(detailed_issue);
+        }
+
+        self.dispatch_ready_issues(&detailed, observed_at).await
     }
 
     async fn dispatch_ready_issues(
@@ -1350,8 +1748,163 @@ fn normalized_state_name(name: &str) -> String {
     name.trim().to_ascii_lowercase()
 }
 
+fn tracker_issue_summary_from_issue(issue: TrackerIssue) -> TrackerIssueSummary {
+    TrackerIssueSummary {
+        id: issue.id,
+        identifier: issue.identifier,
+        url: issue.url,
+        title: issue.title,
+        priority: issue.priority,
+        state: issue.state,
+        state_kind: issue.state_kind,
+        blocked_by: issue.blocked_by,
+        sub_issues: issue.sub_issues,
+        created_at: issue.created_at,
+        updated_at: issue.updated_at,
+    }
+}
+
+fn tracker_issue_from_normalized(issue: &NormalizedIssue) -> TrackerIssue {
+    TrackerIssue {
+        id: issue.id.to_string(),
+        identifier: issue.identifier.to_string(),
+        url: issue.url.clone().unwrap_or_default(),
+        title: issue.title.clone(),
+        description: issue.description.clone(),
+        priority: issue.priority,
+        state: issue.state.name.clone(),
+        state_kind: tracker_state_kind_from_issue_state(&issue.state),
+        labels: issue.labels.clone(),
+        project_id: issue.project_id.clone(),
+        project_slug: issue.project_slug.clone(),
+        project_name: issue.project_name.clone(),
+        parent_id: issue.parent_id.as_ref().map(ToString::to_string),
+        parent: None,
+        project_milestone: None,
+        blocked_by: issue
+            .blocked_by
+            .iter()
+            .filter_map(|blocker| {
+                let id = blocker.id.as_ref()?.to_string();
+                let identifier = blocker.identifier.as_ref()?.to_string();
+                let state_name = blocker.state.clone().unwrap_or_default();
+                Some(TrackerIssueBlocker {
+                    id,
+                    identifier: identifier.clone(),
+                    title: identifier,
+                    state: tracker_issue_state_from_name(&state_name),
+                })
+            })
+            .collect(),
+        sub_issues: issue
+            .sub_issues
+            .iter()
+            .map(|child| TrackerIssueRef {
+                id: child.id.to_string(),
+                identifier: child.identifier.to_string(),
+                title: None,
+                url: None,
+                state: child.state.clone(),
+            })
+            .collect(),
+        created_at: timestamp_to_datetime(issue.created_at),
+        updated_at: timestamp_to_datetime(issue.updated_at),
+    }
+}
+
+fn filter_issue_summaries_for_dispatch<I>(
+    summaries: I,
+    terminal_states: &HashSet<String>,
+) -> Vec<TrackerIssueSummary>
+where
+    I: IntoIterator<Item = TrackerIssueSummary>,
+{
+    let mut filtered = summaries
+        .into_iter()
+        .filter(|issue| should_dispatch_issue_summary(issue, terminal_states))
+        .collect::<Vec<_>>();
+    filtered.sort_by(|left, right| {
+        summary_priority_rank(left)
+            .cmp(&summary_priority_rank(right))
+            .then_with(|| left.sub_issues.len().cmp(&right.sub_issues.len()))
+            .then_with(|| left.created_at.cmp(&right.created_at))
+            .then_with(|| left.identifier.cmp(&right.identifier))
+    });
+    filtered
+}
+
+fn should_dispatch_issue_summary(
+    issue: &TrackerIssueSummary,
+    terminal_states: &HashSet<String>,
+) -> bool {
+    !issue
+        .blocked_by
+        .iter()
+        .any(|blocker| !blocker.is_terminal())
+        && (issue.sub_issues.is_empty()
+            || issue
+                .sub_issues
+                .iter()
+                .all(|sub_issue| sub_issue.is_terminal(terminal_states)))
+}
+
+fn summary_priority_rank(issue: &TrackerIssueSummary) -> u8 {
+    issue.priority.unwrap_or(u8::MAX)
+}
+
+fn tracker_issue_state_from_name(name: &str) -> TrackerIssueState {
+    let kind = tracker_state_kind_from_name(name);
+    TrackerIssueState {
+        id: normalized_state_name(name),
+        name: name.to_string(),
+        tracker_type: tracker_type_for_state_kind(&kind).to_string(),
+        kind,
+    }
+}
+
+fn tracker_state_kind_from_issue_state(state: &IssueState) -> TrackerIssueStateKind {
+    match state.category {
+        IssueStateCategory::Active => TrackerIssueStateKind::Started,
+        IssueStateCategory::Terminal => tracker_state_kind_from_name(&state.name),
+        IssueStateCategory::NonActive => tracker_state_kind_from_name(&state.name),
+    }
+}
+
+fn tracker_state_kind_from_name(name: &str) -> TrackerIssueStateKind {
+    match normalized_state_name(name).as_str() {
+        "backlog" => TrackerIssueStateKind::Backlog,
+        "todo" => TrackerIssueStateKind::Unstarted,
+        "done" | "completed" | "closed" => TrackerIssueStateKind::Completed,
+        "canceled" | "cancelled" => TrackerIssueStateKind::Canceled,
+        "triage" | "triaged" => TrackerIssueStateKind::Triage,
+        "in progress" | "review" | "human review" => TrackerIssueStateKind::Started,
+        other => TrackerIssueStateKind::Unknown(other.to_string()),
+    }
+}
+
+fn tracker_type_for_state_kind(kind: &TrackerIssueStateKind) -> &'static str {
+    match kind {
+        TrackerIssueStateKind::Backlog => "backlog",
+        TrackerIssueStateKind::Unstarted => "unstarted",
+        TrackerIssueStateKind::Started => "started",
+        TrackerIssueStateKind::Completed => "completed",
+        TrackerIssueStateKind::Canceled => "canceled",
+        TrackerIssueStateKind::Triage => "triage",
+        TrackerIssueStateKind::Unknown(_) => "unknown",
+    }
+}
+
 fn effective_stall_timeout(stall_timeout_ms: Option<u64>) -> DurationMs {
     DurationMs::new(stall_timeout_ms.unwrap_or(DISABLED_STALL_TIMEOUT_MS))
+}
+
+fn due(last_observed_at: Option<TimestampMs>, interval_ms: u64, observed_at: TimestampMs) -> bool {
+    last_observed_at
+        .is_none_or(|last| observed_at.as_u64() >= last.as_u64().saturating_add(interval_ms))
+}
+
+fn duration_millis_saturating(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 fn datetime_to_timestamp(datetime: DateTime<Utc>) -> TimestampMs {
@@ -1361,6 +1914,12 @@ fn datetime_to_timestamp(datetime: DateTime<Utc>) -> TimestampMs {
     } else {
         TimestampMs::new(millis as u64)
     }
+}
+
+fn timestamp_to_datetime(timestamp: Option<TimestampMs>) -> DateTime<Utc> {
+    let millis = timestamp.map(|value| value.as_u64()).unwrap_or_default();
+    let millis = i64::try_from(millis).unwrap_or(i64::MAX);
+    DateTime::<Utc>::from_timestamp_millis(millis).unwrap_or_else(Utc::now)
 }
 
 fn current_epoch_millis() -> u64 {

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -1,16 +1,18 @@
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     path::PathBuf,
+    time::Duration,
 };
 
+use crate::opensymphony_domain::TrackerErrorCategory;
 use crate::opensymphony_orchestrator::{
     ConversationId, ConversationMetadata, IssueId, IssueIdentifier, IssueRef, IssueState,
     IssueStateCategory, NormalizedIssue, RecoveryRecord, ReleaseReason, RetryReason,
     RuntimeStreamState, Scheduler, SchedulerConfig, SchedulerStatus, TimestampMs, TrackerBackend,
     TrackerIssue, TrackerIssueState, TrackerIssueStateKind, TrackerIssueStateSnapshot,
-    WorkerAbortReason, WorkerBackend, WorkerId, WorkerLaunch, WorkerOutcomeKind,
-    WorkerOutcomeRecord, WorkerStartRequest, WorkerUpdate, WorkspaceBackend, WorkspaceKey,
-    WorkspaceRecord, decide_issue_route,
+    TrackerIssueSummary, WorkerAbortReason, WorkerBackend, WorkerId, WorkerLaunch,
+    WorkerOutcomeKind, WorkerOutcomeRecord, WorkerStartRequest, WorkerUpdate, WorkspaceBackend,
+    WorkspaceKey, WorkspaceRecord, decide_issue_route,
 };
 use crate::opensymphony_workflow::RoutingConfig;
 use chrono::{TimeZone, Utc};
@@ -71,6 +73,22 @@ fn tracker_issue(id: &str, identifier: &str, state: &str, created_at: u64) -> Tr
         sub_issues: Vec::new(),
         created_at: dt(created_at),
         updated_at: dt(created_at),
+    }
+}
+
+fn tracker_issue_summary(issue: TrackerIssue) -> TrackerIssueSummary {
+    TrackerIssueSummary {
+        id: issue.id,
+        identifier: issue.identifier,
+        url: issue.url,
+        title: issue.title,
+        priority: issue.priority,
+        state: issue.state,
+        state_kind: issue.state_kind,
+        blocked_by: issue.blocked_by,
+        sub_issues: issue.sub_issues,
+        created_at: issue.created_at,
+        updated_at: issue.updated_at,
     }
 }
 
@@ -229,11 +247,25 @@ fn conversation(worker_id: &WorkerId) -> ConversationMetadata {
 }
 
 #[derive(Debug, Clone)]
-struct FakeError(String);
+struct FakeError {
+    message: String,
+    category: Option<TrackerErrorCategory>,
+    retry_after: Option<Duration>,
+}
+
+impl FakeError {
+    fn rate_limited(retry_after: Duration) -> Self {
+        Self {
+            message: "rate limited".to_string(),
+            category: Some(TrackerErrorCategory::RateLimited),
+            retry_after: Some(retry_after),
+        }
+    }
+}
 
 impl std::fmt::Display for FakeError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.0)
+        formatter.write_str(&self.message)
     }
 }
 
@@ -244,6 +276,16 @@ struct FakeTracker {
     active: Vec<TrackerIssue>,
     terminal: Vec<TrackerIssue>,
     states: HashMap<String, TrackerIssueStateSnapshot>,
+    detail_issues: Option<Vec<TrackerIssue>>,
+    candidate_errors: VecDeque<FakeError>,
+    summary_errors: VecDeque<FakeError>,
+    terminal_errors: VecDeque<FakeError>,
+    detail_errors: VecDeque<FakeError>,
+    state_errors: VecDeque<FakeError>,
+    active_requests: usize,
+    summary_requests: usize,
+    terminal_requests: usize,
+    detail_requests: Vec<Vec<String>>,
     state_requests: Vec<Vec<String>>,
 }
 
@@ -251,11 +293,52 @@ impl TrackerBackend for FakeTracker {
     type Error = FakeError;
 
     async fn candidate_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error> {
+        self.active_requests += 1;
+        if let Some(error) = self.candidate_errors.pop_front() {
+            return Err(error);
+        }
         Ok(self.active.clone())
     }
 
+    async fn candidate_issue_summaries(&mut self) -> Result<Vec<TrackerIssueSummary>, Self::Error> {
+        self.summary_requests += 1;
+        if let Some(error) = self.summary_errors.pop_front() {
+            return Err(error);
+        }
+        Ok(self
+            .active
+            .clone()
+            .into_iter()
+            .map(tracker_issue_summary)
+            .collect())
+    }
+
     async fn terminal_issues(&mut self) -> Result<Vec<TrackerIssue>, Self::Error> {
+        self.terminal_requests += 1;
+        if let Some(error) = self.terminal_errors.pop_front() {
+            return Err(error);
+        }
         Ok(self.terminal.clone())
+    }
+
+    async fn issues_by_identifiers(
+        &mut self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, Self::Error> {
+        self.detail_requests.push(identifiers.to_vec());
+        if let Some(error) = self.detail_errors.pop_front() {
+            return Err(error);
+        }
+        let requested = identifiers
+            .iter()
+            .map(|identifier| identifier.to_ascii_uppercase())
+            .collect::<std::collections::HashSet<_>>();
+        let source = self.detail_issues.as_ref().unwrap_or(&self.active);
+        Ok(source
+            .iter()
+            .filter(|issue| requested.contains(&issue.identifier.to_ascii_uppercase()))
+            .cloned()
+            .collect())
     }
 
     async fn issue_states_by_ids(
@@ -263,10 +346,21 @@ impl TrackerBackend for FakeTracker {
         issue_ids: &[String],
     ) -> Result<Vec<TrackerIssueStateSnapshot>, Self::Error> {
         self.state_requests.push(issue_ids.to_vec());
+        if let Some(error) = self.state_errors.pop_front() {
+            return Err(error);
+        }
         Ok(issue_ids
             .iter()
             .filter_map(|id| self.states.get(id).cloned())
             .collect())
+    }
+
+    fn error_category(error: &Self::Error) -> Option<TrackerErrorCategory> {
+        error.category
+    }
+
+    fn retry_after(error: &Self::Error) -> Option<Duration> {
+        error.retry_after
     }
 }
 
@@ -351,6 +445,326 @@ impl WorkerBackend for FakeWorker {
         self.aborted.push((worker_id.to_string(), reason));
         Ok(())
     }
+}
+
+#[tokio::test]
+async fn rate_limit_cooldown_skips_linear_reads_but_keeps_worker_updates_flowing() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-500", "COE-500", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should dispatch");
+
+    let first_run = scheduler.worker().launches[0].run.clone();
+    scheduler
+        .tracker_mut()
+        .state_errors
+        .push_back(FakeError::rate_limited(Duration::from_secs(60)));
+    scheduler
+        .worker_mut()
+        .updates
+        .push_back(WorkerUpdate::TokenUsageUpdate {
+            worker_id: first_run.worker_id.clone(),
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 5,
+            total_tokens: 35,
+        });
+
+    let blocked_snapshot = scheduler
+        .tick(ts(30_100))
+        .await
+        .expect("rate-limited state refresh should not fail the tick");
+
+    assert_eq!(
+        blocked_snapshot.daemon.health,
+        crate::opensymphony_domain::HealthStatus::Degraded
+    );
+    assert_eq!(scheduler.tracker().state_requests.len(), 1);
+    let execution = scheduler
+        .execution(&IssueId::new("lin-500").expect("issue id should be valid"))
+        .expect("execution should still exist");
+    assert_eq!(
+        execution
+            .conversation()
+            .expect("conversation metadata should exist")
+            .total_tokens,
+        35
+    );
+
+    let active_requests = scheduler.tracker().active_requests;
+    let summary_requests = scheduler.tracker().summary_requests;
+    let terminal_requests = scheduler.tracker().terminal_requests;
+    let detail_requests = scheduler.tracker().detail_requests.len();
+    let state_requests = scheduler.tracker().state_requests.len();
+
+    let still_blocked = scheduler
+        .tick(ts(35_100))
+        .await
+        .expect("cooldown should skip Linear reads");
+
+    assert_eq!(
+        still_blocked.daemon.health,
+        crate::opensymphony_domain::HealthStatus::Degraded
+    );
+    assert_eq!(scheduler.tracker().active_requests, active_requests);
+    assert_eq!(scheduler.tracker().summary_requests, summary_requests);
+    assert_eq!(scheduler.tracker().terminal_requests, terminal_requests);
+    assert_eq!(scheduler.tracker().detail_requests.len(), detail_requests);
+    assert_eq!(scheduler.tracker().state_requests.len(), state_requests);
+}
+
+#[tokio::test]
+async fn rate_limited_running_state_read_retries_after_cooldown() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-505", "COE-505", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should dispatch");
+    scheduler
+        .tracker_mut()
+        .state_errors
+        .push_back(FakeError::rate_limited(Duration::from_secs(1)));
+
+    scheduler
+        .tick(ts(30_100))
+        .await
+        .expect("rate-limited state refresh should not fail the tick");
+    assert_eq!(scheduler.tracker().state_requests.len(), 1);
+
+    scheduler
+        .tick(ts(31_100))
+        .await
+        .expect("state refresh should retry immediately after cooldown");
+    assert_eq!(scheduler.tracker().state_requests.len(), 2);
+}
+
+#[tokio::test]
+async fn rate_limited_terminal_read_retries_after_cooldown() {
+    let tracker = FakeTracker::default();
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should succeed");
+    scheduler
+        .tracker_mut()
+        .terminal_errors
+        .push_back(FakeError::rate_limited(Duration::from_secs(1)));
+
+    scheduler
+        .tick(ts(300_100))
+        .await
+        .expect("rate-limited terminal refresh should not fail the tick");
+    assert_eq!(scheduler.tracker().terminal_requests, 2);
+
+    scheduler
+        .tick(ts(301_100))
+        .await
+        .expect("terminal refresh should retry immediately after cooldown");
+    assert_eq!(scheduler.tracker().terminal_requests, 3);
+}
+
+#[tokio::test]
+async fn rate_limited_dispatch_discovery_retries_after_cooldown() {
+    let tracker = FakeTracker::default();
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should succeed");
+    scheduler
+        .tracker_mut()
+        .summary_errors
+        .push_back(FakeError::rate_limited(Duration::from_secs(1)));
+
+    scheduler
+        .tick(ts(60_100))
+        .await
+        .expect("rate-limited dispatch discovery should not fail the tick");
+    assert_eq!(scheduler.tracker().summary_requests, 1);
+
+    scheduler
+        .tick(ts(61_100))
+        .await
+        .expect("dispatch discovery should retry immediately after cooldown");
+    assert_eq!(scheduler.tracker().summary_requests, 2);
+}
+
+#[tokio::test]
+async fn dispatch_discovery_uses_sixty_second_cadence_and_selected_detail_reads() {
+    let tracker = FakeTracker::default();
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    config.max_concurrent_agents = 2;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should succeed");
+
+    assert_eq!(scheduler.tracker().active_requests, 1);
+    assert_eq!(scheduler.tracker().summary_requests, 0);
+    assert!(scheduler.tracker().detail_requests.is_empty());
+
+    scheduler.tracker_mut().active = vec![
+        tracker_issue("lin-501", "COE-501", "In Progress", 0),
+        tracker_issue("lin-502", "COE-502", "In Progress", 1),
+    ];
+
+    scheduler
+        .tick(ts(5_100))
+        .await
+        .expect("five-second tick should avoid Linear discovery");
+    assert_eq!(scheduler.tracker().summary_requests, 0);
+    assert!(scheduler.tracker().detail_requests.is_empty());
+    assert!(scheduler.worker().launches.is_empty());
+
+    scheduler
+        .tick(ts(60_100))
+        .await
+        .expect("sixty-second dispatch discovery should run");
+
+    assert_eq!(scheduler.tracker().summary_requests, 1);
+    assert_eq!(
+        scheduler.tracker().detail_requests,
+        vec![vec!["COE-501".to_string(), "COE-502".to_string()]]
+    );
+    assert_eq!(scheduler.worker().launches.len(), 2);
+
+    scheduler
+        .tick(ts(65_100))
+        .await
+        .expect("next five-second tick should avoid another discovery");
+    assert_eq!(scheduler.tracker().summary_requests, 1);
+
+    scheduler
+        .tick(ts(3_600_100))
+        .await
+        .expect("hourly full detail refresh should run");
+    assert_eq!(scheduler.tracker().active_requests, 2);
+}
+
+#[tokio::test]
+async fn running_state_polling_uses_lightweight_state_refresh_interval() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-502", "COE-502", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    config.active_states.push("Human Review".to_string());
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should dispatch");
+    scheduler.tracker_mut().states.insert(
+        "lin-502".to_string(),
+        tracker_state_snapshot("lin-502", "COE-502", "Human Review", "started", 30_000),
+    );
+
+    scheduler
+        .tick(ts(5_100))
+        .await
+        .expect("five-second tick should avoid state refresh");
+    assert!(scheduler.tracker().state_requests.is_empty());
+
+    scheduler
+        .tick(ts(30_100))
+        .await
+        .expect("thirty-second tick should refresh running state");
+
+    assert_eq!(scheduler.tracker().active_requests, 1);
+    assert_eq!(scheduler.tracker().terminal_requests, 1);
+    assert_eq!(scheduler.tracker().summary_requests, 0);
+    assert_eq!(
+        scheduler.tracker().state_requests,
+        vec![vec!["lin-502".to_string()]]
+    );
+    assert_eq!(
+        scheduler
+            .execution(&IssueId::new("lin-502").expect("issue id should be valid"))
+            .expect("execution should exist")
+            .issue()
+            .state
+            .name,
+        "Human Review"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_discovery_skips_candidates_missing_or_inactive_after_detail_refresh() {
+    let tracker = FakeTracker::default();
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should succeed");
+
+    scheduler.tracker_mut().active = vec![tracker_issue("lin-503", "COE-503", "In Progress", 0)];
+    scheduler.tracker_mut().detail_issues = Some(Vec::new());
+
+    scheduler
+        .tick(ts(60_100))
+        .await
+        .expect("missing detail should skip stale summary candidate");
+
+    assert_eq!(
+        scheduler.tracker().detail_requests,
+        vec![vec!["COE-503".to_string()]]
+    );
+    assert!(scheduler.worker().launches.is_empty());
+
+    scheduler.tracker_mut().detail_issues =
+        Some(vec![tracker_issue("lin-503", "COE-503", "Todo", 0)]);
+
+    scheduler
+        .tick(ts(120_100))
+        .await
+        .expect("inactive detail should skip stale summary candidate");
+
+    assert_eq!(scheduler.tracker().detail_requests.len(), 2);
+    assert!(scheduler.worker().launches.is_empty());
 }
 
 #[tokio::test]
@@ -602,7 +1016,7 @@ async fn terminal_reconciliation_aborts_running_worker_and_cleans_up_workspace()
     scheduler.tracker_mut().terminal = vec![tracker_issue("lin-270", "COE-270", "Done", 0)];
 
     scheduler
-        .tick(ts(200))
+        .tick(ts(300_200))
         .await
         .expect("terminal reconciliation should succeed");
 
@@ -789,9 +1203,9 @@ async fn tracker_inactive_release_frees_the_per_state_slot() {
     );
 
     scheduler
-        .tick(ts(200))
+        .tick(ts(30_200))
         .await
-        .expect("inactive reconciliation should release and replace the running issue");
+        .expect("inactive reconciliation should release the running issue");
 
     let released = scheduler
         .execution(&IssueId::new("lin-277").expect("issue id should be valid"))
@@ -808,6 +1222,11 @@ async fn tracker_inactive_release_frees_the_per_state_slot() {
         scheduler.worker().aborted[0].1,
         WorkerAbortReason::TrackerInactive
     );
+
+    scheduler
+        .tick(ts(60_200))
+        .await
+        .expect("dispatch discovery should replace the released issue");
     assert_eq!(scheduler.worker().launches.len(), 2);
     assert_eq!(
         scheduler.worker().launches[1].issue.identifier.as_str(),
@@ -845,11 +1264,25 @@ async fn running_count_follows_active_state_reconciliation() {
         tracker_issue("lin-281", "COE-281", "In Progress", 1),
         tracker_issue("lin-282", "COE-282", "Code Review", 2),
     ];
+    scheduler.tracker_mut().states.insert(
+        "lin-280".to_string(),
+        tracker_state_snapshot("lin-280", "COE-280", "Code Review", "started", 200),
+    );
 
     scheduler
-        .tick(ts(200))
+        .tick(ts(30_200))
         .await
-        .expect("active-state reconciliation should update running counts");
+        .expect("running-state refresh should update running counts");
+
+    scheduler
+        .tick(ts(60_200))
+        .await
+        .expect("running-state refresh should run before dispatch discovery");
+
+    scheduler
+        .tick(ts(65_200))
+        .await
+        .expect("dispatch discovery should use the updated running counts");
 
     let refreshed = scheduler
         .execution(&IssueId::new("lin-280").expect("issue id should be valid"))
@@ -861,12 +1294,10 @@ async fn running_count_follows_active_state_reconciliation() {
         scheduler.worker().launches[1].issue.identifier.as_str(),
         "COE-281"
     );
-    assert_eq!(
+    assert!(
         scheduler
             .execution(&IssueId::new("lin-282").expect("issue id should be valid"))
-            .expect("reconciled active issue should exist")
-            .status(),
-        SchedulerStatus::Unclaimed
+            .is_none()
     );
 }
 

--- a/docs/linear-and-tools.md
+++ b/docs/linear-and-tools.md
@@ -36,6 +36,29 @@ Current workflow contract:
   the gateway task graph reader is optional and, when unavailable, causes only
   the task graph endpoint to return `503`
 
+Local scheduler polling keeps the 5s worker/snapshot tick, but Linear reads are
+cadenced separately so a busy local workstation does not burn through the shared
+Linear API quota:
+
+- running issue state is refreshed with the lightweight by-ID state query every
+  30s
+- dispatch discovery uses a lightweight active-issue summary query every 60s
+- terminal cleanup reads run at startup and then every 5 minutes
+- full-detail active issue reads run at startup, for selected dispatches, and
+  then hourly
+
+The lightweight dispatch query returns summary-shaped scheduler data only.
+Selected candidates must be reloaded through the project-scoped full-detail
+lookup before workspace creation, prompt construction, or worker launch.
+
+When Linear returns a rate-limit error with retry metadata longer than the
+client's short retry backoff, the Linear client returns the error immediately
+instead of sleeping inside the request. The inline retry boundary is the lower
+of `tracker.retry_policy.max_backoff` and 30 seconds; longer reset windows are
+handed to the scheduler. The scheduler records one shared Linear cooldown,
+skips Linear reads until it expires, and continues draining worker updates and
+publishing snapshots.
+
 Important normalization rules:
 
 - `blocked_by` is derived from `inverseRelations` entries whose relation type is

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -319,6 +319,14 @@ Operational implications:
 
 - there is no separate local Linear bridge process to start
 - initialized target repos rely on `LINEAR_API_KEY`
+- `opensymphony run` keeps its local worker/snapshot tick every 5s, while
+  Linear reads use cheaper internal cadences: running state every 30s,
+  dispatch discovery every 60s, terminal cleanup every 5 minutes, and full
+  issue details hourly after startup/dispatch
+- if Linear returns a long rate-limit reset, the scheduler pauses all Linear
+  reads behind one shared cooldown but continues processing worker updates; the
+  Linear client only sleeps inline for short rate-limit retry windows up to the
+  lower of `tracker.retry_policy.max_backoff` and 30 seconds
 - the checked-in helper lives at
   `.agents/skills/linear/scripts/linear_graphql.py`
 - checked-in query files under `.agents/skills/linear/queries/` are the

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -85,8 +85,9 @@ Current implementation:
   `target/duckdb-download` and reused across rebuilds in the same target
   directory.
 - `cargo test` exercises the full root package, including the fake-server contract suite from `tests/fake_server_contract.rs`
-- `cargo test --test linear_client` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, archived terminal cleanup reads, archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
-- `cargo test --test hierarchy_selection --test scheduler` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, cached per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, active-state reconciliation, and manifest-backed workspace recovery against fake tracker/workspace/worker backends
+- `cargo test --test linear_client` exercises fixture-backed GraphQL normalization, parent/child hierarchy extraction, personal-API-key auth headers, required API-key/project/state configuration validation, issue URL/raw-priority preservation, full label pagination, raw workflow-state type preservation alongside normalized kinds, non-archived candidate polling, lightweight dispatch-summary reads, archived terminal cleanup reads, archived by-ID state refresh, GraphQL 400/429 rate-limit retries including reset-header handling, long rate-limit reset return-without-sleep behavior with the 30s inline cap, retryable 5xx GraphQL error envelopes, project-scoped by-ID state refresh, and tracker error mapping against a local stub server
+- `cargo test --test linear_client live_linear_client_reads_opensymphony_project -- --ignored --nocapture` is a read-only live evidence probe for PRs that need to show the actual Linear HTTP/GraphQL client path against the OpenSymphony project
+- `cargo test --test hierarchy_selection --test scheduler` exercises blocker-aware and hierarchy-aware dispatch filtering, leaf-before-parent ordering, cached per-state capacity limiting, continuation retry, exponential failure backoff, runtime-event-fed stall detection, terminal cleanup/release, active-state reconciliation, Linear cooldown behavior, separated Linear polling cadences, and manifest-backed workspace recovery against fake tracker/workspace/worker backends
 - `cargo test --lib orchestrator_run::backends::tests` covers runtime workspace-manifest recovery, in-flight run detection from `run.json`, and launch-path failure handling in the concrete CLI adapter
 - `tests/doctor.rs` runs the CLI live-probe path against the internal `opensymphony_testkit` module
 - `scripts/smoke_local.sh` runs the static doctor pass
@@ -250,13 +251,14 @@ and login -> Enable device code authorization for Codex before retrying.
 - failure retry backoff
 - continuation retry at fixed delay
 - stall detection
-- active-state refresh
+- lightweight active-state refresh cadence
+- Linear rate-limit cooldown that does not block worker updates
 - terminal cleanup
 - restart recovery from manifests
 
 Current repository implementation:
 
-- `tests/scheduler.rs` covers continuation retry, failure backoff, cached per-state dispatch limits across finish/stall/inactive/terminal/reconciliation transitions, runtime-event-fed stall detection, terminal reconciliation with cleanup, and manifest-backed workspace recovery using fake backends
+- `tests/scheduler.rs` covers continuation retry, failure backoff, cached per-state dispatch limits across finish/stall/inactive/terminal/reconciliation transitions, runtime-event-fed stall detection, terminal reconciliation with cleanup, Linear read cooldown and cadence, lightweight running-state refresh, and manifest-backed workspace recovery using fake backends
 - local restart validation should confirm that `opensymphony run` publishes a recovered snapshot before the first post-restart launch wave, so the TUI issue list repopulates even when reused conversations still take time to attach
 - `crates/opensymphony-cli/src/orchestrator_run/backends.rs` covers immediate launch-failure cleanup and abort-on-drop cleanup for tracked runtime worker tasks in the production CLI adapter
 


### PR DESCRIPTION
## Summary

Reduce local Linear API pressure in `opensymphony run` by separating the scheduler's 5s worker tick from Linear read cadences and by surfacing long Linear rate-limit resets to the scheduler instead of sleeping inside the client request.

## Changes

- Added long-delay `429` / GraphQL `RATELIMITED` return-without-sleep behavior to the Linear client, with a 30s inline retry cap under `tracker.retry_policy.max_backoff`.
- Split scheduler Linear reads into lightweight running-state refreshes, lightweight dispatch discovery, terminal cleanup, and hourly full-detail refreshes with one shared cooldown.
- Fixed cooldown recovery so failed Linear reads do not advance lane cadence timestamps before the tracker call succeeds.
- Added a `TrackerIssueSummary` dispatch candidate type so lightweight Linear reads stay separate from full-detail issue records.
- Kept dispatch summaries lightweight by avoiding relation-page expansion; selected candidates are then reloaded through the project-scoped full-detail Linear lookup before launch.
- Skipped stale dispatch candidates that disappear or leave active states before workspace creation, prompt construction, or worker launch.
- Updated Linear and operations docs for the local polling model.

## Evidence

### Test output

```text
cargo test-system-duckdb --test scheduler
# 22 passed; 0 failed
# includes:
# - rate_limit_cooldown_skips_linear_reads_but_keeps_worker_updates_flowing
# - rate_limited_running_state_read_retries_after_cooldown
# - rate_limited_terminal_read_retries_after_cooldown
# - rate_limited_dispatch_discovery_retries_after_cooldown
# - dispatch_discovery_uses_sixty_second_cadence_and_selected_detail_reads
# - dispatch_discovery_skips_candidates_missing_or_inactive_after_detail_refresh
# - running_state_polling_uses_lightweight_state_refresh_interval

cargo test-system-duckdb --test linear_client
# 27 passed; 0 failed; 1 ignored
# includes candidate_issue_summaries_do_not_expand_relation_pages

cargo test-system-duckdb --test issue_session_runner
# 18 passed; 0 failed

cargo test-system-duckdb --test linear_client live_linear_client_reads_opensymphony_project -- --ignored --nocapture
# live candidate summaries fetched: 14
# live issue detail: COE-504 Done Linear Polling And Rate-Limit Recovery
# 1 passed; 0 failed

target/debug/opensymphony run --dry-run --config <mock config>
# mock-openhands /openapi.json -> 200
# mock-linear full issue read -> 200 empty states=['In Progress']
# mock-linear full issue read -> 200 empty states=['Done']
# mock-linear IssueSummariesByState #1 -> 429 Retry-After=2
# mock-linear IssueSummariesByState #2 -> 200 empty
# DEBUG retrying Linear GraphQL request attempt=1 delay_ms=2000 category=RateLimited
# INFO received shutdown signal
# opensymphony exit code: 0
# mock openhands probes observed: 1
# mock summary requests observed: 2

cargo fmt --check
# passed

git diff --check
# passed

cargo clippy-system-duckdb
# finished successfully
```

### Verification

Verified the Linear client no longer sleeps for long reset headers, short retry delays still retry, large configured `max_backoff` values cannot bypass the 30s inline cap, scheduler worker updates continue during Linear cooldown, failed Linear reads do not advance lane cadence timestamps before success, Linear discovery no longer runs every 5s, lightweight dispatch summaries do not expand relation pages or get reused as full issue details, selected dispatch detail reads are batched, stale summary candidates are skipped before launch, running-state refresh uses the lightweight by-ID path for running executions, live Linear reads can fetch COE-504 through the project-scoped detail path, and the actual `opensymphony run --dry-run` path exercises the mock Linear `Retry-After` retry flow.

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: Not applicable

## Breaking changes

None.

## Related issues

- COE-504: https://linear.app/trilogy-ai-coe/issue/COE-504/linear-polling-and-rate-limit-recovery

## Additional notes

Full `cargo test` was not run; focused Rust integration/unit test files, the live Linear client probe, the mock `opensymphony run --dry-run` cooldown evidence run, and the repo clippy alias passed. `AGENTS.md` was not updated because the repository operating rules did not change.
