### PR TITLE
Fix OpenHands agent-server interrupt adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ Do not silently invent behavior when the upstream spec or chosen integration con
 - Operations are REST. Runtime streaming is WebSocket.
 - The WebSocket readiness barrier is the first `ConversationStateUpdateEvent`.
 - Always reconcile events after WebSocket readiness and after reconnect.
+- Harness interrupts for OpenHands-backed runs use
+  `POST /api/conversations/{conversation_id}/interrupt` as the primary
+  mid-turn stop request. Use `POST /api/conversations/{conversation_id}/pause`
+  only as an older-server fallback when `/interrupt` is unavailable, and record
+  that fallback in diagnostics. Report acknowledgement only after
+  attach/reconcile observes a stopped state such as `paused`, or after the
+  configured timeout path records a timeout diagnostic.
 - One OpenHands conversation is reused per issue by default.
 - A fresh conversation gets the full workflow prompt. A resumed conversation gets continuation guidance only.
 - Local MVP uses one local agent-server subprocess shared across issues, not one server per issue.

--- a/crates/opensymphony-openhands/src/client.rs
+++ b/crates/opensymphony-openhands/src/client.rs
@@ -1070,11 +1070,12 @@ impl OpenHandsClient {
         &self,
         conversation_id: Uuid,
     ) -> Result<AcceptedResponse, OpenHandsError> {
+        let request = serde_json::json!({});
         let response = send(
             self.json_request(
                 self.post_request(&format!("/api/conversations/{conversation_id}/interrupt"))?,
                 "interrupt conversation",
-                &ConversationRunRequest::default(),
+                &request,
             )?,
             "interrupt conversation",
         )
@@ -1086,11 +1087,12 @@ impl OpenHandsClient {
         &self,
         conversation_id: Uuid,
     ) -> Result<AcceptedResponse, OpenHandsError> {
+        let request = serde_json::json!({});
         let response = send(
             self.json_request(
                 self.post_request(&format!("/api/conversations/{conversation_id}/pause"))?,
                 "pause conversation",
-                &ConversationRunRequest::default(),
+                &request,
             )?,
             "pause conversation",
         )

--- a/crates/opensymphony-openhands/src/client.rs
+++ b/crates/opensymphony-openhands/src/client.rs
@@ -1066,6 +1066,38 @@ impl OpenHandsClient {
         decode_accepted(response, "trigger conversation run").await
     }
 
+    pub async fn interrupt_conversation(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<AcceptedResponse, OpenHandsError> {
+        let response = send(
+            self.json_request(
+                self.post_request(&format!("/api/conversations/{conversation_id}/interrupt"))?,
+                "interrupt conversation",
+                &ConversationRunRequest::default(),
+            )?,
+            "interrupt conversation",
+        )
+        .await?;
+        decode_accepted(response, "interrupt conversation").await
+    }
+
+    pub async fn pause_conversation(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<AcceptedResponse, OpenHandsError> {
+        let response = send(
+            self.json_request(
+                self.post_request(&format!("/api/conversations/{conversation_id}/pause"))?,
+                "pause conversation",
+                &ConversationRunRequest::default(),
+            )?,
+            "pause conversation",
+        )
+        .await?;
+        decode_accepted(response, "pause conversation").await
+    }
+
     pub async fn search_events_page(
         &self,
         conversation_id: Uuid,

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -44,6 +44,7 @@ const OPENAI_SUBSCRIPTION_CREDENTIAL_MODE: &str = "openai_subscription";
 const OPENAI_CODEX_SUBSCRIPTION_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const DEFAULT_REUSE_POLICY: &str = "per_issue";
 const FRESH_EACH_RUN_REUSE_POLICY: &str = "fresh_each_run";
+const INTERRUPT_RECENT_EVENT_LIMIT: usize = 20;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IssueSessionReusePolicy {
@@ -1227,16 +1228,21 @@ impl IssueSessionRunner {
             Err(error) => return Err(error),
         };
 
+        // OpenHands exposes a broadcast runtime stream, so this short-lived
+        // acknowledgement attachment does not steal events from the main worker
+        // stream. The post-attach reconcile is the authoritative ack signal.
         let mut stream = self
             .client
             .attach_runtime_stream_with_recent_events(
                 conversation_id,
                 self.config.runtime_stream.clone(),
-                20,
+                INTERRUPT_RECENT_EVENT_LIMIT,
             )
             .await?;
         let deadline = Instant::now() + self.config.runtime_stream.readiness_timeout;
-        let mut reconciled_events = stream.reconcile_recent_events(20).await?;
+        let mut reconciled_events = stream
+            .reconcile_recent_events(INTERRUPT_RECENT_EVENT_LIMIT)
+            .await?;
         loop {
             if stream
                 .state_mirror()
@@ -1255,7 +1261,9 @@ impl IssueSessionRunner {
             match wait {
                 Ok(Ok(Some(_))) => {}
                 Ok(Ok(None)) | Ok(Err(_)) => {
-                    reconciled_events += stream.reconcile_recent_events(20).await?;
+                    reconciled_events += stream
+                        .reconcile_recent_events(INTERRUPT_RECENT_EVENT_LIMIT)
+                        .await?;
                 }
                 Err(_) => {
                     return Ok(OpenHandsInterruptAcknowledgement {
@@ -1278,7 +1286,9 @@ impl IssueSessionRunner {
                     });
                 }
             }
-            reconciled_events += stream.reconcile_recent_events(20).await?;
+            reconciled_events += stream
+                .reconcile_recent_events(INTERRUPT_RECENT_EVENT_LIMIT)
+                .await?;
         }
     }
 
@@ -4037,6 +4047,55 @@ mod tests {
                 .diagnostic
                 .as_deref()
                 .is_some_and(|diagnostic| diagnostic.contains("/interrupt unavailable"))
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupt_reports_timeout_when_reconciliation_never_stops() {
+        let server = FakeOpenHandsServer::start_with_config(FakeOpenHandsConfig {
+            initial_execution_status: "running",
+            interrupt_execution_status: "running",
+            ..FakeOpenHandsConfig::default()
+        })
+        .await
+        .expect("fake server should start");
+        let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+        let conversation = client
+            .create_conversation(&ConversationCreateRequest::doctor_probe(
+                "/tmp/opensymphony-live",
+                "/tmp/opensymphony-live/.opensymphony/openhands",
+                Some("fake-model".to_string()),
+                None,
+            ))
+            .await
+            .expect("conversation should be created");
+        let runner = IssueSessionRunner::new(
+            client,
+            IssueSessionRunnerConfig {
+                runtime_stream: RuntimeStreamConfig {
+                    readiness_timeout: Duration::from_millis(20),
+                    reconnect_initial_backoff: Duration::from_millis(25),
+                    reconnect_max_backoff: Duration::from_millis(25),
+                    max_reconnect_attempts: 1,
+                    replay_existing_events_on_attach: false,
+                },
+                ..IssueSessionRunnerConfig::default()
+            },
+        );
+
+        let acknowledgement = runner
+            .interrupt(&interrupt_command(conversation.conversation_id))
+            .await
+            .expect("timeout path should return a diagnostic acknowledgement");
+
+        assert_eq!(acknowledgement.method, OpenHandsInterruptMethod::Interrupt);
+        assert_eq!(acknowledgement.execution_status.as_deref(), Some("running"));
+        assert!(
+            acknowledgement
+                .diagnostic
+                .as_deref()
+                .is_some_and(|diagnostic| diagnostic
+                    .contains("timed out waiting for interrupt acknowledgement"))
         );
     }
 

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -1247,7 +1247,7 @@ impl IssueSessionRunner {
             if stream
                 .state_mirror()
                 .execution_status()
-                .is_some_and(turn_has_stopped)
+                .is_some_and(interrupt_acknowledgement_observed)
             {
                 return Ok(OpenHandsInterruptAcknowledgement {
                     method,
@@ -3077,11 +3077,15 @@ fn configured_persistence_dir(workflow: &ResolvedWorkflow, workspace: &Workspace
 }
 
 fn turn_is_in_progress(status: &str) -> bool {
-    !matches!(status, "idle" | "finished" | "error" | "stuck" | "paused")
+    !matches!(status, "idle" | "finished" | "error" | "stuck")
 }
 
 fn turn_has_stopped(status: &str) -> bool {
     !turn_is_in_progress(status)
+}
+
+fn interrupt_acknowledgement_observed(status: &str) -> bool {
+    status == "paused" || turn_has_stopped(status)
 }
 
 fn build_continuation_guidance(issue: &NormalizedIssue, run: &RunAttempt) -> String {

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use crate::opensymphony_domain::{
-    ConversationId, ConversationMetadata, DurationMs, HarnessAdapter, IssueId, IssueIdentifier,
-    NormalizedIssue, RunAttempt, RuntimeStreamState, TimestampMs, WorkerId, WorkerOutcomeKind,
-    WorkerOutcomeRecord,
+    ConversationId, ConversationMetadata, DurationMs, HarnessAdapter, HarnessInterruptCommand,
+    IssueId, IssueIdentifier, NormalizedIssue, RunAttempt, RuntimeStreamState, TimestampMs,
+    WorkerId, WorkerOutcomeKind, WorkerOutcomeRecord,
 };
 #[cfg(test)]
 use crate::opensymphony_domain::{RuntimeLivenessPhase, RuntimeProgressSnapshot};
@@ -98,6 +98,20 @@ pub struct WorkpadComment {
     pub id: String,
     pub body: String,
     pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenHandsInterruptMethod {
+    Interrupt,
+    PauseFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenHandsInterruptAcknowledgement {
+    pub method: OpenHandsInterruptMethod,
+    pub reconciled_events: usize,
+    pub execution_status: Option<String>,
+    pub diagnostic: Option<String>,
 }
 
 #[async_trait]
@@ -1181,6 +1195,91 @@ impl IssueSessionRunner {
 
     pub fn config(&self) -> &IssueSessionRunnerConfig {
         &self.config
+    }
+
+    pub async fn interrupt(
+        &self,
+        command: &HarnessInterruptCommand,
+    ) -> Result<OpenHandsInterruptAcknowledgement, OpenHandsError> {
+        let conversation_id =
+            Uuid::parse_str(command.conversation_id.as_str()).map_err(|error| {
+                OpenHandsError::InvalidConfiguration {
+                    detail: format!(
+                        "interrupt command conversation id `{}` is not a UUID: {error}",
+                        command.conversation_id
+                    ),
+                }
+            })?;
+
+        let (method, diagnostic) = match self.client.interrupt_conversation(conversation_id).await {
+            Ok(_) => (OpenHandsInterruptMethod::Interrupt, None),
+            Err(OpenHandsError::HttpStatus {
+                status_code, body, ..
+            }) if matches!(status_code, 404 | 405 | 501) => {
+                self.client.pause_conversation(conversation_id).await?;
+                (
+                    OpenHandsInterruptMethod::PauseFallback,
+                    Some(format!(
+                        "OpenHands /interrupt unavailable with HTTP {status_code}; fell back to /pause: {body}"
+                    )),
+                )
+            }
+            Err(error) => return Err(error),
+        };
+
+        let mut stream = self
+            .client
+            .attach_runtime_stream_with_recent_events(
+                conversation_id,
+                self.config.runtime_stream.clone(),
+                20,
+            )
+            .await?;
+        let deadline = Instant::now() + self.config.runtime_stream.readiness_timeout;
+        let mut reconciled_events = stream.reconcile_recent_events(20).await?;
+        loop {
+            if stream
+                .state_mirror()
+                .execution_status()
+                .is_some_and(turn_has_stopped)
+            {
+                return Ok(OpenHandsInterruptAcknowledgement {
+                    method,
+                    reconciled_events,
+                    execution_status: stream.state_mirror().execution_status().map(str::to_owned),
+                    diagnostic,
+                });
+            }
+
+            let wait = timeout_at(deadline, stream.next_event()).await;
+            match wait {
+                Ok(Ok(Some(_))) => {}
+                Ok(Ok(None)) | Ok(Err(_)) => {
+                    reconciled_events += stream.reconcile_recent_events(20).await?;
+                }
+                Err(_) => {
+                    return Ok(OpenHandsInterruptAcknowledgement {
+                        method,
+                        reconciled_events,
+                        execution_status: stream
+                            .state_mirror()
+                            .execution_status()
+                            .map(str::to_owned),
+                        diagnostic: Some(match diagnostic {
+                            Some(diagnostic) => format!(
+                                "{diagnostic}; timed out waiting for interrupt acknowledgement after {:?}",
+                                self.config.runtime_stream.readiness_timeout
+                            ),
+                            None => format!(
+                                "timed out waiting for interrupt acknowledgement after {:?}",
+                                self.config.runtime_stream.readiness_timeout
+                            ),
+                        }),
+                    });
+                }
+            }
+            reconciled_events += stream.reconcile_recent_events(20).await?;
+        }
     }
 
     pub async fn run(
@@ -2968,7 +3067,7 @@ fn configured_persistence_dir(workflow: &ResolvedWorkflow, workspace: &Workspace
 }
 
 fn turn_is_in_progress(status: &str) -> bool {
-    !matches!(status, "idle" | "finished" | "error" | "stuck")
+    !matches!(status, "idle" | "finished" | "error" | "stuck" | "paused")
 }
 
 fn turn_has_stopped(status: &str) -> bool {
@@ -3571,9 +3670,10 @@ mod tests {
     };
 
     use crate::opensymphony_domain::{
-        BlockerRef, IssueRef, IssueState, IssueStateCategory, WorkerOutcomeKind,
+        BlockerRef, ConversationId, HarnessInterruptExpectedNextState, HarnessInterruptReason,
+        IssueRef, IssueState, IssueStateCategory, WorkerOutcomeKind,
     };
-    use crate::opensymphony_testkit::FakeOpenHandsServer;
+    use crate::opensymphony_testkit::{FakeOpenHandsConfig, FakeOpenHandsServer};
     use axum::{Json, Router, extract::State, routing::post};
     use tokio::{net::TcpListener, sync::Mutex};
 
@@ -3845,6 +3945,111 @@ mod tests {
                 ]
             }
         }))
+    }
+
+    #[tokio::test]
+    async fn interrupt_acknowledges_after_reconciled_paused_state() {
+        let server = FakeOpenHandsServer::start_with_config(FakeOpenHandsConfig {
+            initial_execution_status: "running",
+            ..FakeOpenHandsConfig::default()
+        })
+        .await
+        .expect("fake server should start");
+        let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+        let conversation = client
+            .create_conversation(&ConversationCreateRequest::doctor_probe(
+                "/tmp/opensymphony-live",
+                "/tmp/opensymphony-live/.opensymphony/openhands",
+                Some("fake-model".to_string()),
+                None,
+            ))
+            .await
+            .expect("conversation should be created");
+        let runner = IssueSessionRunner::new(
+            client,
+            IssueSessionRunnerConfig {
+                runtime_stream: RuntimeStreamConfig {
+                    readiness_timeout: Duration::from_millis(500),
+                    reconnect_initial_backoff: Duration::from_millis(25),
+                    reconnect_max_backoff: Duration::from_millis(25),
+                    max_reconnect_attempts: 1,
+                    replay_existing_events_on_attach: false,
+                },
+                ..IssueSessionRunnerConfig::default()
+            },
+        );
+
+        let acknowledgement = runner
+            .interrupt(&interrupt_command(conversation.conversation_id))
+            .await
+            .expect("interrupt should acknowledge after reconciliation");
+
+        assert_eq!(acknowledgement.method, OpenHandsInterruptMethod::Interrupt);
+        assert_eq!(acknowledgement.execution_status.as_deref(), Some("paused"));
+        assert!(acknowledgement.diagnostic.is_none());
+    }
+
+    #[tokio::test]
+    async fn interrupt_falls_back_to_pause_when_interrupt_route_is_missing() {
+        let server = FakeOpenHandsServer::start_with_config(FakeOpenHandsConfig {
+            initial_execution_status: "running",
+            interrupt_supported: false,
+            ..FakeOpenHandsConfig::default()
+        })
+        .await
+        .expect("fake server should start");
+        let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+        let conversation = client
+            .create_conversation(&ConversationCreateRequest::doctor_probe(
+                "/tmp/opensymphony-live",
+                "/tmp/opensymphony-live/.opensymphony/openhands",
+                Some("fake-model".to_string()),
+                None,
+            ))
+            .await
+            .expect("conversation should be created");
+        let runner = IssueSessionRunner::new(
+            client,
+            IssueSessionRunnerConfig {
+                runtime_stream: RuntimeStreamConfig {
+                    readiness_timeout: Duration::from_millis(500),
+                    reconnect_initial_backoff: Duration::from_millis(25),
+                    reconnect_max_backoff: Duration::from_millis(25),
+                    max_reconnect_attempts: 1,
+                    replay_existing_events_on_attach: false,
+                },
+                ..IssueSessionRunnerConfig::default()
+            },
+        );
+
+        let acknowledgement = runner
+            .interrupt(&interrupt_command(conversation.conversation_id))
+            .await
+            .expect("pause fallback should acknowledge after reconciliation");
+
+        assert_eq!(
+            acknowledgement.method,
+            OpenHandsInterruptMethod::PauseFallback
+        );
+        assert_eq!(acknowledgement.execution_status.as_deref(), Some("paused"));
+        assert!(
+            acknowledgement
+                .diagnostic
+                .as_deref()
+                .is_some_and(|diagnostic| diagnostic.contains("/interrupt unavailable"))
+        );
+    }
+
+    fn interrupt_command(conversation_id: Uuid) -> HarnessInterruptCommand {
+        HarnessInterruptCommand {
+            run_id: "COE-489".to_string(),
+            issue_id: must(IssueId::new("issue-489")),
+            harness_kind: "openhands_agent_server".to_string(),
+            conversation_id: must(ConversationId::new(conversation_id.to_string())),
+            turn_id: None,
+            reason: HarnessInterruptReason::OperatorCancel,
+            expected_next_state: HarnessInterruptExpectedNextState::Paused,
+        }
     }
 
     #[tokio::test]

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -1258,12 +1258,13 @@ impl IssueSessionRunner {
             }
 
             let wait = timeout_at(deadline, stream.next_event()).await;
-            match wait {
-                Ok(Ok(Some(_))) => {}
+            let reconcile_after_event = match wait {
+                Ok(Ok(Some(_))) => true,
                 Ok(Ok(None)) | Ok(Err(_)) => {
                     reconciled_events += stream
                         .reconcile_recent_events(INTERRUPT_RECENT_EVENT_LIMIT)
                         .await?;
+                    false
                 }
                 Err(_) => {
                     return Ok(OpenHandsInterruptAcknowledgement {
@@ -1285,10 +1286,12 @@ impl IssueSessionRunner {
                         }),
                     });
                 }
+            };
+            if reconcile_after_event {
+                reconciled_events += stream
+                    .reconcile_recent_events(INTERRUPT_RECENT_EVENT_LIMIT)
+                    .await?;
             }
-            reconciled_events += stream
-                .reconcile_recent_events(INTERRUPT_RECENT_EVENT_LIMIT)
-                .await?;
         }
     }
 

--- a/crates/opensymphony-openhands/tests/client_resilience.rs
+++ b/crates/opensymphony-openhands/tests/client_resilience.rs
@@ -91,6 +91,14 @@ async fn query_param_api_key_authenticates_rest_and_websocket_operations() {
         .await
         .expect("run should carry auth");
     client
+        .interrupt_conversation(conversation.conversation_id)
+        .await
+        .expect("interrupt should carry auth");
+    client
+        .pause_conversation(conversation.conversation_id)
+        .await
+        .expect("pause should carry auth");
+    client
         .search_all_events(conversation.conversation_id)
         .await
         .expect("search should carry auth");
@@ -146,6 +154,10 @@ async fn header_api_key_with_websocket_query_fallback_authenticates_operations()
         .run_conversation(conversation.conversation_id)
         .await
         .expect("run should carry header auth");
+    client
+        .interrupt_conversation(conversation.conversation_id)
+        .await
+        .expect("interrupt should carry header auth");
 }
 
 #[tokio::test]
@@ -192,6 +204,47 @@ async fn path_prefixed_base_urls_preserve_rest_and_websocket_authentication() {
         .run_conversation(conversation.conversation_id)
         .await
         .expect("run should preserve the path prefix");
+    client
+        .interrupt_conversation(conversation.conversation_id)
+        .await
+        .expect("interrupt should preserve the path prefix");
+}
+
+#[tokio::test]
+async fn interrupt_and_pause_use_distinct_agent_server_routes() {
+    let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+    let server = TestServer::start(
+        Router::new()
+            .route(
+                "/api/conversations/{conversation_id}/interrupt",
+                post(record_interrupt),
+            )
+            .route(
+                "/api/conversations/{conversation_id}/pause",
+                post(record_pause),
+            )
+            .with_state(calls.clone()),
+    )
+    .await;
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()));
+    let conversation_id = Uuid::new_v4();
+
+    client
+        .interrupt_conversation(conversation_id)
+        .await
+        .expect("interrupt should use /interrupt");
+    client
+        .pause_conversation(conversation_id)
+        .await
+        .expect("pause fallback should use /pause");
+
+    assert_eq!(
+        *calls.lock().await,
+        vec![
+            format!("interrupt:{conversation_id}:{{}}"),
+            format!("pause:{conversation_id}:{{}}")
+        ]
+    );
 }
 
 #[tokio::test]
@@ -1376,6 +1429,14 @@ fn auth_router(expectations: AuthExpectations) -> Router {
             post(run_conversation),
         )
         .route(
+            "/api/conversations/{conversation_id}/interrupt",
+            post(interrupt_conversation),
+        )
+        .route(
+            "/api/conversations/{conversation_id}/pause",
+            post(pause_conversation),
+        )
+        .route(
             "/api/conversations/{conversation_id}/events/search",
             get(search_events),
         )
@@ -1445,6 +1506,26 @@ async fn run_conversation(
     Ok(Json(json!({ "success": true })))
 }
 
+async fn interrupt_conversation(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+) -> Result<Json<Value>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    Ok(Json(json!({ "success": true })))
+}
+
+async fn pause_conversation(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    Path(_conversation_id): Path<Uuid>,
+) -> Result<Json<Value>, StatusCode> {
+    ensure_expected_auth(&state.expectations.rest, &headers, &query)?;
+    Ok(Json(json!({ "success": true })))
+}
+
 async fn search_events(
     State(state): State<AuthState>,
     headers: HeaderMap,
@@ -1470,6 +1551,30 @@ async fn search_events(
         events: page,
         next_page_id,
     }))
+}
+
+async fn record_interrupt(
+    State(calls): State<Arc<Mutex<Vec<String>>>>,
+    Path(conversation_id): Path<Uuid>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    calls
+        .lock()
+        .await
+        .push(format!("interrupt:{conversation_id}:{body}"));
+    Json(json!({ "success": true }))
+}
+
+async fn record_pause(
+    State(calls): State<Arc<Mutex<Vec<String>>>>,
+    Path(conversation_id): Path<Uuid>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    calls
+        .lock()
+        .await
+        .push(format!("pause:{conversation_id}:{body}"));
+    Json(json!({ "success": true }))
 }
 
 async fn authenticated_readiness_socket(

--- a/crates/opensymphony-openhands/tests/live_pinned_server.rs
+++ b/crates/opensymphony-openhands/tests/live_pinned_server.rs
@@ -150,6 +150,35 @@ async fn live_pinned_server_rejects_missing_http_auth_and_wrong_websocket_auth()
 }
 
 #[tokio::test]
+async fn live_pinned_server_handles_interrupt_route() {
+    if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {
+        eprintln!("skipping live pinned-server test; set {LIVE_GATE_ENV}=1 to enable it");
+        return;
+    }
+
+    let server = PinnedServer::start(SESSION_API_KEY).await;
+    let workspace = TempDir::new().expect("workspace temp dir should be created");
+    let request = doctor_probe_request(workspace.path());
+
+    let client = OpenHandsClient::new(TransportConfig::new(server.base_url()).with_auth(
+        AuthConfig::header_api_key_with_websocket_query_fallback(
+            SESSION_API_KEY_HEADER,
+            SESSION_API_KEY_QUERY_PARAM,
+            SESSION_API_KEY,
+        ),
+    ));
+
+    let conversation = client
+        .create_conversation(&request)
+        .await
+        .expect("create conversation should authenticate");
+    client
+        .interrupt_conversation(conversation.conversation_id)
+        .await
+        .expect("pinned agent-server should handle /interrupt");
+}
+
+#[tokio::test]
 #[ignore = "requires a prepared local machine with live OpenHands credentials"]
 async fn live_pinned_server_condenses_long_history_without_prompt_overflow() {
     if env::var(LIVE_GATE_ENV).as_deref() != Ok("1") {

--- a/crates/opensymphony-testkit/src/lib.rs
+++ b/crates/opensymphony-testkit/src/lib.rs
@@ -34,6 +34,7 @@ pub struct FakeOpenHandsConfig {
     pub run_terminal_status: &'static str,
     pub initial_execution_status: &'static str,
     pub interrupt_supported: bool,
+    pub interrupt_execution_status: &'static str,
 }
 
 impl Default for FakeOpenHandsConfig {
@@ -43,6 +44,7 @@ impl Default for FakeOpenHandsConfig {
             run_terminal_status: "finished",
             initial_execution_status: "idle",
             interrupt_supported: true,
+            interrupt_execution_status: "paused",
         }
     }
 }
@@ -266,6 +268,7 @@ struct Inner {
     run_terminal_status: String,
     initial_execution_status: String,
     interrupt_supported: bool,
+    interrupt_execution_status: String,
     next_event_index: u64,
 }
 
@@ -304,6 +307,7 @@ impl FakeOpenHandsServer {
                 run_terminal_status: config.run_terminal_status.to_string(),
                 initial_execution_status: config.initial_execution_status.to_string(),
                 interrupt_supported: config.interrupt_supported,
+                interrupt_execution_status: config.interrupt_execution_status.to_string(),
                 next_event_index: 1,
             })),
         };
@@ -684,7 +688,8 @@ async fn interrupt_conversation(
     if !inner.interrupt_supported {
         return Err(StatusCode::NOT_FOUND);
     }
-    pause_conversation_inner(&mut inner, conversation_id)
+    let execution_status = inner.interrupt_execution_status.clone();
+    pause_conversation_inner(&mut inner, conversation_id, execution_status)
 }
 
 async fn pause_conversation(
@@ -692,12 +697,13 @@ async fn pause_conversation(
     Path(conversation_id): Path<Uuid>,
 ) -> Result<Json<Value>, StatusCode> {
     let mut inner = state.inner.lock().await;
-    pause_conversation_inner(&mut inner, conversation_id)
+    pause_conversation_inner(&mut inner, conversation_id, "paused".to_string())
 }
 
 fn pause_conversation_inner(
     inner: &mut Inner,
     conversation_id: Uuid,
+    execution_status: String,
 ) -> Result<Json<Value>, StatusCode> {
     let paused_event = EventEnvelope::new(
         next_event_id(inner),
@@ -705,9 +711,9 @@ fn pause_conversation_inner(
         "runtime",
         "ConversationStateUpdateEvent",
         json!({
-            "execution_status": "paused",
+            "execution_status": execution_status.clone(),
             "state_delta": {
-                "execution_status": "paused",
+                "execution_status": execution_status,
             },
         }),
     );

--- a/crates/opensymphony-testkit/src/lib.rs
+++ b/crates/opensymphony-testkit/src/lib.rs
@@ -33,6 +33,7 @@ pub struct FakeOpenHandsConfig {
     pub search_page_size: usize,
     pub run_terminal_status: &'static str,
     pub initial_execution_status: &'static str,
+    pub interrupt_supported: bool,
 }
 
 impl Default for FakeOpenHandsConfig {
@@ -41,6 +42,7 @@ impl Default for FakeOpenHandsConfig {
             search_page_size: 2,
             run_terminal_status: "finished",
             initial_execution_status: "idle",
+            interrupt_supported: true,
         }
     }
 }
@@ -263,6 +265,7 @@ struct Inner {
     search_page_size: usize,
     run_terminal_status: String,
     initial_execution_status: String,
+    interrupt_supported: bool,
     next_event_index: u64,
 }
 
@@ -300,6 +303,7 @@ impl FakeOpenHandsServer {
                 search_page_size: config.search_page_size,
                 run_terminal_status: config.run_terminal_status.to_string(),
                 initial_execution_status: config.initial_execution_status.to_string(),
+                interrupt_supported: config.interrupt_supported,
                 next_event_index: 1,
             })),
         };
@@ -318,6 +322,14 @@ impl FakeOpenHandsServer {
             .route(
                 "/api/conversations/{conversation_id}/run",
                 post(run_conversation),
+            )
+            .route(
+                "/api/conversations/{conversation_id}/interrupt",
+                post(interrupt_conversation),
+            )
+            .route(
+                "/api/conversations/{conversation_id}/pause",
+                post(pause_conversation),
             )
             .route(
                 "/api/conversations/{conversation_id}/events/search",
@@ -661,6 +673,49 @@ async fn run_conversation(
     apply_event_to_conversation(conversation, running_event);
     apply_event_to_conversation(conversation, completion_event);
     apply_event_to_conversation(conversation, finished_event);
+    Ok(Json(json!({ "success": true })))
+}
+
+async fn interrupt_conversation(
+    State(state): State<AppState>,
+    Path(conversation_id): Path<Uuid>,
+) -> Result<Json<Value>, StatusCode> {
+    let mut inner = state.inner.lock().await;
+    if !inner.interrupt_supported {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    pause_conversation_inner(&mut inner, conversation_id)
+}
+
+async fn pause_conversation(
+    State(state): State<AppState>,
+    Path(conversation_id): Path<Uuid>,
+) -> Result<Json<Value>, StatusCode> {
+    let mut inner = state.inner.lock().await;
+    pause_conversation_inner(&mut inner, conversation_id)
+}
+
+fn pause_conversation_inner(
+    inner: &mut Inner,
+    conversation_id: Uuid,
+) -> Result<Json<Value>, StatusCode> {
+    let paused_event = EventEnvelope::new(
+        next_event_id(inner),
+        Utc::now(),
+        "runtime",
+        "ConversationStateUpdateEvent",
+        json!({
+            "execution_status": "paused",
+            "state_delta": {
+                "execution_status": "paused",
+            },
+        }),
+    );
+    let conversation = inner
+        .conversations
+        .get_mut(&conversation_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    apply_event_to_conversation(conversation, paused_event);
     Ok(Json(json!({ "success": true })))
 }
 

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -7,6 +7,7 @@ OpenSymphony integrates with the OpenHands SDK agent-server surface from Rust.
 In scope:
 
 - conversation create/get/send/run
+- conversation interrupt, with pause as an older-server fallback only
 - event search
 - runtime event streaming over WebSocket
 - workspace-aware conversation launch
@@ -136,6 +137,14 @@ The internal `opensymphony_openhands` module owns:
 - WebSocket attach/reconcile/reconnect behavior
 - ready-state detection
 - issue session launch and reuse
+
+Harness interrupt uses `POST /api/conversations/{id}/interrupt` as the primary
+mid-turn stop request. If an older agent-server returns a missing-route status
+for that endpoint, the adapter falls back to `POST /api/conversations/{id}/pause`
+and records that fallback in acknowledgement diagnostics. The adapter reports
+acknowledgement only after it reattaches/reconciles runtime state and observes a
+stopped conversation status such as `paused`, or after the configured readiness
+timeout path records a timeout diagnostic.
 
 For reused conversations that are already `queued` or `running`, the runtime now
 surfaces launch metadata immediately after a successful attach so the


### PR DESCRIPTION
## Summary

Wire OpenHands harness interruption to the agent-server `/interrupt` endpoint, with `/pause` retained only as an older-server fallback.

## Changes

- Add explicit OpenHands REST client methods for `/interrupt` and `/pause` using empty JSON request bodies.
- Add `IssueSessionRunner::interrupt` to prefer `/interrupt`, record fallback diagnostics, and wait for reconciled stopped runtime state or timeout diagnostics before acknowledgement.
- Keep `paused` scoped to interrupt acknowledgement only, leaving the global turn lifecycle stopped predicate unchanged.
- Extend fake OpenHands server and tests for request shape, auth/path-prefix coverage, successful acknowledgement, fallback handling, and timeout diagnostics.
- Add a gated live pinned-server test that creates a real conversation and calls the real `/interrupt` route.
- Document the supported OpenHands interrupt contract in `docs/openhands-agent-server.md` and `AGENTS.md`.

## Evidence

### Test output

```
OPENSYMPHONY_LIVE_OPENHANDS=1 cargo test-system-duckdb live_pinned_server_handles_interrupt_route --test live_pinned_server -- --nocapture
# 1 passed; real pinned server created conversation 0950791c-5f10-469a-b4e6-b19e5153e5bb and POST /api/conversations/.../interrupt returned HTTP 200

cargo test-system-duckdb --test client_resilience
# 24 passed; 0 failed

cargo test-system-duckdb interrupt_ --lib
# 12 passed; 0 failed

cargo test-system-duckdb openhands --lib
# 125 passed; 0 failed

cargo clippy-system-duckdb
# Finished dev profile successfully

cargo fmt --check
# passed

git diff --check
# passed
```

Pinned local agent-server route probe also confirmed the OpenAPI contract:

```
OPENHANDS_SERVER_PORT=18765 OPENHANDS_SUPPRESS_BANNER=1 tools/openhands-server/run-local.sh

curl -fsS http://127.0.0.1:18765/openapi.json >/tmp/openhands-openapi.json
jq -r '.paths | keys[]' /tmp/openhands-openapi.json | rg 'interrupt|pause'
# /api/conversations/{conversation_id}/interrupt
# /api/conversations/{conversation_id}/pause
```

### Verification

Reproduction before the change: source inspection showed `OpenHandsClient` had create/get/send/run/search methods but no interrupt method, and the OpenHands runner had no concrete interrupt acknowledgement helper. The new tests assert `/interrupt` is the primary route, `/pause` remains distinct, fallback diagnostics are recorded when `/interrupt` is unavailable, timeout diagnostics are returned when reconciliation never observes a stopped state, and acknowledgement observes `paused` only in the interrupt-specific path. The gated live pinned-server test verifies the real runtime creates a conversation and handles `/interrupt` with HTTP 200.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

COE-489

## Additional notes

The `paused` state is accepted only for interrupt acknowledgement because the desktop run detail operations spec records that agent-server `/interrupt` transitions the conversation to paused. General runner lifecycle predicates still treat `paused` as in-progress/resumable unless another terminal status appears.
