### PR TITLE
Route gateway cancels to harness interrupts

### DIFF
--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -10,12 +10,14 @@ use std::{
 };
 
 use crate::opensymphony_control::{RecentEvent, RecentEventKind, SnapshotStore};
-use crate::opensymphony_domain::TimestampMs;
+use crate::opensymphony_domain::{InMemoryEventJournal, StreamBroker, TimestampMs};
 use crate::opensymphony_gateway::{GatewayServer, LinearTaskGraphClient};
+use crate::opensymphony_gateway_schema::event_journal::{EventKind, EventRecord};
 use crate::opensymphony_linear::LinearError;
 use crate::opensymphony_openhands::OpenHandsError;
 use crate::opensymphony_orchestrator::{
     IssueStateCategory, OrchestratorSnapshot, Scheduler, SchedulerConfig, SchedulerError,
+    TrackerBackend, WorkerBackend, WorkspaceBackend,
 };
 use crate::opensymphony_workspace::WorkspaceError;
 use chrono::{DateTime, Utc};
@@ -255,9 +257,13 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     let listener = TcpListener::bind(runtime.bind)
         .await
         .map_err(RunCommandError::BindListener)?;
-    let server = GatewayServer::new(store.clone())
-        .with_linear_task_graph(build_optional_task_graph_client(&runtime.workflow));
+    let gateway_journal = InMemoryEventJournal::new(10_000, 256);
+    let gateway_broker = StreamBroker::new(gateway_journal.clone());
+    let server =
+        GatewayServer::with_journal(store.clone(), gateway_journal.clone(), gateway_broker)
+            .with_linear_task_graph(build_optional_task_graph_client(&runtime.workflow));
     let mut server_task = tokio::spawn(async move { server.serve(listener).await });
+    let mut gateway_action_cursor = 0;
 
     let bootstrap_snapshot = tokio::select! {
         _ = tokio::signal::ctrl_c() => {
@@ -332,7 +338,16 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
             result = async {
                 ticker.tick().await;
                 let observed_at = now_timestamp();
-                (observed_at, scheduler.tick(observed_at).await)
+                let result = match apply_gateway_action_events(
+                    &mut scheduler,
+                    &gateway_journal,
+                    &mut gateway_action_cursor,
+                    observed_at,
+                ).await {
+                    Ok(()) => scheduler.tick(observed_at).await,
+                    Err(error) => Err(error),
+                };
+                (observed_at, result)
             } => {
                 let (observed_at, result) = result;
                 match result {
@@ -423,6 +438,44 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     }
 
     Ok(())
+}
+
+async fn apply_gateway_action_events<T, W, M>(
+    scheduler: &mut Scheduler<T, W, M>,
+    journal: &InMemoryEventJournal,
+    cursor: &mut u64,
+    observed_at: TimestampMs,
+) -> Result<(), SchedulerError>
+where
+    T: TrackerBackend,
+    W: WorkspaceBackend,
+    M: WorkerBackend,
+{
+    for event in journal.all_events().await {
+        if event.sequence <= *cursor {
+            continue;
+        }
+        *cursor = event.sequence;
+        let Some(target) = gateway_cancel_target(&event) else {
+            continue;
+        };
+        scheduler
+            .interrupt_operator_cancel(target, observed_at)
+            .await?;
+    }
+    Ok(())
+}
+
+fn gateway_cancel_target(event: &EventRecord) -> Option<&str> {
+    match &event.kind {
+        EventKind::GatewayActionDispatched { action } if action == "cancel" => {}
+        _ => return None,
+    }
+    let payload = event.payload.as_ref()?;
+    if payload["status"] != "accepted" {
+        return None;
+    }
+    payload["target_entity"]["id"].as_str()
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -455,13 +455,15 @@ where
         if event.sequence <= *cursor {
             continue;
         }
-        *cursor = event.sequence;
+        let sequence = event.sequence;
         let Some(target) = gateway_cancel_target(&event) else {
+            *cursor = sequence;
             continue;
         };
         scheduler
             .interrupt_operator_cancel(target, observed_at)
             .await?;
+        *cursor = sequence;
     }
     Ok(())
 }

--- a/crates/opensymphony-cli/tests/run.rs
+++ b/crates/opensymphony-cli/tests/run.rs
@@ -1,6 +1,6 @@
 use std::{process::Stdio, time::Duration};
 
-use crate::opensymphony_testkit::FakeOpenHandsServer;
+use crate::opensymphony_testkit::{FakeOpenHandsConfig, FakeOpenHandsServer};
 use crate::{
     opensymphony_domain::{ConversationId, IssueId, IssueIdentifier},
     opensymphony_openhands::IssueConversationManifest,
@@ -181,6 +181,57 @@ async fn run_recovers_human_review_worker_and_interrupts_when_tracker_reports_me
         "run command should call the OpenHands /interrupt route exactly once"
     );
     println!("fake OpenHands interrupt requests: {interrupt_requests}");
+
+    terminate_child(&mut child).await;
+}
+
+#[tokio::test]
+async fn run_dispatches_gateway_cancel_to_openhands_interrupt() {
+    let openhands = FakeOpenHandsServer::start_with_config(FakeOpenHandsConfig {
+        run_terminal_status: "running",
+        ..Default::default()
+    })
+    .await
+    .expect("fake OpenHands server should start");
+    let linear = MockLinearGraphqlServer::start_with_active_issue().await;
+    let project = TempDir::new().expect("temp project should exist");
+    let bind_addr = reserve_socket_addr();
+
+    write_project_files_with_workflow_extra(
+        project.path(),
+        linear.base_url(),
+        openhands.base_url(),
+        format!("control_plane:\n  bind: {bind_addr}\nlinear:\n  enabled: false\n"),
+        "polling:\n  interval_ms: 50\n",
+    );
+    write_memory_config(project.path());
+
+    let mut child = spawn_run_child(project.path(), &[]);
+    let gateway_base = format!("http://{bind_addr}");
+    wait_for_running_issue(&format!("{gateway_base}/api/v1/snapshot"), "COE-429")
+        .await
+        .expect("run command should expose a running issue before cancel");
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_base}/api/v1/actions/dispatch"))
+        .json(&json!({
+            "schema_version": { "major": 1, "minor": 0, "patch": 0 },
+            "correlation_id": "corr_cancel_gateway_to_harness",
+            "action_kind": "cancel",
+            "target_entity": {
+                "entity_kind": "run",
+                "entity_id": "COE-429"
+            },
+            "idempotency_key": "cancel-COE-429"
+        }))
+        .send()
+        .await
+        .expect("cancel action should be posted");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    wait_for_openhands_interrupt(&openhands)
+        .await
+        .expect("gateway cancel should reach fake OpenHands interrupt");
 
     terminate_child(&mut child).await;
 }
@@ -486,6 +537,33 @@ async fn wait_for_dry_run_route_decision(url: &str) -> Result<(), String> {
     ))
 }
 
+async fn wait_for_running_issue(url: &str, identifier: &str) -> Result<(), String> {
+    let client = reqwest::Client::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if let Ok(response) = client.get(url).send().await
+            && response.status().is_success()
+            && let Ok(snapshot) = response.json::<Value>().await
+            && issue_runtime_state_visible(&snapshot, identifier, "running")
+        {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    Err(format!("timed out waiting for running issue at {url}"))
+}
+
+async fn wait_for_openhands_interrupt(openhands: &FakeOpenHandsServer) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if openhands.total_interrupt_request_count().await == 1 {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    Err("timed out waiting for fake OpenHands interrupt request".to_string())
+}
+
 async fn wait_for_merging_supersede_event(url: &str) -> Result<Value, String> {
     let client = reqwest::Client::new();
     let deadline = Instant::now() + Duration::from_secs(45);
@@ -502,6 +580,17 @@ async fn wait_for_merging_supersede_event(url: &str) -> Result<Value, String> {
     Err(format!(
         "timed out waiting for Merging supersede event at {url}"
     ))
+}
+
+fn issue_runtime_state_visible(envelope: &Value, identifier: &str, state: &str) -> bool {
+    envelope["snapshot"]["issues"]
+        .as_array()
+        .and_then(|issues| {
+            issues
+                .iter()
+                .find(|issue| issue["identifier"] == identifier)
+        })
+        .is_some_and(|issue| issue["runtime_state"] == state)
 }
 
 fn print_merging_supersede_evidence(envelope: &Value) {

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -1240,7 +1240,8 @@ where
                     execution.observe_runtime_event(
                         observed_at,
                         Some(format!(
-                            "tracker-merging-interrupt-acknowledged-{}",
+                            "{}-interrupt-acknowledged-{}",
+                            reason.as_str(),
                             observed_at.as_u64()
                         )),
                         Some("scheduler.interrupt_acknowledged".to_string()),

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -585,6 +585,53 @@ where
         Ok(self.snapshot(observed_at))
     }
 
+    pub async fn interrupt_operator_cancel(
+        &mut self,
+        target: &str,
+        observed_at: TimestampMs,
+    ) -> Result<bool, SchedulerError> {
+        let Some((issue_id, mut execution, run, harness_kind)) =
+            self.operator_cancel_candidate(target)
+        else {
+            return Ok(false);
+        };
+
+        let (command, queued) = execution.request_interrupt(
+            harness_kind,
+            None,
+            HarnessInterruptReason::OperatorCancel,
+            HarnessInterruptExpectedNextState::Paused,
+            observed_at,
+        )?;
+
+        if queued {
+            execution.observe_runtime_event(
+                observed_at,
+                Some(format!(
+                    "operator-cancel-interrupt-{}",
+                    observed_at.as_u64()
+                )),
+                Some("scheduler.interrupt_requested".to_string()),
+                Some("Operator cancel requested: operator_cancel".to_string()),
+                Some(serde_json::json!({
+                    "reason": HarnessInterruptReason::OperatorCancel.as_str(),
+                    "worker_id": run.worker_id.as_str(),
+                    "target": target,
+                })),
+            )?;
+            let result = self.worker.interrupt_worker(command).await;
+            Self::apply_interrupt_result(
+                &mut execution,
+                HarnessInterruptReason::OperatorCancel,
+                observed_at,
+                result,
+            )?;
+        }
+
+        self.insert_execution(issue_id, execution);
+        Ok(true)
+    }
+
     pub async fn run_until_shutdown<F>(&mut self, shutdown: F) -> Result<(), SchedulerError>
     where
         F: Future<Output = ()>,
@@ -1056,7 +1103,12 @@ where
         )?;
         if let Some(command) = command {
             let result = self.worker.interrupt_worker(command).await;
-            Self::apply_merging_interrupt_result(&mut execution, observed_at, result)?;
+            Self::apply_interrupt_result(
+                &mut execution,
+                HarnessInterruptReason::TrackerMergingSupersedesHumanReview,
+                observed_at,
+                result,
+            )?;
         }
 
         self.insert_execution(issue_id, execution);
@@ -1100,6 +1152,40 @@ where
         Some((issue_id, execution, run, harness_kind))
     }
 
+    fn operator_cancel_candidate(
+        &self,
+        target: &str,
+    ) -> Option<(IssueId, IssueExecution, RunAttempt, String)> {
+        let (issue_id, execution) = self.executions.iter().find(|(_, execution)| {
+            execution
+                .issue()
+                .identifier
+                .as_str()
+                .eq_ignore_ascii_case(target)
+                || execution
+                    .current_run()
+                    .is_some_and(|run| run.issue_identifier.as_str().eq_ignore_ascii_case(target))
+                || execution
+                    .conversation()
+                    .is_some_and(|conversation| conversation.conversation_id.as_str() == target)
+        })?;
+        if !matches!(
+            execution.status(),
+            SchedulerStatus::Claimed | SchedulerStatus::Running
+        ) {
+            return None;
+        }
+
+        let execution = execution.clone();
+        let run = execution.current_run().cloned()?;
+        let harness_kind = self
+            .worker_metadata
+            .get(&run.worker_id)
+            .and_then(|metadata| metadata.harness_kind.clone())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        Some((issue_id.clone(), execution, run, harness_kind))
+    }
+
     fn prepare_merging_interrupt(
         execution: &mut IssueExecution,
         issue: &NormalizedIssue,
@@ -1141,8 +1227,9 @@ where
         Ok(Some(command))
     }
 
-    fn apply_merging_interrupt_result(
+    fn apply_interrupt_result(
         execution: &mut IssueExecution,
+        reason: HarnessInterruptReason,
         observed_at: TimestampMs,
         result: Result<WorkerInterruptAcknowledgement, M::Error>,
     ) -> Result<(), SchedulerError> {
@@ -1159,7 +1246,7 @@ where
                         Some("scheduler.interrupt_acknowledged".to_string()),
                         Some(detail),
                         Some(serde_json::json!({
-                            "reason": HarnessInterruptReason::TrackerMergingSupersedesHumanReview.as_str(),
+                            "reason": reason.as_str(),
                         })),
                     )?;
                 }

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -755,7 +755,13 @@ async fn operator_cancel_interrupts_active_worker_once() {
         ..Default::default()
     };
     let workspace = FakeWorkspace::default();
-    let worker = FakeWorker::default();
+    let mut worker = FakeWorker::default();
+    worker
+        .interrupt_results
+        .push_back(Ok(WorkerInterruptAcknowledgement {
+            accepted: true,
+            detail: Some("operator cancel acknowledged".to_string()),
+        }));
     let mut config = scheduler_config();
     config.stall_timeout_ms = None;
     let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
@@ -793,6 +799,19 @@ async fn operator_cancel_interrupts_active_worker_once() {
             .recent_activity
             .iter()
             .any(|event| event.summary.contains("operator_cancel"))
+    );
+    let activity_ids: Vec<_> = execution
+        .conversation()
+        .expect("conversation should remain attached")
+        .recent_activity
+        .iter()
+        .map(|event| event.event_id.as_str())
+        .collect();
+    assert!(
+        activity_ids
+            .iter()
+            .any(|event_id| event_id.starts_with("operator_cancel-interrupt-acknowledged-")),
+        "operator cancel acknowledgement should use a reason-specific event id; activity IDs: {activity_ids:?}"
     );
 
     scheduler

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -749,6 +749,60 @@ async fn running_state_polling_uses_lightweight_state_refresh_interval() {
 }
 
 #[tokio::test]
+async fn operator_cancel_interrupts_active_worker_once() {
+    let tracker = FakeTracker {
+        active: vec![tracker_issue("lin-493", "COE-493", "In Progress", 0)],
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace::default();
+    let worker = FakeWorker::default();
+    let mut config = scheduler_config();
+    config.stall_timeout_ms = None;
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, config);
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("startup full refresh should dispatch active worker");
+
+    assert!(
+        scheduler
+            .interrupt_operator_cancel("COE-493", ts(200))
+            .await
+            .expect("operator cancel should be handled")
+    );
+
+    assert_eq!(scheduler.worker().interrupts.len(), 1);
+    assert_eq!(
+        scheduler.worker().interrupts[0].reason,
+        HarnessInterruptReason::OperatorCancel
+    );
+    let execution = scheduler
+        .execution(&IssueId::new("lin-493").expect("issue id should be valid"))
+        .expect("execution should still be tracked");
+    let interrupt = execution.interrupt().expect("interrupt should be recorded");
+    assert_eq!(interrupt.status, HarnessInterruptStatus::Acknowledged);
+    assert_eq!(
+        interrupt.command.reason,
+        HarnessInterruptReason::OperatorCancel
+    );
+    assert!(
+        execution
+            .conversation()
+            .expect("conversation should remain attached")
+            .recent_activity
+            .iter()
+            .any(|event| event.summary.contains("operator_cancel"))
+    );
+
+    scheduler
+        .interrupt_operator_cancel("COE-493", ts(300))
+        .await
+        .expect("repeated operator cancel should be idempotent");
+    assert_eq!(scheduler.worker().interrupts.len(), 1);
+}
+
+#[tokio::test]
 async fn merging_supersedes_human_review_polling_once_and_continues_same_issue() {
     let tracker = FakeTracker {
         active: vec![tracker_issue("lin-492", "COE-492", "Human Review", 0)],

--- a/crates/opensymphony-testkit/src/lib.rs
+++ b/crates/opensymphony-testkit/src/lib.rs
@@ -421,6 +421,11 @@ impl FakeOpenHandsServer {
             .unwrap_or_default()
     }
 
+    pub async fn total_interrupt_request_count(&self) -> usize {
+        let inner = self.state.inner.lock().await;
+        inner.interrupt_requests.values().sum()
+    }
+
     pub async fn fail_next_conversation_gets(
         &self,
         conversation_id: Uuid,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,6 +245,11 @@ harness interrupt. Harness adapters later translate that command to their
 native protocol, but scheduler state does not depend on desktop-local state or
 adapter-private DTOs.
 
+`opensymphony run` consumes accepted gateway `cancel` actions from the gateway
+event journal and forwards them into the scheduler-owned `operator_cancel`
+interrupt path. The gateway validates and records the operator intent, but it
+does not mutate scheduling state directly.
+
 Run Detail diagnostics surface the orchestrator-owned cancel state as
 requested, acknowledged, failed, timed out, and reason fields. Terminal cancel
 states are sticky: late acknowledgements, failures, or timeouts do not overwrite


### PR DESCRIPTION
## Summary

Routes accepted desktop/gateway cancel actions from `opensymphony run` into the scheduler-owned harness interrupt path, with focused integration coverage for COE-493.

## Changes

- Added a scheduler `operator_cancel` interrupt path that targets active claimed/running executions and records scheduler-owned diagnostics.
- Wired `opensymphony run` to consume accepted gateway cancel events from the gateway event journal before scheduler ticks.
- Preserved accepted cancel events until the scheduler successfully handles them, so transient interrupt handoff errors do not drop operator cancel intent.
- Made shared interrupt acknowledgement diagnostics reason-specific so operator-cancel acknowledgements are not labelled as tracker-merging events.
- Added focused integration/regression coverage for gateway cancel reaching fake OpenHands, Human Review to Merging interrupt behavior, desktop Run Detail smoke coverage, and launcher aliases.
- Documented that gateway cancel events record operator intent while scheduler remains the state mutation boundary.

## Evidence

### Test output

```
cargo fmt --check
# passed

cargo test-system-duckdb --test run run_dispatches_gateway_cancel_to_openhands_interrupt
# test result: ok. 1 passed; 0 failed; 6 filtered out

cargo test-system-duckdb --test run run_recovers_human_review_worker_and_interrupts_when_tracker_reports_merging
# test result: ok. 1 passed; 0 failed; 6 filtered out

cargo test-system-duckdb --test scheduler operator_cancel_interrupts_active_worker_once
# test result: ok. 1 passed; 0 failed; 25 filtered out

cargo test-system-duckdb --test scheduler merging_supersedes_human_review_polling_once_and_continues_same_issue
# test result: ok. 1 passed; 0 failed; 25 filtered out

cargo test-system-duckdb --test scheduler recovered_human_review_run_uses_restored_harness_kind_for_merging_interrupt
# test result: ok. 1 passed; 0 failed; 25 filtered out

cargo test-system-duckdb app_and_desktop_alias_parse_to_same_command
# test result: ok. 1 passed; 0 failed; 625 filtered out

cargo test-system-duckdb local_bundle_materializes_and_verifies_from_manifest
# test result: ok. 1 passed; 0 failed; 625 filtered out

cargo test-system-duckdb --test gateway gateway_serves_run_detail_cancel_diagnostics
# test result: ok. 1 passed; 0 failed; 53 filtered out

npx jest --config jest.config.js --runTestsByPath packages/ui-core/__tests__/run-actions.test.ts packages/ui-core/__tests__/run-detail-views.test.ts apps/desktop/__tests__/app-shell-render.test.ts --runInBand
# Test Suites: 3 passed, 3 total
# Tests: 40 passed, 40 total

npm run type-check
# tsc --build tsconfig.projects.json passed

git diff --check
# passed

cargo clippy-system-duckdb
# Finished `dev` profile
```

Latest local review-fix validation on `edf7ebe`:

```
cargo fmt --check
cargo test-system-duckdb --test scheduler operator_cancel_interrupts_active_worker_once
cargo test-system-duckdb --test scheduler merging_supersedes_human_review_polling_once_and_continues_same_issue
cargo test-system-duckdb --test run run_dispatches_gateway_cancel_to_openhands_interrupt
git diff --check
cargo clippy-system-duckdb
# all passed
```

GitHub Actions after prior PR push:

```
typescript: SUCCESS
rust: SUCCESS
openhands-review: SUCCESS
```

### Verification

The new `run_dispatches_gateway_cancel_to_openhands_interrupt` test starts `opensymphony run` against fake Linear and fake OpenHands, posts a gateway cancel action, and waits until the fake OpenHands interrupt endpoint receives the interrupt request. The scheduler operator-cancel test asserts the interrupt is acknowledged once and that acknowledgement diagnostics use an `operator_cancel` event ID. Existing and focused regression tests cover Human Review to Merging supersede diagnostics, Run Detail cancel diagnostics, desktop Run Detail action/TUI parity, and `opensymphony app`/`opensymphony desktop` launcher parsing and bundle materialization.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

COE-493

## Additional notes

This keeps the gateway as an event/validation boundary and routes scheduling state changes through the scheduler.
