### PR TITLE
Expose memory graph DTOs and endpoints

### DIFF
--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -259,7 +259,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         .map_err(RunCommandError::BindListener)?;
     let gateway_journal = InMemoryEventJournal::new(10_000, 256);
     let gateway_broker = StreamBroker::new(gateway_journal.clone());
-    let gateway_memory_config = if runtime.memory.server.is_some() {
+    let gateway_memory_config = if runtime.memory.server.is_some() || runtime.memory.auto_capture {
         Some(crate::opensymphony_memory::MemoryConfig::load(
             &runtime.target_repo,
             None,
@@ -267,10 +267,15 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     } else {
         None
     };
+    let server_memory_config = if runtime.memory.server.is_some() {
+        gateway_memory_config.clone()
+    } else {
+        None
+    };
     let server =
         GatewayServer::with_journal(store.clone(), gateway_journal.clone(), gateway_broker)
             .with_linear_task_graph(build_optional_task_graph_client(&runtime.workflow))
-            .with_memory_config(gateway_memory_config);
+            .with_memory_config(server_memory_config);
     let mut server_task = tokio::spawn(async move { server.serve(listener).await });
     let mut gateway_action_cursor = 0;
 
@@ -409,6 +414,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                                     supervisor: &mut supervisor,
                                     agent_server_base_url: client.base_url(),
                                     memory_server: memory_server.as_ref(),
+                                    memory_config: gateway_memory_config.as_ref(),
                                     recent_events: &mut recent_events,
                                     store: &store,
                                 },
@@ -570,8 +576,10 @@ async fn publish_auto_capture_event(
     journal: &InMemoryEventJournal,
     context: SnapshotPublishContext<'_>,
 ) {
-    if should_publish_memory_graph_update(&result) {
-        match append_memory_graph_updated_event(journal, &context.runtime.target_repo).await {
+    if should_publish_memory_graph_update(&result)
+        && let Some(config) = context.memory_config
+    {
+        match append_memory_graph_updated_event(journal, config).await {
             Ok(_) => {}
             Err(error) => {
                 warn!(%error, "failed to publish memory graph update event");
@@ -604,19 +612,20 @@ async fn publish_auto_capture_event(
 fn should_publish_memory_graph_update(
     result: &Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
 ) -> bool {
-    result
-        .as_ref()
-        .is_ok_and(|report| report.capture_completed && !report.captured_issue_keys.is_empty())
+    result.as_ref().is_ok_and(|report| {
+        report.capture_completed
+            && (!report.captured_issue_keys.is_empty()
+                || !report.archived_issue_keys.is_empty()
+                || !report.docs_written.is_empty())
+    })
 }
 
 async fn append_memory_graph_updated_event(
     journal: &InMemoryEventJournal,
-    repo_root: &std::path::Path,
+    config: &crate::opensymphony_memory::MemoryConfig,
 ) -> Result<EventRecord, String> {
-    let config = crate::opensymphony_memory::MemoryConfig::load(repo_root, None)
-        .map_err(|error| error.to_string())?;
     let update = crate::opensymphony_memory::memory_graph_updated_event(
-        &config,
+        config,
         crate::opensymphony_memory::DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
         crate::opensymphony_memory::MemoryGraphAccess::AllAccessible,
     )
@@ -648,6 +657,7 @@ struct SnapshotPublishContext<'a> {
     supervisor: &'a mut Option<crate::opensymphony_openhands::LocalServerSupervisor>,
     agent_server_base_url: &'a str,
     memory_server: Option<&'a super::memory::MemoryServerHandle>,
+    memory_config: Option<&'a crate::opensymphony_memory::MemoryConfig>,
     recent_events: &'a mut VecDeque<RecentEvent>,
     store: &'a SnapshotStore,
 }
@@ -903,6 +913,20 @@ mod tests {
             ..super::super::memory::AutoMemoryReport::default()
         });
         assert!(!should_publish_memory_graph_update(&no_write));
+
+        let archived = Ok(super::super::memory::AutoMemoryReport {
+            archived_issue_keys: vec!["COE-2".to_string()],
+            capture_completed: true,
+            ..super::super::memory::AutoMemoryReport::default()
+        });
+        assert!(should_publish_memory_graph_update(&archived));
+
+        let docs_synced = Ok(super::super::memory::AutoMemoryReport {
+            docs_written: vec![PathBuf::from("docs/memory.md")],
+            capture_completed: true,
+            ..super::super::memory::AutoMemoryReport::default()
+        });
+        assert!(should_publish_memory_graph_update(&docs_synced));
 
         let failed = Err(MemoryError::InvalidInput("capture failed".to_string()));
         assert!(!should_publish_memory_graph_update(&failed));

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::opensymphony_control::{RecentEvent, RecentEventKind, SnapshotStore};
 use crate::opensymphony_domain::{InMemoryEventJournal, StreamBroker, TimestampMs};
 use crate::opensymphony_gateway::{GatewayServer, LinearTaskGraphClient};
-use crate::opensymphony_gateway_schema::event_journal::{EventKind, EventRecord};
+use crate::opensymphony_gateway_schema::event_journal::{EventActor, EventKind, EventRecord};
 use crate::opensymphony_linear::LinearError;
 use crate::opensymphony_openhands::OpenHandsError;
 use crate::opensymphony_orchestrator::{
@@ -403,6 +403,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                             publish_auto_capture_event(
                                 auto_capture_result,
                                 &snapshot,
+                                &gateway_journal,
                                 SnapshotPublishContext {
                                     runtime: &runtime,
                                     supervisor: &mut supervisor,
@@ -566,8 +567,25 @@ async fn start_runtime_memory_server(
 async fn publish_auto_capture_event(
     result: Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
     snapshot: &OrchestratorSnapshot,
+    journal: &InMemoryEventJournal,
     context: SnapshotPublishContext<'_>,
 ) {
+    if should_publish_memory_graph_update(&result) {
+        match append_memory_graph_updated_event(journal, &context.runtime.target_repo).await {
+            Ok(_) => {}
+            Err(error) => {
+                warn!(%error, "failed to publish memory graph update event");
+                push_recent_event(
+                    context.recent_events,
+                    RecentEventKind::Warning,
+                    None,
+                    format!("memory graph update event publish failed: {error}"),
+                    Utc::now(),
+                );
+            }
+        }
+    }
+
     if record_auto_capture_recent_event(context.recent_events, result) {
         context
             .store
@@ -581,6 +599,48 @@ async fn publish_auto_capture_event(
             ))
             .await;
     }
+}
+
+fn should_publish_memory_graph_update(
+    result: &Result<super::memory::AutoMemoryReport, crate::opensymphony_memory::MemoryError>,
+) -> bool {
+    result
+        .as_ref()
+        .is_ok_and(|report| report.capture_completed && !report.captured_issue_keys.is_empty())
+}
+
+async fn append_memory_graph_updated_event(
+    journal: &InMemoryEventJournal,
+    repo_root: &std::path::Path,
+) -> Result<EventRecord, String> {
+    let config = crate::opensymphony_memory::MemoryConfig::load(repo_root, None)
+        .map_err(|error| error.to_string())?;
+    let update = crate::opensymphony_memory::memory_graph_updated_event(
+        &config,
+        crate::opensymphony_memory::DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+        crate::opensymphony_memory::MemoryGraphAccess::AllAccessible,
+    )
+    .map_err(|error| error.to_string())?;
+    let record = memory_graph_updated_record(update)?;
+    journal
+        .append(record)
+        .await
+        .map_err(|error| format!("{error:?}"))
+}
+
+fn memory_graph_updated_record(
+    update: crate::opensymphony_gateway_schema::memory_graph::MemoryGraphUpdatedEvent,
+) -> Result<EventRecord, String> {
+    let bundle_id = update.bundle_id.clone();
+    let payload = serde_json::to_value(&update).map_err(|error| error.to_string())?;
+    Ok(EventRecord::builder()
+        .actor(EventActor::system("memory"))
+        .kind(EventKind::MemoryGraphUpdated {
+            bundle_id: bundle_id.clone(),
+        })
+        .summary(format!("memory graph updated for bundle {bundle_id}"))
+        .payload(payload)
+        .build())
 }
 
 struct SnapshotPublishContext<'a> {
@@ -822,5 +882,54 @@ mod tests {
         mark_auto_capture_completed(&mut completed, &candidates, &result);
 
         assert_eq!(completed, issue_set(&["COE-1"]));
+    }
+
+    #[test]
+    fn memory_graph_update_publish_requires_completed_capture() {
+        let captured = Ok(super::super::memory::AutoMemoryReport {
+            completed_issue_keys: vec!["COE-2".to_string()],
+            captured_issue_keys: vec!["COE-2".to_string()],
+            archived_issue_keys: Vec::new(),
+            docs_written: Vec::new(),
+            capture_completed: true,
+            docs_sync_completed: true,
+            archive_completed: true,
+            warnings: Vec::new(),
+        });
+        assert!(should_publish_memory_graph_update(&captured));
+
+        let no_write = Ok(super::super::memory::AutoMemoryReport {
+            capture_completed: true,
+            ..super::super::memory::AutoMemoryReport::default()
+        });
+        assert!(!should_publish_memory_graph_update(&no_write));
+
+        let failed = Err(MemoryError::InvalidInput("capture failed".to_string()));
+        assert!(!should_publish_memory_graph_update(&failed));
+    }
+
+    #[test]
+    fn memory_graph_updated_record_carries_payload() {
+        let update = crate::opensymphony_gateway_schema::memory_graph::MemoryGraphUpdatedEvent {
+            schema_version: crate::opensymphony_gateway_schema::version::SchemaVersion::v1(),
+            bundle_id: "local-default".to_string(),
+            cursor: crate::opensymphony_gateway_schema::cursor::StreamCursor::new(
+                42,
+                "memory-graph:local-default",
+            ),
+            updated_at: Utc::now(),
+        };
+
+        let record = memory_graph_updated_record(update.clone()).expect("record should build");
+
+        assert_eq!(record.actor, EventActor::system("memory"));
+        assert!(matches!(
+            record.kind,
+            EventKind::MemoryGraphUpdated { ref bundle_id } if bundle_id == "local-default"
+        ));
+        assert_eq!(
+            record.payload,
+            Some(serde_json::to_value(update).expect("payload should serialize"))
+        );
     }
 }

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -259,9 +259,18 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         .map_err(RunCommandError::BindListener)?;
     let gateway_journal = InMemoryEventJournal::new(10_000, 256);
     let gateway_broker = StreamBroker::new(gateway_journal.clone());
+    let gateway_memory_config = if runtime.memory.server.is_some() {
+        Some(crate::opensymphony_memory::MemoryConfig::load(
+            &runtime.target_repo,
+            None,
+        )?)
+    } else {
+        None
+    };
     let server =
         GatewayServer::with_journal(store.clone(), gateway_journal.clone(), gateway_broker)
-            .with_linear_task_graph(build_optional_task_graph_client(&runtime.workflow));
+            .with_linear_task_graph(build_optional_task_graph_client(&runtime.workflow))
+            .with_memory_config(gateway_memory_config);
     let mut server_task = tokio::spawn(async move { server.serve(listener).await });
     let mut gateway_action_cursor = 0;
 

--- a/crates/opensymphony-gateway-schema/src/event_journal.rs
+++ b/crates/opensymphony-gateway-schema/src/event_journal.rs
@@ -225,6 +225,9 @@ impl EventKind {
             Self::TaskGraphSubIssueUpdated { .. } => "task_graph.sub_issue_updated".into(),
             Self::TaskGraphRelationCreated { .. } => "task_graph.relation_created".into(),
             Self::TaskGraphCommentCreated { .. } => "task_graph.comment_created".into(),
+            // The graph-view contract intentionally names this stream event
+            // `memory_graph_updated`; keep the underscore tag stable for
+            // clients even though older gateway event families use dotted tags.
             Self::MemoryGraphUpdated { .. } => "memory_graph_updated".into(),
             Self::Unknown { raw_kind } => raw_kind.clone(),
         }

--- a/crates/opensymphony-gateway-schema/src/event_journal.rs
+++ b/crates/opensymphony-gateway-schema/src/event_journal.rs
@@ -175,6 +175,10 @@ pub enum EventKind {
         issue_id: String,
     },
 
+    MemoryGraphUpdated {
+        bundle_id: String,
+    },
+
     // Catch-all for unknown future events
     Unknown {
         raw_kind: String,
@@ -221,6 +225,7 @@ impl EventKind {
             Self::TaskGraphSubIssueUpdated { .. } => "task_graph.sub_issue_updated".into(),
             Self::TaskGraphRelationCreated { .. } => "task_graph.relation_created".into(),
             Self::TaskGraphCommentCreated { .. } => "task_graph.comment_created".into(),
+            Self::MemoryGraphUpdated { .. } => "memory_graph_updated".into(),
             Self::Unknown { raw_kind } => raw_kind.clone(),
         }
     }

--- a/crates/opensymphony-gateway-schema/src/lib.rs
+++ b/crates/opensymphony-gateway-schema/src/lib.rs
@@ -4,6 +4,7 @@ pub mod capability;
 pub mod cursor;
 pub mod envelope;
 pub mod event_journal;
+pub mod memory_graph;
 pub mod model_settings;
 pub mod planning;
 pub mod run;

--- a/crates/opensymphony-gateway-schema/src/memory_graph.rs
+++ b/crates/opensymphony-gateway-schema/src/memory_graph.rs
@@ -1,0 +1,236 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::{cursor::StreamCursor, version::SchemaVersion};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryBundleList {
+    pub schema_version: SchemaVersion,
+    pub bundles: Vec<MemoryBundleSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryBundleSummary {
+    pub id: String,
+    pub title: String,
+    pub okf_version: String,
+    pub visibility: MemoryGraphVisibility,
+    pub concept_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryGraphSnapshot {
+    pub schema_version: SchemaVersion,
+    pub bundle_id: String,
+    pub cursor: StreamCursor,
+    pub nodes: Vec<MemoryGraphNode>,
+    pub edges: Vec<MemoryGraphEdge>,
+    pub communities: Vec<MemoryGraphCommunity>,
+    #[serde(default)]
+    pub filters_applied: Vec<String>,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryConceptDetail {
+    pub schema_version: SchemaVersion,
+    pub bundle_id: String,
+    pub concept_id: String,
+    pub frontmatter_view: MemoryFrontmatterView,
+    pub body_markdown: String,
+    #[serde(default)]
+    pub links: Vec<MemoryGraphLink>,
+    #[serde(default)]
+    pub citations: Vec<MemoryGraphCitation>,
+    #[serde(default)]
+    pub source_refs: Vec<MemoryGraphSourceRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryCommunityList {
+    pub schema_version: SchemaVersion,
+    pub bundle_id: String,
+    #[serde(default)]
+    pub communities: Vec<MemoryGraphCommunity>,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemorySearchResponse {
+    pub schema_version: SchemaVersion,
+    pub query: String,
+    pub bundle_id: Option<String>,
+    pub results: Vec<MemorySearchResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemorySearchResult {
+    pub bundle_id: String,
+    pub concept_id: String,
+    pub title: String,
+    pub visibility: MemoryGraphVisibility,
+    pub snippet: String,
+    #[serde(default)]
+    pub areas: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryGraphNode {
+    pub id: String,
+    pub kind: MemoryGraphNodeKind,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concept_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concept_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_display: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<MemoryGraphVisibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<MemoryGraphFreshness>,
+    #[serde(default)]
+    pub warning_count: usize,
+    #[serde(default)]
+    pub frontmatter_summary: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub unknown_frontmatter: BTreeMap<String, Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body_preview: Option<String>,
+    #[serde(default)]
+    pub metrics: MemoryGraphNodeMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryGraphEdge {
+    pub id: String,
+    pub kind: MemoryGraphEdgeKind,
+    pub source_id: String,
+    pub target_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub unresolved: bool,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryGraphCommunity {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub node_ids: Vec<String>,
+    #[serde(default)]
+    pub concept_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryFrontmatterView {
+    #[serde(default)]
+    pub primary: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub opensymphony: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub unknown: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryGraphLink {
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryGraphCitation {
+    pub id: String,
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryGraphSourceRef {
+    pub kind: String,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MemoryGraphNodeMetrics {
+    #[serde(default)]
+    pub indegree: usize,
+    #[serde(default)]
+    pub outdegree: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pagerank: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub community_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryGraphUpdatedEvent {
+    pub schema_version: SchemaVersion,
+    pub bundle_id: String,
+    pub cursor: StreamCursor,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryGraphVisibility {
+    Public,
+    Private,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryGraphFreshness {
+    Current,
+    Stale,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryGraphNodeKind {
+    Bundle,
+    Directory,
+    Concept,
+    Tag,
+    Resource,
+    Citation,
+    SourceRef,
+    Community,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryGraphEdgeKind {
+    Contains,
+    MarkdownLink,
+    ExternalLink,
+    Cites,
+    TaggedWith,
+    DescribesResource,
+    ScopedTo,
+    SourceSupportedBy,
+    SameResource,
+}

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::Utc;
 use opensymphony::opensymphony_gateway_schema::{
     action::{ActionDispatch, ActionKind, ActionReceipt, ActionStatus, ActionTarget},
@@ -7,6 +9,12 @@ use opensymphony::opensymphony_gateway_schema::{
     },
     cursor::{PageCursor, StreamCursor},
     envelope::{EntityKind, EntityRef, GatewayEnvelope},
+    event_journal::EventKind,
+    memory_graph::{
+        MemoryBundleList, MemoryBundleSummary, MemoryGraphEdge, MemoryGraphEdgeKind,
+        MemoryGraphFreshness, MemoryGraphNode, MemoryGraphNodeKind, MemoryGraphNodeMetrics,
+        MemoryGraphSnapshot, MemoryGraphUpdatedEvent, MemoryGraphVisibility,
+    },
     model_settings::{
         CodexCliProbe, CodexLocalReadiness, CredentialReferenceKind, CredentialStatusKind,
         CredentialStatusResponse, CredentialStorageMode, ModelSettingsResponse, ProbeCommandResult,
@@ -87,6 +95,132 @@ fn schema_version_roundtrips() {
 #[test]
 fn gateway_schema_version_constant_matches() {
     assert_eq!(GATEWAY_SCHEMA_VERSION, "1.0.0");
+}
+
+#[test]
+fn memory_graph_dtos_roundtrip_required_kinds_and_update_event() {
+    let node_kinds = [
+        MemoryGraphNodeKind::Bundle,
+        MemoryGraphNodeKind::Directory,
+        MemoryGraphNodeKind::Concept,
+        MemoryGraphNodeKind::Tag,
+        MemoryGraphNodeKind::Resource,
+        MemoryGraphNodeKind::Citation,
+        MemoryGraphNodeKind::SourceRef,
+        MemoryGraphNodeKind::Community,
+    ];
+    let edge_kinds = [
+        MemoryGraphEdgeKind::Contains,
+        MemoryGraphEdgeKind::MarkdownLink,
+        MemoryGraphEdgeKind::ExternalLink,
+        MemoryGraphEdgeKind::Cites,
+        MemoryGraphEdgeKind::TaggedWith,
+        MemoryGraphEdgeKind::DescribesResource,
+        MemoryGraphEdgeKind::ScopedTo,
+        MemoryGraphEdgeKind::SourceSupportedBy,
+        MemoryGraphEdgeKind::SameResource,
+    ];
+
+    assert_eq!(
+        serde_json::to_value(node_kinds).expect("node kinds serialize"),
+        json!([
+            "bundle",
+            "directory",
+            "concept",
+            "tag",
+            "resource",
+            "citation",
+            "source_ref",
+            "community"
+        ])
+    );
+    assert_eq!(
+        serde_json::to_value(edge_kinds).expect("edge kinds serialize"),
+        json!([
+            "contains",
+            "markdown_link",
+            "external_link",
+            "cites",
+            "tagged_with",
+            "describes_resource",
+            "scoped_to",
+            "source_supported_by",
+            "same_resource"
+        ])
+    );
+
+    let snapshot = MemoryGraphSnapshot {
+        schema_version: sample_schema_version(),
+        bundle_id: "local-default".into(),
+        cursor: StreamCursor::new(7, "memory-graph:local-default"),
+        nodes: vec![MemoryGraphNode {
+            id: "concept:issues/COE-123".into(),
+            kind: MemoryGraphNodeKind::Concept,
+            label: "COE-123".into(),
+            bundle_id: Some("local-default".into()),
+            concept_id: Some("issues/COE-123".into()),
+            concept_type: Some("issue-capsule".into()),
+            description: Some("Memory graph fixture".into()),
+            path_display: Some("issues/COE-123.md".into()),
+            resource: None,
+            tags: vec!["memory".into()],
+            timestamp: Some("2026-06-28T00:00:00Z".into()),
+            visibility: Some(MemoryGraphVisibility::Public),
+            freshness: Some(MemoryGraphFreshness::Current),
+            warning_count: 0,
+            frontmatter_summary: BTreeMap::from([("type".into(), json!("issue-capsule"))]),
+            unknown_frontmatter: BTreeMap::new(),
+            body_preview: Some("Fixture".into()),
+            metrics: MemoryGraphNodeMetrics::default(),
+        }],
+        edges: vec![MemoryGraphEdge {
+            id: "contains:bundle:local-default->concept:issues/COE-123".into(),
+            kind: MemoryGraphEdgeKind::Contains,
+            source_id: "bundle:local-default".into(),
+            target_id: "concept:issues/COE-123".into(),
+            label: None,
+            unresolved: false,
+            metadata: BTreeMap::new(),
+        }],
+        communities: Vec::new(),
+        filters_applied: Vec::new(),
+        generated_at: Utc::now(),
+    };
+    let json = must_serialize(&snapshot);
+    let back: MemoryGraphSnapshot = must_deserialize(&json);
+    assert_eq!(back.schema_version, sample_schema_version());
+    assert_eq!(
+        back.nodes[0].visibility,
+        Some(MemoryGraphVisibility::Public)
+    );
+
+    let bundles = MemoryBundleList {
+        schema_version: sample_schema_version(),
+        bundles: vec![MemoryBundleSummary {
+            id: "local-default".into(),
+            title: "OpenSymphony Memory".into(),
+            okf_version: "0.1".into(),
+            visibility: MemoryGraphVisibility::Private,
+            concept_count: 1,
+            updated_at: None,
+        }],
+    };
+    let _: MemoryBundleList = must_deserialize(&must_serialize(&bundles));
+
+    let update = MemoryGraphUpdatedEvent {
+        schema_version: sample_schema_version(),
+        bundle_id: "local-default".into(),
+        cursor: StreamCursor::new(8, "memory-graph:local-default"),
+        updated_at: Utc::now(),
+    };
+    let _: MemoryGraphUpdatedEvent = must_deserialize(&must_serialize(&update));
+    assert_eq!(
+        EventKind::MemoryGraphUpdated {
+            bundle_id: "local-default".into()
+        }
+        .kind_tag(),
+        "memory_graph_updated"
+    );
 }
 
 #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -42,9 +42,9 @@ use crate::opensymphony_gateway_schema::{
     },
 };
 use crate::opensymphony_memory::{
-    MemoryConfig, MemoryGraphAccess, MemoryGraphProjectionError, memory_concept_detail,
-    memory_graph_bundles, memory_graph_communities, memory_graph_search as search_memory_graph,
-    memory_graph_snapshot,
+    MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphProjectionError,
+    memory_concept_detail, memory_graph_bundles, memory_graph_communities,
+    memory_graph_search as search_memory_graph, memory_graph_snapshot,
 };
 
 pub mod action_handler;
@@ -1129,11 +1129,17 @@ fn memory_graph_error(error: MemoryGraphProjectionError) -> (StatusCode, Json<se
         MemoryGraphProjectionError::ConceptNotFound(_) => {
             memory_graph_response(StatusCode::NOT_FOUND, "concept_not_found", &message)
         }
-        MemoryGraphProjectionError::Memory(source) => memory_graph_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "memory_graph_error",
-            &source.to_string(),
-        ),
+        MemoryGraphProjectionError::Memory(source) => {
+            let (status, code) = memory_graph_memory_error_status(&source);
+            memory_graph_response(status, code, &source.to_string())
+        }
+    }
+}
+
+fn memory_graph_memory_error_status(error: &MemoryError) -> (StatusCode, &'static str) {
+    match error {
+        MemoryError::InvalidInput(_) => (StatusCode::BAD_REQUEST, "invalid_memory_request"),
+        _ => (StatusCode::INTERNAL_SERVER_ERROR, "memory_graph_error"),
     }
 }
 

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -42,8 +42,9 @@ use crate::opensymphony_gateway_schema::{
     },
 };
 use crate::opensymphony_memory::{
-    MemoryConfig, MemoryError, MemoryGraphAccess, memory_concept_detail, memory_graph_bundles,
-    memory_graph_communities, memory_graph_search as search_memory_graph, memory_graph_snapshot,
+    MemoryConfig, MemoryGraphAccess, MemoryGraphProjectionError, memory_concept_detail,
+    memory_graph_bundles, memory_graph_communities, memory_graph_search as search_memory_graph,
+    memory_graph_snapshot,
 };
 
 pub mod action_handler;
@@ -1104,10 +1105,13 @@ fn memory_graph_access(
         .map(str::to_ascii_lowercase)
         .as_deref()
     {
-        None | Some("all") | Some("private") | Some("all_accessible") => {
-            Ok(MemoryGraphAccess::AllAccessible)
-        }
+        None | Some("all") | Some("all_accessible") => Ok(MemoryGraphAccess::AllAccessible),
         Some("public") => Ok(MemoryGraphAccess::Public),
+        Some("private") => Err(memory_graph_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_visibility",
+            "`visibility=private` is ambiguous; omit the parameter or use `visibility=all_accessible` for the local accessible catalog",
+        )),
         Some(other) => Err(memory_graph_response(
             StatusCode::BAD_REQUEST,
             "invalid_visibility",
@@ -1116,22 +1120,19 @@ fn memory_graph_access(
     }
 }
 
-fn memory_graph_error(error: MemoryError) -> (StatusCode, Json<serde_json::Value>) {
+fn memory_graph_error(error: MemoryGraphProjectionError) -> (StatusCode, Json<serde_json::Value>) {
     let message = error.to_string();
-    match &error {
-        MemoryError::InvalidInput(_) if message.starts_with("unknown memory bundle") => {
+    match error {
+        MemoryGraphProjectionError::BundleNotFound(_) => {
             memory_graph_response(StatusCode::NOT_FOUND, "bundle_not_found", &message)
         }
-        MemoryError::InvalidInput(_) if message.starts_with("no concept found") => {
+        MemoryGraphProjectionError::ConceptNotFound(_) => {
             memory_graph_response(StatusCode::NOT_FOUND, "concept_not_found", &message)
         }
-        MemoryError::InvalidInput(_) => {
-            memory_graph_response(StatusCode::BAD_REQUEST, "invalid_memory_request", &message)
-        }
-        _ => memory_graph_response(
+        MemoryGraphProjectionError::Memory(source) => memory_graph_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "memory_graph_error",
-            &message,
+            &source.to_string(),
         ),
     }
 }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -41,6 +41,10 @@ use crate::opensymphony_gateway_schema::{
         RunLogEntry, RunLogPage, TerminalJumpResult, TerminalSearchMatch, TerminalSearchResult,
     },
 };
+use crate::opensymphony_memory::{
+    MemoryConfig, MemoryError, MemoryGraphAccess, memory_concept_detail, memory_graph_bundles,
+    memory_graph_communities, memory_graph_search as search_memory_graph, memory_graph_snapshot,
+};
 
 pub mod action_handler;
 pub mod task_graph_mutations;
@@ -77,6 +81,10 @@ pub use crate::opensymphony_gateway_schema::{
     },
     cursor::PageCursor,
     event_journal::{EventPage as GatewayEventPage, JournalError as EventJournalError},
+    memory_graph::{
+        MemoryBundleList, MemoryCommunityList, MemoryConceptDetail, MemoryGraphSnapshot,
+        MemoryGraphUpdatedEvent, MemorySearchResponse,
+    },
     model_settings::{
         CodexCliProbe, CodexLocalReadiness, CredentialStatusResponse, ModelSettingsResponse,
         ProbeCommandResult,
@@ -254,6 +262,7 @@ pub struct GatewayState {
     pub action_handler: ActionHandler,
     pub linear_mutations: Option<Arc<dyn LinearMutationClient>>,
     pub linear_task_graph: Option<Arc<dyn LinearTaskGraphClient>>,
+    pub memory_config: Option<MemoryConfig>,
     pub codex_readiness_cache: Arc<CodexReadinessCache>,
 }
 
@@ -268,6 +277,7 @@ impl Clone for GatewayState {
             action_handler: self.action_handler.clone(),
             linear_mutations: self.linear_mutations.clone(),
             linear_task_graph: self.linear_task_graph.clone(),
+            memory_config: self.memory_config.clone(),
             codex_readiness_cache: self.codex_readiness_cache.clone(),
         }
     }
@@ -305,6 +315,7 @@ pub struct GatewayServer {
     web_assets_dir: Option<String>,
     linear_mutations: Option<Arc<dyn LinearMutationClient>>,
     linear_task_graph: Option<Arc<dyn LinearTaskGraphClient>>,
+    memory_config: Option<MemoryConfig>,
     terminal_ingest_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -317,6 +328,7 @@ impl Clone for GatewayServer {
             web_assets_dir: self.web_assets_dir.clone(),
             linear_mutations: self.linear_mutations.clone(),
             linear_task_graph: self.linear_task_graph.clone(),
+            memory_config: self.memory_config.clone(),
             // Each cloned server owns its own ingest handle. The task is tied
             // to the specific server instance that spawned it, so Drop aborts
             // reliably without depending on Arc uniqueness.
@@ -340,6 +352,7 @@ impl std::fmt::Debug for GatewayServer {
                 "linear_task_graph",
                 &self.linear_task_graph.as_ref().map(|_| "..."),
             )
+            .field("memory_config", &self.memory_config.as_ref().map(|_| "..."))
             .field("terminal_ingest_handle", &"<handle>")
             .finish()
     }
@@ -369,6 +382,7 @@ impl GatewayServer {
             web_assets_dir: None,
             linear_mutations: None,
             linear_task_graph: None,
+            memory_config: None,
             terminal_ingest_handle: Mutex::new(None),
         }
     }
@@ -386,6 +400,7 @@ impl GatewayServer {
             web_assets_dir: None,
             linear_mutations: None,
             linear_task_graph: None,
+            memory_config: None,
             terminal_ingest_handle: Mutex::new(None),
         }
     }
@@ -419,6 +434,12 @@ impl GatewayServer {
         self
     }
 
+    /// Install the local memory catalog used by `/api/v1/memory/*` reads.
+    pub fn with_memory_config(mut self, config: Option<MemoryConfig>) -> Self {
+        self.memory_config = config;
+        self
+    }
+
     /// Extract clones of the journal and broker so the caller can keep them for testing.
     pub fn journal_and_broker(self) -> (InMemoryEventJournal, StreamBroker) {
         (self.journal.clone(), self.broker.clone())
@@ -435,6 +456,7 @@ impl GatewayServer {
             action_handler: ActionHandler::new(self.journal.clone()),
             linear_mutations: self.linear_mutations.clone(),
             linear_task_graph: self.linear_task_graph.clone(),
+            memory_config: self.memory_config.clone(),
             codex_readiness_cache: Arc::new(CodexReadinessCache::default()),
         };
 
@@ -491,6 +513,20 @@ impl GatewayServer {
             .route("/api/v1/events", get(events))
             .route("/api/v1/event-journal", get(event_journal_query))
             .route("/api/v1/streams/events", get(event_stream_ws))
+            .route("/api/v1/memory/bundles", get(get_memory_bundles))
+            .route(
+                "/api/v1/memory/bundles/{bundle_id}/graph",
+                get(get_memory_graph),
+            )
+            .route(
+                "/api/v1/memory/bundles/{bundle_id}/concepts/{*concept_id}",
+                get(get_memory_concept),
+            )
+            .route(
+                "/api/v1/memory/bundles/{bundle_id}/communities",
+                get(get_memory_communities),
+            )
+            .route("/api/v1/memory/search", get(search_memory))
             .route("/api/v1/projects", get(list_projects))
             .route("/api/v1/projects/{project_id}", get(get_project))
             .route(
@@ -960,6 +996,160 @@ async fn model_credential_statuses(
     Json(CredentialStatusResponse::from_model_settings(
         &build_model_settings(&state).await,
     ))
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct MemoryVisibilityQuery {
+    visibility: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct MemorySearchQuery {
+    q: Option<String>,
+    query: Option<String>,
+    limit: Option<usize>,
+    visibility: Option<String>,
+}
+
+async fn get_memory_bundles(
+    State(state): State<GatewayState>,
+    Query(params): Query<MemoryVisibilityQuery>,
+) -> Result<Json<MemoryBundleList>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_memory(&state)?;
+    let access = memory_graph_access(params.visibility.as_deref())?;
+    memory_graph_bundles(config, access)
+        .map(Json)
+        .map_err(memory_graph_error)
+}
+
+async fn get_memory_graph(
+    State(state): State<GatewayState>,
+    AxumPath(bundle_id): AxumPath<String>,
+    Query(params): Query<MemoryVisibilityQuery>,
+) -> Result<Json<MemoryGraphSnapshot>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_memory(&state)?;
+    let access = memory_graph_access(params.visibility.as_deref())?;
+    memory_graph_snapshot(config, &bundle_id, access)
+        .map(Json)
+        .map_err(memory_graph_error)
+}
+
+async fn get_memory_concept(
+    State(state): State<GatewayState>,
+    AxumPath((bundle_id, concept_id)): AxumPath<(String, String)>,
+    Query(params): Query<MemoryVisibilityQuery>,
+) -> Result<Json<MemoryConceptDetail>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_memory(&state)?;
+    let access = memory_graph_access(params.visibility.as_deref())?;
+    memory_concept_detail(config, &bundle_id, &concept_id, access)
+        .map(Json)
+        .map_err(memory_graph_error)
+}
+
+async fn get_memory_communities(
+    State(state): State<GatewayState>,
+    AxumPath(bundle_id): AxumPath<String>,
+    Query(params): Query<MemoryVisibilityQuery>,
+) -> Result<Json<MemoryCommunityList>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_memory(&state)?;
+    let access = memory_graph_access(params.visibility.as_deref())?;
+    memory_graph_communities(config, &bundle_id, access)
+        .map(Json)
+        .map_err(memory_graph_error)
+}
+
+async fn search_memory(
+    State(state): State<GatewayState>,
+    Query(params): Query<MemorySearchQuery>,
+) -> Result<Json<MemorySearchResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_memory(&state)?;
+    let query = params
+        .query
+        .or(params.q)
+        .and_then(|query| {
+            let query = query.trim().to_string();
+            (!query.is_empty()).then_some(query)
+        })
+        .ok_or_else(|| {
+            memory_graph_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_query",
+                "memory search requires `query` or `q`",
+            )
+        })?;
+    let access = memory_graph_access(params.visibility.as_deref())?;
+    search_memory_graph(config, &query, params.limit.unwrap_or(10), access)
+        .map(Json)
+        .map_err(memory_graph_error)
+}
+
+fn configured_memory(
+    state: &GatewayState,
+) -> Result<&MemoryConfig, (StatusCode, Json<serde_json::Value>)> {
+    state.memory_config.as_ref().ok_or_else(|| {
+        memory_graph_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "memory_not_configured",
+            "memory graph endpoints require a configured memory catalog",
+        )
+    })
+}
+
+fn memory_graph_access(
+    visibility: Option<&str>,
+) -> Result<MemoryGraphAccess, (StatusCode, Json<serde_json::Value>)> {
+    match visibility
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        None | Some("all") | Some("private") | Some("all_accessible") => {
+            Ok(MemoryGraphAccess::AllAccessible)
+        }
+        Some("public") => Ok(MemoryGraphAccess::Public),
+        Some(other) => Err(memory_graph_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_visibility",
+            &format!("unsupported memory visibility `{other}`"),
+        )),
+    }
+}
+
+fn memory_graph_error(error: MemoryError) -> (StatusCode, Json<serde_json::Value>) {
+    let message = error.to_string();
+    match &error {
+        MemoryError::InvalidInput(_) if message.starts_with("unknown memory bundle") => {
+            memory_graph_response(StatusCode::NOT_FOUND, "bundle_not_found", &message)
+        }
+        MemoryError::InvalidInput(_) if message.starts_with("no concept found") => {
+            memory_graph_response(StatusCode::NOT_FOUND, "concept_not_found", &message)
+        }
+        MemoryError::InvalidInput(_) => {
+            memory_graph_response(StatusCode::BAD_REQUEST, "invalid_memory_request", &message)
+        }
+        _ => memory_graph_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "memory_graph_error",
+            &message,
+        ),
+    }
+}
+
+fn memory_graph_response(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        status,
+        Json(json!({
+            "error": {
+                "code": code,
+                "message": message
+            }
+        })),
+    )
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1131,7 +1131,7 @@ fn memory_graph_error(error: MemoryGraphProjectionError) -> (StatusCode, Json<se
         }
         MemoryGraphProjectionError::Memory(source) => {
             let (status, code) = memory_graph_memory_error_status(&source);
-            memory_graph_response(status, code, &source.to_string())
+            memory_graph_response(status, code, memory_graph_memory_error_message(&source))
         }
     }
 }
@@ -1140,6 +1140,13 @@ fn memory_graph_memory_error_status(error: &MemoryError) -> (StatusCode, &'stati
     match error {
         MemoryError::InvalidInput(_) => (StatusCode::BAD_REQUEST, "invalid_memory_request"),
         _ => (StatusCode::INTERNAL_SERVER_ERROR, "memory_graph_error"),
+    }
+}
+
+fn memory_graph_memory_error_message(error: &MemoryError) -> &'static str {
+    match error {
+        MemoryError::InvalidInput(_) => "invalid memory graph request",
+        _ => "memory graph projection failed",
     }
 }
 
@@ -3813,6 +3820,28 @@ mod tests {
             )),
             TaskGraphStateCategory::Todo
         );
+    }
+
+    #[test]
+    fn memory_graph_memory_errors_do_not_expose_local_paths() {
+        let local_path = PathBuf::from("/tmp/private/index.duckdb");
+        let (status, Json(body)) = memory_graph_error(MemoryGraphProjectionError::Memory(
+            MemoryError::PathOutsideRepo {
+                path: local_path.clone(),
+                repo_root: PathBuf::from("/tmp/private/repo"),
+            },
+        ));
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["error"]["message"], "memory graph projection failed");
+        assert!(!body.to_string().contains("/tmp/private"));
+
+        let (status, Json(body)) = memory_graph_error(MemoryGraphProjectionError::Memory(
+            MemoryError::InvalidInput(format!("bad request for {}", local_path.display())),
+        ));
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["message"], "invalid memory graph request");
+        assert!(!body.to_string().contains("/tmp/private"));
     }
 
     #[cfg(unix)]

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -1832,6 +1832,24 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
     assert_eq!(search.results.len(), 1);
     assert_eq!(search.results[0].concept_id, "issues/COE-200");
 
+    let invalid_visibility = client
+        .get(format!("{base}/bundles?visibility=private"))
+        .send()
+        .await
+        .expect("fetch invalid visibility");
+    assert_eq!(
+        invalid_visibility.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    let invalid_visibility_body = invalid_visibility
+        .json::<serde_json::Value>()
+        .await
+        .expect("decode invalid visibility response");
+    assert_eq!(
+        invalid_visibility_body.pointer("/error/code"),
+        Some(&serde_json::json!("invalid_visibility"))
+    );
+
     server_task.abort();
 }
 

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -1749,6 +1749,16 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
     assert_eq!(bundles.bundles[0].id, "local-default");
     assert_eq!(bundles.bundles[0].concept_count, 1);
 
+    let all_bundles = client
+        .get(format!("{base}/bundles"))
+        .send()
+        .await
+        .expect("fetch default bundles")
+        .json::<MemoryBundleList>()
+        .await
+        .expect("decode default bundles");
+    assert_eq!(all_bundles.bundles[0].concept_count, 2);
+
     let graph = client
         .get(format!(
             "{base}/bundles/local-default/graph?visibility=public"
@@ -1770,6 +1780,20 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
             .iter()
             .any(|edge| edge.kind == MemoryGraphEdgeKind::ExternalLink)
     );
+
+    let all_graph = client
+        .get(format!("{base}/bundles/local-default/graph"))
+        .send()
+        .await
+        .expect("fetch default graph")
+        .json::<MemoryGraphSnapshot>()
+        .await
+        .expect("decode default graph");
+    let all_graph_json = serde_json::to_string(&all_graph).expect("default graph serializes");
+    assert!(all_graph_json.contains("COE-200"));
+    assert!(all_graph_json.contains("COE-201"));
+    assert!(!all_graph_json.contains(".opensymphony/memory"));
+    assert!(!all_graph_json.contains(&repo.path().display().to_string()));
 
     let detail = client
         .get(format!(

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -22,12 +22,17 @@ use opensymphony::opensymphony_gateway_schema::action::{
     ActionDispatch, ActionKind, ActionReceipt, ActionStatus, ActionTarget,
 };
 use opensymphony::opensymphony_gateway_schema::envelope::EntityKind;
+use opensymphony::opensymphony_gateway_schema::memory_graph::{
+    MemoryBundleList, MemoryCommunityList, MemoryConceptDetail, MemoryGraphEdgeKind,
+    MemoryGraphSnapshot, MemorySearchResponse,
+};
 use opensymphony::opensymphony_gateway_schema::model_settings::{
     CodexCliProbe, CodexLocalReadiness, CredentialStatusKind, CredentialStatusResponse,
     ModelSettingsResponse, ProbeCommandResult,
 };
 use opensymphony::opensymphony_gateway_schema::run::DiffLine;
 use opensymphony::opensymphony_gateway_schema::validation::ValidationStatus;
+use opensymphony::opensymphony_memory::{MemoryConfig, refresh_memory_index_from_okf};
 use tokio::net::TcpListener;
 use url::Url;
 
@@ -207,6 +212,86 @@ fn tracker_state_kind_from_name(state: &str) -> TrackerIssueStateKind {
         "canceled" | "cancelled" => TrackerIssueStateKind::Canceled,
         other => TrackerIssueStateKind::Unknown(other.to_owned()),
     }
+}
+
+fn write_memory_graph_fixture(repo: &std::path::Path) -> MemoryConfig {
+    let config_path = repo.join("opensymphony-memory.yaml");
+    std::fs::write(
+        &config_path,
+        r#"
+areas:
+  graph-view:
+    title: Graph View
+    docs_target: docs/graph-view.md
+    status: stable
+    confidence: 90
+"#,
+    )
+    .expect("memory config should write");
+    let memory_root = repo.join(".opensymphony/memory");
+    let issues_dir = memory_root.join("issues");
+    std::fs::create_dir_all(&issues_dir).expect("memory issues dir should write");
+    std::fs::write(
+        issues_dir.join("COE-200.md"),
+        format!(
+            r#"---
+type: topic-doc
+title: "COE-200: Public graph concept"
+description: Public graph DTO fixture.
+resource: https://linear.app/example/issue/COE-200
+tags: [memory, graph]
+timestamp: 2026-06-22T10:00:00Z
+custom_unknown: keep-me
+opensymphony:
+  visibility: public
+  scope_refs:
+    - kind: work_item
+      id: COE-200
+    - kind: area
+      id: graph-view
+  source_refs:
+    - kind: linear_issue
+      id: COE-200
+      url: https://linear.app/example/issue/COE-200
+  citations:
+    - id: "1"
+      target: https://linear.app/example/issue/COE-200
+      label: COE-200
+---
+
+# COE-200: Public graph concept
+
+Public graph body mentions .opensymphony/memory/issues/COE-999.md and {}.
+
+See [external](https://example.com/reference).
+"#,
+            repo.display()
+        ),
+    )
+    .expect("public concept should write");
+    std::fs::write(
+        issues_dir.join("COE-201.md"),
+        r#"---
+type: issue-capsule
+title: "COE-201: Private graph concept"
+description: Private graph DTO fixture.
+tags: [memory, graph]
+opensymphony:
+  visibility: private
+  scope_refs:
+    - kind: work_item
+      id: COE-201
+    - kind: area
+      id: graph-view
+---
+
+# COE-201: Private graph concept
+
+Private graph body.
+"#,
+    )
+    .expect("private concept should write");
+    MemoryConfig::load(repo, Some(&config_path)).expect("memory config should load")
 }
 
 fn fixture_snapshot(step: u64) -> DaemonSnapshot {
@@ -1625,6 +1710,127 @@ async fn gateway_serves_project_list() {
     assert_eq!(response.projects[0].project_id, "default");
     assert_eq!(response.projects[0].name, "OpenSymphony");
     assert_eq!(response.projects[0].issue_count, 1);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_memory_graph_contract_endpoints() {
+    let repo = tempfile::tempdir().expect("memory repo");
+    let config = write_memory_graph_fixture(repo.path());
+    refresh_memory_index_from_okf(&config, &repo.path().join(".opensymphony/memory"))
+        .expect("fixture should reindex");
+
+    let store = SnapshotStore::new(fixture_snapshot(0));
+    let server = GatewayServer::new(store).with_memory_config(Some(config));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://{address}/api/v1/memory");
+
+    let bundles = client
+        .get(format!("{base}/bundles?visibility=public"))
+        .send()
+        .await
+        .expect("fetch bundles")
+        .json::<MemoryBundleList>()
+        .await
+        .expect("decode bundles");
+    assert_eq!(bundles.schema_version.major, 1);
+    assert_eq!(bundles.bundles[0].id, "local-default");
+    assert_eq!(bundles.bundles[0].concept_count, 1);
+
+    let graph = client
+        .get(format!(
+            "{base}/bundles/local-default/graph?visibility=public"
+        ))
+        .send()
+        .await
+        .expect("fetch graph")
+        .json::<MemoryGraphSnapshot>()
+        .await
+        .expect("decode graph");
+    let graph_json = serde_json::to_string(&graph).expect("graph serializes");
+    assert!(graph_json.contains("COE-200"));
+    assert!(!graph_json.contains("COE-201"));
+    assert!(!graph_json.contains(".opensymphony/memory"));
+    assert!(!graph_json.contains(&repo.path().display().to_string()));
+    assert!(
+        graph
+            .edges
+            .iter()
+            .any(|edge| edge.kind == MemoryGraphEdgeKind::ExternalLink)
+    );
+
+    let detail = client
+        .get(format!(
+            "{base}/bundles/local-default/concepts/issues/COE-200?visibility=public"
+        ))
+        .send()
+        .await
+        .expect("fetch concept")
+        .json::<MemoryConceptDetail>()
+        .await
+        .expect("decode concept");
+    assert_eq!(detail.concept_id, "issues/COE-200");
+    assert!(
+        detail
+            .frontmatter_view
+            .opensymphony
+            .contains_key("scope_refs")
+    );
+    assert!(
+        detail
+            .frontmatter_view
+            .unknown
+            .contains_key("custom_unknown")
+    );
+    assert!(!detail.body_markdown.contains(".opensymphony/memory"));
+    assert!(
+        !detail
+            .body_markdown
+            .contains(&repo.path().display().to_string())
+    );
+
+    let communities = client
+        .get(format!(
+            "{base}/bundles/local-default/communities?visibility=public"
+        ))
+        .send()
+        .await
+        .expect("fetch communities")
+        .json::<MemoryCommunityList>()
+        .await
+        .expect("decode communities");
+    assert_eq!(communities.bundle_id, "local-default");
+    assert!(
+        communities
+            .communities
+            .iter()
+            .any(|community| { community.id == "area:graph-view" && community.concept_count == 1 })
+    );
+
+    let search = client
+        .get(format!(
+            "{base}/search?query=public%20graph&visibility=public"
+        ))
+        .send()
+        .await
+        .expect("fetch search")
+        .json::<MemorySearchResponse>()
+        .await
+        .expect("decode search");
+    assert_eq!(search.results.len(), 1);
+    assert_eq!(search.results[0].concept_id, "issues/COE-200");
 
     server_task.abort();
 }

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -395,12 +395,13 @@ pub fn memory_graph_search(
     access: MemoryGraphAccess,
 ) -> Result<MemorySearchResponse, MemoryGraphProjectionError> {
     let issues = accessible_issues(config, access)?;
+    let limit = limit.max(1);
     let by_issue = issues
         .iter()
         .map(|issue| (issue.issue_key.clone(), issue))
         .collect::<BTreeMap<_, _>>();
     let scope = MemoryScopeFilter::default();
-    let results = search_with_scope(config, query, limit, &scope)?
+    let results = search_with_scope(config, query, usize::MAX, &scope)?
         .into_iter()
         .filter_map(|result| {
             let issue = by_issue.get(&result.issue_key)?;
@@ -413,6 +414,7 @@ pub fn memory_graph_search(
                 areas: result.areas,
             })
         })
+        .take(limit)
         .collect();
 
     Ok(MemorySearchResponse {
@@ -424,12 +426,11 @@ pub fn memory_graph_search(
 }
 
 pub fn memory_graph_updated_event(
-    config: &MemoryConfig,
+    _config: &MemoryConfig,
     bundle_id: &str,
-    access: MemoryGraphAccess,
+    _access: MemoryGraphAccess,
 ) -> Result<MemoryGraphUpdatedEvent, MemoryGraphProjectionError> {
     ensure_default_memory_bundle(bundle_id)?;
-    let _ = accessible_issues(config, access)?;
     let updated_at = Utc::now();
     Ok(MemoryGraphUpdatedEvent {
         schema_version: SchemaVersion::v1(),
@@ -652,10 +653,43 @@ fn resolve_index_path(config: &MemoryConfig, path: &Path) -> PathBuf {
 fn redact_for_dto(config: &MemoryConfig, value: &str) -> String {
     let repo_root = config.repo_root.to_string_lossy();
     let memory_root = config.memory_root.to_string_lossy();
-    value
-        .replace(repo_root.as_ref(), "[redacted-local-path]")
-        .replace(memory_root.as_ref(), "[redacted-memory-path]")
-        .replace(".opensymphony/memory/", "[redacted-memory-path]/")
+    let value = replace_path_token(value, repo_root.as_ref(), "[redacted-local-path]");
+    let value = replace_path_token(&value, memory_root.as_ref(), "[redacted-memory-path]");
+    value.replace(".opensymphony/memory/", "[redacted-memory-path]/")
+}
+
+fn replace_path_token(value: &str, needle: &str, replacement: &str) -> String {
+    if needle.is_empty() {
+        return value.to_string();
+    }
+    let mut result = String::with_capacity(value.len());
+    let mut remaining = value;
+    while let Some(index) = remaining.find(needle) {
+        result.push_str(&remaining[..index]);
+        let after = &remaining[index + needle.len()..];
+        if is_path_token_boundary(after) {
+            result.push_str(replacement);
+        } else {
+            result.push_str(needle);
+        }
+        remaining = after;
+    }
+    result.push_str(remaining);
+    result
+}
+
+fn is_path_token_boundary(after: &str) -> bool {
+    let mut chars = after.chars();
+    match chars.next() {
+        None => true,
+        Some('/') | Some('\\') => true,
+        Some('.') => chars.next().is_none_or(|next| {
+            next.is_whitespace() || matches!(next, ',' | ';' | ':' | ')' | ']' | '}')
+        }),
+        Some(character) => {
+            !(character.is_ascii_alphanumeric() || character == '-' || character == '_')
+        }
+    }
 }
 
 fn parsed_okf_concept(config: &MemoryConfig, issue: &IndexedIssue) -> Option<OkfConcept> {

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use crate::opensymphony_gateway_schema::{
     cursor::StreamCursor,
     memory_graph::{
@@ -11,6 +13,7 @@ use crate::opensymphony_gateway_schema::{
 };
 
 pub const DEFAULT_MEMORY_GRAPH_BUNDLE_ID: &str = "local-default";
+static MEMORY_GRAPH_SEQUENCE_FLOOR: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, thiserror::Error)]
 pub enum MemoryGraphProjectionError {
@@ -505,7 +508,23 @@ fn memory_graph_cursor(bundle_id: &str, timestamp: DateTime<Utc>) -> StreamCurso
 }
 
 fn memory_graph_sequence(timestamp: DateTime<Utc>) -> u64 {
-    timestamp.timestamp_millis().max(0) as u64
+    let candidate = timestamp
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| timestamp.timestamp_millis().saturating_mul(1_000_000))
+        .max(0) as u64;
+    let mut previous = MEMORY_GRAPH_SEQUENCE_FLOOR.load(Ordering::Relaxed);
+    loop {
+        let next = candidate.max(previous.saturating_add(1));
+        match MEMORY_GRAPH_SEQUENCE_FLOOR.compare_exchange_weak(
+            previous,
+            next,
+            Ordering::SeqCst,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return next,
+            Err(current) => previous = current,
+        }
+    }
 }
 
 fn concept_node_id(issue: &IndexedIssue) -> String {
@@ -554,7 +573,8 @@ fn insert_edge(
 ) {
     let label_key = label.as_deref().unwrap_or_default();
     let id = format!(
-        "{kind:?}:{source_id}->{target_id}:{}:{:016x}",
+        "{}:{source_id}->{target_id}:{}:{:016x}",
+        edge_kind_key(kind),
         unresolved,
         stable_edge_hash(label_key)
     );
@@ -815,8 +835,22 @@ fn normalize_concept_id(concept_id: &str) -> String {
 
 fn issue_matches_concept(issue: &IndexedIssue, concept_id: &str) -> bool {
     issue.concept_id == concept_id
-        || issue.issue_key == normalize_issue_key(concept_id)
-        || concept_id.ends_with(&issue.issue_key)
+        || issue.concept_id.trim_start_matches('/') == concept_id.trim_start_matches('/')
+        || (!concept_id.contains('/') && issue.issue_key == normalize_issue_key(concept_id))
+}
+
+fn edge_kind_key(kind: MemoryGraphEdgeKind) -> &'static str {
+    match kind {
+        MemoryGraphEdgeKind::Contains => "contains",
+        MemoryGraphEdgeKind::MarkdownLink => "markdown_link",
+        MemoryGraphEdgeKind::ExternalLink => "external_link",
+        MemoryGraphEdgeKind::Cites => "cites",
+        MemoryGraphEdgeKind::TaggedWith => "tagged_with",
+        MemoryGraphEdgeKind::DescribesResource => "describes_resource",
+        MemoryGraphEdgeKind::ScopedTo => "scoped_to",
+        MemoryGraphEdgeKind::SourceSupportedBy => "source_supported_by",
+        MemoryGraphEdgeKind::SameResource => "same_resource",
+    }
 }
 
 fn scope_kind_key(kind: &KnowledgeScopeKind) -> &'static str {

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -1,0 +1,881 @@
+use crate::opensymphony_gateway_schema::{
+    cursor::StreamCursor,
+    memory_graph::{
+        MemoryBundleList, MemoryBundleSummary, MemoryCommunityList, MemoryConceptDetail,
+        MemoryFrontmatterView, MemoryGraphCitation, MemoryGraphCommunity, MemoryGraphEdge,
+        MemoryGraphEdgeKind, MemoryGraphFreshness, MemoryGraphLink, MemoryGraphNode,
+        MemoryGraphNodeKind, MemoryGraphNodeMetrics, MemoryGraphSnapshot, MemoryGraphSourceRef,
+        MemoryGraphVisibility, MemorySearchResponse, MemorySearchResult,
+    },
+    version::SchemaVersion,
+};
+
+pub const DEFAULT_MEMORY_GRAPH_BUNDLE_ID: &str = "local-default";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryGraphAccess {
+    Public,
+    AllAccessible,
+}
+
+pub fn memory_graph_bundles(
+    config: &MemoryConfig,
+    access: MemoryGraphAccess,
+) -> Result<MemoryBundleList, MemoryError> {
+    let issues = accessible_issues(config, access)?;
+    Ok(MemoryBundleList {
+        schema_version: SchemaVersion::v1(),
+        bundles: vec![MemoryBundleSummary {
+            id: DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string(),
+            title: "OpenSymphony Memory".to_string(),
+            okf_version: OKF_VERSION.to_string(),
+            visibility: bundle_visibility(&issues),
+            concept_count: issues.len(),
+            updated_at: issues.iter().filter_map(indexed_issue_updated_at).max(),
+        }],
+    })
+}
+
+pub fn memory_graph_snapshot(
+    config: &MemoryConfig,
+    bundle_id: &str,
+    access: MemoryGraphAccess,
+) -> Result<MemoryGraphSnapshot, MemoryError> {
+    ensure_default_memory_bundle(bundle_id)?;
+    let issues = accessible_issues(config, access)?;
+    let communities = memory_graph_communities_from_issues(&issues);
+    let mut nodes = BTreeMap::<String, MemoryGraphNode>::new();
+    let mut edges = BTreeMap::<String, MemoryGraphEdge>::new();
+
+    insert_node(
+        &mut nodes,
+        MemoryGraphNode {
+            id: "bundle:local-default".to_string(),
+            kind: MemoryGraphNodeKind::Bundle,
+            label: "OpenSymphony Memory".to_string(),
+            bundle_id: Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string()),
+            concept_id: None,
+            concept_type: None,
+            description: None,
+            path_display: None,
+            resource: None,
+            tags: Vec::new(),
+            timestamp: None,
+            visibility: Some(bundle_visibility(&issues)),
+            freshness: None,
+            warning_count: 0,
+            frontmatter_summary: BTreeMap::new(),
+            unknown_frontmatter: BTreeMap::new(),
+            body_preview: None,
+            metrics: MemoryGraphNodeMetrics::default(),
+        },
+    );
+
+    for community in &communities {
+        insert_node(
+            &mut nodes,
+            MemoryGraphNode {
+                id: format!("community:{}", community.id),
+                kind: MemoryGraphNodeKind::Community,
+                label: community.label.clone(),
+                bundle_id: Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string()),
+                concept_id: None,
+                concept_type: None,
+                description: None,
+                path_display: None,
+                resource: None,
+                tags: Vec::new(),
+                timestamp: None,
+                visibility: None,
+                freshness: None,
+                warning_count: 0,
+                frontmatter_summary: BTreeMap::new(),
+                unknown_frontmatter: BTreeMap::new(),
+                body_preview: None,
+                metrics: MemoryGraphNodeMetrics::default(),
+            },
+        );
+    }
+
+    let concept_ids = issues
+        .iter()
+        .map(|issue| (issue.concept_id.clone(), concept_node_id(issue)))
+        .collect::<BTreeMap<_, _>>();
+    for issue in &issues {
+        let concept_node_id = concept_node_id(issue);
+        insert_directory_nodes(config, issue, &mut nodes, &mut edges);
+
+        let parsed = parsed_okf_concept(config, issue);
+        let frontmatter = parsed.as_ref().map(|concept| frontmatter_view(config, concept));
+        let resource = parsed
+            .as_ref()
+            .and_then(|concept| concept.frontmatter.resource.as_ref())
+            .map(|resource| redact_for_dto(config, resource));
+        let timestamp = parsed
+            .as_ref()
+            .and_then(|concept| concept.frontmatter.timestamp.clone())
+            .or_else(|| issue.completion_time.clone());
+
+        insert_node(
+            &mut nodes,
+            MemoryGraphNode {
+                id: concept_node_id.clone(),
+                kind: MemoryGraphNodeKind::Concept,
+                label: redact_for_dto(config, &issue.title),
+                bundle_id: Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string()),
+                concept_id: Some(issue.concept_id.clone()),
+                concept_type: Some(issue.concept_type.clone()),
+                description: issue.description.as_ref().map(|value| redact_for_dto(config, value)),
+                path_display: Some(safe_memory_path(config, &issue.capsule_path, &issue.concept_id)),
+                resource: resource.clone(),
+                tags: issue.tags.clone(),
+                timestamp,
+                visibility: Some(visibility_dto(issue.visibility)),
+                freshness: Some(freshness_dto(issue.freshness)),
+                warning_count: issue.warning_count,
+                frontmatter_summary: frontmatter
+                    .as_ref()
+                    .map(|view| view.primary.clone())
+                    .unwrap_or_default(),
+                unknown_frontmatter: frontmatter
+                    .as_ref()
+                    .map(|view| view.unknown.clone())
+                    .unwrap_or_default(),
+                body_preview: Some(redact_for_dto(config, &summarize_text(&issue.body, 280))),
+                metrics: MemoryGraphNodeMetrics::default(),
+            },
+        );
+
+        for tag in &issue.tags {
+            let tag_node = format!("tag:{tag}");
+            insert_node(
+                &mut nodes,
+                simple_node(&tag_node, MemoryGraphNodeKind::Tag, tag, Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID)),
+            );
+            insert_edge(
+                &mut edges,
+                MemoryGraphEdgeKind::TaggedWith,
+                &concept_node_id,
+                &tag_node,
+                None,
+                false,
+            );
+        }
+
+        if let Some(resource) = resource {
+            let resource_node = format!("resource:{resource}");
+            insert_node(
+                &mut nodes,
+                simple_node(
+                    &resource_node,
+                    MemoryGraphNodeKind::Resource,
+                    &resource,
+                    Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+                ),
+            );
+            insert_edge(
+                &mut edges,
+                MemoryGraphEdgeKind::DescribesResource,
+                &concept_node_id,
+                &resource_node,
+                None,
+                false,
+            );
+        }
+
+        for link in &issue.links {
+            let target = redact_for_dto(config, &link.target);
+            if is_external_target(&target) {
+                let target_node = format!("resource:{target}");
+                insert_node(
+                    &mut nodes,
+                    simple_node(
+                        &target_node,
+                        MemoryGraphNodeKind::Resource,
+                        &target,
+                        Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+                    ),
+                );
+                insert_edge(
+                    &mut edges,
+                    MemoryGraphEdgeKind::ExternalLink,
+                    &concept_node_id,
+                    &target_node,
+                    link.label.clone(),
+                    false,
+                );
+            } else {
+                let (target_node, unresolved) =
+                    resolve_markdown_link_target(&target, &concept_ids).unwrap_or_else(|| {
+                        (format!("unresolved:{target}"), true)
+                    });
+                insert_edge(
+                    &mut edges,
+                    MemoryGraphEdgeKind::MarkdownLink,
+                    &concept_node_id,
+                    &target_node,
+                    link.label.clone(),
+                    unresolved,
+                );
+            }
+        }
+
+        for citation in &issue.citations {
+            let target = redact_for_dto(config, &citation.target);
+            let citation_node = format!("citation:{}", citation.id);
+            insert_node(
+                &mut nodes,
+                simple_node(
+                    &citation_node,
+                    MemoryGraphNodeKind::Citation,
+                    citation.label.as_deref().unwrap_or(&target),
+                    Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+                ),
+            );
+            insert_edge(
+                &mut edges,
+                MemoryGraphEdgeKind::Cites,
+                &concept_node_id,
+                &citation_node,
+                citation.label.clone(),
+                false,
+            );
+        }
+
+        for source_ref in &issue.source_refs {
+            let source_node = format!("source_ref:{}:{}", source_ref.kind, source_ref.id);
+            insert_node(
+                &mut nodes,
+                simple_node(
+                    &source_node,
+                    MemoryGraphNodeKind::SourceRef,
+                    &format!("{}: {}", source_ref.kind, source_ref.id),
+                    Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+                ),
+            );
+            insert_edge(
+                &mut edges,
+                MemoryGraphEdgeKind::SourceSupportedBy,
+                &concept_node_id,
+                &source_node,
+                None,
+                false,
+            );
+        }
+
+        for scope_ref in &issue.scope_refs {
+            let scope_node = format!("scope_ref:{:?}:{}", scope_ref.kind, scope_ref.id);
+            insert_node(
+                &mut nodes,
+                simple_node(
+                    &scope_node,
+                    MemoryGraphNodeKind::SourceRef,
+                    scope_ref.label.as_deref().unwrap_or(&scope_ref.id),
+                    Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+                ),
+            );
+            insert_edge(
+                &mut edges,
+                MemoryGraphEdgeKind::ScopedTo,
+                &concept_node_id,
+                &scope_node,
+                None,
+                false,
+            );
+        }
+    }
+
+    insert_same_resource_edges(&issues, config, &mut edges);
+
+    let mut nodes = nodes.into_values().collect::<Vec<_>>();
+    let edges = edges.into_values().collect::<Vec<_>>();
+    apply_node_metrics(&mut nodes, &edges, &communities);
+
+    Ok(MemoryGraphSnapshot {
+        schema_version: SchemaVersion::v1(),
+        bundle_id: bundle_id.to_string(),
+        cursor: StreamCursor::new(memory_graph_sequence(&issues), format!("memory-graph:{bundle_id}")),
+        nodes,
+        edges,
+        communities,
+        filters_applied: filters_applied(access),
+        generated_at: Utc::now(),
+    })
+}
+
+pub fn memory_concept_detail(
+    config: &MemoryConfig,
+    bundle_id: &str,
+    concept_id: &str,
+    access: MemoryGraphAccess,
+) -> Result<MemoryConceptDetail, MemoryError> {
+    ensure_default_memory_bundle(bundle_id)?;
+    let concept_id = normalize_concept_id(concept_id);
+    let issue = accessible_issues(config, access)?
+        .into_iter()
+        .find(|issue| issue_matches_concept(issue, &concept_id))
+        .ok_or_else(|| MemoryError::InvalidInput(format!("no concept found for `{concept_id}`")))?;
+    let parsed = parsed_okf_concept(config, &issue);
+
+    Ok(MemoryConceptDetail {
+        schema_version: SchemaVersion::v1(),
+        bundle_id: bundle_id.to_string(),
+        concept_id: issue.concept_id.clone(),
+        frontmatter_view: parsed
+            .as_ref()
+            .map(|concept| frontmatter_view(config, concept))
+            .unwrap_or_else(|| fallback_frontmatter_view(config, &issue)),
+        body_markdown: redact_for_dto(config, &issue.body),
+        links: issue
+            .links
+            .iter()
+            .map(|link| MemoryGraphLink {
+                target: redact_for_dto(config, &link.target),
+                label: link.label.clone(),
+            })
+            .collect(),
+        citations: issue
+            .citations
+            .iter()
+            .map(|citation| MemoryGraphCitation {
+                id: citation.id.clone(),
+                target: redact_for_dto(config, &citation.target),
+                label: citation.label.clone(),
+            })
+            .collect(),
+        source_refs: issue
+            .source_refs
+            .iter()
+            .map(|source| MemoryGraphSourceRef {
+                kind: source.kind.clone(),
+                id: source.id.clone(),
+                url: source.url.as_ref().map(|url| redact_for_dto(config, url)),
+            })
+            .collect(),
+    })
+}
+
+pub fn memory_graph_communities(
+    config: &MemoryConfig,
+    bundle_id: &str,
+    access: MemoryGraphAccess,
+) -> Result<MemoryCommunityList, MemoryError> {
+    ensure_default_memory_bundle(bundle_id)?;
+    let issues = accessible_issues(config, access)?;
+    Ok(MemoryCommunityList {
+        schema_version: SchemaVersion::v1(),
+        bundle_id: bundle_id.to_string(),
+        communities: memory_graph_communities_from_issues(&issues),
+        generated_at: Utc::now(),
+    })
+}
+
+pub fn memory_graph_search(
+    config: &MemoryConfig,
+    query: &str,
+    limit: usize,
+    access: MemoryGraphAccess,
+) -> Result<MemorySearchResponse, MemoryError> {
+    let issues = accessible_issues(config, access)?;
+    let by_issue = issues
+        .iter()
+        .map(|issue| (issue.issue_key.clone(), issue))
+        .collect::<BTreeMap<_, _>>();
+    let scope = MemoryScopeFilter::default();
+    let results = search_with_scope(config, query, limit, &scope)?
+        .into_iter()
+        .filter_map(|result| {
+            let issue = by_issue.get(&result.issue_key)?;
+            Some(MemorySearchResult {
+                bundle_id: DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string(),
+                concept_id: issue.concept_id.clone(),
+                title: redact_for_dto(config, &issue.title),
+                visibility: visibility_dto(issue.visibility),
+                snippet: redact_for_dto(config, &result.snippet),
+                areas: result.areas,
+            })
+        })
+        .collect();
+
+    Ok(MemorySearchResponse {
+        schema_version: SchemaVersion::v1(),
+        query: query.to_string(),
+        bundle_id: Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string()),
+        results,
+    })
+}
+
+fn accessible_issues(
+    config: &MemoryConfig,
+    access: MemoryGraphAccess,
+) -> Result<Vec<IndexedIssue>, MemoryError> {
+    let mut issues = load_indexed_issues(config)?;
+    if access == MemoryGraphAccess::Public {
+        issues.retain(|issue| issue.visibility == MemoryVisibility::Public);
+    }
+    Ok(issues)
+}
+
+fn ensure_default_memory_bundle(bundle_id: &str) -> Result<(), MemoryError> {
+    if bundle_id == DEFAULT_MEMORY_GRAPH_BUNDLE_ID {
+        Ok(())
+    } else {
+        Err(MemoryError::InvalidInput(format!(
+            "unknown memory bundle `{bundle_id}`"
+        )))
+    }
+}
+
+fn bundle_visibility(issues: &[IndexedIssue]) -> MemoryGraphVisibility {
+    if issues
+        .iter()
+        .any(|issue| issue.visibility == MemoryVisibility::Private)
+    {
+        MemoryGraphVisibility::Private
+    } else {
+        MemoryGraphVisibility::Public
+    }
+}
+
+fn visibility_dto(visibility: MemoryVisibility) -> MemoryGraphVisibility {
+    match visibility {
+        MemoryVisibility::Public => MemoryGraphVisibility::Public,
+        MemoryVisibility::Private => MemoryGraphVisibility::Private,
+    }
+}
+
+fn freshness_dto(freshness: MemoryFreshness) -> MemoryGraphFreshness {
+    match freshness {
+        MemoryFreshness::Current => MemoryGraphFreshness::Current,
+        MemoryFreshness::Stale => MemoryGraphFreshness::Stale,
+        MemoryFreshness::Unknown => MemoryGraphFreshness::Unknown,
+    }
+}
+
+fn filters_applied(access: MemoryGraphAccess) -> Vec<String> {
+    match access {
+        MemoryGraphAccess::Public => vec!["visibility:public".to_string()],
+        MemoryGraphAccess::AllAccessible => Vec::new(),
+    }
+}
+
+fn indexed_issue_updated_at(issue: &IndexedIssue) -> Option<DateTime<Utc>> {
+    issue
+        .completion_time
+        .as_deref()
+        .or(Some(issue.captured_at.as_str()))
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+}
+
+fn memory_graph_sequence(issues: &[IndexedIssue]) -> u64 {
+    let mut hash = 14_695_981_039_346_656_037u64;
+    for issue in issues {
+        for byte in issue
+            .concept_id
+            .bytes()
+            .chain(issue.source_hash.bytes())
+            .chain(issue.captured_at.bytes())
+        {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(1_099_511_628_211);
+        }
+    }
+    hash
+}
+
+fn concept_node_id(issue: &IndexedIssue) -> String {
+    format!("concept:{}", issue.concept_id)
+}
+
+fn insert_node(nodes: &mut BTreeMap<String, MemoryGraphNode>, node: MemoryGraphNode) {
+    nodes.entry(node.id.clone()).or_insert(node);
+}
+
+fn simple_node(
+    id: &str,
+    kind: MemoryGraphNodeKind,
+    label: &str,
+    bundle_id: Option<&str>,
+) -> MemoryGraphNode {
+    MemoryGraphNode {
+        id: id.to_string(),
+        kind,
+        label: label.to_string(),
+        bundle_id: bundle_id.map(str::to_string),
+        concept_id: None,
+        concept_type: None,
+        description: None,
+        path_display: None,
+        resource: None,
+        tags: Vec::new(),
+        timestamp: None,
+        visibility: None,
+        freshness: None,
+        warning_count: 0,
+        frontmatter_summary: BTreeMap::new(),
+        unknown_frontmatter: BTreeMap::new(),
+        body_preview: None,
+        metrics: MemoryGraphNodeMetrics::default(),
+    }
+}
+
+fn insert_edge(
+    edges: &mut BTreeMap<String, MemoryGraphEdge>,
+    kind: MemoryGraphEdgeKind,
+    source_id: &str,
+    target_id: &str,
+    label: Option<String>,
+    unresolved: bool,
+) {
+    let id = format!("{kind:?}:{source_id}->{target_id}");
+    edges.entry(id.clone()).or_insert(MemoryGraphEdge {
+        id,
+        kind,
+        source_id: source_id.to_string(),
+        target_id: target_id.to_string(),
+        label,
+        unresolved,
+        metadata: BTreeMap::new(),
+    });
+}
+
+fn insert_directory_nodes(
+    config: &MemoryConfig,
+    issue: &IndexedIssue,
+    nodes: &mut BTreeMap<String, MemoryGraphNode>,
+    edges: &mut BTreeMap<String, MemoryGraphEdge>,
+) {
+    let path = safe_memory_path(config, &issue.capsule_path, &issue.concept_id);
+    let parts = path.split('/').collect::<Vec<_>>();
+    let mut parent = "bundle:local-default".to_string();
+    let mut accumulated = Vec::<&str>::new();
+    for part in parts.iter().take(parts.len().saturating_sub(1)) {
+        accumulated.push(part);
+        let dir = accumulated.join("/");
+        let id = format!("directory:{dir}");
+        insert_node(
+            nodes,
+            simple_node(&id, MemoryGraphNodeKind::Directory, &dir, Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID)),
+        );
+        insert_edge(edges, MemoryGraphEdgeKind::Contains, &parent, &id, None, false);
+        parent = id;
+    }
+    insert_edge(
+        edges,
+        MemoryGraphEdgeKind::Contains,
+        &parent,
+        &concept_node_id(issue),
+        None,
+        false,
+    );
+}
+
+fn safe_memory_path(config: &MemoryConfig, path: &Path, fallback_concept_id: &str) -> String {
+    let absolute = resolve_index_path(config, path);
+    absolute
+        .strip_prefix(&config.memory_root)
+        .or_else(|_| absolute.strip_prefix(&config.repo_root))
+        .map(|relative| relative.display().to_string())
+        .unwrap_or_else(|_| fallback_concept_id.to_string())
+}
+
+fn resolve_index_path(config: &MemoryConfig, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    let repo_path = config.repo_root.join(path);
+    if repo_path.exists() {
+        return repo_path;
+    }
+    config.memory_root.join(path)
+}
+
+fn redact_for_dto(config: &MemoryConfig, value: &str) -> String {
+    let repo_root = config.repo_root.to_string_lossy();
+    let memory_root = config.memory_root.to_string_lossy();
+    value
+        .replace(repo_root.as_ref(), "[redacted-local-path]")
+        .replace(memory_root.as_ref(), "[redacted-memory-path]")
+        .replace(".opensymphony/memory/", "[redacted-memory-path]/")
+}
+
+fn parsed_okf_concept(config: &MemoryConfig, issue: &IndexedIssue) -> Option<OkfConcept> {
+    let path = resolve_index_path(config, &issue.capsule_path);
+    let contents = fs::read_to_string(&path).ok()?;
+    let relative_path = path
+        .strip_prefix(&config.memory_root)
+        .or_else(|_| path.strip_prefix(config.repo_root.join(DEFAULT_MEMORY_ROOT)))
+        .map(Path::to_path_buf)
+        .ok()
+        .or_else(|| issue.capsule_path.is_relative().then(|| issue.capsule_path.clone()))
+        .or_else(|| memory_relative_path_from_components(&path))?;
+    parse_okf_concept(&config.memory_root, &relative_path, &contents).ok()
+}
+
+fn memory_relative_path_from_components(path: &Path) -> Option<PathBuf> {
+    let parts = path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    let marker = [".opensymphony", "memory"];
+    let index = parts
+        .windows(marker.len())
+        .position(|window| window == marker)?;
+    let mut relative = PathBuf::new();
+    for part in &parts[index + marker.len()..] {
+        relative.push(part);
+    }
+    Some(relative)
+}
+
+fn frontmatter_view(config: &MemoryConfig, concept: &OkfConcept) -> MemoryFrontmatterView {
+    let mut primary = BTreeMap::new();
+    primary.insert("type".to_string(), json_string(&concept.frontmatter.concept_type));
+    if let Some(title) = &concept.frontmatter.title {
+        primary.insert("title".to_string(), json_string(&redact_for_dto(config, title)));
+    }
+    if let Some(description) = &concept.frontmatter.description {
+        primary.insert(
+            "description".to_string(),
+            json_string(&redact_for_dto(config, description)),
+        );
+    }
+    if let Some(resource) = &concept.frontmatter.resource {
+        primary.insert(
+            "resource".to_string(),
+            json_string(&redact_for_dto(config, resource)),
+        );
+    }
+    if !concept.frontmatter.tags.is_empty() {
+        primary.insert(
+            "tags".to_string(),
+            serde_json::to_value(&concept.frontmatter.tags).unwrap_or(serde_json::Value::Null),
+        );
+    }
+    if let Some(timestamp) = &concept.frontmatter.timestamp {
+        primary.insert("timestamp".to_string(), json_string(timestamp));
+    }
+
+    MemoryFrontmatterView {
+        primary,
+        opensymphony: concept
+            .frontmatter
+            .opensymphony
+            .as_ref()
+            .and_then(json_object_map)
+            .map(|map| redact_map_for_dto(config, map))
+            .unwrap_or_default(),
+        unknown: concept
+            .frontmatter
+            .extra
+            .iter()
+            .map(|(key, value)| {
+                (
+                    key.clone(),
+                    serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+                )
+            })
+            .map(|(key, value)| (key, redact_value_for_dto(config, value)))
+            .collect(),
+    }
+}
+
+fn fallback_frontmatter_view(config: &MemoryConfig, issue: &IndexedIssue) -> MemoryFrontmatterView {
+    let mut primary = BTreeMap::new();
+    primary.insert("type".to_string(), json_string(&issue.concept_type));
+    primary.insert("title".to_string(), json_string(&redact_for_dto(config, &issue.title)));
+    if let Some(description) = &issue.description {
+        primary.insert(
+            "description".to_string(),
+            json_string(&redact_for_dto(config, description)),
+        );
+    }
+    if !issue.tags.is_empty() {
+        primary.insert(
+            "tags".to_string(),
+            serde_json::to_value(&issue.tags).unwrap_or(serde_json::Value::Null),
+        );
+    }
+    let mut opensymphony = BTreeMap::new();
+    opensymphony.insert(
+        "visibility".to_string(),
+        serde_json::to_value(issue.visibility).unwrap_or(serde_json::Value::Null),
+    );
+    opensymphony.insert(
+        "scope_refs".to_string(),
+        serde_json::to_value(&issue.scope_refs).unwrap_or(serde_json::Value::Null),
+    );
+    opensymphony.insert(
+        "source_refs".to_string(),
+        serde_json::to_value(&issue.source_refs).unwrap_or(serde_json::Value::Null),
+    );
+    opensymphony.insert(
+        "links".to_string(),
+        serde_json::to_value(&issue.links).unwrap_or(serde_json::Value::Null),
+    );
+    opensymphony.insert(
+        "citations".to_string(),
+        serde_json::to_value(&issue.citations).unwrap_or(serde_json::Value::Null),
+    );
+    MemoryFrontmatterView {
+        primary,
+        opensymphony: redact_map_for_dto(config, opensymphony),
+        unknown: BTreeMap::new(),
+    }
+}
+
+fn redact_map_for_dto(
+    config: &MemoryConfig,
+    map: BTreeMap<String, serde_json::Value>,
+) -> BTreeMap<String, serde_json::Value> {
+    map.into_iter()
+        .map(|(key, value)| (key, redact_value_for_dto(config, value)))
+        .collect()
+}
+
+fn redact_value_for_dto(
+    config: &MemoryConfig,
+    value: serde_json::Value,
+) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(value) => serde_json::Value::String(redact_for_dto(config, &value)),
+        serde_json::Value::Array(values) => serde_json::Value::Array(
+            values
+                .into_iter()
+                .map(|value| redact_value_for_dto(config, value))
+                .collect(),
+        ),
+        serde_json::Value::Object(values) => serde_json::Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, redact_value_for_dto(config, value)))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+fn json_string(value: &str) -> serde_json::Value {
+    serde_json::Value::String(value.to_string())
+}
+
+fn json_object_map<T: Serialize>(value: &T) -> Option<BTreeMap<String, serde_json::Value>> {
+    serde_json::to_value(value)
+        .ok()?
+        .as_object()
+        .map(|map| map.iter().map(|(key, value)| (key.clone(), value.clone())).collect())
+}
+
+fn normalize_concept_id(concept_id: &str) -> String {
+    concept_id
+        .trim()
+        .trim_matches('/')
+        .trim_end_matches(".md")
+        .to_string()
+}
+
+fn issue_matches_concept(issue: &IndexedIssue, concept_id: &str) -> bool {
+    issue.concept_id == concept_id
+        || issue.issue_key == normalize_issue_key(concept_id)
+        || concept_id.ends_with(&issue.issue_key)
+}
+
+fn is_external_target(target: &str) -> bool {
+    target.starts_with("http://") || target.starts_with("https://")
+}
+
+fn resolve_markdown_link_target(
+    target: &str,
+    concept_ids: &BTreeMap<String, String>,
+) -> Option<(String, bool)> {
+    let normalized = normalize_concept_id(target);
+    concept_ids
+        .get(&normalized)
+        .cloned()
+        .or_else(|| concept_ids.get(normalized.trim_start_matches('/')).cloned())
+        .or_else(|| {
+            concept_ids
+                .iter()
+                .find(|(concept_id, _)| concept_id.ends_with(&normalized))
+                .map(|(_, node_id)| node_id.clone())
+        })
+        .map(|node_id| (node_id, false))
+}
+
+fn insert_same_resource_edges(
+    issues: &[IndexedIssue],
+    config: &MemoryConfig,
+    edges: &mut BTreeMap<String, MemoryGraphEdge>,
+) {
+    let mut by_resource = BTreeMap::<String, Vec<&IndexedIssue>>::new();
+    for issue in issues {
+        if let Some(resource) = parsed_okf_concept(config, issue)
+            .and_then(|concept| concept.frontmatter.resource)
+        {
+            by_resource.entry(resource).or_default().push(issue);
+        }
+    }
+    for issues in by_resource.values() {
+        for (index, left) in issues.iter().enumerate() {
+            for right in issues.iter().skip(index + 1) {
+                insert_edge(
+                    edges,
+                    MemoryGraphEdgeKind::SameResource,
+                    &concept_node_id(left),
+                    &concept_node_id(right),
+                    None,
+                    false,
+                );
+            }
+        }
+    }
+}
+
+fn memory_graph_communities_from_issues(issues: &[IndexedIssue]) -> Vec<MemoryGraphCommunity> {
+    let mut by_area = BTreeMap::<String, Vec<String>>::new();
+    for issue in issues {
+        for area in issue.areas() {
+            by_area.entry(area).or_default().push(concept_node_id(issue));
+        }
+    }
+    by_area
+        .into_iter()
+        .map(|(area, mut node_ids)| {
+            node_ids.sort();
+            MemoryGraphCommunity {
+                id: format!("area:{area}"),
+                label: area,
+                concept_count: node_ids.len(),
+                node_ids,
+            }
+        })
+        .collect()
+}
+
+fn apply_node_metrics(
+    nodes: &mut [MemoryGraphNode],
+    edges: &[MemoryGraphEdge],
+    communities: &[MemoryGraphCommunity],
+) {
+    let mut indegree = BTreeMap::<String, usize>::new();
+    let mut outdegree = BTreeMap::<String, usize>::new();
+    for edge in edges {
+        *outdegree.entry(edge.source_id.clone()).or_default() += 1;
+        *indegree.entry(edge.target_id.clone()).or_default() += 1;
+    }
+    let community_by_node = communities
+        .iter()
+        .flat_map(|community| {
+            community
+                .node_ids
+                .iter()
+                .map(move |node_id| (node_id.clone(), community.id.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    for node in nodes {
+        node.metrics.indegree = indegree.get(&node.id).copied().unwrap_or_default();
+        node.metrics.outdegree = outdegree.get(&node.id).copied().unwrap_or_default();
+        node.metrics.community_id = community_by_node.get(&node.id).cloned();
+    }
+}

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -5,12 +5,22 @@ use crate::opensymphony_gateway_schema::{
         MemoryFrontmatterView, MemoryGraphCitation, MemoryGraphCommunity, MemoryGraphEdge,
         MemoryGraphEdgeKind, MemoryGraphFreshness, MemoryGraphLink, MemoryGraphNode,
         MemoryGraphNodeKind, MemoryGraphNodeMetrics, MemoryGraphSnapshot, MemoryGraphSourceRef,
-        MemoryGraphVisibility, MemorySearchResponse, MemorySearchResult,
+        MemoryGraphUpdatedEvent, MemoryGraphVisibility, MemorySearchResponse, MemorySearchResult,
     },
     version::SchemaVersion,
 };
 
 pub const DEFAULT_MEMORY_GRAPH_BUNDLE_ID: &str = "local-default";
+
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryGraphProjectionError {
+    #[error("unknown memory bundle `{0}`")]
+    BundleNotFound(String),
+    #[error("no concept found for `{0}`")]
+    ConceptNotFound(String),
+    #[error(transparent)]
+    Memory(#[from] MemoryError),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryGraphAccess {
@@ -21,7 +31,7 @@ pub enum MemoryGraphAccess {
 pub fn memory_graph_bundles(
     config: &MemoryConfig,
     access: MemoryGraphAccess,
-) -> Result<MemoryBundleList, MemoryError> {
+) -> Result<MemoryBundleList, MemoryGraphProjectionError> {
     let issues = accessible_issues(config, access)?;
     Ok(MemoryBundleList {
         schema_version: SchemaVersion::v1(),
@@ -40,8 +50,9 @@ pub fn memory_graph_snapshot(
     config: &MemoryConfig,
     bundle_id: &str,
     access: MemoryGraphAccess,
-) -> Result<MemoryGraphSnapshot, MemoryError> {
+) -> Result<MemoryGraphSnapshot, MemoryGraphProjectionError> {
     ensure_default_memory_bundle(bundle_id)?;
+    let generated_at = Utc::now();
     let issues = accessible_issues(config, access)?;
     let communities = memory_graph_communities_from_issues(&issues);
     let mut nodes = BTreeMap::<String, MemoryGraphNode>::new();
@@ -264,7 +275,11 @@ pub fn memory_graph_snapshot(
         }
 
         for scope_ref in &issue.scope_refs {
-            let scope_node = format!("scope_ref:{:?}:{}", scope_ref.kind, scope_ref.id);
+            let scope_node = format!(
+                "scope_ref:{}:{}",
+                scope_kind_key(&scope_ref.kind),
+                scope_ref.id
+            );
             insert_node(
                 &mut nodes,
                 simple_node(
@@ -294,12 +309,12 @@ pub fn memory_graph_snapshot(
     Ok(MemoryGraphSnapshot {
         schema_version: SchemaVersion::v1(),
         bundle_id: bundle_id.to_string(),
-        cursor: StreamCursor::new(memory_graph_sequence(&issues), format!("memory-graph:{bundle_id}")),
+        cursor: memory_graph_cursor(bundle_id, generated_at),
         nodes,
         edges,
         communities,
         filters_applied: filters_applied(access),
-        generated_at: Utc::now(),
+        generated_at,
     })
 }
 
@@ -308,13 +323,13 @@ pub fn memory_concept_detail(
     bundle_id: &str,
     concept_id: &str,
     access: MemoryGraphAccess,
-) -> Result<MemoryConceptDetail, MemoryError> {
+) -> Result<MemoryConceptDetail, MemoryGraphProjectionError> {
     ensure_default_memory_bundle(bundle_id)?;
     let concept_id = normalize_concept_id(concept_id);
     let issue = accessible_issues(config, access)?
         .into_iter()
         .find(|issue| issue_matches_concept(issue, &concept_id))
-        .ok_or_else(|| MemoryError::InvalidInput(format!("no concept found for `{concept_id}`")))?;
+        .ok_or_else(|| MemoryGraphProjectionError::ConceptNotFound(concept_id.clone()))?;
     let parsed = parsed_okf_concept(config, &issue);
 
     Ok(MemoryConceptDetail {
@@ -359,7 +374,7 @@ pub fn memory_graph_communities(
     config: &MemoryConfig,
     bundle_id: &str,
     access: MemoryGraphAccess,
-) -> Result<MemoryCommunityList, MemoryError> {
+) -> Result<MemoryCommunityList, MemoryGraphProjectionError> {
     ensure_default_memory_bundle(bundle_id)?;
     let issues = accessible_issues(config, access)?;
     Ok(MemoryCommunityList {
@@ -375,7 +390,7 @@ pub fn memory_graph_search(
     query: &str,
     limit: usize,
     access: MemoryGraphAccess,
-) -> Result<MemorySearchResponse, MemoryError> {
+) -> Result<MemorySearchResponse, MemoryGraphProjectionError> {
     let issues = accessible_issues(config, access)?;
     let by_issue = issues
         .iter()
@@ -405,10 +420,26 @@ pub fn memory_graph_search(
     })
 }
 
+pub fn memory_graph_updated_event(
+    config: &MemoryConfig,
+    bundle_id: &str,
+    access: MemoryGraphAccess,
+) -> Result<MemoryGraphUpdatedEvent, MemoryGraphProjectionError> {
+    ensure_default_memory_bundle(bundle_id)?;
+    let _ = accessible_issues(config, access)?;
+    let updated_at = Utc::now();
+    Ok(MemoryGraphUpdatedEvent {
+        schema_version: SchemaVersion::v1(),
+        bundle_id: bundle_id.to_string(),
+        cursor: memory_graph_cursor(bundle_id, updated_at),
+        updated_at,
+    })
+}
+
 fn accessible_issues(
     config: &MemoryConfig,
     access: MemoryGraphAccess,
-) -> Result<Vec<IndexedIssue>, MemoryError> {
+) -> Result<Vec<IndexedIssue>, MemoryGraphProjectionError> {
     let mut issues = load_indexed_issues(config)?;
     if access == MemoryGraphAccess::Public {
         issues.retain(|issue| issue.visibility == MemoryVisibility::Public);
@@ -416,13 +447,11 @@ fn accessible_issues(
     Ok(issues)
 }
 
-fn ensure_default_memory_bundle(bundle_id: &str) -> Result<(), MemoryError> {
+fn ensure_default_memory_bundle(bundle_id: &str) -> Result<(), MemoryGraphProjectionError> {
     if bundle_id == DEFAULT_MEMORY_GRAPH_BUNDLE_ID {
         Ok(())
     } else {
-        Err(MemoryError::InvalidInput(format!(
-            "unknown memory bundle `{bundle_id}`"
-        )))
+        Err(MemoryGraphProjectionError::BundleNotFound(bundle_id.to_string()))
     }
 }
 
@@ -468,20 +497,15 @@ fn indexed_issue_updated_at(issue: &IndexedIssue) -> Option<DateTime<Utc>> {
         .map(|value| value.with_timezone(&Utc))
 }
 
-fn memory_graph_sequence(issues: &[IndexedIssue]) -> u64 {
-    let mut hash = 14_695_981_039_346_656_037u64;
-    for issue in issues {
-        for byte in issue
-            .concept_id
-            .bytes()
-            .chain(issue.source_hash.bytes())
-            .chain(issue.captured_at.bytes())
-        {
-            hash ^= u64::from(byte);
-            hash = hash.wrapping_mul(1_099_511_628_211);
-        }
-    }
-    hash
+fn memory_graph_cursor(bundle_id: &str, timestamp: DateTime<Utc>) -> StreamCursor {
+    StreamCursor::new(
+        memory_graph_sequence(timestamp),
+        format!("memory-graph:{bundle_id}"),
+    )
+}
+
+fn memory_graph_sequence(timestamp: DateTime<Utc>) -> u64 {
+    timestamp.timestamp_millis().max(0) as u64
 }
 
 fn concept_node_id(issue: &IndexedIssue) -> String {
@@ -528,7 +552,12 @@ fn insert_edge(
     label: Option<String>,
     unresolved: bool,
 ) {
-    let id = format!("{kind:?}:{source_id}->{target_id}");
+    let label_key = label.as_deref().unwrap_or_default();
+    let id = format!(
+        "{kind:?}:{source_id}->{target_id}:{}:{:016x}",
+        unresolved,
+        stable_edge_hash(label_key)
+    );
     edges.entry(id.clone()).or_insert(MemoryGraphEdge {
         id,
         kind,
@@ -538,6 +567,15 @@ fn insert_edge(
         unresolved,
         metadata: BTreeMap::new(),
     });
+}
+
+fn stable_edge_hash(value: &str) -> u64 {
+    let mut hash = 14_695_981_039_346_656_037u64;
+    for byte in value.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(1_099_511_628_211);
+    }
+    hash
 }
 
 fn insert_directory_nodes(
@@ -779,6 +817,20 @@ fn issue_matches_concept(issue: &IndexedIssue, concept_id: &str) -> bool {
     issue.concept_id == concept_id
         || issue.issue_key == normalize_issue_key(concept_id)
         || concept_id.ends_with(&issue.issue_key)
+}
+
+fn scope_kind_key(kind: &KnowledgeScopeKind) -> &'static str {
+    match kind {
+        KnowledgeScopeKind::LocalInstance => "local_instance",
+        KnowledgeScopeKind::Organization => "organization",
+        KnowledgeScopeKind::ProjectSet => "project_set",
+        KnowledgeScopeKind::Project => "project",
+        KnowledgeScopeKind::Milestone => "milestone",
+        KnowledgeScopeKind::WorkItem => "work_item",
+        KnowledgeScopeKind::Repository => "repository",
+        KnowledgeScopeKind::CodePath => "code_path",
+        KnowledgeScopeKind::Area => "area",
+    }
 }
 
 fn is_external_target(target: &str) -> bool {

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -842,17 +842,32 @@ fn resolve_markdown_link_target(
     concept_ids: &BTreeMap<String, String>,
 ) -> Option<(String, bool)> {
     let normalized = normalize_concept_id(target);
-    concept_ids
+    let exact = concept_ids
         .get(&normalized)
-        .cloned()
-        .or_else(|| concept_ids.get(normalized.trim_start_matches('/')).cloned())
-        .or_else(|| {
-            concept_ids
-                .iter()
-                .find(|(concept_id, _)| concept_id.ends_with(&normalized))
-                .map(|(_, node_id)| node_id.clone())
+        .or_else(|| concept_ids.get(normalized.trim_start_matches('/')));
+    if let Some(node_id) = exact {
+        return Some((node_id.clone(), false));
+    }
+
+    let normalized_leaf = normalized.trim_start_matches('/');
+    let mut suffix_matches = concept_ids
+        .iter()
+        .filter(|(concept_id, _)| {
+            concept_id
+                .rsplit('/')
+                .next()
+                .is_some_and(|leaf| leaf == normalized_leaf)
+                || concept_id.ends_with(&format!("/{normalized_leaf}"))
         })
-        .map(|node_id| (node_id, false))
+        .map(|(_, node_id)| node_id.clone())
+        .collect::<Vec<_>>();
+    suffix_matches.sort();
+    suffix_matches.dedup();
+    if suffix_matches.len() == 1 {
+        suffix_matches.pop().map(|node_id| (node_id, false))
+    } else {
+        None
+    }
 }
 
 fn insert_same_resource_edges(

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{fmt::Write as _, sync::atomic::{AtomicU64, Ordering}};
 
 use crate::opensymphony_gateway_schema::{
     cursor::StreamCursor,
@@ -115,11 +115,17 @@ pub fn memory_graph_snapshot(
         .iter()
         .map(|issue| (issue.concept_id.clone(), concept_node_id(issue)))
         .collect::<BTreeMap<_, _>>();
+    let parsed_concepts = issues
+        .iter()
+        .map(|issue| (issue.concept_id.clone(), parsed_okf_concept(config, issue)))
+        .collect::<BTreeMap<_, _>>();
     for issue in &issues {
         let concept_node_id = concept_node_id(issue);
         insert_directory_nodes(config, issue, &mut nodes, &mut edges);
 
-        let parsed = parsed_okf_concept(config, issue);
+        let parsed = parsed_concepts
+            .get(&issue.concept_id)
+            .and_then(Option::as_ref);
         let frontmatter = parsed.as_ref().map(|concept| frontmatter_view(config, concept));
         let resource = parsed
             .as_ref()
@@ -303,7 +309,7 @@ pub fn memory_graph_snapshot(
         }
     }
 
-    insert_same_resource_edges(&issues, config, &mut edges);
+    insert_same_resource_edges(&issues, &parsed_concepts, &mut edges);
 
     let mut nodes = nodes.into_values().collect::<Vec<_>>();
     let edges = edges.into_values().collect::<Vec<_>>();
@@ -572,12 +578,15 @@ fn insert_edge(
     label: Option<String>,
     unresolved: bool,
 ) {
-    let label_key = label.as_deref().unwrap_or_default();
+    let label_key = label
+        .as_deref()
+        .map(|value| format!("label:{}", edge_id_component(value)))
+        .unwrap_or_else(|| "no_label".to_string());
     let id = format!(
-        "{}:{source_id}->{target_id}:{}:{:016x}",
+        "{}:{source_id}->{target_id}:{}:{}",
         edge_kind_key(kind),
         unresolved,
-        stable_edge_hash(label_key)
+        label_key
     );
     edges.entry(id.clone()).or_insert(MemoryGraphEdge {
         id,
@@ -590,13 +599,16 @@ fn insert_edge(
     });
 }
 
-fn stable_edge_hash(value: &str) -> u64 {
-    let mut hash = 14_695_981_039_346_656_037u64;
+fn edge_id_component(value: &str) -> String {
+    let mut escaped = String::new();
     for byte in value.bytes() {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(1_099_511_628_211);
+        if matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'-' | b'_') {
+            escaped.push(char::from(byte));
+        } else {
+            write!(&mut escaped, "%{byte:02X}").expect("writing to String cannot fail");
+        }
     }
-    hash
+    escaped
 }
 
 fn insert_directory_nodes(
@@ -655,7 +667,7 @@ fn redact_for_dto(config: &MemoryConfig, value: &str) -> String {
     let memory_root = config.memory_root.to_string_lossy();
     let value = replace_path_token(value, repo_root.as_ref(), "[redacted-local-path]");
     let value = replace_path_token(&value, memory_root.as_ref(), "[redacted-memory-path]");
-    value.replace(".opensymphony/memory/", "[redacted-memory-path]/")
+    replace_path_token(&value, ".opensymphony/memory", "[redacted-memory-path]")
 }
 
 fn replace_path_token(value: &str, needle: &str, replacement: &str) -> String {
@@ -666,8 +678,9 @@ fn replace_path_token(value: &str, needle: &str, replacement: &str) -> String {
     let mut remaining = value;
     while let Some(index) = remaining.find(needle) {
         result.push_str(&remaining[..index]);
+        let before = &remaining[..index];
         let after = &remaining[index + needle.len()..];
-        if is_path_token_boundary(after) {
+        if is_path_token_left_boundary(before) && is_path_token_right_boundary(after) {
             result.push_str(replacement);
         } else {
             result.push_str(needle);
@@ -678,7 +691,18 @@ fn replace_path_token(value: &str, needle: &str, replacement: &str) -> String {
     result
 }
 
-fn is_path_token_boundary(after: &str) -> bool {
+fn is_path_token_left_boundary(before: &str) -> bool {
+    match before.chars().next_back() {
+        None => true,
+        Some('/') | Some('\\') => true,
+        Some(character) => {
+            !(character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '_' | '.'))
+        }
+    }
+}
+
+fn is_path_token_right_boundary(after: &str) -> bool {
     let mut chars = after.chars();
     match chars.next() {
         None => true,
@@ -940,15 +964,17 @@ fn resolve_markdown_link_target(
 
 fn insert_same_resource_edges(
     issues: &[IndexedIssue],
-    config: &MemoryConfig,
+    parsed_concepts: &BTreeMap<String, Option<OkfConcept>>,
     edges: &mut BTreeMap<String, MemoryGraphEdge>,
 ) {
     let mut by_resource = BTreeMap::<String, Vec<&IndexedIssue>>::new();
     for issue in issues {
-        if let Some(resource) = parsed_okf_concept(config, issue)
-            .and_then(|concept| concept.frontmatter.resource)
+        if let Some(resource) = parsed_concepts
+            .get(&issue.concept_id)
+            .and_then(Option::as_ref)
+            .and_then(|concept| concept.frontmatter.resource.as_ref())
         {
-            by_resource.entry(resource).or_default().push(issue);
+            by_resource.entry(resource.clone()).or_default().push(issue);
         }
     }
     for issues in by_resource.values() {

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -400,14 +400,16 @@ pub fn memory_graph_search(
     limit: usize,
     access: MemoryGraphAccess,
 ) -> Result<MemorySearchResponse, MemoryGraphProjectionError> {
-    let issues = accessible_issues(config, access)?;
+    let all_issues = load_indexed_issues(config)?;
+    let search_limit = all_issues.len().max(limit.max(1));
+    let issues = filter_issues_for_access(all_issues, access);
     let limit = limit.max(1);
     let by_issue = issues
         .iter()
         .map(|issue| (issue.issue_key.clone(), issue))
         .collect::<BTreeMap<_, _>>();
     let scope = MemoryScopeFilter::default();
-    let results = search_with_scope(config, query, usize::MAX, &scope)?
+    let results = search_with_scope(config, query, search_limit, &scope)?
         .into_iter()
         .filter_map(|result| {
             let issue = by_issue.get(&result.issue_key)?;
@@ -450,11 +452,17 @@ fn accessible_issues(
     config: &MemoryConfig,
     access: MemoryGraphAccess,
 ) -> Result<Vec<IndexedIssue>, MemoryGraphProjectionError> {
-    let mut issues = load_indexed_issues(config)?;
+    Ok(filter_issues_for_access(load_indexed_issues(config)?, access))
+}
+
+fn filter_issues_for_access(
+    mut issues: Vec<IndexedIssue>,
+    access: MemoryGraphAccess,
+) -> Vec<IndexedIssue> {
     if access == MemoryGraphAccess::Public {
         issues.retain(|issue| issue.visibility == MemoryVisibility::Public);
     }
-    Ok(issues)
+    issues
 }
 
 fn ensure_default_memory_bundle(bundle_id: &str) -> Result<(), MemoryGraphProjectionError> {
@@ -655,11 +663,18 @@ fn resolve_index_path(config: &MemoryConfig, path: &Path) -> PathBuf {
     if path.is_absolute() {
         return path.to_path_buf();
     }
+    if path.starts_with(DEFAULT_MEMORY_ROOT) {
+        return config.repo_root.join(path);
+    }
+    let memory_path = config.memory_root.join(path);
+    if memory_path.exists() {
+        return memory_path;
+    }
     let repo_path = config.repo_root.join(path);
     if repo_path.exists() {
         return repo_path;
     }
-    config.memory_root.join(path)
+    memory_path
 }
 
 fn redact_for_dto(config: &MemoryConfig, value: &str) -> String {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -385,7 +385,7 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
 
     let mut statement = connection
         .prepare(
-            "SELECT issue_key, title, state, milestone, labels_json, capsule_path, visibility, source_hash, warning_count, docs_sync_status, completion_time, captured_at, body FROM issues ORDER BY issue_key",
+            "SELECT issue_key, title, state, milestone, labels_json, capsule_path, visibility, source_hash, warning_count, docs_sync_status, completion_time, captured_at, body, concept_id, concept_type, description, tags_json, scope_refs_json, source_refs_json, links_json, citations_json, freshness, warnings_json FROM issues ORDER BY issue_key",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -394,12 +394,22 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
     let rows = statement
         .query_map([], |row| {
             let labels_json: String = row.get(4)?;
+            let tags_json: String = row.get(16)?;
+            let scope_refs_json: String = row.get(17)?;
+            let source_refs_json: String = row.get(18)?;
+            let links_json: String = row.get(19)?;
+            let citations_json: String = row.get(20)?;
+            let warnings_json: String = row.get(22)?;
             Ok(IndexedIssue {
                 issue_key: row.get(0)?,
+                concept_id: row.get(13)?,
+                concept_type: row.get(14)?,
                 title: row.get(1)?,
+                description: row.get(15)?,
                 state: row.get(2)?,
                 milestone: row.get(3)?,
                 labels: serde_json::from_str::<Vec<String>>(&labels_json).unwrap_or_default(),
+                tags: serde_json::from_str::<Vec<String>>(&tags_json).unwrap_or_default(),
                 areas: Vec::new(),
                 capsule_path: PathBuf::from(row.get::<_, String>(5)?),
                 visibility: match row.get::<_, String>(6)?.as_str() {
@@ -412,6 +422,20 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
                 completion_time: row.get(10)?,
                 captured_at: row.get(11)?,
                 changed_files: Vec::new(),
+                scope_refs: serde_json::from_str::<Vec<KnowledgeScope>>(&scope_refs_json)
+                    .unwrap_or_default(),
+                source_refs: serde_json::from_str::<Vec<MemorySourceRef>>(&source_refs_json)
+                    .unwrap_or_default(),
+                links: serde_json::from_str::<Vec<OkfLink>>(&links_json).unwrap_or_default(),
+                citations: serde_json::from_str::<Vec<OkfCitation>>(&citations_json)
+                    .unwrap_or_default(),
+                freshness: match row.get::<_, String>(21)?.as_str() {
+                    "current" => MemoryFreshness::Current,
+                    "stale" => MemoryFreshness::Stale,
+                    _ => MemoryFreshness::Unknown,
+                },
+                warnings: serde_json::from_str::<Vec<String>>(&warnings_json)
+                    .unwrap_or_default(),
                 body: row.get(12)?,
             })
         })
@@ -1310,10 +1334,14 @@ mod index_tests {
     fn issue_log_date_uses_stable_sentinel_for_malformed_timestamps() {
         let issue = IndexedIssue {
             issue_key: "COE-999".to_string(),
+            concept_id: "issues/COE-999".to_string(),
+            concept_type: "issue-capsule".to_string(),
             title: "Malformed timestamps".to_string(),
+            description: None,
             state: None,
             milestone: None,
             labels: Vec::new(),
+            tags: Vec::new(),
             areas: Vec::new(),
             capsule_path: PathBuf::from(".opensymphony/memory/issues/COE-999.md"),
             visibility: MemoryVisibility::Private,
@@ -1323,6 +1351,12 @@ mod index_tests {
             completion_time: Some("not-a-date".to_string()),
             captured_at: "also-not-a-date".to_string(),
             changed_files: Vec::new(),
+            scope_refs: Vec::new(),
+            source_refs: Vec::new(),
+            links: Vec::new(),
+            citations: Vec::new(),
+            freshness: MemoryFreshness::Unknown,
+            warnings: Vec::new(),
             body: String::new(),
         };
 

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1410,14 +1410,34 @@ opensymphony:
 # COE-200: Public graph concept
 
 Public graph body mentions .opensymphony/memory/issues/COE-999.md and {}.
+Sibling prefix must not be mangled: {}bed.
 
 See [private concept](COE-123.md), [external](https://example.com/reference),
 and [external mirror](https://example.com/reference).
 "#,
+                repo.path().display(),
                 repo.path().display()
             ),
         )
         .expect("public concept should write");
+        fs::write(
+            issues_dir.join("AAA-111.md"),
+            r#"---
+type: issue
+title: "AAA-111: Private ranked search match"
+opensymphony:
+  visibility: private
+  scope_refs:
+    - kind: work_item
+      id: AAA-111
+---
+
+# AAA-111: Private ranked search match
+
+public graph
+"#,
+        )
+        .expect("private search concept should write");
         fs::create_dir_all(bundle.join("backlog")).expect("backlog dir should write");
         fs::write(
             bundle.join("backlog/COE-222.md"),
@@ -1538,7 +1558,9 @@ opensymphony:
         assert!(!public_json.contains("concept:issues/COE-123"));
         assert!(!public_json.contains("COE-123: OKF catalog rebuild"));
         assert!(!public_json.contains(".opensymphony/memory"));
-        assert!(!public_json.contains(&repo.path().display().to_string()));
+        assert!(!public_json.contains(&format!("{}/", repo.path().display())));
+        assert!(!public_json.contains(&format!("{}.", repo.path().display())));
+        assert!(!public_json.contains("[redacted-local-path]bed"));
 
         let detail = memory_concept_detail(
             &config,
@@ -1568,7 +1590,12 @@ opensymphony:
         assert!(
             !detail
                 .body_markdown
-                .contains(&repo.path().display().to_string())
+                .contains(&format!("{}/", repo.path().display()))
+        );
+        assert!(
+            !detail
+                .body_markdown
+                .contains(&format!("{}.", repo.path().display()))
         );
         let bare_issue_detail = memory_concept_detail(
             &config,
@@ -1589,7 +1616,7 @@ opensymphony:
             Err(MemoryGraphProjectionError::ConceptNotFound(_))
         ));
 
-        let search = memory_graph_search(&config, "public graph", 10, MemoryGraphAccess::Public)
+        let search = memory_graph_search(&config, "public graph", 1, MemoryGraphAccess::Public)
             .expect("public graph search");
         assert_eq!(search.results.len(), 1);
         assert_eq!(search.results[0].concept_id, "issues/COE-200");

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1411,7 +1411,8 @@ opensymphony:
 
 Public graph body mentions .opensymphony/memory/issues/COE-999.md and {}.
 
-See [private concept](COE-123.md) and [external](https://example.com/reference).
+See [private concept](COE-123.md), [external](https://example.com/reference),
+and [external mirror](https://example.com/reference).
 "#,
                 repo.path().display()
             ),
@@ -1472,6 +1473,28 @@ See [private concept](COE-123.md) and [external](https://example.com/reference).
         ] {
             assert!(edge_kinds.contains(&kind), "missing edge kind {kind:?}");
         }
+        let parallel_external_edges = all_graph
+            .edges
+            .iter()
+            .filter(|edge| {
+                edge.kind == EdgeKind::ExternalLink
+                    && edge.target_id == "resource:https://example.com/reference"
+            })
+            .count();
+        assert_eq!(parallel_external_edges, 2);
+
+        let update = memory_graph_updated_event(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            MemoryGraphAccess::AllAccessible,
+        )
+        .expect("update event payload");
+        assert_eq!(update.bundle_id, DEFAULT_MEMORY_GRAPH_BUNDLE_ID);
+        assert_eq!(
+            update.cursor.partition,
+            "memory-graph:local-default".to_string()
+        );
+        assert!(update.cursor.sequence > 0);
 
         let public_graph = memory_graph_snapshot(
             &config,

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1526,6 +1526,18 @@ opensymphony:
             .expect("external edge");
         assert!(external_edge.id.starts_with("external_link:"));
         assert!(!external_edge.id.starts_with("ExternalLink:"));
+        assert!(
+            all_graph
+                .edges
+                .iter()
+                .any(|edge| edge.id.ends_with(":label:external"))
+        );
+        assert!(
+            all_graph
+                .edges
+                .iter()
+                .any(|edge| edge.id.ends_with(":label:external%20mirror"))
+        );
 
         let update = memory_graph_updated_event(
             &config,
@@ -1620,6 +1632,38 @@ opensymphony:
             .expect("public graph search");
         assert_eq!(search.results.len(), 1);
         assert_eq!(search.results[0].concept_id, "issues/COE-200");
+    }
+
+    #[test]
+    fn memory_graph_path_redaction_respects_token_boundaries() {
+        assert_eq!(
+            replace_path_token("/tmp/repo/file.md", "/tmp/repo", "[redacted]"),
+            "[redacted]/file.md"
+        );
+        assert_eq!(
+            replace_path_token("/foo/tmp/repo/file.md", "/tmp/repo", "[redacted]"),
+            "/foo/tmp/repo/file.md"
+        );
+        assert_eq!(
+            replace_path_token("/tmp/repository/file.md", "/tmp/repo", "[redacted]"),
+            "/tmp/repository/file.md"
+        );
+        assert_eq!(
+            replace_path_token(
+                ".opensymphony/memory/issues/COE-200.md",
+                ".opensymphony/memory",
+                "[redacted-memory-path]",
+            ),
+            "[redacted-memory-path]/issues/COE-200.md"
+        );
+        assert_eq!(
+            replace_path_token(
+                "prefix.opensymphony/memory/issues/COE-200.md",
+                ".opensymphony/memory",
+                "[redacted-memory-path]",
+            ),
+            "prefix.opensymphony/memory/issues/COE-200.md"
+        );
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1667,6 +1667,33 @@ opensymphony:
     }
 
     #[test]
+    fn memory_graph_resolves_relative_capsules_under_memory_root_first() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = config_for(repo.path());
+        fs::create_dir_all(repo.path().join("issues")).expect("repo issues dir");
+        fs::create_dir_all(config.memory_root.join("issues")).expect("memory issues dir");
+        fs::write(repo.path().join("issues/COE-200.md"), "repo file").expect("repo file");
+        fs::write(config.memory_root.join("issues/COE-200.md"), "memory file")
+            .expect("memory file");
+
+        assert_eq!(
+            resolve_index_path(&config, Path::new("issues/COE-200.md")),
+            config.memory_root.join("issues/COE-200.md")
+        );
+        assert_eq!(
+            resolve_index_path(
+                &config,
+                Path::new(DEFAULT_MEMORY_ROOT)
+                    .join("issues/COE-200.md")
+                    .as_path(),
+            ),
+            repo.path()
+                .join(DEFAULT_MEMORY_ROOT)
+                .join("issues/COE-200.md")
+        );
+    }
+
+    #[test]
     fn migration_adds_okf_columns_with_new_table_nullability() {
         let repo = TempDir::new().expect("temp repo");
         let config = config_for(repo.path());

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -754,10 +754,14 @@ pub struct ArchiveIssuePlan {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct IndexedIssue {
     issue_key: String,
+    concept_id: String,
+    concept_type: String,
     title: String,
+    description: Option<String>,
     state: Option<String>,
     milestone: Option<String>,
     labels: Vec<String>,
+    tags: Vec<String>,
     areas: Vec<String>,
     capsule_path: PathBuf,
     visibility: MemoryVisibility,
@@ -767,6 +771,12 @@ struct IndexedIssue {
     completion_time: Option<String>,
     captured_at: String,
     changed_files: Vec<PathBuf>,
+    scope_refs: Vec<KnowledgeScope>,
+    source_refs: Vec<MemorySourceRef>,
+    links: Vec<OkfLink>,
+    citations: Vec<OkfCitation>,
+    freshness: MemoryFreshness,
+    warnings: Vec<String>,
     body: String,
 }
 
@@ -774,6 +784,7 @@ include!("config.rs");
 include!("okf.rs");
 include!("capture.rs");
 include!("query.rs");
+include!("graph.rs");
 include!("docs_sync.rs");
 include!("archive.rs");
 include!("capture_render.rs");
@@ -1359,6 +1370,157 @@ type: topic-doc
             )
             .expect("doc link count should query");
         assert_eq!(doc_link_count, 1);
+    }
+
+    #[test]
+    fn memory_graph_projection_filters_private_and_redacts_local_paths() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = config_for(repo.path());
+        let bundle = repo.path().join(".opensymphony/memory");
+        let issues_dir = bundle.join("issues");
+        copy_dir_recursive(&okf_fixture("okf-reindex"), &bundle);
+        fs::write(
+            issues_dir.join("COE-200.md"),
+            format!(
+                r#"---
+type: topic-doc
+title: "COE-200: Public graph concept"
+description: Public graph DTO fixture.
+resource: https://linear.app/example/issue/COE-123
+tags: [memory, graph]
+timestamp: 2026-06-22T10:00:00Z
+unknown_field: keep-me
+opensymphony:
+  visibility: public
+  scope_refs:
+    - kind: work_item
+      id: COE-200
+    - kind: area
+      id: graph-view
+  source_refs:
+    - kind: linear_issue
+      id: COE-200
+      url: https://linear.app/example/issue/COE-200
+  citations:
+    - id: "1"
+      target: https://linear.app/example/issue/COE-200
+      label: COE-200
+---
+
+# COE-200: Public graph concept
+
+Public graph body mentions .opensymphony/memory/issues/COE-999.md and {}.
+
+See [private concept](COE-123.md) and [external](https://example.com/reference).
+"#,
+                repo.path().display()
+            ),
+        )
+        .expect("public concept should write");
+
+        refresh_memory_index_from_okf(&config, &bundle).expect("OKF reindex should work");
+
+        let public_bundles =
+            memory_graph_bundles(&config, MemoryGraphAccess::Public).expect("bundles");
+        assert_eq!(public_bundles.bundles[0].concept_count, 1);
+        assert_eq!(
+            public_bundles.bundles[0].visibility,
+            MemoryGraphVisibility::Public
+        );
+
+        let all_graph = memory_graph_snapshot(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            MemoryGraphAccess::AllAccessible,
+        )
+        .expect("graph snapshot");
+        let node_kinds = all_graph
+            .nodes
+            .iter()
+            .map(|node| node.kind)
+            .collect::<BTreeSet<_>>();
+        let edge_kinds = all_graph
+            .edges
+            .iter()
+            .map(|edge| edge.kind)
+            .collect::<BTreeSet<_>>();
+        use crate::opensymphony_gateway_schema::memory_graph::{
+            MemoryGraphEdgeKind as EdgeKind, MemoryGraphNodeKind as NodeKind,
+        };
+        for kind in [
+            NodeKind::Bundle,
+            NodeKind::Directory,
+            NodeKind::Concept,
+            NodeKind::Tag,
+            NodeKind::Resource,
+            NodeKind::Citation,
+            NodeKind::SourceRef,
+            NodeKind::Community,
+        ] {
+            assert!(node_kinds.contains(&kind), "missing node kind {kind:?}");
+        }
+        for kind in [
+            EdgeKind::Contains,
+            EdgeKind::MarkdownLink,
+            EdgeKind::ExternalLink,
+            EdgeKind::Cites,
+            EdgeKind::TaggedWith,
+            EdgeKind::DescribesResource,
+            EdgeKind::ScopedTo,
+            EdgeKind::SourceSupportedBy,
+            EdgeKind::SameResource,
+        ] {
+            assert!(edge_kinds.contains(&kind), "missing edge kind {kind:?}");
+        }
+
+        let public_graph = memory_graph_snapshot(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            MemoryGraphAccess::Public,
+        )
+        .expect("public graph snapshot");
+        let public_json = serde_json::to_string(&public_graph).expect("public graph serializes");
+        assert!(public_json.contains("COE-200"));
+        assert!(!public_json.contains("concept:issues/COE-123"));
+        assert!(!public_json.contains("COE-123: OKF catalog rebuild"));
+        assert!(!public_json.contains(".opensymphony/memory"));
+        assert!(!public_json.contains(&repo.path().display().to_string()));
+
+        let detail = memory_concept_detail(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            "issues/COE-200",
+            MemoryGraphAccess::Public,
+        )
+        .expect("concept detail");
+        assert_eq!(
+            detail.frontmatter_view.primary.get("type"),
+            Some(&serde_json::json!("topic-doc"))
+        );
+        assert!(
+            detail
+                .frontmatter_view
+                .opensymphony
+                .contains_key("scope_refs")
+        );
+        assert_eq!(
+            detail.frontmatter_view.unknown.get("unknown_field"),
+            Some(&serde_json::json!("keep-me"))
+        );
+        assert!(!detail.links.is_empty());
+        assert!(!detail.citations.is_empty());
+        assert!(!detail.source_refs.is_empty());
+        assert!(!detail.body_markdown.contains(".opensymphony/memory"));
+        assert!(
+            !detail
+                .body_markdown
+                .contains(&repo.path().display().to_string())
+        );
+
+        let search = memory_graph_search(&config, "public graph", 10, MemoryGraphAccess::Public)
+            .expect("public graph search");
+        assert_eq!(search.results.len(), 1);
+        assert_eq!(search.results[0].concept_id, "issues/COE-200");
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1418,12 +1418,29 @@ and [external mirror](https://example.com/reference).
             ),
         )
         .expect("public concept should write");
+        fs::create_dir_all(bundle.join("backlog")).expect("backlog dir should write");
+        fs::write(
+            bundle.join("backlog/COE-222.md"),
+            r#"---
+type: issue
+title: "Backlog COE-222"
+opensymphony:
+  visibility: public
+  scope_refs:
+    - kind: work_item
+      id: COE-222
+---
+
+# Backlog COE-222
+"#,
+        )
+        .expect("backlog concept should write");
 
         refresh_memory_index_from_okf(&config, &bundle).expect("OKF reindex should work");
 
         let public_bundles =
             memory_graph_bundles(&config, MemoryGraphAccess::Public).expect("bundles");
-        assert_eq!(public_bundles.bundles[0].concept_count, 1);
+        assert_eq!(public_bundles.bundles[0].concept_count, 2);
         assert_eq!(
             public_bundles.bundles[0].visibility,
             MemoryGraphVisibility::Public
@@ -1482,6 +1499,13 @@ and [external mirror](https://example.com/reference).
             })
             .count();
         assert_eq!(parallel_external_edges, 2);
+        let external_edge = all_graph
+            .edges
+            .iter()
+            .find(|edge| edge.kind == EdgeKind::ExternalLink)
+            .expect("external edge");
+        assert!(external_edge.id.starts_with("external_link:"));
+        assert!(!external_edge.id.starts_with("ExternalLink:"));
 
         let update = memory_graph_updated_event(
             &config,
@@ -1495,6 +1519,13 @@ and [external mirror](https://example.com/reference).
             "memory-graph:local-default".to_string()
         );
         assert!(update.cursor.sequence > 0);
+        let later_update = memory_graph_updated_event(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            MemoryGraphAccess::AllAccessible,
+        )
+        .expect("later update event payload");
+        assert!(later_update.cursor.sequence > update.cursor.sequence);
 
         let public_graph = memory_graph_snapshot(
             &config,
@@ -1539,6 +1570,24 @@ and [external mirror](https://example.com/reference).
                 .body_markdown
                 .contains(&repo.path().display().to_string())
         );
+        let bare_issue_detail = memory_concept_detail(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            "COE-222",
+            MemoryGraphAccess::AllAccessible,
+        )
+        .expect("bare issue key lookup");
+        assert_eq!(bare_issue_detail.concept_id, "backlog/COE-222");
+        let wrong_path_detail = memory_concept_detail(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            "issues/COE-222",
+            MemoryGraphAccess::AllAccessible,
+        );
+        assert!(matches!(
+            wrong_path_detail,
+            Err(MemoryGraphProjectionError::ConceptNotFound(_))
+        ));
 
         let search = memory_graph_search(&config, "public graph", 10, MemoryGraphAccess::Public)
             .expect("public graph search");

--- a/docs/specs/llm-wiki-graph-view-spec.md
+++ b/docs/specs/llm-wiki-graph-view-spec.md
@@ -220,11 +220,14 @@ All memory graph responses are versioned with `schema_version`. The initial
 local bundle ID is `local-default`; hosted adapters may expose additional bundle
 IDs later without changing the DTO shape.
 
-Read endpoints accept `visibility=public` to return only public concepts. The
-default local loopback mode returns concepts accessible to the local process.
-Hosted gateway adapters must resolve credentials to an equivalent accessible
-scope before calling the DTO boundary. DTOs must not expose absolute local paths
-or `.opensymphony/memory/` paths; concept path fields are bundle-relative display
+Read endpoints accept `visibility=public` to return only public concepts, or
+`visibility=all_accessible` to make the default local-accessible scope explicit.
+The default local loopback mode returns concepts accessible to the local process.
+`visibility=private` is intentionally rejected because it is ambiguous: private
+does not mean "only private concepts" in the local gateway contract. Hosted
+gateway adapters must resolve credentials to an equivalent accessible scope
+before calling the DTO boundary. DTOs must not expose absolute local paths or
+`.opensymphony/memory/` paths; concept path fields are bundle-relative display
 paths only, and body/snippet fields are redacted at the server boundary.
 
 `memory_graph_updated` uses the gateway event journal envelope and carries this
@@ -238,6 +241,11 @@ payload:
   "updated_at": "2026-06-13T17:01:00Z"
 }
 ```
+
+Servers publish `memory_graph_updated` after memory capture, OKF import, or
+catalog reindex operations make a new graph snapshot available. The payload
+cursor uses the same monotonic timestamp sequence as graph snapshots so stream
+consumers can compare `sequence > last_seen` without depending on hash ordering.
 
 The same schemas can be used by a Tauri native adapter, loopback HTTP, or hosted HTTPS.
 

--- a/docs/specs/llm-wiki-graph-view-spec.md
+++ b/docs/specs/llm-wiki-graph-view-spec.md
@@ -250,8 +250,9 @@ payload:
 
 Servers publish `memory_graph_updated` after memory capture, OKF import, or
 catalog reindex operations make a new graph snapshot available. The payload
-cursor uses the same monotonic timestamp sequence as graph snapshots so stream
-consumers can compare `sequence > last_seen` without depending on hash ordering.
+cursor uses the same strictly monotonic timestamp-derived sequence as graph
+snapshots, including same-tick collision protection, so stream consumers can
+compare `sequence > last_seen` without depending on hash ordering.
 
 The same schemas can be used by a Tauri native adapter, loopback HTTP, or hosted HTTPS.
 

--- a/docs/specs/llm-wiki-graph-view-spec.md
+++ b/docs/specs/llm-wiki-graph-view-spec.md
@@ -230,6 +230,12 @@ before calling the DTO boundary. DTOs must not expose absolute local paths or
 `.opensymphony/memory/` paths; concept path fields are bundle-relative display
 paths only, and body/snippet fields are redacted at the server boundary.
 
+`GET /api/v1/memory/search` is global across the caller's accessible concepts in
+the v1 contract. It accepts `query` or `q`, `limit`, and the same visibility
+filter, but it does not yet accept bundle, community, area, or project scope
+filters. Scoped search can be added compatibly by extending the query object
+without changing the response DTO shape.
+
 `memory_graph_updated` uses the gateway event journal envelope and carries this
 payload:
 

--- a/docs/specs/llm-wiki-graph-view-spec.md
+++ b/docs/specs/llm-wiki-graph-view-spec.md
@@ -213,8 +213,31 @@ Recommended gateway endpoints:
 - `GET /api/v1/memory/bundles/{bundle_id}/graph`
 - `GET /api/v1/memory/bundles/{bundle_id}/concepts/{concept_id}`
 - `GET /api/v1/memory/bundles/{bundle_id}/communities`
-- `GET /api/v1/memory/search`
+- `GET /api/v1/memory/search?query=...`
 - event stream kind `memory_graph_updated`
+
+All memory graph responses are versioned with `schema_version`. The initial
+local bundle ID is `local-default`; hosted adapters may expose additional bundle
+IDs later without changing the DTO shape.
+
+Read endpoints accept `visibility=public` to return only public concepts. The
+default local loopback mode returns concepts accessible to the local process.
+Hosted gateway adapters must resolve credentials to an equivalent accessible
+scope before calling the DTO boundary. DTOs must not expose absolute local paths
+or `.opensymphony/memory/` paths; concept path fields are bundle-relative display
+paths only, and body/snippet fields are redacted at the server boundary.
+
+`memory_graph_updated` uses the gateway event journal envelope and carries this
+payload:
+
+```json
+{
+  "schema_version": {"major": 1, "minor": 0, "patch": 0},
+  "bundle_id": "local-default",
+  "cursor": {"sequence": 1843, "partition": "memory-graph:local-default"},
+  "updated_at": "2026-06-13T17:01:00Z"
+}
+```
 
 The same schemas can be used by a Tauri native adapter, loopback HTTP, or hosted HTTPS.
 

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -25,6 +25,30 @@ export type {
   TaskGraphMutationResult,
 } from "./task_graph_runtime.js";
 
+// memory graph
+export type {
+  MemoryBundleList,
+  MemoryBundleSummary,
+  MemoryCommunityList,
+  MemoryConceptDetail,
+  MemoryFrontmatterView,
+  MemoryGraphCitation,
+  MemoryGraphCommunity,
+  MemoryGraphEdge,
+  MemoryGraphEdgeKind,
+  MemoryGraphFreshness,
+  MemoryGraphLink,
+  MemoryGraphNode,
+  MemoryGraphNodeKind,
+  MemoryGraphNodeMetrics,
+  MemoryGraphSnapshot,
+  MemoryGraphSourceRef,
+  MemoryGraphUpdatedEvent,
+  MemoryGraphVisibility,
+  MemorySearchResponse,
+  MemorySearchResult,
+} from "./memory_graph.js";
+
 // run
 export type {
   RunStatus,

--- a/packages/gateway-schema/src/memory_graph.ts
+++ b/packages/gateway-schema/src/memory_graph.ts
@@ -1,0 +1,160 @@
+import type { StreamCursor } from "./cursor.js";
+import type { SchemaVersion } from "./version.js";
+
+export type MemoryGraphVisibility = "public" | "private";
+export type MemoryGraphFreshness = "current" | "stale" | "unknown";
+
+export type MemoryGraphNodeKind =
+  | "bundle"
+  | "directory"
+  | "concept"
+  | "tag"
+  | "resource"
+  | "citation"
+  | "source_ref"
+  | "community";
+
+export type MemoryGraphEdgeKind =
+  | "contains"
+  | "markdown_link"
+  | "external_link"
+  | "cites"
+  | "tagged_with"
+  | "describes_resource"
+  | "scoped_to"
+  | "source_supported_by"
+  | "same_resource";
+
+export interface MemoryBundleList {
+  schema_version: SchemaVersion;
+  bundles: MemoryBundleSummary[];
+}
+
+export interface MemoryBundleSummary {
+  id: string;
+  title: string;
+  okf_version: string;
+  visibility: MemoryGraphVisibility;
+  concept_count: number;
+  updated_at?: string;
+}
+
+export interface MemoryGraphSnapshot {
+  schema_version: SchemaVersion;
+  bundle_id: string;
+  cursor: StreamCursor;
+  nodes: MemoryGraphNode[];
+  edges: MemoryGraphEdge[];
+  communities: MemoryGraphCommunity[];
+  filters_applied: string[];
+  generated_at: string;
+}
+
+export interface MemoryConceptDetail {
+  schema_version: SchemaVersion;
+  bundle_id: string;
+  concept_id: string;
+  frontmatter_view: MemoryFrontmatterView;
+  body_markdown: string;
+  links: MemoryGraphLink[];
+  citations: MemoryGraphCitation[];
+  source_refs: MemoryGraphSourceRef[];
+}
+
+export interface MemoryCommunityList {
+  schema_version: SchemaVersion;
+  bundle_id: string;
+  communities: MemoryGraphCommunity[];
+  generated_at: string;
+}
+
+export interface MemorySearchResponse {
+  schema_version: SchemaVersion;
+  query: string;
+  bundle_id?: string;
+  results: MemorySearchResult[];
+}
+
+export interface MemorySearchResult {
+  bundle_id: string;
+  concept_id: string;
+  title: string;
+  visibility: MemoryGraphVisibility;
+  snippet: string;
+  areas: string[];
+}
+
+export interface MemoryGraphNode {
+  id: string;
+  kind: MemoryGraphNodeKind;
+  label: string;
+  bundle_id?: string;
+  concept_id?: string;
+  concept_type?: string;
+  description?: string;
+  path_display?: string;
+  resource?: string;
+  tags: string[];
+  timestamp?: string;
+  visibility?: MemoryGraphVisibility;
+  freshness?: MemoryGraphFreshness;
+  warning_count: number;
+  frontmatter_summary: Record<string, unknown>;
+  unknown_frontmatter: Record<string, unknown>;
+  body_preview?: string;
+  metrics: MemoryGraphNodeMetrics;
+}
+
+export interface MemoryGraphEdge {
+  id: string;
+  kind: MemoryGraphEdgeKind;
+  source_id: string;
+  target_id: string;
+  label?: string;
+  unresolved: boolean;
+  metadata: Record<string, unknown>;
+}
+
+export interface MemoryGraphCommunity {
+  id: string;
+  label: string;
+  node_ids: string[];
+  concept_count: number;
+}
+
+export interface MemoryFrontmatterView {
+  primary: Record<string, unknown>;
+  opensymphony: Record<string, unknown>;
+  unknown: Record<string, unknown>;
+}
+
+export interface MemoryGraphLink {
+  target: string;
+  label?: string;
+}
+
+export interface MemoryGraphCitation {
+  id: string;
+  target: string;
+  label?: string;
+}
+
+export interface MemoryGraphSourceRef {
+  kind: string;
+  id: string;
+  url?: string;
+}
+
+export interface MemoryGraphNodeMetrics {
+  indegree: number;
+  outdegree: number;
+  pagerank?: number;
+  community_id?: string;
+}
+
+export interface MemoryGraphUpdatedEvent {
+  schema_version: SchemaVersion;
+  bundle_id: string;
+  cursor: StreamCursor;
+  updated_at: string;
+}

--- a/packages/ui-core/__tests__/remote-parity.test.ts
+++ b/packages/ui-core/__tests__/remote-parity.test.ts
@@ -182,8 +182,8 @@ async function snapshotMode(mode: "web" | "desktop"): Promise<ModeSnapshot> {
     transport: buildTransport(),
   });
 
-  // Dashboard + task graph (both modes render the panel heading and nodes)
-  await flushUntil(() => root.querySelector(".os-task-graph-panel h2") !== null);
+  // Dashboard + task graph (both modes render the shared graph toggle and nodes)
+  await flushUntil(() => root.querySelector("[data-testid='graph-view-toggle']") !== null);
   await flushUntil(() => root.querySelector("[data-node-id='run-parity']") !== null);
   // Run detail: navigate to the run node so the run panel loads the mock run.
   (root.querySelector("[data-node-id='run-parity']") as HTMLElement).click();


### PR DESCRIPTION
## Summary

Adds stable, schema-versioned memory graph DTOs and read-only gateway endpoints for COE-461 so graph clients can consume OKF-backed memory data without parsing private files directly.

## Changes

- Add Rust and TypeScript DTOs for memory bundles, graph snapshots, concept details, communities, search results, graph nodes, graph edges, and `memory_graph_updated` events.
- Project OKF-indexed memory into read-only `/api/v1/memory/*` gateway endpoints with default all-accessible and public-only visibility modes.
- Separate concept detail into primary, OpenSymphony, unknown frontmatter, links, citations, and source refs.
- Filter private concepts in public mode and recursively redact local paths from DTO body, frontmatter, links, citations, and source refs.
- Use strictly monotonic timestamp-derived memory graph cursors with same-tick collision protection.
- Preserve parallel labeled edges with stable snake_case edge IDs, map typed projection errors, reject ambiguous `visibility=private`, and avoid ambiguous concept path suffix lookup.
- Publish `memory_graph_updated` journal events after successful auto-capture writes make a refreshed graph available.
- Apply search result limits after visibility filtering with catalog-bounded over-fetch, keep update event payload creation independent of index reloads, use path-token-aware local path redaction, cache parsed OKF concepts for same-resource edges, and reuse loaded memory config for graph update publication.
- Sanitize memory-backed graph endpoint error messages so local filesystem paths cannot leak through raw `MemoryError` text.
- Prefer memory-root resolution for relative capsule paths before repo-root fallback to avoid graph nodes resolving to colliding non-memory files.
- Cover default all-accessible bundle/graph responses, document global-only v1 search scope, wire memory config into the run gateway, and document endpoint/event contracts in the graph-view spec.

## Evidence

### Test output

```text
cargo fmt --check
cargo test-system-duckdb memory_graph
cargo test-system-duckdb --test gateway_schema
cargo test-system-duckdb --test gateway
cargo test-system-duckdb --test memory
cargo clippy-system-duckdb
npm run build --workspace=@opensymphony/gateway-schema
npm run type-check
npx jest --config jest.config.js --testPathIgnorePatterns="apps"
```

Latest review-fix validation:

```text
cargo fmt --check
cargo test-system-duckdb memory_graph
6 filtered memory graph tests passed, including graph contract filters, sanitized error response coverage, redaction boundary coverage, and memory-root path resolution coverage.

cargo test-system-duckdb --test gateway_schema
57 passed.

cargo test-system-duckdb --test gateway
56 passed.

cargo test-system-duckdb --test memory
42 passed.

cargo clippy-system-duckdb
Finished clean.
```

### Verification

- Reproduced the missing behavior before changes: no shared memory graph DTO module or `/api/v1/memory/*` gateway routes existed for bundles, graph snapshots, concept details, communities, or search.
- Verified public graph responses omit private concepts and local filesystem paths while default all-accessible responses include accessible private concepts with local-path redaction intact.
- Verified concept detail exposes primary/OpenSymphony/unknown frontmatter separately with links, citations, and source refs.
- Verified graph node and edge DTOs include the required graph-view kinds.
- Verified review feedback fixes: graph update publication, strictly increasing graph cursors, snake_case edge IDs, unambiguous concept lookup, typed error mapping, private visibility rejection, parallel edge preservation, public-search limiting after filtering, update payload construction without index reload, path-token-aware redaction with both-side token boundaries, direct percent-escaped label components in edge IDs, cached same-resource parsing, loaded-config reuse during update publication, archive/docs-only graph update publication, sanitized memory error responses, bounded search over-fetch, and memory-root-first path resolution.

## Checklist

- [x] Tests pass (`cargo test-system-duckdb ...` targeted suites)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (graph endpoint and event contract)
- [x] `AGENTS.md` updated (not required; no repo guidance changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: not applicable

## Breaking changes

None.

## Related issues

COE-461

## Additional notes

Inline AI review comments were addressed in-thread with fixed commit references. The latest follow-up commit is `aae15a4`.