### PR TITLE
Derive OKF memory graph metrics and communities

### DIFF
--- a/crates/opensymphony-gateway-schema/src/memory_graph.rs
+++ b/crates/opensymphony-gateway-schema/src/memory_graph.rs
@@ -32,6 +32,8 @@ pub struct MemoryGraphSnapshot {
     pub edges: Vec<MemoryGraphEdge>,
     pub communities: Vec<MemoryGraphCommunity>,
     #[serde(default)]
+    pub metrics: MemoryGraphSnapshotMetrics,
+    #[serde(default)]
     pub filters_applied: Vec<String>,
     pub generated_at: DateTime<Utc>,
 }
@@ -140,6 +142,18 @@ pub struct MemoryGraphCommunity {
     pub concept_count: usize,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryGraphSnapshotMetrics {
+    #[serde(default)]
+    pub orphan_count: usize,
+    #[serde(default)]
+    pub broken_link_count: usize,
+    #[serde(default)]
+    pub stale_concept_count: usize,
+    #[serde(default)]
+    pub warning_count: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MemoryFrontmatterView {
     #[serde(default)]
@@ -176,9 +190,15 @@ pub struct MemoryGraphSourceRef {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct MemoryGraphNodeMetrics {
     #[serde(default)]
+    pub degree: usize,
+    #[serde(default)]
     pub indegree: usize,
     #[serde(default)]
     pub outdegree: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub centrality: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge_score: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pagerank: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
+++ b/crates/opensymphony-gateway-schema/tests/gateway_schema.rs
@@ -183,6 +183,7 @@ fn memory_graph_dtos_roundtrip_required_kinds_and_update_event() {
             metadata: BTreeMap::new(),
         }],
         communities: Vec::new(),
+        metrics: Default::default(),
         filters_applied: Vec::new(),
         generated_at: Utc::now(),
     };

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -42,9 +42,10 @@ use crate::opensymphony_gateway_schema::{
     },
 };
 use crate::opensymphony_memory::{
-    MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphProjectionError,
-    memory_concept_detail, memory_graph_bundles, memory_graph_communities,
-    memory_graph_search as search_memory_graph, memory_graph_snapshot,
+    MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphCommunityOptions,
+    MemoryGraphProjectionError, memory_concept_detail, memory_graph_bundles,
+    memory_graph_communities_with_options, memory_graph_search as search_memory_graph,
+    memory_graph_snapshot_with_options,
 };
 
 pub mod action_handler;
@@ -1005,6 +1006,14 @@ struct MemoryVisibilityQuery {
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
+struct MemoryGraphQuery {
+    visibility: Option<String>,
+    include_tags: Option<bool>,
+    include_citations: Option<bool>,
+    include_source_refs: Option<bool>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
 struct MemorySearchQuery {
     q: Option<String>,
     query: Option<String>,
@@ -1026,11 +1035,11 @@ async fn get_memory_bundles(
 async fn get_memory_graph(
     State(state): State<GatewayState>,
     AxumPath(bundle_id): AxumPath<String>,
-    Query(params): Query<MemoryVisibilityQuery>,
+    Query(params): Query<MemoryGraphQuery>,
 ) -> Result<Json<MemoryGraphSnapshot>, (StatusCode, Json<serde_json::Value>)> {
     let config = configured_memory(&state)?;
     let access = memory_graph_access(params.visibility.as_deref())?;
-    memory_graph_snapshot(config, &bundle_id, access)
+    memory_graph_snapshot_with_options(config, &bundle_id, access, community_options(&params))
         .map(Json)
         .map_err(memory_graph_error)
 }
@@ -1050,11 +1059,11 @@ async fn get_memory_concept(
 async fn get_memory_communities(
     State(state): State<GatewayState>,
     AxumPath(bundle_id): AxumPath<String>,
-    Query(params): Query<MemoryVisibilityQuery>,
+    Query(params): Query<MemoryGraphQuery>,
 ) -> Result<Json<MemoryCommunityList>, (StatusCode, Json<serde_json::Value>)> {
     let config = configured_memory(&state)?;
     let access = memory_graph_access(params.visibility.as_deref())?;
-    memory_graph_communities(config, &bundle_id, access)
+    memory_graph_communities_with_options(config, &bundle_id, access, community_options(&params))
         .map(Json)
         .map_err(memory_graph_error)
 }
@@ -1117,6 +1126,14 @@ fn memory_graph_access(
             "invalid_visibility",
             &format!("unsupported memory visibility `{other}`"),
         )),
+    }
+}
+
+fn community_options(params: &MemoryGraphQuery) -> MemoryGraphCommunityOptions {
+    MemoryGraphCommunityOptions {
+        include_tags: params.include_tags.unwrap_or(false),
+        include_citations: params.include_citations.unwrap_or(false),
+        include_source_refs: params.include_source_refs.unwrap_or(false),
     }
 }
 

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -1781,6 +1781,28 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
             .any(|edge| edge.kind == MemoryGraphEdgeKind::ExternalLink)
     );
     assert_eq!(graph.metrics.orphan_count, 0);
+    let graph_with_tags = client
+        .get(format!(
+            "{base}/bundles/local-default/graph?visibility=public&include_tags=true"
+        ))
+        .send()
+        .await
+        .expect("fetch graph with tags")
+        .json::<MemoryGraphSnapshot>()
+        .await
+        .expect("decode graph with tags");
+    assert!(
+        graph_with_tags
+            .filters_applied
+            .contains(&"communities:include_tags".to_string())
+    );
+    assert!(graph_with_tags.communities.iter().any(|community| {
+        community.id == "area:graph-view"
+            && community
+                .node_ids
+                .iter()
+                .any(|node_id| node_id == "tag:graph")
+    }));
 
     let all_graph = client
         .get(format!("{base}/bundles/local-default/graph"))

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -1780,6 +1780,7 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
             .iter()
             .any(|edge| edge.kind == MemoryGraphEdgeKind::ExternalLink)
     );
+    assert_eq!(graph.metrics.orphan_count, 0);
 
     let all_graph = client
         .get(format!("{base}/bundles/local-default/graph"))
@@ -1842,6 +1843,23 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
             .iter()
             .any(|community| { community.id == "area:graph-view" && community.concept_count == 1 })
     );
+    let communities_with_tags = client
+        .get(format!(
+            "{base}/bundles/local-default/communities?visibility=public&include_tags=true"
+        ))
+        .send()
+        .await
+        .expect("fetch communities with tags")
+        .json::<MemoryCommunityList>()
+        .await
+        .expect("decode communities with tags");
+    assert!(communities_with_tags.communities.iter().any(|community| {
+        community.id == "area:graph-view"
+            && community
+                .node_ids
+                .iter()
+                .any(|node_id| node_id == "tag:graph")
+    }));
 
     let search = client
         .get(format!(

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -1110,6 +1110,8 @@ fn memory_graph_communities_from_issues(
 }
 
 fn community_key(issue: &IndexedIssue) -> (String, String) {
+    // Assign exactly one stable community per concept. Multiple areas are
+    // ordered before selecting the first; tags keep frontmatter order.
     if let Some(area) = issue.areas().into_iter().next() {
         return (format!("area:{area}"), area);
     }
@@ -1144,6 +1146,8 @@ fn apply_node_metrics(
         })
         .max()
         .unwrap_or(0);
+    // Centrality is global normalized degree across all graph node kinds, not
+    // concept-only centrality.
     let community_by_node = communities
         .iter()
         .flat_map(|community| {

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -7,7 +7,8 @@ use crate::opensymphony_gateway_schema::{
         MemoryFrontmatterView, MemoryGraphCitation, MemoryGraphCommunity, MemoryGraphEdge,
         MemoryGraphEdgeKind, MemoryGraphFreshness, MemoryGraphLink, MemoryGraphNode,
         MemoryGraphNodeKind, MemoryGraphNodeMetrics, MemoryGraphSnapshot, MemoryGraphSourceRef,
-        MemoryGraphUpdatedEvent, MemoryGraphVisibility, MemorySearchResponse, MemorySearchResult,
+        MemoryGraphSnapshotMetrics, MemoryGraphUpdatedEvent, MemoryGraphVisibility,
+        MemorySearchResponse, MemorySearchResult,
     },
     version::SchemaVersion,
 };
@@ -29,6 +30,13 @@ pub enum MemoryGraphProjectionError {
 pub enum MemoryGraphAccess {
     Public,
     AllAccessible,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MemoryGraphCommunityOptions {
+    pub include_tags: bool,
+    pub include_citations: bool,
+    pub include_source_refs: bool,
 }
 
 pub fn memory_graph_bundles(
@@ -54,10 +62,24 @@ pub fn memory_graph_snapshot(
     bundle_id: &str,
     access: MemoryGraphAccess,
 ) -> Result<MemoryGraphSnapshot, MemoryGraphProjectionError> {
+    memory_graph_snapshot_with_options(
+        config,
+        bundle_id,
+        access,
+        MemoryGraphCommunityOptions::default(),
+    )
+}
+
+pub fn memory_graph_snapshot_with_options(
+    config: &MemoryConfig,
+    bundle_id: &str,
+    access: MemoryGraphAccess,
+    community_options: MemoryGraphCommunityOptions,
+) -> Result<MemoryGraphSnapshot, MemoryGraphProjectionError> {
     ensure_default_memory_bundle(bundle_id)?;
     let generated_at = Utc::now();
     let issues = accessible_issues(config, access)?;
-    let communities = memory_graph_communities_from_issues(&issues);
+    let communities = memory_graph_communities_from_issues(&issues, community_options);
     let mut nodes = BTreeMap::<String, MemoryGraphNode>::new();
     let mut edges = BTreeMap::<String, MemoryGraphEdge>::new();
 
@@ -314,6 +336,7 @@ pub fn memory_graph_snapshot(
     let mut nodes = nodes.into_values().collect::<Vec<_>>();
     let edges = edges.into_values().collect::<Vec<_>>();
     apply_node_metrics(&mut nodes, &edges, &communities);
+    let metrics = graph_snapshot_metrics(&nodes, &edges);
 
     Ok(MemoryGraphSnapshot {
         schema_version: SchemaVersion::v1(),
@@ -322,7 +345,8 @@ pub fn memory_graph_snapshot(
         nodes,
         edges,
         communities,
-        filters_applied: filters_applied(access),
+        metrics,
+        filters_applied: filters_applied(access, community_options),
         generated_at,
     })
 }
@@ -384,12 +408,26 @@ pub fn memory_graph_communities(
     bundle_id: &str,
     access: MemoryGraphAccess,
 ) -> Result<MemoryCommunityList, MemoryGraphProjectionError> {
+    memory_graph_communities_with_options(
+        config,
+        bundle_id,
+        access,
+        MemoryGraphCommunityOptions::default(),
+    )
+}
+
+pub fn memory_graph_communities_with_options(
+    config: &MemoryConfig,
+    bundle_id: &str,
+    access: MemoryGraphAccess,
+    community_options: MemoryGraphCommunityOptions,
+) -> Result<MemoryCommunityList, MemoryGraphProjectionError> {
     ensure_default_memory_bundle(bundle_id)?;
     let issues = accessible_issues(config, access)?;
     Ok(MemoryCommunityList {
         schema_version: SchemaVersion::v1(),
         bundle_id: bundle_id.to_string(),
-        communities: memory_graph_communities_from_issues(&issues),
+        communities: memory_graph_communities_from_issues(&issues, community_options),
         generated_at: Utc::now(),
     })
 }
@@ -499,11 +537,24 @@ fn freshness_dto(freshness: MemoryFreshness) -> MemoryGraphFreshness {
     }
 }
 
-fn filters_applied(access: MemoryGraphAccess) -> Vec<String> {
-    match access {
+fn filters_applied(
+    access: MemoryGraphAccess,
+    community_options: MemoryGraphCommunityOptions,
+) -> Vec<String> {
+    let mut filters = match access {
         MemoryGraphAccess::Public => vec!["visibility:public".to_string()],
         MemoryGraphAccess::AllAccessible => Vec::new(),
+    };
+    if community_options.include_tags {
+        filters.push("communities:include_tags".to_string());
     }
+    if community_options.include_citations {
+        filters.push("communities:include_citations".to_string());
+    }
+    if community_options.include_source_refs {
+        filters.push("communities:include_source_refs".to_string());
+    }
+    filters
 }
 
 fn indexed_issue_updated_at(issue: &IndexedIssue) -> Option<DateTime<Utc>> {
@@ -1008,25 +1059,70 @@ fn insert_same_resource_edges(
     }
 }
 
-fn memory_graph_communities_from_issues(issues: &[IndexedIssue]) -> Vec<MemoryGraphCommunity> {
-    let mut by_area = BTreeMap::<String, Vec<String>>::new();
+fn memory_graph_communities_from_issues(
+    issues: &[IndexedIssue],
+    options: MemoryGraphCommunityOptions,
+) -> Vec<MemoryGraphCommunity> {
+    let mut communities = BTreeMap::<String, (String, Vec<String>)>::new();
     for issue in issues {
-        for area in issue.areas() {
-            by_area.entry(area).or_default().push(concept_node_id(issue));
+        let (id, label) = community_key(issue);
+        let (_, node_ids) = communities
+            .entry(id)
+            .or_insert_with(|| (label, Vec::new()));
+        node_ids.push(concept_node_id(issue));
+        if options.include_tags {
+            node_ids.extend(issue.tags.iter().map(|tag| format!("tag:{tag}")));
+        }
+        if options.include_citations {
+            node_ids.extend(
+                issue
+                    .citations
+                    .iter()
+                    .map(|citation| format!("citation:{}", citation.id)),
+            );
+        }
+        if options.include_source_refs {
+            node_ids.extend(
+                issue
+                    .source_refs
+                    .iter()
+                    .map(|source_ref| format!("source_ref:{}:{}", source_ref.kind, source_ref.id)),
+            );
         }
     }
-    by_area
+    communities
         .into_iter()
-        .map(|(area, mut node_ids)| {
+        .map(|(id, (label, mut node_ids))| {
             node_ids.sort();
+            node_ids.dedup();
+            let concept_count = node_ids
+                .iter()
+                .filter(|node_id| node_id.starts_with("concept:"))
+                .count();
             MemoryGraphCommunity {
-                id: format!("area:{area}"),
-                label: area,
-                concept_count: node_ids.len(),
+                id,
+                label,
+                concept_count,
                 node_ids,
             }
         })
         .collect()
+}
+
+fn community_key(issue: &IndexedIssue) -> (String, String) {
+    if let Some(area) = issue.areas().into_iter().next() {
+        return (format!("area:{area}"), area);
+    }
+    if let Some(tag) = issue.tags.first() {
+        return (format!("tag:{tag}"), tag.clone());
+    }
+    if let Some((directory, _)) = issue.concept_id.rsplit_once('/') {
+        return (format!("directory:{directory}"), directory.to_string());
+    }
+    (
+        format!("type:{}", issue.concept_type),
+        issue.concept_type.clone(),
+    )
 }
 
 fn apply_node_metrics(
@@ -1040,6 +1136,14 @@ fn apply_node_metrics(
         *outdegree.entry(edge.source_id.clone()).or_default() += 1;
         *indegree.entry(edge.target_id.clone()).or_default() += 1;
     }
+    let max_degree = nodes
+        .iter()
+        .map(|node| {
+            indegree.get(&node.id).copied().unwrap_or_default()
+                + outdegree.get(&node.id).copied().unwrap_or_default()
+        })
+        .max()
+        .unwrap_or(0);
     let community_by_node = communities
         .iter()
         .flat_map(|community| {
@@ -1049,9 +1153,60 @@ fn apply_node_metrics(
                 .map(move |node_id| (node_id.clone(), community.id.clone()))
         })
         .collect::<BTreeMap<_, _>>();
+    let mut bridge_edges = BTreeMap::<String, usize>::new();
+    for edge in edges {
+        let source_community = community_by_node.get(&edge.source_id);
+        let target_community = community_by_node.get(&edge.target_id);
+        if source_community.zip(target_community).is_some_and(|(left, right)| left != right) {
+            *bridge_edges.entry(edge.source_id.clone()).or_default() += 1;
+            *bridge_edges.entry(edge.target_id.clone()).or_default() += 1;
+        }
+    }
     for node in nodes {
-        node.metrics.indegree = indegree.get(&node.id).copied().unwrap_or_default();
-        node.metrics.outdegree = outdegree.get(&node.id).copied().unwrap_or_default();
+        let indegree = indegree.get(&node.id).copied().unwrap_or_default();
+        let outdegree = outdegree.get(&node.id).copied().unwrap_or_default();
+        let degree = indegree + outdegree;
+        node.metrics.degree = degree;
+        node.metrics.indegree = indegree;
+        node.metrics.outdegree = outdegree;
+        if max_degree > 0 {
+            node.metrics.centrality = Some(degree as f64 / max_degree as f64);
+        }
+        if let Some(bridge_count) = bridge_edges.get(&node.id).copied() {
+            node.metrics.bridge_score = Some(bridge_count as f64);
+        }
         node.metrics.community_id = community_by_node.get(&node.id).cloned();
+    }
+}
+
+fn graph_snapshot_metrics(
+    nodes: &[MemoryGraphNode],
+    edges: &[MemoryGraphEdge],
+) -> MemoryGraphSnapshotMetrics {
+    let mut semantic_nodes = BTreeSet::<String>::new();
+    for edge in edges.iter().filter(|edge| edge.kind != MemoryGraphEdgeKind::Contains) {
+        semantic_nodes.insert(edge.source_id.clone());
+        semantic_nodes.insert(edge.target_id.clone());
+    }
+    MemoryGraphSnapshotMetrics {
+        orphan_count: nodes
+            .iter()
+            .filter(|node| {
+                node.kind == MemoryGraphNodeKind::Concept && !semantic_nodes.contains(&node.id)
+            })
+            .count(),
+        broken_link_count: edges.iter().filter(|edge| edge.unresolved).count(),
+        stale_concept_count: nodes
+            .iter()
+            .filter(|node| {
+                node.kind == MemoryGraphNodeKind::Concept
+                    && node.freshness == Some(MemoryGraphFreshness::Stale)
+            })
+            .count(),
+        warning_count: nodes
+            .iter()
+            .filter(|node| node.kind == MemoryGraphNodeKind::Concept)
+            .map(|node| node.warning_count)
+            .sum(),
     }
 }

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1438,6 +1438,22 @@ public graph
 "#,
         )
         .expect("private search concept should write");
+        fs::write(
+            issues_dir.join("COE-333.md"),
+            r#"---
+type: issue
+title: "COE-333: Isolated private concept"
+description: No semantic graph edges.
+opensymphony:
+  visibility: private
+---
+
+# COE-333: Isolated private concept
+
+This concept intentionally has no tags, links, citations, resources, or refs.
+"#,
+        )
+        .expect("isolated private concept should write");
         fs::create_dir_all(bundle.join("backlog")).expect("backlog dir should write");
         fs::write(
             bundle.join("backlog/COE-222.md"),
@@ -1472,6 +1488,10 @@ opensymphony:
             MemoryGraphAccess::AllAccessible,
         )
         .expect("graph snapshot");
+        assert_eq!(all_graph.metrics.broken_link_count, 1);
+        assert_eq!(all_graph.metrics.stale_concept_count, 1);
+        assert!(all_graph.metrics.warning_count >= 1);
+        assert_eq!(all_graph.metrics.orphan_count, 1);
         let node_kinds = all_graph
             .nodes
             .iter()
@@ -1530,6 +1550,24 @@ opensymphony:
             all_graph
                 .edges
                 .iter()
+                .any(|edge| edge.kind == EdgeKind::MarkdownLink && edge.unresolved)
+        );
+        let linked_private_node = all_graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "concept:issues/COE-123")
+            .expect("linked private concept node");
+        assert!(linked_private_node.metrics.degree > 0);
+        assert!(linked_private_node.metrics.centrality.is_some());
+        assert!(linked_private_node.metrics.bridge_score.is_some());
+        assert_eq!(
+            linked_private_node.metrics.community_id.as_deref(),
+            Some("area:openhands-runtime")
+        );
+        assert!(
+            all_graph
+                .edges
+                .iter()
                 .any(|edge| edge.id.ends_with(":label:external"))
         );
         assert!(
@@ -1573,6 +1611,57 @@ opensymphony:
         assert!(!public_json.contains(&format!("{}/", repo.path().display())));
         assert!(!public_json.contains(&format!("{}.", repo.path().display())));
         assert!(!public_json.contains("[redacted-local-path]bed"));
+        assert!(
+            public_graph
+                .communities
+                .iter()
+                .any(|community| community.label == "graph-view")
+        );
+        assert!(public_graph.communities.iter().all(|community| {
+            !community
+                .node_ids
+                .iter()
+                .any(|node_id| node_id == "tag:graph")
+        }));
+        let public_graph_with_aux = memory_graph_snapshot_with_options(
+            &config,
+            DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
+            MemoryGraphAccess::Public,
+            MemoryGraphCommunityOptions {
+                include_tags: true,
+                include_citations: true,
+                include_source_refs: true,
+            },
+        )
+        .expect("public graph with auxiliary community inputs");
+        let graph_view = public_graph_with_aux
+            .communities
+            .iter()
+            .find(|community| community.id == "area:graph-view")
+            .expect("graph-view community");
+        assert!(
+            graph_view
+                .node_ids
+                .iter()
+                .any(|node_id| node_id == "tag:graph")
+        );
+        assert!(
+            graph_view
+                .node_ids
+                .iter()
+                .any(|node_id| node_id == "citation:1")
+        );
+        assert!(
+            graph_view
+                .node_ids
+                .iter()
+                .any(|node_id| { node_id == "source_ref:linear_issue:COE-200" })
+        );
+        assert!(
+            public_graph_with_aux
+                .filters_applied
+                .contains(&"communities:include_tags".to_string())
+        );
 
         let detail = memory_concept_detail(
             &config,

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1724,6 +1724,145 @@ opensymphony:
     }
 
     #[test]
+    fn memory_graph_snapshot_metrics_count_only_semantic_orphans() {
+        use crate::opensymphony_gateway_schema::memory_graph::{
+            MemoryGraphEdgeKind as EdgeKind, MemoryGraphNodeKind as NodeKind,
+        };
+
+        let nodes = vec![
+            simple_node(
+                "bundle:local-default",
+                NodeKind::Bundle,
+                "bundle",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+            simple_node(
+                "concept:isolated",
+                NodeKind::Concept,
+                "isolated",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+            simple_node(
+                "concept:linked",
+                NodeKind::Concept,
+                "linked",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+            simple_node(
+                "tag:memory",
+                NodeKind::Tag,
+                "memory",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+        ];
+        let mut edges = BTreeMap::new();
+        insert_edge(
+            &mut edges,
+            EdgeKind::Contains,
+            "bundle:local-default",
+            "concept:isolated",
+            None,
+            false,
+        );
+        insert_edge(
+            &mut edges,
+            EdgeKind::Contains,
+            "bundle:local-default",
+            "concept:linked",
+            None,
+            false,
+        );
+        insert_edge(
+            &mut edges,
+            EdgeKind::TaggedWith,
+            "concept:linked",
+            "tag:memory",
+            None,
+            false,
+        );
+
+        let metrics = graph_snapshot_metrics(&nodes, &edges.into_values().collect::<Vec<_>>());
+
+        assert_eq!(metrics.orphan_count, 1);
+    }
+
+    #[test]
+    fn memory_graph_bridge_score_counts_only_cross_community_edges() {
+        use crate::opensymphony_gateway_schema::memory_graph::{
+            MemoryGraphCommunity, MemoryGraphEdgeKind as EdgeKind, MemoryGraphNodeKind as NodeKind,
+        };
+
+        let mut nodes = vec![
+            simple_node(
+                "concept:left",
+                NodeKind::Concept,
+                "left",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+            simple_node(
+                "concept:unknown",
+                NodeKind::Concept,
+                "unknown",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+            simple_node(
+                "concept:right",
+                NodeKind::Concept,
+                "right",
+                Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID),
+            ),
+        ];
+        let communities = vec![
+            MemoryGraphCommunity {
+                id: "area:left".to_string(),
+                label: "left".to_string(),
+                node_ids: vec!["concept:left".to_string()],
+                concept_count: 1,
+            },
+            MemoryGraphCommunity {
+                id: "area:right".to_string(),
+                label: "right".to_string(),
+                node_ids: vec!["concept:right".to_string()],
+                concept_count: 1,
+            },
+        ];
+        let mut edges = BTreeMap::new();
+        insert_edge(
+            &mut edges,
+            EdgeKind::MarkdownLink,
+            "concept:left",
+            "concept:unknown",
+            None,
+            false,
+        );
+        insert_edge(
+            &mut edges,
+            EdgeKind::MarkdownLink,
+            "concept:left",
+            "concept:right",
+            None,
+            false,
+        );
+
+        apply_node_metrics(
+            &mut nodes,
+            &edges.into_values().collect::<Vec<_>>(),
+            &communities,
+        );
+
+        let metric = |id: &str| {
+            &nodes
+                .iter()
+                .find(|node| node.id == id)
+                .expect("node")
+                .metrics
+        };
+        assert_eq!(metric("concept:left").bridge_score, Some(1.0));
+        assert_eq!(metric("concept:right").bridge_score, Some(1.0));
+        assert_eq!(metric("concept:unknown").bridge_score, None);
+    }
+
+    #[test]
     fn memory_graph_path_redaction_respects_token_boundaries() {
         assert_eq!(
             replace_path_token("/tmp/repo/file.md", "/tmp/repo", "[redacted]"),

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -151,6 +151,22 @@ Migration is intentionally incremental:
 - Phase 3 can expose graph, hosted import/export, and visibility-filtered APIs
   from the OKF-derived catalog.
 
+The memory graph projection is derived from the OKF catalog, not from client
+edits. Graph snapshots include bundle, directory, concept, tag, resource,
+citation, source-ref, and community nodes plus derived containment, Markdown,
+external, citation, tag, resource, scope, source-support, and same-resource
+edges. Broken Markdown links are kept as unresolved edges. Snapshot metrics
+report orphan, broken-link, stale-concept, and warning counts, while node
+metrics report degree, normalized centrality, bridge score, and community ID.
+Community labels prefer concept areas, then tags, directories, and concept type.
+Tags, citations, and source refs are excluded from community membership by
+default and can be included with the memory graph endpoint query flags.
+
+No graph-library dependency is currently selected for memory graph extraction:
+the shipped backend work only derives deterministic catalog relationships and
+metadata communities. Add a graph library when the server owns true clustering
+or graph algorithms beyond these deterministic DTO metrics.
+
 The default visibility posture is private memory with optional public docs.
 Private capsules may include Linear comments, review context, and source
 snapshots, while public docs should contain public source refs such as issue

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -160,7 +160,11 @@ report orphan, broken-link, stale-concept, and warning counts, while node
 metrics report degree, normalized centrality, bridge score, and community ID.
 Community labels prefer concept areas, then tags, directories, and concept type.
 Tags, citations, and source refs are excluded from community membership by
-default and can be included with the memory graph endpoint query flags.
+default and can be included with the memory graph endpoint query flags. Those
+flags also parameterize node community IDs and bridge scores because the
+community membership input set changes with the query. Community IDs are stable
+grouping keys, not graph node IDs; community graph nodes are separately
+namespaced with `community:<id>`.
 
 No graph-library dependency is currently selected for memory graph extraction:
 the shipped backend work only derives deterministic catalog relationships and

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -157,8 +157,11 @@ citation, source-ref, and community nodes plus derived containment, Markdown,
 external, citation, tag, resource, scope, source-support, and same-resource
 edges. Broken Markdown links are kept as unresolved edges. Snapshot metrics
 report orphan, broken-link, stale-concept, and warning counts, while node
-metrics report degree, normalized centrality, bridge score, and community ID.
-Community labels prefer concept areas, then tags, directories, and concept type.
+metrics report degree, global normalized centrality across all graph node
+kinds, bridge score, and community ID. Community labels prefer concept areas,
+then tags, directories, and concept type. Each concept is assigned to exactly
+one deterministic community; when multiple areas are present the sorted first
+area wins, and tag fallback uses frontmatter order.
 Tags, citations, and source refs are excluded from community membership by
 default and can be included with the memory graph endpoint query flags. Those
 flags also parameterize node community IDs and bridge scores because the

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -42,6 +42,7 @@ export type {
   MemoryGraphNodeKind,
   MemoryGraphNodeMetrics,
   MemoryGraphSnapshot,
+  MemoryGraphSnapshotMetrics,
   MemoryGraphSourceRef,
   MemoryGraphUpdatedEvent,
   MemoryGraphVisibility,

--- a/packages/gateway-schema/src/memory_graph.ts
+++ b/packages/gateway-schema/src/memory_graph.ts
@@ -154,7 +154,7 @@ export interface MemoryGraphSourceRef {
 }
 
 export interface MemoryGraphNodeMetrics {
-  degree: number;
+  degree?: number;
   indegree: number;
   outdegree: number;
   centrality?: number;

--- a/packages/gateway-schema/src/memory_graph.ts
+++ b/packages/gateway-schema/src/memory_graph.ts
@@ -46,7 +46,7 @@ export interface MemoryGraphSnapshot {
   nodes: MemoryGraphNode[];
   edges: MemoryGraphEdge[];
   communities: MemoryGraphCommunity[];
-  metrics: MemoryGraphSnapshotMetrics;
+  metrics?: MemoryGraphSnapshotMetrics;
   filters_applied: string[];
   generated_at: string;
 }

--- a/packages/gateway-schema/src/memory_graph.ts
+++ b/packages/gateway-schema/src/memory_graph.ts
@@ -46,6 +46,7 @@ export interface MemoryGraphSnapshot {
   nodes: MemoryGraphNode[];
   edges: MemoryGraphEdge[];
   communities: MemoryGraphCommunity[];
+  metrics: MemoryGraphSnapshotMetrics;
   filters_applied: string[];
   generated_at: string;
 }
@@ -122,6 +123,13 @@ export interface MemoryGraphCommunity {
   concept_count: number;
 }
 
+export interface MemoryGraphSnapshotMetrics {
+  orphan_count: number;
+  broken_link_count: number;
+  stale_concept_count: number;
+  warning_count: number;
+}
+
 export interface MemoryFrontmatterView {
   primary: Record<string, unknown>;
   opensymphony: Record<string, unknown>;
@@ -146,8 +154,11 @@ export interface MemoryGraphSourceRef {
 }
 
 export interface MemoryGraphNodeMetrics {
+  degree: number;
   indegree: number;
   outdegree: number;
+  centrality?: number;
+  bridge_score?: number;
   pagerank?: number;
   community_id?: string;
 }


### PR DESCRIPTION
## Summary

Derives OKF memory graph metrics and deterministic communities so graph clients receive counts, scores, and community membership from the existing catalog projection.

## Changes

- Added snapshot metrics for orphan, broken-link, stale-concept, and warning counts, plus node degree, normalized centrality, bridge score, and community IDs.
- Added deterministic community labeling from areas, tags, directories, or concept type, with query flags to include tags, citations, and source refs in community membership.
- Updated Rust/TypeScript memory graph DTOs, gateway endpoint tests, OKF fixture coverage, and memory docs.
- Kept TypeScript `MemoryGraphSnapshot.metrics` and `MemoryGraphNodeMetrics.degree` optional for backward-compatible response consumers.
- Added focused tests for semantic orphan counting and bridge-score behavior when an edge endpoint has no community.

## Evidence

### Test output

```
cargo test-system-duckdb memory_graph_projection_filters_private_and_redacts_local_paths
# test opensymphony_memory::tests::memory_graph_projection_filters_private_and_redacts_local_paths ... ok

cargo test-system-duckdb memory_graph_snapshot_metrics_count_only_semantic_orphans
# test opensymphony_memory::tests::memory_graph_snapshot_metrics_count_only_semantic_orphans ... ok

cargo test-system-duckdb memory_graph_bridge_score_counts_only_cross_community_edges
# test opensymphony_memory::tests::memory_graph_bridge_score_counts_only_cross_community_edges ... ok

cargo test-system-duckdb --test memory graph
# test memory::memory_capture_expands_linear_children_and_links_graph ... ok

cargo test-system-duckdb --test gateway gateway_serves_memory_graph_contract_endpoints
# test gateway::gateway_serves_memory_graph_contract_endpoints ... ok

cargo test-system-duckdb memory_graph_dtos_roundtrip_required_kinds_and_update_event
# test gateway_schema::memory_graph_dtos_roundtrip_required_kinds_and_update_event ... ok

cargo clippy-system-duckdb
# Finished `dev` profile [unoptimized + debuginfo]

npx -y -p typescript@5.8.3 tsc --build packages/gateway-schema/tsconfig.json
# passed

cargo fmt --check
# passed

git diff --check HEAD~1 HEAD
# passed
```

### Verification

The OKF reindex fixture asserts deterministic graph snapshots include required node/edge kinds, unresolved Markdown-link edges, snapshot metric counts, node metric scores, community IDs, default exclusion of auxiliary community nodes, and opt-in tag/citation/source-ref community membership. The gateway test verifies the HTTP graph and communities endpoints serve the updated DTOs and query behavior.

A temporary local harness started the real gateway and ran curl against the memory graph endpoints. The harness was removed before commit. Key output:

```sh
$ curl -fsS 'http://127.0.0.1:60843/api/v1/memory/bundles/local-default/graph?visibility=public&include_tags=true&include_citations=true&include_source_refs=true'
```

```json
{
  "bundle_id": "local-default",
  "communities": [
    {
      "id": "area:graph-view",
      "label": "graph-view",
      "node_ids": [
        "citation:1",
        "concept:issues/COE-200",
        "source_ref:linear_issue:COE-200",
        "tag:graph",
        "tag:memory"
      ],
      "concept_count": 1
    }
  ],
  "metrics": {
    "orphan_count": 0,
    "broken_link_count": 1,
    "stale_concept_count": 0,
    "warning_count": 3
  },
  "filters_applied": [
    "visibility:public",
    "communities:include_tags",
    "communities:include_citations",
    "communities:include_source_refs"
  ],
  "edges_include_unresolved_markdown_link": true
}
```

```sh
$ curl -fsS 'http://127.0.0.1:60843/api/v1/memory/bundles/local-default/communities?visibility=public&include_tags=true'
```

```json
{
  "bundle_id": "local-default",
  "communities": [
    {
      "id": "area:graph-view",
      "label": "graph-view",
      "node_ids": [
        "concept:issues/COE-200",
        "tag:graph",
        "tag:memory"
      ],
      "concept_count": 1
    }
  ]
}
```

## Checklist

- [x] Tests pass (`cargo test`) - targeted cargo tests listed above
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed) - not applicable
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: not applicable

## Breaking changes

None. New Rust DTO fields use serde defaults, and the TypeScript graph snapshot metrics plus node degree fields are optional for backward-compatible response consumers.

## Related issues

COE-464

## Additional notes

No graph-library dependency is added. This slice derives deterministic catalog relationships and metadata communities; a graph algorithm library should be introduced only when the server owns true clustering beyond these DTO metrics.

