### PR TITLE
Add shared frontend graph package

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@opensymphony/api-client": "*",
     "@opensymphony/gateway-schema": "*",
+    "@opensymphony/graph": "*",
     "@opensymphony/state": "*",
     "@opensymphony/ui-core": "*"
   },

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -5,6 +5,11 @@ import {
   type ActionReceipt,
   type GatewayTransport,
 } from "@opensymphony/api-client";
+import {
+  createGatewayGraphAdapter,
+  createTauriNativeGraphAdapter,
+  type NativeGraphApi,
+} from "@opensymphony/graph";
 import type { ConnectionProfile } from "@opensymphony/gateway-schema";
 import type { RunDetail } from "@opensymphony/gateway-schema";
 import { defaultModelProfiles } from "@opensymphony/gateway-schema";
@@ -20,6 +25,14 @@ import {
 } from "@opensymphony/ui-core";
 
 const DEFAULT_GATEWAY_URL = "http://127.0.0.1:2468";
+
+export function createDesktopGraphAdapter(gatewayUrl = DEFAULT_GATEWAY_URL) {
+  return createGatewayGraphAdapter(gatewayUrl);
+}
+
+export function createDesktopNativeGraphAdapter(api: NativeGraphApi) {
+  return createTauriNativeGraphAdapter(api);
+}
 
 type TauriInvoke = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@opensymphony/gateway-schema": "*",
     "@opensymphony/api-client": "*",
+    "@opensymphony/graph": "*",
     "@opensymphony/ui-core": "*",
     "@opensymphony/state": "*"
   },

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -7,6 +7,7 @@
  */
 
 import { HttpGatewayTransport } from "@opensymphony/api-client";
+import { createGatewayGraphAdapter } from "@opensymphony/graph";
 import { renderOpenSymphonyApp } from "@opensymphony/ui-core";
 import { createWebAppConfig } from "./config.js";
 import { createWebModelProfileController } from "./model-profile-controller.js";
@@ -21,6 +22,10 @@ export function createWebTransport(gatewayUrl = defaultGatewayUrl) {
     baseUri: gatewayUrl,
     transport: "loopback_http",
   });
+}
+
+export function createWebGraphAdapter(gatewayUrl = defaultGatewayUrl) {
+  return createGatewayGraphAdapter(gatewayUrl);
 }
 
 if (root) {

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -1,0 +1,75 @@
+import {
+  applyGraphFilters,
+  createFixtureGraphAdapter,
+  createGatewayGraphAdapter,
+  fixtureGraphSnapshot,
+  graphReducer,
+  graphStateToHistory,
+  initialGraphFilters,
+  initialGraphState,
+  searchGraphSnapshot,
+} from "@opensymphony/graph";
+
+describe("@opensymphony/graph", () => {
+  it("loads DTOs and switches through all graph modes", () => {
+    let state = graphReducer(initialGraphState, {
+      type: "SNAPSHOT_LOADED",
+      snapshot: fixtureGraphSnapshot,
+    });
+    for (const mode of ["atlas", "bundle", "community", "neighborhood", "timeline", "evidence"] as const) {
+      state = graphReducer(state, { type: "MODE_SET", mode });
+      expect(state.mode).toBe(mode);
+    }
+  });
+
+  it("applies deterministic filters and search results", () => {
+    const filtered = applyGraphFilters(fixtureGraphSnapshot, {
+      ...initialGraphFilters,
+      tags: ["graph-view"],
+      areas: ["graph-view"],
+    });
+    expect(filtered.nodes.map((node) => node.id)).toEqual(["concept:coe-465"]);
+    expect(filtered.filters_applied).toEqual(["area:graph-view", "tag:graph-view"]);
+
+    const results = searchGraphSnapshot(fixtureGraphSnapshot, "graph", initialGraphFilters);
+    expect(results.map((result) => result.concept_id)).toEqual(["issues/COE-465", "tag:graph-view"]);
+  });
+
+  it("normalizes selection and history state for URLs or app history", () => {
+    const state = graphReducer(initialGraphState, {
+      type: "HISTORY_RESTORED",
+      state: {
+        mode: "neighborhood",
+        bundleId: "local-default",
+        focusedNodeId: "concept:coe-465",
+        selectedNodeIds: ["tag:graph-view", "concept:coe-465", "tag:graph-view"],
+        searchQuery: "  graph   view ",
+        filters: { ...initialGraphFilters, tags: ["frontend", "graph-view", "frontend"] },
+        neighborhoodDepth: 2,
+      },
+    });
+    expect(graphStateToHistory(state)).toMatchObject({
+      mode: "neighborhood",
+      selectedNodeIds: ["concept:coe-465", "tag:graph-view"],
+      searchQuery: "graph view",
+      neighborhoodDepth: 2,
+    });
+    expect(graphStateToHistory(state).filters.tags).toEqual(["frontend", "graph-view"]);
+  });
+
+  it("provides fixture and HTTP adapters without Tauri imports", async () => {
+    const fixture = createFixtureGraphAdapter();
+    await expect(fixture.listBundles()).resolves.toMatchObject({
+      bundles: [{ id: "local-default" }],
+    });
+
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ bundles: [] }),
+    })) as unknown as typeof fetch;
+    const gateway = createGatewayGraphAdapter("http://localhost:2468", fetchMock);
+    await gateway.listBundles();
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/memory/bundles");
+  });
+});

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -59,6 +59,36 @@ describe("@opensymphony/graph", () => {
     expect(graphStateToHistory(state).filters.tags).toEqual(["frontend", "graph-view"]);
   });
 
+  it("restores history clearing values without carrying stale state", () => {
+    const populated = graphReducer(initialGraphState, {
+      type: "HISTORY_RESTORED",
+      state: {
+        mode: "neighborhood",
+        bundleId: "local-default",
+        focusedNodeId: "concept:coe-465",
+        selectedNodeIds: ["concept:coe-465"],
+        searchQuery: "graph",
+        filters: { ...initialGraphFilters, tags: ["graph-view"] },
+        neighborhoodDepth: 2,
+      },
+    });
+
+    const restored = graphReducer(populated, {
+      type: "HISTORY_RESTORED",
+      state: {
+        bundleId: null,
+        focusedNodeId: null,
+        selectedNodeIds: [],
+      },
+    });
+
+    expect(restored.selectedBundleId).toBeNull();
+    expect(restored.focusedNodeId).toBeNull();
+    expect(restored.selectedNodeIds).toEqual([]);
+    expect(restored.searchQuery).toBe("graph");
+    expect(restored.filters.tags).toEqual(["graph-view"]);
+  });
+
   it("provides fixture and HTTP adapters without Tauri imports", async () => {
     const fixture = createFixtureGraphAdapter();
     await expect(fixture.listBundles()).resolves.toMatchObject({
@@ -81,6 +111,19 @@ describe("@opensymphony/graph", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "http://localhost:2468/api/v1/memory/search?visibility=public&query=graph&limit=5&bundle_id=local-default",
     );
+  });
+
+  it("rejects non-OK HTTP graph responses before parsing JSON", async () => {
+    const json = jest.fn();
+    const fetchMock = jest.fn(async () => ({
+      ok: false,
+      status: 503,
+      json,
+    })) as unknown as typeof fetch;
+    const gateway = createGatewayGraphAdapter("http://localhost:2468", fetchMock);
+
+    await expect(gateway.listBundles()).rejects.toThrow("Graph request failed: HTTP 503");
+    expect(json).not.toHaveBeenCalled();
   });
 
   it("keeps filtered community concept counts aligned to concept nodes only", () => {
@@ -108,9 +151,9 @@ describe("@opensymphony/graph", () => {
     );
     expect(filtered.nodes.map((node) => node.id)).toEqual([
       "concept:coe-465",
-      "tag:graph-view",
-      "bundle:local-default",
       "source:osym-822",
+      "bundle:local-default",
+      "tag:graph-view",
     ]);
     expect(filtered.filters_applied).toEqual([
       "neighborhood-depth:2",

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -141,6 +141,31 @@ describe("@opensymphony/graph", () => {
     ]);
   });
 
+  it("sorts communities with code-point ordering", () => {
+    const filtered = applyGraphFilters({
+      ...fixtureGraphSnapshot,
+      communities: [
+        {
+          id: "a-community",
+          label: "lowercase",
+          node_ids: ["concept:coe-465"],
+          concept_count: 1,
+        },
+        {
+          id: "B-community",
+          label: "uppercase",
+          node_ids: ["concept:coe-465"],
+          concept_count: 1,
+        },
+      ],
+    }, initialGraphFilters);
+
+    expect(filtered.communities.map((community) => community.id)).toEqual([
+      "B-community",
+      "a-community",
+    ]);
+  });
+
   it("expands neighborhoods beyond direct neighbors deterministically", () => {
     const filtered = applyGraphFilters(
       fixtureGraphSnapshot,

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -2,6 +2,7 @@ import {
   applyGraphFilters,
   createFixtureGraphAdapter,
   createGatewayGraphAdapter,
+  createTauriNativeGraphAdapter,
   fixtureGraphSnapshot,
   graphReducer,
   graphStateToHistory,
@@ -71,5 +72,43 @@ describe("@opensymphony/graph", () => {
     const gateway = createGatewayGraphAdapter("http://localhost:2468", fetchMock);
     await gateway.listBundles();
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/memory/bundles");
+  });
+
+  it("keeps filtered community concept counts aligned to concept nodes only", () => {
+    const filtered = applyGraphFilters(fixtureGraphSnapshot, {
+      ...initialGraphFilters,
+      communities: ["area:graph-view"],
+    });
+    expect(filtered.communities).toEqual([
+      {
+        id: "area:graph-view",
+        label: "Graph View",
+        node_ids: ["concept:coe-465", "tag:graph-view"],
+        concept_count: 1,
+      },
+    ]);
+  });
+
+  it("expands neighborhoods beyond direct neighbors deterministically", () => {
+    const filtered = applyGraphFilters(
+      fixtureGraphSnapshot,
+      initialGraphFilters,
+      "neighborhood",
+      "tag:graph-view",
+      2,
+    );
+    expect(filtered.nodes.map((node) => node.id)).toEqual([
+      "concept:coe-465",
+      "tag:graph-view",
+      "bundle:local-default",
+      "source:osym-822",
+    ]);
+  });
+
+  it("passes through native graph adapters without importing Tauri", async () => {
+    const native = createTauriNativeGraphAdapter(createFixtureGraphAdapter());
+    await expect(native.getCommunities("local-default")).resolves.toMatchObject({
+      communities: [{ id: "area:graph-view", concept_count: 1 }],
+    });
   });
 });

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -79,12 +79,14 @@ describe("@opensymphony/graph", () => {
         bundleId: null,
         focusedNodeId: null,
         selectedNodeIds: [],
+        neighborhoodDepth: 0,
       },
     });
 
     expect(restored.selectedBundleId).toBeNull();
     expect(restored.focusedNodeId).toBeNull();
     expect(restored.selectedNodeIds).toEqual([]);
+    expect(restored.neighborhoodDepth).toBe(0);
     expect(restored.searchQuery).toBe("graph");
     expect(restored.filters.tags).toEqual(["graph-view"]);
   });
@@ -141,6 +143,24 @@ describe("@opensymphony/graph", () => {
     ]);
   });
 
+  it("does not crash when community-filtered DTO nodes omit metrics", () => {
+    const nodeWithoutMetrics = { ...fixtureGraphSnapshot.nodes[0] } as Record<string, unknown>;
+    delete nodeWithoutMetrics.metrics;
+
+    const filtered = applyGraphFilters(
+      {
+        ...fixtureGraphSnapshot,
+        nodes: [nodeWithoutMetrics as never],
+      },
+      {
+        ...initialGraphFilters,
+        communities: ["area:graph-view"],
+      },
+    );
+
+    expect(filtered.nodes).toEqual([]);
+  });
+
   it("sorts communities with code-point ordering", () => {
     const filtered = applyGraphFilters({
       ...fixtureGraphSnapshot,
@@ -164,6 +184,16 @@ describe("@opensymphony/graph", () => {
       "B-community",
       "a-community",
     ]);
+  });
+
+  it("preserves depth zero for focused neighborhoods", () => {
+    const state = graphReducer(initialGraphState, {
+      type: "NODE_FOCUSED",
+      nodeId: "concept:coe-465",
+      neighborhoodDepth: 0,
+    });
+
+    expect(state.neighborhoodDepth).toBe(0);
   });
 
   it("expands neighborhoods beyond direct neighbors deterministically", () => {

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -1,6 +1,7 @@
 import {
   applyGraphFilters,
   createFixtureGraphAdapter,
+  createInitialGraphState,
   createGatewayGraphAdapter,
   createTauriNativeGraphAdapter,
   fixtureGraphSnapshot,
@@ -110,5 +111,20 @@ describe("@opensymphony/graph", () => {
     await expect(native.getCommunities("local-default")).resolves.toMatchObject({
       communities: [{ id: "area:graph-view", concept_count: 1 }],
     });
+  });
+
+  it("returns fresh objects for graph and filter resets", () => {
+    const dirty = {
+      ...createInitialGraphState(),
+      filters: { ...initialGraphFilters, tags: ["graph-view"] },
+    };
+    const filtersReset = graphReducer(dirty, { type: "FILTERS_RESET" });
+    const graphReset = graphReducer(dirty, { type: "GRAPH_RESET" });
+
+    expect(filtersReset.filters).toEqual(initialGraphFilters);
+    expect(filtersReset.filters).not.toBe(initialGraphFilters);
+    expect(graphReset).toEqual(initialGraphState);
+    expect(graphReset).not.toBe(initialGraphState);
+    expect(graphReset.filters).not.toBe(initialGraphFilters);
   });
 });

--- a/packages/graph/__tests__/graph.test.ts
+++ b/packages/graph/__tests__/graph.test.ts
@@ -73,6 +73,14 @@ describe("@opensymphony/graph", () => {
     const gateway = createGatewayGraphAdapter("http://localhost:2468", fetchMock);
     await gateway.listBundles();
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/memory/bundles");
+    await gateway.search("graph", {
+      visibility: "public",
+      limit: 5,
+      bundleId: "local-default",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:2468/api/v1/memory/search?visibility=public&query=graph&limit=5&bundle_id=local-default",
+    );
   });
 
   it("keeps filtered community concept counts aligned to concept nodes only", () => {
@@ -104,12 +112,28 @@ describe("@opensymphony/graph", () => {
       "bundle:local-default",
       "source:osym-822",
     ]);
+    expect(filtered.filters_applied).toEqual([
+      "neighborhood-depth:2",
+      "neighborhood:tag:graph-view",
+    ]);
   });
 
   it("passes through native graph adapters without importing Tauri", async () => {
     const native = createTauriNativeGraphAdapter(createFixtureGraphAdapter());
     await expect(native.getCommunities("local-default")).resolves.toMatchObject({
       communities: [{ id: "area:graph-view", concept_count: 1 }],
+    });
+  });
+
+  it("honors fixture search bundle and limit options", async () => {
+    const fixture = createFixtureGraphAdapter();
+    await expect(fixture.search("graph", { bundleId: "other-bundle" })).resolves.toMatchObject({
+      bundle_id: "other-bundle",
+      results: [],
+    });
+    await expect(fixture.search("graph", { bundleId: "local-default", limit: 1 })).resolves.toMatchObject({
+      bundle_id: "local-default",
+      results: [{ concept_id: "issues/COE-465" }],
     });
   });
 

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@opensymphony/graph",
+  "version": "2.0.0",
+  "description": "Transport-agnostic memory graph state and adapters for OpenSymphony clients",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsc --build tsconfig.json",
+    "type-check": "tsc --build tsconfig.json --pretty false",
+    "test": "jest --config ../../jest.config.js --runTestsByPath __tests__/graph.test.ts"
+  },
+  "dependencies": {
+    "@opensymphony/gateway-schema": "*"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/graph/src/fixture.ts
+++ b/packages/graph/src/fixture.ts
@@ -17,7 +17,7 @@ export const fixtureBundleList: MemoryBundleList = {
       title: "OpenSymphony Memory",
       okf_version: "0.1",
       visibility: "private",
-      concept_count: 3,
+      concept_count: 1,
       updated_at: generated_at,
     },
   ],

--- a/packages/graph/src/fixture.ts
+++ b/packages/graph/src/fixture.ts
@@ -1,0 +1,169 @@
+import type {
+  MemoryBundleList,
+  MemoryCommunityList,
+  MemoryConceptDetail,
+  MemoryGraphSnapshot,
+  MemorySearchResponse,
+} from "@opensymphony/gateway-schema";
+
+const schema_version = { major: 1, minor: 0, patch: 0 };
+const generated_at = "2026-06-28T00:00:00Z";
+
+export const fixtureBundleList: MemoryBundleList = {
+  schema_version,
+  bundles: [
+    {
+      id: "local-default",
+      title: "OpenSymphony Memory",
+      okf_version: "0.1",
+      visibility: "private",
+      concept_count: 3,
+      updated_at: generated_at,
+    },
+  ],
+};
+
+export const fixtureGraphSnapshot: MemoryGraphSnapshot = {
+  schema_version,
+  bundle_id: "local-default",
+  cursor: { sequence: 1, partition: "memory-graph:local-default" },
+  generated_at,
+  filters_applied: [],
+  communities: [
+    {
+      id: "area:graph-view",
+      label: "Graph View",
+      node_ids: ["concept:coe-465", "tag:graph-view"],
+      concept_count: 1,
+    },
+  ],
+  nodes: [
+    {
+      id: "bundle:local-default",
+      kind: "bundle",
+      label: "OpenSymphony Memory",
+      bundle_id: "local-default",
+      tags: [],
+      visibility: "private",
+      freshness: "current",
+      warning_count: 0,
+      frontmatter_summary: {},
+      unknown_frontmatter: {},
+      metrics: { indegree: 0, outdegree: 2 },
+    },
+    {
+      id: "concept:coe-465",
+      kind: "concept",
+      label: "COE-465 Shared Graph Frontend Package And Reducers",
+      bundle_id: "local-default",
+      concept_id: "issues/COE-465",
+      concept_type: "issue",
+      path_display: "issues/COE-465.md",
+      tags: ["graph-view", "frontend"],
+      timestamp: generated_at,
+      visibility: "private",
+      freshness: "current",
+      warning_count: 0,
+      frontmatter_summary: {
+        area: "graph-view",
+        project: "OpenSymphony-bootstrap",
+        milestone: "M11.5",
+        issue: "COE-465",
+        repository: "OpenSymphony",
+      },
+      unknown_frontmatter: {},
+      body_preview: "Shared frontend graph package used by web and desktop clients.",
+      metrics: { indegree: 1, outdegree: 2, community_id: "area:graph-view" },
+    },
+    {
+      id: "tag:graph-view",
+      kind: "tag",
+      label: "graph-view",
+      bundle_id: "local-default",
+      tags: ["graph-view"],
+      visibility: "private",
+      freshness: "current",
+      warning_count: 0,
+      frontmatter_summary: {},
+      unknown_frontmatter: {},
+      metrics: { indegree: 1, outdegree: 0, community_id: "area:graph-view" },
+    },
+    {
+      id: "source:osym-822",
+      kind: "source_ref",
+      label: "OSYM-822",
+      bundle_id: "local-default",
+      tags: [],
+      visibility: "private",
+      freshness: "current",
+      warning_count: 0,
+      frontmatter_summary: { source_kind: "task" },
+      unknown_frontmatter: {},
+      metrics: { indegree: 1, outdegree: 0 },
+    },
+  ],
+  edges: [
+    {
+      id: "edge:bundle-local-default:concept-coe-465",
+      kind: "contains",
+      source_id: "bundle:local-default",
+      target_id: "concept:coe-465",
+      unresolved: false,
+      metadata: {},
+    },
+    {
+      id: "edge:concept-coe-465:tag-graph-view",
+      kind: "tagged_with",
+      source_id: "concept:coe-465",
+      target_id: "tag:graph-view",
+      unresolved: false,
+      metadata: {},
+    },
+    {
+      id: "edge:concept-coe-465:source-osym-822",
+      kind: "source_supported_by",
+      source_id: "concept:coe-465",
+      target_id: "source:osym-822",
+      unresolved: false,
+      metadata: { source_kind: "task" },
+    },
+  ],
+};
+
+export const fixtureCommunityList: MemoryCommunityList = {
+  schema_version,
+  bundle_id: fixtureGraphSnapshot.bundle_id,
+  generated_at,
+  communities: fixtureGraphSnapshot.communities,
+};
+
+export const fixtureConceptDetail: MemoryConceptDetail = {
+  schema_version,
+  bundle_id: fixtureGraphSnapshot.bundle_id,
+  concept_id: "issues/COE-465",
+  frontmatter_view: {
+    primary: { title: "Shared Graph Frontend Package And Reducers" },
+    opensymphony: { issue: "COE-465", milestone: "M11.5" },
+    unknown: {},
+  },
+  body_markdown: "# COE-465\n\nShared graph frontend package and reducers.",
+  links: [{ target: "tag:graph-view", label: "graph-view" }],
+  citations: [],
+  source_refs: [{ kind: "task", id: "OSYM-822" }],
+};
+
+export const fixtureSearchResponse: MemorySearchResponse = {
+  schema_version,
+  query: "graph",
+  bundle_id: fixtureGraphSnapshot.bundle_id,
+  results: [
+    {
+      bundle_id: fixtureGraphSnapshot.bundle_id,
+      concept_id: "issues/COE-465",
+      title: "COE-465 Shared Graph Frontend Package And Reducers",
+      visibility: "private",
+      snippet: "Shared frontend graph package used by web and desktop clients.",
+      areas: ["graph-view"],
+    },
+  ],
+};

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -285,29 +285,29 @@ export function applyGraphFilters(
     if (neighborhood && !neighborhood.has(node.id)) return false;
     return matchesNodeFilters(node, normalized);
   });
-  const nodeIds = new Set(nodes.map((node) => node.id));
+  const nodeKindById = new Map(nodes.map((node) => [node.id, node.kind]));
   const edges = snapshot.edges.filter((edge) => {
-    if (!nodeIds.has(edge.source_id) || !nodeIds.has(edge.target_id)) return false;
+    if (!nodeKindById.has(edge.source_id) || !nodeKindById.has(edge.target_id)) return false;
     if (normalized.edgeKinds.length > 0 && !normalized.edgeKinds.includes(edge.kind)) return false;
     return true;
   });
   const communities = snapshot.communities
     .map((community) => ({
       ...community,
-      node_ids: community.node_ids.filter((nodeId) => nodeIds.has(nodeId)).sort(),
-      concept_count: community.node_ids.filter((nodeId) => {
-        const node = snapshot.nodes.find((candidate) => candidate.id === nodeId);
-        return nodeIds.has(nodeId) && node?.kind === "concept";
-      }).length,
+      node_ids: community.node_ids.filter((nodeId) => nodeKindById.has(nodeId)).sort(),
+      concept_count: community.node_ids.filter((nodeId) => nodeKindById.get(nodeId) === "concept").length,
     }))
     .filter((community) => community.node_ids.length > 0)
     .sort((a, b) => a.id.localeCompare(b.id));
+  const neighborhoodTokens = neighborhood
+    ? [`neighborhood:${focusedNodeId}`, `neighborhood-depth:${neighborhoodDepth}`]
+    : [];
   return {
     ...snapshot,
     nodes: [...nodes].sort(compareNodes),
     edges: [...edges].sort(compareEdges),
     communities,
-    filters_applied: filterTokens(normalized),
+    filters_applied: [...filterTokens(normalized), ...neighborhoodTokens].sort(),
   };
 }
 
@@ -370,6 +370,7 @@ export function createHttpGraphAdapter(baseUri: string, fetchFn: typeof fetch = 
       const params = visibilityParams(options);
       params.set("query", query);
       if (options?.limit !== undefined) params.set("limit", String(options.limit));
+      if (options?.bundleId) params.set("bundle_id", options.bundleId);
       return read<MemorySearchResponse>("/api/v1/memory/search", params);
     },
   };
@@ -399,11 +400,19 @@ export function createFixtureGraphAdapter(fixtures: {
     getGraphSnapshot: async () => snapshot,
     getConceptDetail: async () => conceptDetail,
     getCommunities: async () => communities,
-    search: async (query) => ({
-      ...search,
-      query,
-      results: query === search.query ? search.results : searchGraphSnapshot(snapshot, query),
-    }),
+    search: async (query, options) => {
+      const results = options?.bundleId && options.bundleId !== snapshot.bundle_id
+        ? []
+        : query === search.query
+          ? search.results
+          : searchGraphSnapshot(snapshot, query);
+      return {
+        ...search,
+        query,
+        bundle_id: options?.bundleId ?? search.bundle_id,
+        results: results.slice(0, options?.limit ?? results.length),
+      };
+    },
   };
 }
 
@@ -471,15 +480,15 @@ function collectNeighborhood(
   depth: number,
 ): Set<string> {
   const seen = new Set([rootId]);
-  let frontier = [rootId];
+  let frontier = new Set([rootId]);
   for (let step = 0; step < Math.max(0, depth); step++) {
     const next: string[] = [];
     for (const edge of edges) {
-      if (frontier.includes(edge.source_id) && !seen.has(edge.target_id)) next.push(edge.target_id);
-      if (frontier.includes(edge.target_id) && !seen.has(edge.source_id)) next.push(edge.source_id);
+      if (frontier.has(edge.source_id) && !seen.has(edge.target_id)) next.push(edge.target_id);
+      if (frontier.has(edge.target_id) && !seen.has(edge.source_id)) next.push(edge.source_id);
     }
     for (const id of next) seen.add(id);
-    frontier = uniqueSorted(next);
+    frontier = new Set(next);
   }
   return seen;
 }

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -137,40 +137,47 @@ export const graphModes: readonly GraphMode[] = [
   "evidence",
 ];
 
-export const initialGraphFilters: GraphFilters = {
-  bundleIds: [],
-  nodeKinds: [],
-  tags: [],
-  areas: [],
-  projects: [],
-  milestones: [],
-  issues: [],
-  repositories: [],
-  visibility: [],
-  freshness: [],
-  warning: "all",
-  sourceKinds: [],
-  edgeKinds: [],
-  communities: [],
-};
+export const initialGraphFilters: GraphFilters = createInitialGraphFilters();
+export const initialGraphState: GraphState = createInitialGraphState();
 
-export const initialGraphState: GraphState = {
-  bundles: null,
-  snapshots: {},
-  conceptDetails: {},
-  communities: {},
-  mode: "atlas",
-  selectedBundleId: null,
-  focusedNodeId: null,
-  selectedNodeIds: [],
-  searchQuery: "",
-  searchResults: [],
-  filters: initialGraphFilters,
-  layoutStatus: "idle",
-  layoutError: null,
-  neighborhoodDepth: 1,
-  lastUpdatedAt: null,
-};
+export function createInitialGraphFilters(): GraphFilters {
+  return {
+    bundleIds: [],
+    nodeKinds: [],
+    tags: [],
+    areas: [],
+    projects: [],
+    milestones: [],
+    issues: [],
+    repositories: [],
+    visibility: [],
+    freshness: [],
+    warning: "all",
+    sourceKinds: [],
+    edgeKinds: [],
+    communities: [],
+  };
+}
+
+export function createInitialGraphState(): GraphState {
+  return {
+    bundles: null,
+    snapshots: {},
+    conceptDetails: {},
+    communities: {},
+    mode: "atlas",
+    selectedBundleId: null,
+    focusedNodeId: null,
+    selectedNodeIds: [],
+    searchQuery: "",
+    searchResults: [],
+    filters: createInitialGraphFilters(),
+    layoutStatus: "idle",
+    layoutError: null,
+    neighborhoodDepth: 1,
+    lastUpdatedAt: null,
+  };
+}
 
 export function graphReducer(state: GraphState, action: GraphAction): GraphState {
   switch (action.type) {
@@ -223,7 +230,7 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
     case "FILTERS_SET":
       return { ...state, filters: normalizeFilters({ ...state.filters, ...action.filters }) };
     case "FILTERS_RESET":
-      return { ...state, filters: initialGraphFilters };
+      return { ...state, filters: createInitialGraphFilters() };
     case "SEARCH_SET":
       return { ...state, searchQuery: normalizeQuery(action.query) };
     case "SEARCH_RESULTS_LOADED":
@@ -246,7 +253,7 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
         neighborhoodDepth: action.state.neighborhoodDepth ?? state.neighborhoodDepth,
       };
     case "GRAPH_RESET":
-      return initialGraphState;
+      return createInitialGraphState();
     default:
       return state;
   }

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,0 +1,547 @@
+import type {
+  MemoryBundleList,
+  MemoryCommunityList,
+  MemoryConceptDetail,
+  MemoryGraphEdge,
+  MemoryGraphEdgeKind,
+  MemoryGraphFreshness,
+  MemoryGraphNode,
+  MemoryGraphNodeKind,
+  MemoryGraphSnapshot,
+  MemoryGraphVisibility,
+  MemorySearchResponse,
+  MemorySearchResult,
+} from "@opensymphony/gateway-schema";
+import {
+  fixtureBundleList,
+  fixtureCommunityList,
+  fixtureConceptDetail,
+  fixtureGraphSnapshot,
+  fixtureSearchResponse,
+} from "./fixture.js";
+
+export type {
+  MemoryBundleList,
+  MemoryCommunityList,
+  MemoryConceptDetail,
+  MemoryGraphSnapshot,
+  MemorySearchResponse,
+} from "@opensymphony/gateway-schema";
+export {
+  fixtureBundleList,
+  fixtureCommunityList,
+  fixtureConceptDetail,
+  fixtureGraphSnapshot,
+  fixtureSearchResponse,
+} from "./fixture.js";
+
+export type GraphMode =
+  | "atlas"
+  | "bundle"
+  | "community"
+  | "neighborhood"
+  | "timeline"
+  | "evidence";
+
+export type LayoutStatus = "idle" | "loading" | "stabilizing" | "ready" | "failed";
+
+export interface GraphFilters {
+  bundleIds: string[];
+  nodeKinds: MemoryGraphNodeKind[];
+  tags: string[];
+  areas: string[];
+  projects: string[];
+  milestones: string[];
+  issues: string[];
+  repositories: string[];
+  visibility: MemoryGraphVisibility[];
+  freshness: MemoryGraphFreshness[];
+  warning: "all" | "with_warnings" | "without_warnings";
+  sourceKinds: string[];
+  edgeKinds: MemoryGraphEdgeKind[];
+  communities: string[];
+}
+
+export interface GraphDeepLinkState {
+  mode: GraphMode;
+  bundleId: string | null;
+  focusedNodeId: string | null;
+  selectedNodeIds: string[];
+  searchQuery: string;
+  filters: GraphFilters;
+  neighborhoodDepth: number;
+}
+
+export interface GraphState {
+  bundles: MemoryBundleList | null;
+  snapshots: Record<string, MemoryGraphSnapshot>;
+  conceptDetails: Record<string, MemoryConceptDetail>;
+  communities: Record<string, MemoryCommunityList>;
+  mode: GraphMode;
+  selectedBundleId: string | null;
+  focusedNodeId: string | null;
+  selectedNodeIds: string[];
+  searchQuery: string;
+  searchResults: MemorySearchResult[];
+  filters: GraphFilters;
+  layoutStatus: LayoutStatus;
+  layoutError: string | null;
+  neighborhoodDepth: number;
+  lastUpdatedAt: string | null;
+}
+
+export type GraphAction =
+  | { type: "BUNDLES_LOADED"; bundles: MemoryBundleList }
+  | { type: "SNAPSHOT_LOADED"; snapshot: MemoryGraphSnapshot }
+  | { type: "CONCEPT_DETAIL_LOADED"; detail: MemoryConceptDetail }
+  | { type: "COMMUNITIES_LOADED"; communities: MemoryCommunityList }
+  | { type: "MODE_SET"; mode: GraphMode }
+  | { type: "BUNDLE_SELECTED"; bundleId: string | null }
+  | { type: "COMMUNITY_SELECTED"; communityId: string | null }
+  | { type: "NODE_FOCUSED"; nodeId: string | null; neighborhoodDepth?: number }
+  | { type: "SELECTION_SET"; nodeIds: string[] }
+  | { type: "FILTERS_SET"; filters: Partial<GraphFilters> }
+  | { type: "FILTERS_RESET" }
+  | { type: "SEARCH_SET"; query: string }
+  | { type: "SEARCH_RESULTS_LOADED"; response: MemorySearchResponse }
+  | { type: "LAYOUT_STATUS_SET"; status: LayoutStatus; error?: string | null }
+  | { type: "HISTORY_RESTORED"; state: Partial<GraphDeepLinkState> }
+  | { type: "GRAPH_RESET" };
+
+export interface GraphDataAdapter {
+  listBundles(): Promise<MemoryBundleList>;
+  getGraphSnapshot(bundleId: string, options?: GraphRequestOptions): Promise<MemoryGraphSnapshot>;
+  getConceptDetail(bundleId: string, conceptId: string, options?: GraphRequestOptions): Promise<MemoryConceptDetail>;
+  getCommunities(bundleId: string, options?: GraphRequestOptions): Promise<MemoryCommunityList>;
+  search(query: string, options?: GraphSearchOptions): Promise<MemorySearchResponse>;
+}
+
+export interface GraphRequestOptions {
+  visibility?: MemoryGraphVisibility | "all_accessible";
+}
+
+export interface GraphSearchOptions extends GraphRequestOptions {
+  limit?: number;
+  bundleId?: string;
+}
+
+export interface NativeGraphApi {
+  listBundles(): Promise<MemoryBundleList>;
+  getGraphSnapshot(bundleId: string, options?: GraphRequestOptions): Promise<MemoryGraphSnapshot>;
+  getConceptDetail(bundleId: string, conceptId: string, options?: GraphRequestOptions): Promise<MemoryConceptDetail>;
+  getCommunities(bundleId: string, options?: GraphRequestOptions): Promise<MemoryCommunityList>;
+  search(query: string, options?: GraphSearchOptions): Promise<MemorySearchResponse>;
+}
+
+export const graphModes: readonly GraphMode[] = [
+  "atlas",
+  "bundle",
+  "community",
+  "neighborhood",
+  "timeline",
+  "evidence",
+];
+
+export const initialGraphFilters: GraphFilters = {
+  bundleIds: [],
+  nodeKinds: [],
+  tags: [],
+  areas: [],
+  projects: [],
+  milestones: [],
+  issues: [],
+  repositories: [],
+  visibility: [],
+  freshness: [],
+  warning: "all",
+  sourceKinds: [],
+  edgeKinds: [],
+  communities: [],
+};
+
+export const initialGraphState: GraphState = {
+  bundles: null,
+  snapshots: {},
+  conceptDetails: {},
+  communities: {},
+  mode: "atlas",
+  selectedBundleId: null,
+  focusedNodeId: null,
+  selectedNodeIds: [],
+  searchQuery: "",
+  searchResults: [],
+  filters: initialGraphFilters,
+  layoutStatus: "idle",
+  layoutError: null,
+  neighborhoodDepth: 1,
+  lastUpdatedAt: null,
+};
+
+export function graphReducer(state: GraphState, action: GraphAction): GraphState {
+  switch (action.type) {
+    case "BUNDLES_LOADED":
+      return {
+        ...state,
+        bundles: action.bundles,
+        selectedBundleId: state.selectedBundleId ?? action.bundles.bundles[0]?.id ?? null,
+        lastUpdatedAt: latestBundleTimestamp(action.bundles),
+      };
+    case "SNAPSHOT_LOADED":
+      return {
+        ...state,
+        snapshots: { ...state.snapshots, [action.snapshot.bundle_id]: action.snapshot },
+        selectedBundleId: state.selectedBundleId ?? action.snapshot.bundle_id,
+        lastUpdatedAt: action.snapshot.generated_at,
+      };
+    case "CONCEPT_DETAIL_LOADED":
+      return {
+        ...state,
+        conceptDetails: {
+          ...state.conceptDetails,
+          [conceptDetailKey(action.detail.bundle_id, action.detail.concept_id)]: action.detail,
+        },
+      };
+    case "COMMUNITIES_LOADED":
+      return {
+        ...state,
+        communities: { ...state.communities, [action.communities.bundle_id]: action.communities },
+      };
+    case "MODE_SET":
+      return { ...state, mode: action.mode };
+    case "BUNDLE_SELECTED":
+      return { ...state, selectedBundleId: action.bundleId, focusedNodeId: null, selectedNodeIds: [] };
+    case "COMMUNITY_SELECTED":
+      return graphReducer(
+        { ...state, mode: "community" },
+        { type: "FILTERS_SET", filters: { communities: action.communityId ? [action.communityId] : [] } },
+      );
+    case "NODE_FOCUSED":
+      return {
+        ...state,
+        mode: action.nodeId ? "neighborhood" : state.mode,
+        focusedNodeId: action.nodeId,
+        selectedNodeIds: action.nodeId ? uniqueSorted([...state.selectedNodeIds, action.nodeId]) : state.selectedNodeIds,
+        neighborhoodDepth: action.neighborhoodDepth ?? state.neighborhoodDepth,
+      };
+    case "SELECTION_SET":
+      return { ...state, selectedNodeIds: uniqueSorted(action.nodeIds) };
+    case "FILTERS_SET":
+      return { ...state, filters: normalizeFilters({ ...state.filters, ...action.filters }) };
+    case "FILTERS_RESET":
+      return { ...state, filters: initialGraphFilters };
+    case "SEARCH_SET":
+      return { ...state, searchQuery: normalizeQuery(action.query) };
+    case "SEARCH_RESULTS_LOADED":
+      return {
+        ...state,
+        searchQuery: normalizeQuery(action.response.query),
+        searchResults: [...action.response.results].sort(compareSearchResults),
+      };
+    case "LAYOUT_STATUS_SET":
+      return { ...state, layoutStatus: action.status, layoutError: action.error ?? null };
+    case "HISTORY_RESTORED":
+      return {
+        ...state,
+        mode: action.state.mode ?? state.mode,
+        selectedBundleId: action.state.bundleId ?? state.selectedBundleId,
+        focusedNodeId: action.state.focusedNodeId ?? state.focusedNodeId,
+        selectedNodeIds: uniqueSorted(action.state.selectedNodeIds ?? state.selectedNodeIds),
+        searchQuery: normalizeQuery(action.state.searchQuery ?? state.searchQuery),
+        filters: normalizeFilters(action.state.filters ?? state.filters),
+        neighborhoodDepth: action.state.neighborhoodDepth ?? state.neighborhoodDepth,
+      };
+    case "GRAPH_RESET":
+      return initialGraphState;
+    default:
+      return state;
+  }
+}
+
+export function currentGraphSnapshot(state: GraphState): MemoryGraphSnapshot | null {
+  const bundleId = state.selectedBundleId;
+  return bundleId ? state.snapshots[bundleId] ?? null : null;
+}
+
+export function visibleGraphSnapshot(state: GraphState): MemoryGraphSnapshot | null {
+  const snapshot = currentGraphSnapshot(state);
+  if (!snapshot) return null;
+  return applyGraphFilters(snapshot, state.filters, state.mode, state.focusedNodeId, state.neighborhoodDepth);
+}
+
+export function applyGraphFilters(
+  snapshot: MemoryGraphSnapshot,
+  filters: GraphFilters,
+  mode: GraphMode = "atlas",
+  focusedNodeId: string | null = null,
+  neighborhoodDepth = 1,
+): MemoryGraphSnapshot {
+  const normalized = normalizeFilters(filters);
+  const neighborhood = mode === "neighborhood" && focusedNodeId
+    ? collectNeighborhood(snapshot.edges, focusedNodeId, neighborhoodDepth)
+    : null;
+  const nodes = snapshot.nodes.filter((node) => {
+    if (neighborhood && !neighborhood.has(node.id)) return false;
+    return matchesNodeFilters(node, normalized);
+  });
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edges = snapshot.edges.filter((edge) => {
+    if (!nodeIds.has(edge.source_id) || !nodeIds.has(edge.target_id)) return false;
+    if (normalized.edgeKinds.length > 0 && !normalized.edgeKinds.includes(edge.kind)) return false;
+    return true;
+  });
+  const communities = snapshot.communities
+    .map((community) => ({
+      ...community,
+      node_ids: community.node_ids.filter((nodeId) => nodeIds.has(nodeId)).sort(),
+      concept_count: community.node_ids.filter((nodeId) => nodeIds.has(nodeId)).length,
+    }))
+    .filter((community) => community.node_ids.length > 0)
+    .sort((a, b) => a.id.localeCompare(b.id));
+  return {
+    ...snapshot,
+    nodes: [...nodes].sort(compareNodes),
+    edges: [...edges].sort(compareEdges),
+    communities,
+    filters_applied: filterTokens(normalized),
+  };
+}
+
+export function searchGraphSnapshot(
+  snapshot: MemoryGraphSnapshot,
+  query: string,
+  filters: GraphFilters = initialGraphFilters,
+): MemorySearchResult[] {
+  const needle = normalizeQuery(query).toLowerCase();
+  if (!needle) return [];
+  return applyGraphFilters(snapshot, filters)
+    .nodes.map((node) => ({ node, score: scoreNode(node, needle) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || compareNodes(a.node, b.node))
+    .map(({ node }) => ({
+      bundle_id: node.bundle_id ?? snapshot.bundle_id,
+      concept_id: node.concept_id ?? node.id,
+      title: node.label,
+      visibility: node.visibility ?? "private",
+      snippet: node.body_preview ?? node.description ?? node.path_display ?? node.label,
+      areas: valuesFor(node, "area"),
+    }));
+}
+
+export function graphStateToHistory(state: GraphState): GraphDeepLinkState {
+  return {
+    mode: state.mode,
+    bundleId: state.selectedBundleId,
+    focusedNodeId: state.focusedNodeId,
+    selectedNodeIds: uniqueSorted(state.selectedNodeIds),
+    searchQuery: normalizeQuery(state.searchQuery),
+    filters: normalizeFilters(state.filters),
+    neighborhoodDepth: state.neighborhoodDepth,
+  };
+}
+
+export function createHttpGraphAdapter(baseUri: string, fetchFn: typeof fetch = globalThis.fetch): GraphDataAdapter {
+  const base = baseUri.replace(/\/+$/, "");
+  async function read<T>(path: string, params: URLSearchParams = new URLSearchParams()): Promise<T> {
+    const query = params.toString();
+    const response = await fetchFn(`${base}${path}${query ? `?${query}` : ""}`);
+    if (!response.ok) throw new Error(`Graph request failed: HTTP ${response.status}`);
+    return await response.json() as T;
+  }
+  return {
+    listBundles: () => read<MemoryBundleList>("/api/v1/memory/bundles"),
+    getGraphSnapshot: (bundleId, options) =>
+      read<MemoryGraphSnapshot>(`/api/v1/memory/bundles/${encodeURIComponent(bundleId)}/graph`, visibilityParams(options)),
+    getConceptDetail: (bundleId, conceptId, options) =>
+      read<MemoryConceptDetail>(
+        `/api/v1/memory/bundles/${encodeURIComponent(bundleId)}/concepts/${encodeURIComponent(conceptId)}`,
+        visibilityParams(options),
+      ),
+    getCommunities: (bundleId, options) =>
+      read<MemoryCommunityList>(
+        `/api/v1/memory/bundles/${encodeURIComponent(bundleId)}/communities`,
+        visibilityParams(options),
+      ),
+    search: (query, options) => {
+      const params = visibilityParams(options);
+      params.set("query", query);
+      if (options?.limit !== undefined) params.set("limit", String(options.limit));
+      return read<MemorySearchResponse>("/api/v1/memory/search", params);
+    },
+  };
+}
+
+export const createGatewayGraphAdapter = createHttpGraphAdapter;
+export const createMemoryServerGraphAdapter = createHttpGraphAdapter;
+
+export function createTauriNativeGraphAdapter(api: NativeGraphApi): GraphDataAdapter {
+  return api;
+}
+
+export function createFixtureGraphAdapter(fixtures: {
+  bundles?: MemoryBundleList;
+  snapshot?: MemoryGraphSnapshot;
+  conceptDetail?: MemoryConceptDetail;
+  communities?: MemoryCommunityList;
+  search?: MemorySearchResponse;
+} = {}): GraphDataAdapter {
+  const bundles = fixtures.bundles ?? fixtureBundleList;
+  const snapshot = fixtures.snapshot ?? fixtureGraphSnapshot;
+  const conceptDetail = fixtures.conceptDetail ?? fixtureConceptDetail;
+  const communities = fixtures.communities ?? fixtureCommunityList;
+  const search = fixtures.search ?? fixtureSearchResponse;
+  return {
+    listBundles: async () => bundles,
+    getGraphSnapshot: async () => snapshot,
+    getConceptDetail: async () => conceptDetail,
+    getCommunities: async () => communities,
+    search: async (query) => ({
+      ...search,
+      query,
+      results: query === search.query ? search.results : searchGraphSnapshot(snapshot, query),
+    }),
+  };
+}
+
+function normalizeFilters(filters: GraphFilters): GraphFilters {
+  return {
+    bundleIds: uniqueSorted(filters.bundleIds),
+    nodeKinds: uniqueSorted(filters.nodeKinds),
+    tags: uniqueSorted(filters.tags),
+    areas: uniqueSorted(filters.areas),
+    projects: uniqueSorted(filters.projects),
+    milestones: uniqueSorted(filters.milestones),
+    issues: uniqueSorted(filters.issues),
+    repositories: uniqueSorted(filters.repositories),
+    visibility: uniqueSorted(filters.visibility),
+    freshness: uniqueSorted(filters.freshness),
+    warning: filters.warning,
+    sourceKinds: uniqueSorted(filters.sourceKinds),
+    edgeKinds: uniqueSorted(filters.edgeKinds),
+    communities: uniqueSorted(filters.communities),
+  };
+}
+
+function matchesNodeFilters(node: MemoryGraphNode, filters: GraphFilters): boolean {
+  if (filters.bundleIds.length > 0 && (!node.bundle_id || !filters.bundleIds.includes(node.bundle_id))) return false;
+  if (filters.nodeKinds.length > 0 && !filters.nodeKinds.includes(node.kind)) return false;
+  if (filters.tags.length > 0 && !filters.tags.some((tag) => node.tags.includes(tag))) return false;
+  if (filters.visibility.length > 0 && (!node.visibility || !filters.visibility.includes(node.visibility))) return false;
+  if (filters.freshness.length > 0 && (!node.freshness || !filters.freshness.includes(node.freshness))) return false;
+  if (filters.warning === "with_warnings" && node.warning_count <= 0) return false;
+  if (filters.warning === "without_warnings" && node.warning_count > 0) return false;
+  if (filters.communities.length > 0 && (!node.metrics.community_id || !filters.communities.includes(node.metrics.community_id))) return false;
+  if (filters.areas.length > 0 && !hasAny(node, "area", filters.areas)) return false;
+  if (filters.projects.length > 0 && !hasAny(node, "project", filters.projects)) return false;
+  if (filters.milestones.length > 0 && !hasAny(node, "milestone", filters.milestones)) return false;
+  if (filters.issues.length > 0 && !hasAny(node, "issue", filters.issues)) return false;
+  if (filters.repositories.length > 0 && !hasAny(node, "repository", filters.repositories)) return false;
+  if (filters.sourceKinds.length > 0 && !hasAny(node, "source_kind", filters.sourceKinds)) return false;
+  return true;
+}
+
+function hasAny(node: MemoryGraphNode, key: string, values: string[]): boolean {
+  const got = valuesFor(node, key);
+  return values.some((value) => got.includes(value));
+}
+
+function valuesFor(node: MemoryGraphNode, key: string): string[] {
+  const values = [
+    node.frontmatter_summary[key],
+    node.frontmatter_summary[`${key}s`],
+    node.unknown_frontmatter[key],
+    node.unknown_frontmatter[`${key}s`],
+  ];
+  return values.flatMap(stringValues).sort();
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === "string" && value) return [value];
+  if (Array.isArray(value)) return value.flatMap(stringValues);
+  return [];
+}
+
+function collectNeighborhood(
+  edges: readonly MemoryGraphEdge[],
+  rootId: string,
+  depth: number,
+): Set<string> {
+  const seen = new Set([rootId]);
+  let frontier = [rootId];
+  for (let step = 0; step < Math.max(0, depth); step++) {
+    const next: string[] = [];
+    for (const edge of edges) {
+      if (frontier.includes(edge.source_id) && !seen.has(edge.target_id)) next.push(edge.target_id);
+      if (frontier.includes(edge.target_id) && !seen.has(edge.source_id)) next.push(edge.source_id);
+    }
+    for (const id of next) seen.add(id);
+    frontier = uniqueSorted(next);
+  }
+  return seen;
+}
+
+function filterTokens(filters: GraphFilters): string[] {
+  return [
+    ...filters.bundleIds.map((v) => `bundle:${v}`),
+    ...filters.nodeKinds.map((v) => `kind:${v}`),
+    ...filters.tags.map((v) => `tag:${v}`),
+    ...filters.areas.map((v) => `area:${v}`),
+    ...filters.projects.map((v) => `project:${v}`),
+    ...filters.milestones.map((v) => `milestone:${v}`),
+    ...filters.issues.map((v) => `issue:${v}`),
+    ...filters.repositories.map((v) => `repository:${v}`),
+    ...filters.visibility.map((v) => `visibility:${v}`),
+    ...filters.freshness.map((v) => `freshness:${v}`),
+    ...(filters.warning === "all" ? [] : [`warning:${filters.warning}`]),
+    ...filters.sourceKinds.map((v) => `source:${v}`),
+    ...filters.edgeKinds.map((v) => `edge:${v}`),
+    ...filters.communities.map((v) => `community:${v}`),
+  ].sort();
+}
+
+function scoreNode(node: MemoryGraphNode, needle: string): number {
+  let score = 0;
+  for (const value of [node.label, node.concept_id, node.path_display, node.description, node.body_preview]) {
+    const text = value?.toLowerCase();
+    if (text === needle) score += 100;
+    else if (text?.includes(needle)) score += 20;
+  }
+  for (const tag of node.tags) {
+    if (tag.toLowerCase() === needle) score += 30;
+    else if (tag.toLowerCase().includes(needle)) score += 10;
+  }
+  return score;
+}
+
+function visibilityParams(options?: GraphRequestOptions): URLSearchParams {
+  const params = new URLSearchParams();
+  if (options?.visibility) params.set("visibility", options.visibility);
+  return params;
+}
+
+function conceptDetailKey(bundleId: string, conceptId: string): string {
+  return `${bundleId}:${conceptId}`;
+}
+
+function latestBundleTimestamp(list: MemoryBundleList): string | null {
+  return [...list.bundles].map((bundle) => bundle.updated_at).filter(Boolean).sort().at(-1) ?? null;
+}
+
+function normalizeQuery(query: string): string {
+  return query.trim().replace(/\s+/g, " ");
+}
+
+function compareNodes(a: MemoryGraphNode, b: MemoryGraphNode): number {
+  return a.label.localeCompare(b.label) || a.id.localeCompare(b.id);
+}
+
+function compareEdges(a: MemoryGraphEdge, b: MemoryGraphEdge): number {
+  return a.kind.localeCompare(b.kind) || a.source_id.localeCompare(b.source_id) || a.target_id.localeCompare(b.target_id) || a.id.localeCompare(b.id);
+}
+
+function compareSearchResults(a: MemorySearchResult, b: MemorySearchResult): number {
+  return a.title.localeCompare(b.title) || a.bundle_id.localeCompare(b.bundle_id) || a.concept_id.localeCompare(b.concept_id);
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort();
+}

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -125,13 +125,8 @@ export interface GraphSearchOptions extends GraphRequestOptions {
   bundleId?: string;
 }
 
-export interface NativeGraphApi {
-  listBundles(): Promise<MemoryBundleList>;
-  getGraphSnapshot(bundleId: string, options?: GraphRequestOptions): Promise<MemoryGraphSnapshot>;
-  getConceptDetail(bundleId: string, conceptId: string, options?: GraphRequestOptions): Promise<MemoryConceptDetail>;
-  getCommunities(bundleId: string, options?: GraphRequestOptions): Promise<MemoryCommunityList>;
-  search(query: string, options?: GraphSearchOptions): Promise<MemorySearchResponse>;
-}
+/** Tauri/native providers expose the same graph DTO contract without importing Tauri here. */
+export type NativeGraphApi = GraphDataAdapter;
 
 export const graphModes: readonly GraphMode[] = [
   "atlas",
@@ -293,7 +288,10 @@ export function applyGraphFilters(
     .map((community) => ({
       ...community,
       node_ids: community.node_ids.filter((nodeId) => nodeIds.has(nodeId)).sort(),
-      concept_count: community.node_ids.filter((nodeId) => nodeIds.has(nodeId)).length,
+      concept_count: community.node_ids.filter((nodeId) => {
+        const node = snapshot.nodes.find((candidate) => candidate.id === nodeId);
+        return nodeIds.has(nodeId) && node?.kind === "concept";
+      }).length,
     }))
     .filter((community) => community.node_ids.length > 0)
     .sort((a, b) => a.id.localeCompare(b.id));

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -300,7 +300,7 @@ export function applyGraphFilters(
       concept_count: community.node_ids.filter((nodeId) => nodeKindById.get(nodeId) === "concept").length,
     }))
     .filter((community) => community.node_ids.length > 0)
-    .sort((a, b) => a.id.localeCompare(b.id));
+    .sort((a, b) => compareStrings(a.id, b.id));
   const neighborhoodTokens = neighborhood
     ? [`neighborhood:${focusedNodeId}`, `neighborhood-depth:${neighborhoodDepth}`]
     : [];

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -241,17 +241,19 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
       };
     case "LAYOUT_STATUS_SET":
       return { ...state, layoutStatus: action.status, layoutError: action.error ?? null };
-    case "HISTORY_RESTORED":
+    case "HISTORY_RESTORED": {
+      const restored = action.state;
       return {
         ...state,
-        mode: action.state.mode ?? state.mode,
-        selectedBundleId: action.state.bundleId ?? state.selectedBundleId,
-        focusedNodeId: action.state.focusedNodeId ?? state.focusedNodeId,
-        selectedNodeIds: uniqueSorted(action.state.selectedNodeIds ?? state.selectedNodeIds),
-        searchQuery: normalizeQuery(action.state.searchQuery ?? state.searchQuery),
-        filters: normalizeFilters(action.state.filters ?? state.filters),
-        neighborhoodDepth: action.state.neighborhoodDepth ?? state.neighborhoodDepth,
+        mode: restored.mode ?? state.mode,
+        selectedBundleId: restored.bundleId === undefined ? state.selectedBundleId : restored.bundleId,
+        focusedNodeId: restored.focusedNodeId === undefined ? state.focusedNodeId : restored.focusedNodeId,
+        selectedNodeIds: uniqueSorted(restored.selectedNodeIds === undefined ? state.selectedNodeIds : restored.selectedNodeIds),
+        searchQuery: normalizeQuery(restored.searchQuery === undefined ? state.searchQuery : restored.searchQuery),
+        filters: normalizeFilters(restored.filters === undefined ? state.filters : restored.filters),
+        neighborhoodDepth: restored.neighborhoodDepth ?? state.neighborhoodDepth,
       };
+    }
     case "GRAPH_RESET":
       return createInitialGraphState();
     default:
@@ -544,16 +546,20 @@ function normalizeQuery(query: string): string {
   return query.trim().replace(/\s+/g, " ");
 }
 
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 function compareNodes(a: MemoryGraphNode, b: MemoryGraphNode): number {
-  return a.label.localeCompare(b.label) || a.id.localeCompare(b.id);
+  return compareStrings(a.label, b.label) || compareStrings(a.id, b.id);
 }
 
 function compareEdges(a: MemoryGraphEdge, b: MemoryGraphEdge): number {
-  return a.kind.localeCompare(b.kind) || a.source_id.localeCompare(b.source_id) || a.target_id.localeCompare(b.target_id) || a.id.localeCompare(b.id);
+  return compareStrings(a.kind, b.kind) || compareStrings(a.source_id, b.source_id) || compareStrings(a.target_id, b.target_id) || compareStrings(a.id, b.id);
 }
 
 function compareSearchResults(a: MemorySearchResult, b: MemorySearchResult): number {
-  return a.title.localeCompare(b.title) || a.bundle_id.localeCompare(b.bundle_id) || a.concept_id.localeCompare(b.concept_id);
+  return compareStrings(a.title, b.title) || compareStrings(a.bundle_id, b.bundle_id) || compareStrings(a.concept_id, b.concept_id);
 }
 
 function uniqueSorted<T extends string>(values: readonly T[]): T[] {

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -223,7 +223,7 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
         mode: action.nodeId ? "neighborhood" : state.mode,
         focusedNodeId: action.nodeId,
         selectedNodeIds: action.nodeId ? uniqueSorted([...state.selectedNodeIds, action.nodeId]) : state.selectedNodeIds,
-        neighborhoodDepth: action.neighborhoodDepth ?? state.neighborhoodDepth,
+        neighborhoodDepth: action.neighborhoodDepth === undefined ? state.neighborhoodDepth : action.neighborhoodDepth,
       };
     case "SELECTION_SET":
       return { ...state, selectedNodeIds: uniqueSorted(action.nodeIds) };
@@ -251,7 +251,7 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
         selectedNodeIds: uniqueSorted(restored.selectedNodeIds === undefined ? state.selectedNodeIds : restored.selectedNodeIds),
         searchQuery: normalizeQuery(restored.searchQuery === undefined ? state.searchQuery : restored.searchQuery),
         filters: normalizeFilters(restored.filters === undefined ? state.filters : restored.filters),
-        neighborhoodDepth: restored.neighborhoodDepth ?? state.neighborhoodDepth,
+        neighborhoodDepth: restored.neighborhoodDepth === undefined ? state.neighborhoodDepth : restored.neighborhoodDepth,
       };
     }
     case "GRAPH_RESET":
@@ -445,7 +445,7 @@ function matchesNodeFilters(node: MemoryGraphNode, filters: GraphFilters): boole
   if (filters.freshness.length > 0 && (!node.freshness || !filters.freshness.includes(node.freshness))) return false;
   if (filters.warning === "with_warnings" && node.warning_count <= 0) return false;
   if (filters.warning === "without_warnings" && node.warning_count > 0) return false;
-  if (filters.communities.length > 0 && (!node.metrics.community_id || !filters.communities.includes(node.metrics.community_id))) return false;
+  if (filters.communities.length > 0 && (!node.metrics?.community_id || !filters.communities.includes(node.metrics.community_id))) return false;
   if (filters.areas.length > 0 && !hasAny(node, "area", filters.areas)) return false;
   if (filters.projects.length > 0 && !hasAny(node, "project", filters.projects)) return false;
   if (filters.milestones.length > 0 && !hasAny(node, "milestone", filters.milestones)) return false;

--- a/packages/graph/tsconfig.json
+++ b/packages/graph/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../gateway-schema" }
+  ]
+}

--- a/tsconfig.projects.json
+++ b/tsconfig.projects.json
@@ -4,6 +4,7 @@
     { "path": "packages/gateway-schema" },
     { "path": "packages/api-client" },
     { "path": "packages/ui-core" },
+    { "path": "packages/graph" },
     { "path": "packages/state" },
     { "path": "packages/state/tsconfig.test.json" },
     { "path": "apps/desktop" },


### PR DESCRIPTION
## Summary

Adds a shared `@opensymphony/graph` frontend package for the LLM wiki graph view. The package consumes gateway memory graph DTOs, owns transport-agnostic graph state, and provides reducer, filter, search, deep-link, adapter, and fixture primitives for web and desktop clients.

## Changes

- Added `packages/graph` with graph modes, reducer actions, deterministic filters/search/history state, gateway/memory-server/fixture/Tauri-native adapter interfaces, and DTO-aligned fixture data.
- Added reducer/adapter tests covering all required modes, deterministic filter/search behavior, history normalization, community counts, neighborhood metadata, fixture search options, HTTP query serialization, native adapter passthrough, and fresh reset state objects.
- Added web and desktop package dependencies plus small adapter helper exports so both clients import the same graph package without pulling Tauri-only code into the web build.

## Evidence

### Test output

```text
npm test --workspace=@opensymphony/graph
PASS __tests__/graph.test.ts
Tests: 9 passed, 9 total

npm run type-check
passed

npm run build --workspace=@opensymphony/graph
passed

npm run build --workspace=@opensymphony/web
passed

npm run build --workspace=@opensymphony/desktop
passed

npx jest --config jest.config.js --runTestsByPath packages/graph/__tests__/graph.test.ts apps/web/__tests__/build-smoke.test.ts apps/desktop/__tests__/build-smoke.test.ts
Test Suites: 3 passed, 3 total
Tests: 11 passed, 11 total

rg -n "@tauri|tauri" packages/graph apps/web/dist || true
no matches

git diff --check
passed
```

### Integration log

```text
rg -n "@opensymphony/graph|createWebGraphAdapter|createDesktopGraphAdapter|createDesktopNativeGraphAdapter" apps/web/src/main.ts apps/desktop/src/index.ts
apps/web/src/main.ts:10:import { createGatewayGraphAdapter } from "@opensymphony/graph";
apps/web/src/main.ts:27:export function createWebGraphAdapter(gatewayUrl = defaultGatewayUrl) {
apps/desktop/src/index.ts:12:} from "@opensymphony/graph";
apps/desktop/src/index.ts:29:export function createDesktopGraphAdapter(gatewayUrl = DEFAULT_GATEWAY_URL) {
apps/desktop/src/index.ts:33:export function createDesktopNativeGraphAdapter(api: NativeGraphApi) {

node --input-type=module <graph fixture exercise>
{
  "graphFixtureBundleCount": 1,
  "graphFixtureSearchCount": 1,
  "graphModes": [
    "atlas",
    "bundle",
    "community",
    "neighborhood",
    "timeline",
    "evidence"
  ],
  "hasGatewayAdapterFactory": "function",
  "hasNativeAdapterFactory": "function"
}
```

### Verification

Verified the new graph package builds from the root TypeScript project graph, the web and desktop Vite builds can resolve the shared package, and the generated web bundle plus `packages/graph` contain no Tauri references. This is a library/package PR, so there is no rendered graph UI screenshot; renderer and live UI wiring are explicitly out of scope for COE-465.

## Checklist

- [x] Tests pass (`npm test --workspace=@opensymphony/graph` plus targeted smoke tests)
- [x] Code is formatted (`git diff --check`)
- [ ] Clippy is clean (`cargo clippy` not run locally; CI Rust check passed)
- [ ] Documentation updated (not required; existing graph spec already covers this package boundary)
- [ ] `AGENTS.md` updated (not required)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other: None

## Breaking changes

None.

## Related issues

Linear: COE-465

## Additional notes

This PR intentionally does not implement Three.js rendering internals or live memory event handling; both are out of scope for COE-465.
