### PR TITLE
feat(memory): use AST code intel for context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,18 @@ logical bundle layout and migration model documented in `docs/memory.md` and
 `docs/specs/okf-memory-spec.md`. Do not move the durable `.opensymphony/memory/` store
 to the final OKF layout unless a task explicitly includes that migration.
 
+### Keep memory code intelligence AST-first and fallback-safe
+
+`memory.context --include-code-intel` uses the Tree-sitter provider first for
+supported requested Rust paths, then falls back to `CodebaseAnalyzer` for
+unsupported languages, parser diagnostics, oversized files, and empty-path
+repository summaries. Mixed supported and unsupported requests should keep both
+AST evidence and fallback trace visibility without changing the public
+`memory.context` contract or adding new MCP tool names. The current
+`opensymphony_code_intel` adapter still implements
+`opensymphony_memory::CodeIntelIndex`; keep that bridge narrow until a follow-up
+inverts trait ownership into the code-intelligence module.
+
 ### Separate Symphony hooks from OpenHands hooks
 
 Symphony workspace hooks:

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -14,6 +14,7 @@ use serde_json::{Value, json};
 use tokio::task::JoinHandle;
 
 use crate::{
+    opensymphony_code_intel::CompositeCodeIntelProvider,
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
     opensymphony_memory::{
@@ -33,7 +34,6 @@ use crate::{
         ConversationMoveOutcome, ConversationStoreKind, IssueConversationManifest,
         OpenHandsConversationStorePaths,
     },
-    opensymphony_planning::CodebaseAnalyzer,
     opensymphony_workflow::WorkflowDefinition,
     opensymphony_workspace::{CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig},
 };
@@ -2215,7 +2215,8 @@ fn append_code_intel_context(
 ) -> Result<(), MemoryError> {
     let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
     let scope_refs = scope_refs_for_context(scope, paths);
-    let artifacts = CodebaseAnalyzer::new(repo_root).code_context(paths, &scope_refs, limit)?;
+    let artifacts =
+        CompositeCodeIntelProvider::new(repo_root).code_context(paths, &scope_refs, limit)?;
     append_code_intel_artifacts(config, output, artifacts);
     Ok(())
 }
@@ -2241,7 +2242,7 @@ async fn code_intel_artifacts_blocking(
     limit: usize,
 ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
     tokio::task::spawn_blocking(move || {
-        CodebaseAnalyzer::new(repo_root).code_context(&paths, &scope_refs, limit)
+        CompositeCodeIntelProvider::new(repo_root).code_context(&paths, &scope_refs, limit)
     })
     .await
     .map_err(|error| {
@@ -3657,6 +3658,41 @@ Public memory concept.
                 .iter()
                 .any(|path| path == "issues/COE-1.md")
         );
+    }
+
+    #[tokio::test]
+    async fn mcp_memory_context_can_include_ast_code_intelligence() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("source file");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let response = call_memory_tool(
+            &config,
+            json!({
+                "name": "memory.context",
+                "arguments": {
+                    "issue": "COE-999",
+                    "paths": ["src/lib.rs"],
+                    "includeCodeIntel": true
+                }
+            }),
+        )
+        .await
+        .expect("context tool");
+
+        let text = response["content"][0]["text"]
+            .as_str()
+            .expect("text content");
+        assert!(text.contains("## Code Intelligence"));
+        assert!(text.contains("ast-summary: src/lib.rs"));
+        assert!(text.contains("function `answer`"));
+        assert!(text.contains("fallback: CodebaseAnalyzer not used"));
     }
 
     #[test]

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -775,7 +775,10 @@ fn memory_context_can_include_code_intelligence_without_a_separate_cli_command()
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("# Memory Context: COE-999"));
     assert!(stdout.contains("## Code Intelligence"));
-    assert!(stdout.contains("Repository summary"));
+    assert!(stdout.contains("ast-summary: src/lib.rs"));
+    assert!(stdout.contains("ast-symbols: Symbols in src/lib.rs"));
+    assert!(stdout.contains("function `answer`"));
+    assert!(stdout.contains("fallback: CodebaseAnalyzer not used"));
 
     let help = run(repo.path(), ["memory", "--help"]);
     assert_success(&help, "memory help");
@@ -783,6 +786,55 @@ fn memory_context_can_include_code_intelligence_without_a_separate_cli_command()
         !String::from_utf8_lossy(&help.stdout).contains("code-context"),
         "memory help should keep context as the agent-facing command"
     );
+}
+
+#[test]
+fn memory_context_code_intelligence_falls_back_for_unsupported_files() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    fs::write(repo.path().join("README.md"), "# Example\n").expect("readme should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "context",
+            "--issue",
+            "COE-999",
+            "--paths",
+            "README.md",
+            "--include-code-intel",
+        ],
+    );
+
+    assert_success(&output, "unsupported code intelligence fallback");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Repository summary"));
+    assert!(stdout.contains("fallback: CodebaseAnalyzer used"));
+    assert!(stdout.contains("README.md has unsupported language"));
+}
+
+#[test]
+fn memory_context_code_intelligence_rejects_outside_paths() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    let outside = TempDir::new().expect("outside repo should exist");
+    let outside_file = outside.path().join("lib.rs");
+    fs::write(&outside_file, "pub fn outside() {}\n").expect("outside file should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "context",
+            "--issue",
+            "COE-999",
+            "--paths",
+            outside_file.to_str().expect("outside path"),
+            "--include-code-intel",
+        ],
+    );
+
+    assert_failure(&output, "outside code intelligence path");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("outside the repository root"));
 }
 
 #[test]

--- a/crates/opensymphony-cli/tests/memory.rs
+++ b/crates/opensymphony-cli/tests/memory.rs
@@ -814,6 +814,65 @@ fn memory_context_code_intelligence_falls_back_for_unsupported_files() {
 }
 
 #[test]
+fn memory_context_code_intelligence_falls_back_without_paths() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    fs::create_dir_all(repo.path().join("src")).expect("src dir should write");
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn answer() -> u8 { 42 }\n",
+    )
+    .expect("source file should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "context",
+            "--issue",
+            "COE-999",
+            "--include-code-intel",
+        ],
+    );
+
+    assert_success(&output, "empty path code intelligence fallback");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Repository summary"));
+    assert!(stdout.contains("no requested paths; repository summary fallback used"));
+}
+
+#[test]
+fn memory_context_code_intelligence_mixes_ast_and_fallback_paths() {
+    let repo = TempDir::new().expect("temp repo should exist");
+    fs::create_dir_all(repo.path().join("src")).expect("src dir should write");
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn answer() -> u8 { 42 }\n",
+    )
+    .expect("source file should write");
+    fs::write(repo.path().join("README.md"), "# Example\n").expect("readme should write");
+
+    let output = run(
+        repo.path(),
+        [
+            "memory",
+            "context",
+            "--issue",
+            "COE-999",
+            "--paths",
+            "src/lib.rs,README.md",
+            "--include-code-intel",
+        ],
+    );
+
+    assert_success(&output, "mixed code intelligence fallback");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ast-summary: src/lib.rs"));
+    assert!(stdout.contains("function `answer`"));
+    assert!(stdout.contains("Repository summary"));
+    assert!(stdout.contains("README.md has unsupported language"));
+}
+
+#[test]
 fn memory_context_code_intelligence_rejects_outside_paths() {
     let repo = TempDir::new().expect("temp repo should exist");
     let outside = TempDir::new().expect("outside repo should exist");

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1,8 +1,19 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator};
+
+use crate::{
+    opensymphony_memory::{
+        CodeIntelArtifact, CodeIntelIndex, KnowledgeScope, MemoryError, MemorySourceRef,
+    },
+    opensymphony_planning::CodebaseAnalyzer,
+};
 
 pub const PROVIDER_NAME: &str = "tree-sitter";
 // Keep these in sync with Cargo.toml pins and queries/rust/metadata.toml.
@@ -11,6 +22,7 @@ pub const RUST_GRAMMAR_VERSION: &str = "0.24.2";
 pub const RUST_QUERY_PACK_VERSION: &str = "rust-definitions-v1";
 
 const RUST_DEFINITIONS_QUERY: &str = include_str!("../queries/rust/definitions.scm");
+const DEFAULT_MAX_FILE_BYTES: u64 = 1_000_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -113,6 +125,340 @@ pub enum CodeIntelError {
     Query(#[from] tree_sitter::QueryError),
     #[error("captured symbol name is not utf-8: {0}")]
     Utf8(#[from] std::str::Utf8Error),
+}
+
+pub struct AstCodeIntelProvider {
+    root: PathBuf,
+    max_file_bytes: u64,
+}
+
+impl AstCodeIntelProvider {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+        }
+    }
+
+    fn code_context_report(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+    ) -> Result<AstCodeIntelReport, MemoryError> {
+        let repo_root = self.canonical_root()?;
+        let commit_sha = git_commit_sha(&repo_root);
+        let mut report = AstCodeIntelReport::default();
+
+        if paths.is_empty() {
+            report
+                .fallback_reasons
+                .push("no requested paths; repository summary fallback used".to_string());
+            return Ok(report);
+        }
+
+        for path in paths {
+            let resolved = self.resolve_requested_path(&repo_root, path)?;
+            let relative_path = resolved
+                .strip_prefix(&repo_root)
+                .unwrap_or(&resolved)
+                .to_path_buf();
+            let relative_display = relative_path.to_string_lossy().to_string();
+            let metadata = match fs::metadata(&resolved) {
+                Ok(metadata) => metadata,
+                Err(source) => {
+                    return Err(MemoryError::ResolvePath {
+                        path: resolved,
+                        source,
+                    });
+                }
+            };
+
+            if !metadata.is_file() {
+                report
+                    .fallback_reasons
+                    .push(format!("{relative_display} is not a file"));
+                continue;
+            }
+            if metadata.len() > self.max_file_bytes {
+                report.fallback_reasons.push(format!(
+                    "{relative_display} is {} bytes; max AST file size is {} bytes",
+                    metadata.len(),
+                    self.max_file_bytes
+                ));
+                continue;
+            }
+            if detect_language(&relative_path).is_none() {
+                report
+                    .fallback_reasons
+                    .push(format!("{relative_display} has unsupported language"));
+                continue;
+            }
+
+            let source = fs::read_to_string(&resolved).map_err(|source| MemoryError::ReadFile {
+                path: resolved.clone(),
+                source,
+            })?;
+            let summary = match parse_path(&relative_path, &source) {
+                Ok(summary) => summary,
+                Err(error) => {
+                    report
+                        .fallback_reasons
+                        .push(format!("{relative_display} AST parse failed: {error}"));
+                    continue;
+                }
+            };
+
+            report.parsed_files += 1;
+            report.query_runs += 1;
+            if summary.has_errors {
+                report.fallback_reasons.push(format!(
+                    "{relative_display} parsed with Tree-sitter diagnostics"
+                ));
+            }
+            report.artifacts.extend(ast_artifacts_for_summary(
+                summary,
+                &relative_path,
+                &relative_display,
+                scope_refs,
+                commit_sha.clone(),
+                limit,
+            ));
+        }
+
+        Ok(report)
+    }
+
+    fn canonical_root(&self) -> Result<PathBuf, MemoryError> {
+        self.root
+            .canonicalize()
+            .map_err(|source| MemoryError::ResolvePath {
+                path: self.root.clone(),
+                source,
+            })
+    }
+
+    fn resolve_requested_path(
+        &self,
+        repo_root: &Path,
+        path: &Path,
+    ) -> Result<PathBuf, MemoryError> {
+        let candidate = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            repo_root.join(path)
+        };
+        let resolved = candidate
+            .canonicalize()
+            .map_err(|source| MemoryError::ResolvePath {
+                path: candidate.clone(),
+                source,
+            })?;
+        if !resolved.starts_with(repo_root) {
+            return Err(MemoryError::PathOutsideRepo {
+                path: resolved,
+                repo_root: repo_root.to_path_buf(),
+            });
+        }
+        Ok(resolved)
+    }
+}
+
+impl CodeIntelIndex for AstCodeIntelProvider {
+    fn code_context(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+        let report = self.code_context_report(paths, scope_refs, limit)?;
+        let trace = report.trace_artifact(scope_refs);
+        let mut artifacts = report.artifacts;
+        artifacts.push(trace);
+        Ok(artifacts)
+    }
+}
+
+pub struct CompositeCodeIntelProvider {
+    ast: AstCodeIntelProvider,
+    fallback: CodebaseAnalyzer,
+}
+
+impl CompositeCodeIntelProvider {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        Self {
+            ast: AstCodeIntelProvider::new(&root),
+            fallback: CodebaseAnalyzer::new(root),
+        }
+    }
+}
+
+impl CodeIntelIndex for CompositeCodeIntelProvider {
+    fn code_context(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+        let report = self.ast.code_context_report(paths, scope_refs, limit)?;
+        let use_fallback = !report.fallback_reasons.is_empty();
+        let trace = report.trace_artifact(scope_refs);
+        let mut artifacts = report.artifacts;
+
+        if use_fallback {
+            artifacts.extend(self.fallback.code_context(paths, scope_refs, limit)?);
+        }
+        artifacts.push(trace);
+        Ok(artifacts)
+    }
+}
+
+#[derive(Default)]
+struct AstCodeIntelReport {
+    artifacts: Vec<CodeIntelArtifact>,
+    fallback_reasons: Vec<String>,
+    parsed_files: usize,
+    query_runs: usize,
+}
+
+impl AstCodeIntelReport {
+    fn trace_artifact(&self, scope_refs: &[KnowledgeScope]) -> CodeIntelArtifact {
+        let fallback = if self.fallback_reasons.is_empty() {
+            "fallback: CodebaseAnalyzer not used".to_string()
+        } else {
+            format!(
+                "fallback: CodebaseAnalyzer used ({})",
+                self.fallback_reasons.join("; ")
+            )
+        };
+        CodeIntelArtifact {
+            provider: "composite-code-intel".to_string(),
+            kind: "trace".to_string(),
+            scope_refs: scope_refs.to_vec(),
+            source_refs: Vec::new(),
+            path: None,
+            commit_sha: None,
+            title: "Code-intelligence trace".to_string(),
+            summary: format!(
+                "- parse: parsed {} file(s)\n- query: ran {} Tree-sitter query pack(s)\n- {fallback}",
+                self.parsed_files, self.query_runs
+            ),
+        }
+    }
+}
+
+fn ast_artifacts_for_summary(
+    summary: ParsedDocumentSummary,
+    relative_path: &Path,
+    relative_display: &str,
+    scope_refs: &[KnowledgeScope],
+    commit_sha: Option<String>,
+    limit: usize,
+) -> Vec<CodeIntelArtifact> {
+    let diagnostic_summary = diagnostics_summary(&summary.diagnostics);
+    let mut artifacts = vec![CodeIntelArtifact {
+        provider: PROVIDER_NAME.to_string(),
+        kind: "ast-summary".to_string(),
+        scope_refs: scope_refs.to_vec(),
+        source_refs: vec![MemorySourceRef {
+            kind: "path".to_string(),
+            id: relative_display.to_string(),
+            url: None,
+        }],
+        path: Some(relative_path.to_path_buf()),
+        commit_sha: commit_sha.clone(),
+        title: relative_display.to_string(),
+        summary: format!(
+            "- Language: {}\n- Content hash: sha256:{}\n- Parser: tree-sitter-rust@{}\n- Query pack: {}\n- Diagnostics: {diagnostic_summary}",
+            source_language_label(summary.source.language),
+            summary.source.sha256,
+            RUST_GRAMMAR_VERSION,
+            summary.versions.query_pack,
+        ),
+    }];
+
+    if !summary.symbols.is_empty() {
+        let max_symbols = limit.max(1);
+        let symbols = summary
+            .symbols
+            .iter()
+            .take(max_symbols)
+            .map(|symbol| {
+                format!(
+                    "- {} `{}` at {}:{}",
+                    symbol_kind_label(&symbol.kind),
+                    symbol.name,
+                    relative_display,
+                    symbol.rendered_span
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        artifacts.push(CodeIntelArtifact {
+            provider: PROVIDER_NAME.to_string(),
+            kind: "ast-symbols".to_string(),
+            scope_refs: scope_refs.to_vec(),
+            source_refs: summary
+                .symbols
+                .iter()
+                .take(max_symbols)
+                .map(|symbol| MemorySourceRef {
+                    kind: "code-symbol".to_string(),
+                    id: format!("{relative_display}:{}", symbol.rendered_span),
+                    url: None,
+                })
+                .collect(),
+            path: Some(relative_path.to_path_buf()),
+            commit_sha,
+            title: format!("Symbols in {relative_display}"),
+            summary: symbols,
+        });
+    }
+
+    artifacts
+}
+
+fn diagnostics_summary(diagnostics: &[AstDiagnostic]) -> String {
+    let errors = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.kind == AstDiagnosticKind::Error)
+        .count();
+    let missing = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.kind == AstDiagnosticKind::Missing)
+        .count();
+    format!("{errors} ERROR, {missing} MISSING")
+}
+
+fn source_language_label(language: SourceLanguage) -> &'static str {
+    match language {
+        SourceLanguage::Rust => "rust",
+    }
+}
+
+fn symbol_kind_label(kind: &SymbolKind) -> &'static str {
+    match kind {
+        SymbolKind::Function => "function",
+        SymbolKind::Struct => "struct",
+        SymbolKind::Enum => "enum",
+        SymbolKind::Trait => "trait",
+        SymbolKind::Method => "method",
+        SymbolKind::Test => "test",
+    }
+}
+
+fn git_commit_sha(root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
 }
 
 pub fn detect_language(path: impl AsRef<Path>) -> Option<SourceLanguage> {
@@ -320,6 +666,8 @@ fn one_based_span(node: Node<'_>) -> SourceSpan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::opensymphony_memory::CodeIntelIndex;
+    use tempfile::TempDir;
 
     const COMPLETE: &str = include_str!("../fixtures/rust/complete.rs");
     const MALFORMED_ERROR: &str = include_str!("../fixtures/rust/malformed_error.rs");
@@ -400,5 +748,58 @@ mod tests {
                 .iter()
                 .any(|diagnostic| diagnostic.kind == AstDiagnosticKind::Missing)
         );
+    }
+
+    #[test]
+    fn composite_falls_back_when_parser_reports_diagnostics() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(repo.path().join("src/lib.rs"), "pub fn broken( {\n").expect("malformed rust");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("src/lib.rs")], &[], 20)
+            .expect("code context");
+
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-summary")
+        );
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace"
+                && artifact
+                    .summary
+                    .contains("parsed with Tree-sitter diagnostics")
+        }));
+    }
+
+    #[test]
+    fn composite_falls_back_when_file_exceeds_ast_size_limit() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            format!("pub const LARGE: &str = \"{}\";\n", "x".repeat(1_000_001)),
+        )
+        .expect("large rust");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("src/lib.rs")], &[], 20)
+            .expect("code context");
+
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-summary")
+        );
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace" && artifact.summary.contains("max AST file size")
+        }));
     }
 }

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -9,8 +9,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator};
 
-// COE-499 adapts the AST provider to memory's existing CodeIntelIndex contract
-// so memory.context gains AST evidence without adding a new public tool surface.
+// TODO(COE-506): invert this adapter so memory consumes a code-intel owned
+// provider trait after the AST integration is stable.
+// COE-499 keeps the existing memory CodeIntelIndex contract so memory.context
+// gains AST evidence without adding a new public tool surface.
 use crate::{
     opensymphony_memory::{
         CodeIntelArtifact, CodeIntelIndex, KnowledgeScope, MemoryError, MemorySourceRef,
@@ -152,7 +154,7 @@ impl AstCodeIntelProvider {
         let repo_root = self.canonical_root()?;
         let commit_sha = git_commit_sha(&repo_root);
         let mut report = AstCodeIntelReport::default();
-        let mut remaining_symbols = limit.max(1);
+        let mut remaining_symbols = limit;
 
         if paths.is_empty() {
             report
@@ -210,6 +212,7 @@ impl AstCodeIntelProvider {
                 remaining_symbols,
             );
             remaining_symbols = remaining_symbols.saturating_sub(used_symbols);
+            report.used_symbols += used_symbols;
             report.artifacts.extend(artifacts);
         }
 
@@ -303,7 +306,7 @@ impl CodeIntelIndex for AstCodeIntelProvider {
         limit: usize,
     ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
         let report = self.code_context_report(paths, scope_refs, limit)?;
-        let trace = report.trace_artifact(scope_refs);
+        let trace = report.trace_artifact(scope_refs, false);
         let mut artifacts = report.artifacts;
         artifacts.push(trace);
         Ok(artifacts)
@@ -332,18 +335,27 @@ impl CodeIntelIndex for CompositeCodeIntelProvider {
         scope_refs: &[KnowledgeScope],
         limit: usize,
     ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
-        let report = self.ast.code_context_report(paths, scope_refs, limit)?;
+        let mut report = self.ast.code_context_report(paths, scope_refs, limit)?;
         let use_fallback = !report.fallback_reasons.is_empty();
-        let trace = report.trace_artifact(scope_refs);
-        let mut artifacts = report.artifacts;
+        let mut artifacts = std::mem::take(&mut report.artifacts);
+        let fallback_paths = if paths.is_empty() {
+            paths
+        } else {
+            &report.fallback_paths
+        };
+        let has_fallback_target = paths.is_empty() || !fallback_paths.is_empty();
+        let fallback_limit = limit.saturating_sub(report.used_symbols);
+        let mut fallback_used = false;
 
-        if use_fallback {
+        if use_fallback && has_fallback_target && (fallback_limit > 0 || artifacts.is_empty()) {
             artifacts.extend(self.fallback.code_context(
-                &report.fallback_paths,
+                fallback_paths,
                 scope_refs,
-                limit,
+                fallback_limit,
             )?);
+            fallback_used = true;
         }
+        let trace = report.trace_artifact(scope_refs, fallback_used);
         artifacts.push(trace);
         Ok(artifacts)
     }
@@ -356,17 +368,25 @@ struct AstCodeIntelReport {
     fallback_paths: Vec<PathBuf>,
     parsed_files: usize,
     query_runs: usize,
+    used_symbols: usize,
 }
 
 impl AstCodeIntelReport {
-    fn trace_artifact(&self, scope_refs: &[KnowledgeScope]) -> CodeIntelArtifact {
-        let fallback = if self.fallback_reasons.is_empty() {
-            "fallback: CodebaseAnalyzer not used".to_string()
-        } else {
-            format!(
+    fn trace_artifact(
+        &self,
+        scope_refs: &[KnowledgeScope],
+        fallback_used: bool,
+    ) -> CodeIntelArtifact {
+        let fallback = match (self.fallback_reasons.is_empty(), fallback_used) {
+            (true, _) => "fallback: CodebaseAnalyzer not used".to_string(),
+            (false, true) => format!(
                 "fallback: CodebaseAnalyzer used ({})",
                 self.fallback_reasons.join("; ")
-            )
+            ),
+            (false, false) => format!(
+                "fallback: CodebaseAnalyzer not used; fallback budget exhausted ({})",
+                self.fallback_reasons.join("; ")
+            ),
         };
         CodeIntelArtifact {
             provider: "composite-code-intel".to_string(),
@@ -838,6 +858,90 @@ mod tests {
         }));
         assert!(artifacts.iter().any(|artifact| {
             artifact.kind == "trace" && artifact.summary.contains("max AST file size")
+        }));
+    }
+
+    #[test]
+    fn composite_preserves_zero_symbol_limit() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("rust file");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("src/lib.rs")], &[], 0)
+            .expect("code context");
+
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-summary")
+        );
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-symbols")
+        );
+    }
+
+    #[test]
+    fn composite_empty_paths_return_repository_summary_fallback() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(repo.path().join("src/lib.rs"), "pub fn answer() {}\n").expect("rust file");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[], &[], 20)
+            .expect("code context");
+
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace" && artifact.summary.contains("no requested paths")
+        }));
+    }
+
+    #[test]
+    fn composite_mixed_paths_partition_fallback_budget() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("rust file");
+        fs::write(repo.path().join("README.md"), "# Example\n").expect("readme");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(
+                &[PathBuf::from("src/lib.rs"), PathBuf::from("README.md")],
+                &[],
+                2,
+            )
+            .expect("code context");
+
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-summary")
+        );
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-symbols")
+        );
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace"
+                && artifact
+                    .summary
+                    .contains("README.md has unsupported language")
         }));
     }
 }

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -382,7 +382,7 @@ impl CodeIntelIndex for AstCodeIntelProvider {
         limit: usize,
     ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
         let report = self.code_context_report(paths, scope_refs, limit)?;
-        let trace = report.trace_artifact(scope_refs, false);
+        let trace = report.trace_artifact(scope_refs, PROVIDER_NAME, report.ast_only_fallback());
         let mut artifacts = report.artifacts;
         artifacts.push(trace);
         Ok(artifacts)
@@ -423,7 +423,7 @@ impl CodeIntelIndex for CompositeCodeIntelProvider {
         let fallback_limit = limit.saturating_sub(report.used_symbols);
         let mut fallback_used = false;
 
-        if use_fallback && has_fallback_target && (fallback_limit > 0 || artifacts.is_empty()) {
+        if use_fallback && has_fallback_target {
             artifacts.extend(self.fallback.code_context(
                 fallback_paths,
                 scope_refs,
@@ -431,7 +431,11 @@ impl CodeIntelIndex for CompositeCodeIntelProvider {
             )?);
             fallback_used = true;
         }
-        let trace = report.trace_artifact(scope_refs, fallback_used);
+        let trace = report.trace_artifact(
+            scope_refs,
+            "composite-code-intel",
+            report.composite_fallback(fallback_used),
+        );
         artifacts.push(trace);
         Ok(artifacts)
     }
@@ -451,21 +455,11 @@ impl AstCodeIntelReport {
     fn trace_artifact(
         &self,
         scope_refs: &[KnowledgeScope],
-        fallback_used: bool,
+        provider: &str,
+        fallback: String,
     ) -> CodeIntelArtifact {
-        let fallback = match (self.fallback_reasons.is_empty(), fallback_used) {
-            (true, _) => "fallback: CodebaseAnalyzer not used".to_string(),
-            (false, true) => format!(
-                "fallback: CodebaseAnalyzer used ({})",
-                self.fallback_reasons.join("; ")
-            ),
-            (false, false) => format!(
-                "fallback: CodebaseAnalyzer not used; fallback budget exhausted ({})",
-                self.fallback_reasons.join("; ")
-            ),
-        };
         CodeIntelArtifact {
-            provider: "composite-code-intel".to_string(),
+            provider: provider.to_string(),
             kind: "trace".to_string(),
             scope_refs: scope_refs.to_vec(),
             source_refs: Vec::new(),
@@ -476,6 +470,31 @@ impl AstCodeIntelReport {
                 "- parse: parsed {} file(s)\n- query: ran {} Tree-sitter query pack(s)\n- {fallback}",
                 self.parsed_files, self.query_runs
             ),
+        }
+    }
+
+    fn composite_fallback(&self, fallback_used: bool) -> String {
+        match (self.fallback_reasons.is_empty(), fallback_used) {
+            (true, _) => "fallback: CodebaseAnalyzer not used".to_string(),
+            (false, true) => format!(
+                "fallback: CodebaseAnalyzer used ({})",
+                self.fallback_reasons.join("; ")
+            ),
+            (false, false) => format!(
+                "fallback: CodebaseAnalyzer not used; fallback budget exhausted ({})",
+                self.fallback_reasons.join("; ")
+            ),
+        }
+    }
+
+    fn ast_only_fallback(&self) -> String {
+        if self.fallback_reasons.is_empty() {
+            "fallback: CodebaseAnalyzer not used".to_string()
+        } else {
+            format!(
+                "fallback: AST provider only; CodebaseAnalyzer fallback not available ({})",
+                self.fallback_reasons.join("; ")
+            )
         }
     }
 }
@@ -996,6 +1015,59 @@ mod tests {
                 .iter()
                 .any(|artifact| artifact.kind == "ast-symbols")
         );
+    }
+
+    #[test]
+    fn composite_mixed_paths_with_zero_limit_still_falls_back() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("rust file");
+        fs::write(repo.path().join("README.md"), "# Example\n").expect("readme");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(
+                &[PathBuf::from("src/lib.rs"), PathBuf::from("README.md")],
+                &[],
+                0,
+            )
+            .expect("code context");
+
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-summary")
+        );
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "ast-symbols")
+        );
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+    }
+
+    #[test]
+    fn ast_provider_trace_says_fallback_is_not_available() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::write(repo.path().join("README.md"), "# Example\n").expect("readme");
+
+        let artifacts = AstCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("README.md")], &[], 20)
+            .expect("code context");
+
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == PROVIDER_NAME
+                && artifact.kind == "trace"
+                && artifact.summary.contains("AST provider only")
+                && artifact
+                    .summary
+                    .contains("CodebaseAnalyzer fallback not available")
+        }));
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
-    io::Read,
-    path::{Path, PathBuf},
+    io::{ErrorKind, Read},
+    path::{Component, Path, PathBuf},
     process::Command,
 };
 
@@ -164,15 +164,22 @@ impl AstCodeIntelProvider {
         }
 
         for path in paths {
-            let resolved = self.resolve_requested_path(&repo_root, path)?;
+            let Some(resolved) = self.resolve_requested_path(&repo_root, path)? else {
+                let relative_path = self.relative_candidate_path(&repo_root, path)?;
+                let relative_display = relative_path.to_string_lossy().to_string();
+                report.fallback_reasons.push(format!(
+                    "{relative_display} could not be read: file not found"
+                ));
+                report.fallback_paths.push(relative_path);
+                continue;
+            };
             let relative_path = resolved
                 .strip_prefix(&repo_root)
                 .unwrap_or(&resolved)
                 .to_path_buf();
             let relative_display = relative_path.to_string_lossy().to_string();
 
-            let Some(source) =
-                self.read_limited_source(&resolved, &relative_display, &mut report)?
+            let Some(source) = self.read_limited_source(&resolved, &relative_display, &mut report)
             else {
                 continue;
             };
@@ -224,43 +231,63 @@ impl AstCodeIntelProvider {
         resolved: &Path,
         relative_display: &str,
         report: &mut AstCodeIntelReport,
-    ) -> Result<Option<String>, MemoryError> {
-        let file = fs::File::open(resolved).map_err(|source| MemoryError::ReadFile {
-            path: resolved.to_path_buf(),
-            source,
-        })?;
-        let metadata = file.metadata().map_err(|source| MemoryError::ReadFile {
-            path: resolved.to_path_buf(),
-            source,
-        })?;
+    ) -> Option<String> {
+        let file = match fs::File::open(resolved) {
+            Ok(file) => file,
+            Err(source) => {
+                report
+                    .fallback_reasons
+                    .push(format!("{relative_display} could not be opened: {source}"));
+                report.fallback_paths.push(PathBuf::from(relative_display));
+                return None;
+            }
+        };
+        let metadata = match file.metadata() {
+            Ok(metadata) => metadata,
+            Err(source) => {
+                report.fallback_reasons.push(format!(
+                    "{relative_display} metadata could not be read: {source}"
+                ));
+                report.fallback_paths.push(PathBuf::from(relative_display));
+                return None;
+            }
+        };
 
         if !metadata.is_file() {
             report
                 .fallback_reasons
                 .push(format!("{relative_display} is not a file"));
             report.fallback_paths.push(PathBuf::from(relative_display));
-            return Ok(None);
+            return None;
         }
 
         let mut bytes = Vec::new();
-        file.take(self.max_file_bytes + 1)
-            .read_to_end(&mut bytes)
-            .map_err(|source| MemoryError::ReadFile {
-                path: resolved.to_path_buf(),
-                source,
-            })?;
+        if let Err(source) = file.take(self.max_file_bytes + 1).read_to_end(&mut bytes) {
+            report
+                .fallback_reasons
+                .push(format!("{relative_display} could not be read: {source}"));
+            report.fallback_paths.push(PathBuf::from(relative_display));
+            return None;
+        }
         if bytes.len() as u64 > self.max_file_bytes {
             report.fallback_reasons.push(format!(
                 "{relative_display} exceeds max AST file size of {} bytes",
                 self.max_file_bytes
             ));
             report.fallback_paths.push(PathBuf::from(relative_display));
-            return Ok(None);
+            return None;
         }
 
-        String::from_utf8(bytes).map(Some).map_err(|error| {
-            MemoryError::InvalidInput(format!("{relative_display} is not UTF-8: {error}"))
-        })
+        match String::from_utf8(bytes) {
+            Ok(source) => Some(source),
+            Err(error) => {
+                report
+                    .fallback_reasons
+                    .push(format!("{relative_display} is not UTF-8: {error}"));
+                report.fallback_paths.push(PathBuf::from(relative_display));
+                None
+            }
+        }
     }
 
     fn canonical_root(&self) -> Result<PathBuf, MemoryError> {
@@ -276,26 +303,75 @@ impl AstCodeIntelProvider {
         &self,
         repo_root: &Path,
         path: &Path,
-    ) -> Result<PathBuf, MemoryError> {
-        let candidate = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            repo_root.join(path)
+    ) -> Result<Option<PathBuf>, MemoryError> {
+        let candidate = requested_candidate(repo_root, path);
+        let resolved = match candidate.canonicalize() {
+            Ok(resolved) => resolved,
+            Err(source) if source.kind() == ErrorKind::NotFound => {
+                let normalized = normalize_lexical(&candidate);
+                if !normalized.starts_with(repo_root) {
+                    return Err(MemoryError::PathOutsideRepo {
+                        path: normalized,
+                        repo_root: repo_root.to_path_buf(),
+                    });
+                }
+                return Ok(None);
+            }
+            Err(source) => {
+                return Err(MemoryError::ResolvePath {
+                    path: candidate.clone(),
+                    source,
+                });
+            }
         };
-        let resolved = candidate
-            .canonicalize()
-            .map_err(|source| MemoryError::ResolvePath {
-                path: candidate.clone(),
-                source,
-            })?;
         if !resolved.starts_with(repo_root) {
             return Err(MemoryError::PathOutsideRepo {
                 path: resolved,
                 repo_root: repo_root.to_path_buf(),
             });
         }
-        Ok(resolved)
+        Ok(Some(resolved))
     }
+
+    fn relative_candidate_path(
+        &self,
+        repo_root: &Path,
+        path: &Path,
+    ) -> Result<PathBuf, MemoryError> {
+        let candidate = normalize_lexical(&requested_candidate(repo_root, path));
+        if !candidate.starts_with(repo_root) {
+            return Err(MemoryError::PathOutsideRepo {
+                path: candidate.clone(),
+                repo_root: repo_root.to_path_buf(),
+            });
+        }
+        Ok(candidate
+            .strip_prefix(repo_root)
+            .unwrap_or(&candidate)
+            .to_path_buf())
+    }
+}
+
+fn requested_candidate(repo_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo_root.join(path)
+    }
+}
+
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 impl CodeIntelIndex for AstCodeIntelProvider {
@@ -858,6 +934,41 @@ mod tests {
         }));
         assert!(artifacts.iter().any(|artifact| {
             artifact.kind == "trace" && artifact.summary.contains("max AST file size")
+        }));
+    }
+
+    #[test]
+    fn composite_falls_back_when_requested_file_is_missing() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("src/missing.rs")], &[], 20)
+            .expect("code context");
+
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace" && artifact.summary.contains("file not found")
+        }));
+    }
+
+    #[test]
+    fn composite_falls_back_when_requested_file_is_not_utf8() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::write(repo.path().join("src/lib.rs"), [0xff, 0xfe]).expect("binary file");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("src/lib.rs")], &[], 20)
+            .expect("code context");
+
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.provider == "codebase-analyzer" && artifact.title == "Repository summary"
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace" && artifact.summary.contains("not UTF-8")
         }));
     }
 

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::Read,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -8,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator};
 
+// COE-499 adapts the AST provider to memory's existing CodeIntelIndex contract
+// so memory.context gains AST evidence without adding a new public tool surface.
 use crate::{
     opensymphony_memory::{
         CodeIntelArtifact, CodeIntelIndex, KnowledgeScope, MemoryError, MemorySourceRef,
@@ -149,6 +152,7 @@ impl AstCodeIntelProvider {
         let repo_root = self.canonical_root()?;
         let commit_sha = git_commit_sha(&repo_root);
         let mut report = AstCodeIntelReport::default();
+        let mut remaining_symbols = limit.max(1);
 
         if paths.is_empty() {
             report
@@ -164,47 +168,27 @@ impl AstCodeIntelProvider {
                 .unwrap_or(&resolved)
                 .to_path_buf();
             let relative_display = relative_path.to_string_lossy().to_string();
-            let metadata = match fs::metadata(&resolved) {
-                Ok(metadata) => metadata,
-                Err(source) => {
-                    return Err(MemoryError::ResolvePath {
-                        path: resolved,
-                        source,
-                    });
-                }
-            };
 
-            if !metadata.is_file() {
-                report
-                    .fallback_reasons
-                    .push(format!("{relative_display} is not a file"));
+            let Some(source) =
+                self.read_limited_source(&resolved, &relative_display, &mut report)?
+            else {
                 continue;
-            }
-            if metadata.len() > self.max_file_bytes {
-                report.fallback_reasons.push(format!(
-                    "{relative_display} is {} bytes; max AST file size is {} bytes",
-                    metadata.len(),
-                    self.max_file_bytes
-                ));
-                continue;
-            }
+            };
             if detect_language(&relative_path).is_none() {
                 report
                     .fallback_reasons
                     .push(format!("{relative_display} has unsupported language"));
+                report.fallback_paths.push(relative_path);
                 continue;
             }
 
-            let source = fs::read_to_string(&resolved).map_err(|source| MemoryError::ReadFile {
-                path: resolved.clone(),
-                source,
-            })?;
             let summary = match parse_path(&relative_path, &source) {
                 Ok(summary) => summary,
                 Err(error) => {
                     report
                         .fallback_reasons
                         .push(format!("{relative_display} AST parse failed: {error}"));
+                    report.fallback_paths.push(relative_path);
                     continue;
                 }
             };
@@ -215,18 +199,65 @@ impl AstCodeIntelProvider {
                 report.fallback_reasons.push(format!(
                     "{relative_display} parsed with Tree-sitter diagnostics"
                 ));
+                report.fallback_paths.push(relative_path.clone());
             }
-            report.artifacts.extend(ast_artifacts_for_summary(
+            let (artifacts, used_symbols) = ast_artifacts_for_summary(
                 summary,
                 &relative_path,
                 &relative_display,
                 scope_refs,
                 commit_sha.clone(),
-                limit,
-            ));
+                remaining_symbols,
+            );
+            remaining_symbols = remaining_symbols.saturating_sub(used_symbols);
+            report.artifacts.extend(artifacts);
         }
 
         Ok(report)
+    }
+
+    fn read_limited_source(
+        &self,
+        resolved: &Path,
+        relative_display: &str,
+        report: &mut AstCodeIntelReport,
+    ) -> Result<Option<String>, MemoryError> {
+        let file = fs::File::open(resolved).map_err(|source| MemoryError::ReadFile {
+            path: resolved.to_path_buf(),
+            source,
+        })?;
+        let metadata = file.metadata().map_err(|source| MemoryError::ReadFile {
+            path: resolved.to_path_buf(),
+            source,
+        })?;
+
+        if !metadata.is_file() {
+            report
+                .fallback_reasons
+                .push(format!("{relative_display} is not a file"));
+            report.fallback_paths.push(PathBuf::from(relative_display));
+            return Ok(None);
+        }
+
+        let mut bytes = Vec::new();
+        file.take(self.max_file_bytes + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|source| MemoryError::ReadFile {
+                path: resolved.to_path_buf(),
+                source,
+            })?;
+        if bytes.len() as u64 > self.max_file_bytes {
+            report.fallback_reasons.push(format!(
+                "{relative_display} exceeds max AST file size of {} bytes",
+                self.max_file_bytes
+            ));
+            report.fallback_paths.push(PathBuf::from(relative_display));
+            return Ok(None);
+        }
+
+        String::from_utf8(bytes).map(Some).map_err(|error| {
+            MemoryError::InvalidInput(format!("{relative_display} is not UTF-8: {error}"))
+        })
     }
 
     fn canonical_root(&self) -> Result<PathBuf, MemoryError> {
@@ -307,7 +338,11 @@ impl CodeIntelIndex for CompositeCodeIntelProvider {
         let mut artifacts = report.artifacts;
 
         if use_fallback {
-            artifacts.extend(self.fallback.code_context(paths, scope_refs, limit)?);
+            artifacts.extend(self.fallback.code_context(
+                &report.fallback_paths,
+                scope_refs,
+                limit,
+            )?);
         }
         artifacts.push(trace);
         Ok(artifacts)
@@ -318,6 +353,7 @@ impl CodeIntelIndex for CompositeCodeIntelProvider {
 struct AstCodeIntelReport {
     artifacts: Vec<CodeIntelArtifact>,
     fallback_reasons: Vec<String>,
+    fallback_paths: Vec<PathBuf>,
     parsed_files: usize,
     query_runs: usize,
 }
@@ -354,8 +390,8 @@ fn ast_artifacts_for_summary(
     relative_display: &str,
     scope_refs: &[KnowledgeScope],
     commit_sha: Option<String>,
-    limit: usize,
-) -> Vec<CodeIntelArtifact> {
+    symbol_limit: usize,
+) -> (Vec<CodeIntelArtifact>, usize) {
     let diagnostic_summary = diagnostics_summary(&summary.diagnostics);
     let mut artifacts = vec![CodeIntelArtifact {
         provider: PROVIDER_NAME.to_string(),
@@ -378,8 +414,9 @@ fn ast_artifacts_for_summary(
         ),
     }];
 
-    if !summary.symbols.is_empty() {
-        let max_symbols = limit.max(1);
+    if !summary.symbols.is_empty() && symbol_limit > 0 {
+        let max_symbols = symbol_limit;
+        let used_symbols = summary.symbols.len().min(max_symbols);
         let symbols = summary
             .symbols
             .iter()
@@ -414,9 +451,10 @@ fn ast_artifacts_for_summary(
             title: format!("Symbols in {relative_display}"),
             summary: symbols,
         });
+        return (artifacts, used_symbols);
     }
 
-    artifacts
+    (artifacts, 0)
 }
 
 fn diagnostics_summary(diagnostics: &[AstDiagnostic]) -> String {

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -481,7 +481,7 @@ impl AstCodeIntelReport {
                 self.fallback_reasons.join("; ")
             ),
             (false, false) => format!(
-                "fallback: CodebaseAnalyzer not used; fallback budget exhausted ({})",
+                "fallback: CodebaseAnalyzer not used; no fallback target ({})",
                 self.fallback_reasons.join("; ")
             ),
         }
@@ -989,6 +989,24 @@ mod tests {
         assert!(artifacts.iter().any(|artifact| {
             artifact.kind == "trace" && artifact.summary.contains("not UTF-8")
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn composite_rejects_symlink_to_outside_repo() {
+        let repo = TempDir::new().expect("temp repo");
+        let outside = TempDir::new().expect("outside repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        let outside_file = outside.path().join("lib.rs");
+        fs::write(&outside_file, "pub fn outside() {}\n").expect("outside file");
+        std::os::unix::fs::symlink(&outside_file, repo.path().join("src/outside.rs"))
+            .expect("symlink");
+
+        let error = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("src/outside.rs")], &[], 20)
+            .expect_err("outside symlink should be rejected");
+
+        assert!(matches!(error, MemoryError::PathOutsideRepo { .. }));
     }
 
     #[test]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -394,7 +394,13 @@ require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or `--admin-token` on
 `opensymphony memory serve`. If an admin token is configured without a separate
 read token, the admin token also protects read tools.
 `memory.context` builds the agent kickoff bundle. Add `--include-code-intel`
-to include available codebase-analysis artifacts alongside selected memory.
+to include code-intelligence artifacts alongside selected memory. For requested
+Rust paths, OpenSymphony renders Tree-sitter AST summaries, symbols, diagnostics,
+and a trace section before falling back to repository analysis. Unsupported
+languages, parser diagnostics, oversized files, and calls without requested
+paths use the existing `CodebaseAnalyzer` repository-summary fallback; mixed
+supported and unsupported requests can include both AST artifacts and fallback
+artifacts. The trace section records parse/query counts and the fallback reason.
 `opensymphony memory reindex --from-okf [bundle-root]` rebuilds the derived
 DuckDB catalog from OKF concept documents, defaulting to the configured memory
 root. Broken links and unknown concept types are indexed as warnings; malformed


### PR DESCRIPTION
## Summary

Wires Tree-sitter AST code intelligence into `memory context --include-code-intel` while preserving the existing CodebaseAnalyzer fallback.

## Changes

- Added `AstCodeIntelProvider` and `CompositeCodeIntelProvider` behind the existing `CodeIntelIndex` trait.
- Replaced direct `CodebaseAnalyzer` calls in CLI and MCP memory context paths with the composite provider.
- Render AST summaries, symbol evidence, and parse/query/fallback trace artifacts.
- Hardened review edge cases for `limit=0`, empty path requests, mixed AST/fallback paths, fallback budgeting, missing requested files, non-UTF-8 requested files, direct AST-provider trace output, mixed zero-limit fallback, and symlink containment.
- Documented AST-first/fallback behavior in `docs/memory.md` and `AGENTS.md`; filed COE-506 for follow-up trait ownership inversion.

## Evidence

### Test output

```
cargo fmt --check
# passed

cargo test-system-duckdb opensymphony_code_intel -- --nocapture
# 14 passed; 0 failed

cargo test-system-duckdb memory_context_code_intelligence --test memory -- --nocapture
# 4 passed; 0 failed

cargo test-system-duckdb mcp_memory_context_can_include_ast_code_intelligence -- --nocapture
# 1 passed; 0 failed

cargo test-system-duckdb --test memory
# 46 passed; 0 failed

cargo clippy-system-duckdb
# Finished dev profile successfully

git diff --check
# passed
```

### Verification

Exact runtime smoke command:

```bash
DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib \
DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include \
DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib \
cargo run --quiet --no-default-features --features duckdb-prebuilt -- \
  memory context --issue COE-499 \
  --paths crates/opensymphony-code-intel/src/lib.rs,README.md \
  --include-code-intel
```

Rendered `## Code Intelligence` section:

```markdown
## Code Intelligence

### ast-summary: crates/opensymphony-code-intel/src/lib.rs

- Provider: tree-sitter
- Path: crates/opensymphony-code-intel/src/lib.rs
- Commit: f379c844b5d66a46aafe3ae858cd77971defd7a6
- Sources: path:crates/opensymphony-code-intel/src/lib.rs

- Language: rust
- Content hash: sha256:289f35b71db0222ae2085be3a94c566ae2a0be2c9fbb9337b27cb80156e0bedf
- Parser: tree-sitter-rust@0.24.2
- Query pack: rust-definitions-v1
- Diagnostics: 0 ERROR, 0 MISSING

### ast-symbols: Symbols in crates/opensymphony-code-intel/src/lib.rs

- Provider: tree-sitter
- Path: crates/opensymphony-code-intel/src/lib.rs
- Commit: f379c844b5d66a46aafe3ae858cd77971defd7a6
- Sources: code-symbol:crates/opensymphony-code-intel/src/lib.rs:34:1-36:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:39:1-45:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:48:1-53:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:56:1-63:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:67:1-74:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:77:5-82:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:87:1-94:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:97:1-104:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:108:1-111:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:114:1-119:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:122:1-133:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:135:1-138:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:141:5-146:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:148:5-227:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:229:5-291:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:293:5-300:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:302:5-334:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:336:5-352:6, code-symbol:crates/opensymphony-code-intel/src/lib.rs:355:1-361:2, code-symbol:crates/opensymphony-code-intel/src/lib.rs:363:1-375:2

- enum `SourceLanguage` at crates/opensymphony-code-intel/src/lib.rs:34:1-36:2
- struct `SourceIdentity` at crates/opensymphony-code-intel/src/lib.rs:39:1-45:2
- struct `ParserVersions` at crates/opensymphony-code-intel/src/lib.rs:48:1-53:2
- struct `ParsedDocumentSummary` at crates/opensymphony-code-intel/src/lib.rs:56:1-63:2
- struct `SourceSpan` at crates/opensymphony-code-intel/src/lib.rs:67:1-74:2
- method `render` at crates/opensymphony-code-intel/src/lib.rs:77:5-82:6
- enum `SymbolKind` at crates/opensymphony-code-intel/src/lib.rs:87:1-94:2
- struct `SymbolRecord` at crates/opensymphony-code-intel/src/lib.rs:97:1-104:2
- enum `AstDiagnosticKind` at crates/opensymphony-code-intel/src/lib.rs:108:1-111:2
- struct `AstDiagnostic` at crates/opensymphony-code-intel/src/lib.rs:114:1-119:2
- enum `CodeIntelError` at crates/opensymphony-code-intel/src/lib.rs:122:1-133:2
- struct `AstCodeIntelProvider` at crates/opensymphony-code-intel/src/lib.rs:135:1-138:2
- method `new` at crates/opensymphony-code-intel/src/lib.rs:141:5-146:6
- method `code_context_report` at crates/opensymphony-code-intel/src/lib.rs:148:5-227:6
- method `read_limited_source` at crates/opensymphony-code-intel/src/lib.rs:229:5-291:6
- method `canonical_root` at crates/opensymphony-code-intel/src/lib.rs:293:5-300:6
- method `resolve_requested_path` at crates/opensymphony-code-intel/src/lib.rs:302:5-334:6
- method `relative_candidate_path` at crates/opensymphony-code-intel/src/lib.rs:336:5-352:6
- function `requested_candidate` at crates/opensymphony-code-intel/src/lib.rs:355:1-361:2
- function `normalize_lexical` at crates/opensymphony-code-intel/src/lib.rs:363:1-375:2

### repository-summary: Repository summary

- Provider: codebase-analyzer
- Commit: f379c844b5d66a46aafe3ae858cd77971defd7a6
- Sources: codebase-analysis:/Users/magos/.opensymphony/workspaces/COE-499

615 files, 193 Rust files, 90 TypeScript files, build systems: cargo, npm

### trace: Code-intelligence trace

- Provider: composite-code-intel

- parse: parsed 1 file(s)
- query: ran 1 Tree-sitter query pack(s)
- fallback: CodebaseAnalyzer used (README.md has unsupported language)
```

Focused tests also verify:

- `limit=0` does not emit AST symbol rows.
- `--include-code-intel` without `--paths` returns a repository-summary fallback.
- Mixed `src/lib.rs,README.md` requests include AST evidence for Rust plus fallback trace for the unsupported Markdown path.
- Missing and non-UTF-8 requested files fall back instead of aborting the whole context request.
- Direct AST-provider trace output identifies AST-only fallback behavior.
- Mixed supported/unsupported requests still invoke fallback when `limit=0`.
- Symlinks that resolve outside the repo root are rejected.

## Checklist

- [x] Tests pass (`cargo test` equivalent: `cargo test-system-duckdb --test memory` plus focused provider/MCP tests)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None. The public `memory.context` contract is unchanged; the optional code-intelligence section is enriched.

## Related issues

COE-499
COE-506

## Additional notes

Skipped persistence, new MCP tool names, and gateway endpoints per scope.
