### PR TITLE
Expose read-only AST MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,15 @@ supported requested Rust paths, then falls back to `CodebaseAnalyzer` for
 unsupported languages, parser diagnostics, oversized files, and empty-path
 repository summaries. Mixed supported and unsupported requests should keep both
 AST evidence and fallback trace visibility without changing the public
-`memory.context` contract or adding new MCP tool names. The current
-`opensymphony_code_intel` adapter still implements
+`memory.context` contract. The memory MCP server may expose read-only
+`code.ast.status`, `code.ast.outline`, `code.ast.symbols`,
+`code.ast.references`, `code.ast.query`, `code.ast.context`, and
+`code.ast.diagnostics` tools only when `code_intel.enabled` and
+`code_intel.ast.enabled` are true. These tools are evidence APIs, not edit APIs:
+keep path containment, file/match/capture limits, parser/query-pack/source
+citations, and trace output intact. `code.ast.query` is local read-only by
+default and becomes admin-gated whenever a memory admin token is configured.
+The current `opensymphony_code_intel` adapter still implements
 `opensymphony_memory::CodeIntelIndex`; keep that bridge narrow until a follow-up
 inverts trait ownership into the code-intelligence module.
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1898,26 +1898,38 @@ async fn call_code_ast_outline_tool(
     ast_mcp_tool_blocking("code.ast.outline", move || {
         let documents = ast_documents(&config, &arguments)?;
         let limit = ast_limit(&config, &arguments);
-        let truncated = documents
-            .iter()
-            .any(|document| document.summary.symbols.len() > limit);
-        Ok(json!({
-            "documents": documents.iter().map(|document| json!({
-                "path": document.display,
-                "language": document.summary.source.language.id(),
-                "contentSha256": document.summary.source.sha256,
-                "parserVersion": parser_version_string(&document.summary),
-                "queryPackVersion": document.summary.versions.query_pack,
-                "symbols": document.summary.symbols.iter().take(limit).map(|symbol| json!({
+        let mut remaining = limit;
+        let mut truncated = false;
+        let mut response_documents = Vec::new();
+        for document in &documents {
+            let selected_symbols = document
+                .summary
+                .symbols
+                .iter()
+                .take(remaining)
+                .map(|symbol| json!({
                     "kind": symbol_kind_id(&symbol.kind),
                     "name": symbol.name,
                     "span": span_json(&symbol.span),
                     "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
                     "parserVersion": symbol.parser_version,
                     "queryPackVersion": symbol.query_pack_version
-                })).collect::<Vec<_>>(),
+                }))
+                .collect::<Vec<_>>();
+            remaining = remaining.saturating_sub(selected_symbols.len());
+            truncated |= document.summary.symbols.len() > selected_symbols.len();
+            response_documents.push(json!({
+                "path": document.display,
+                "language": document.summary.source.language.id(),
+                "contentSha256": document.summary.source.sha256,
+                "parserVersion": parser_version_string(&document.summary),
+                "queryPackVersion": document.summary.versions.query_pack,
+                "symbols": selected_symbols,
                 "diagnostics": diagnostics_json(&document.summary)
-            })).collect::<Vec<_>>(),
+            }));
+        }
+        Ok(json!({
+            "documents": response_documents,
             "limit": limit,
             "trace": ast_trace_json(&config, &documents, truncated)
         }))
@@ -2099,17 +2111,34 @@ async fn call_code_ast_diagnostics_tool(
 ) -> Result<Value, MemoryError> {
     ast_mcp_tool_blocking("code.ast.diagnostics", move || {
         let documents = ast_documents(&config, &arguments)?;
-        Ok(json!({
-            "diagnostics": documents.iter().flat_map(|document| {
-                document.summary.diagnostics.iter().map(|diagnostic| json!({
+        let limit = ast_limit(&config, &arguments);
+        let mut diagnostics = Vec::new();
+        for document in &documents {
+            for diagnostic in &document.summary.diagnostics {
+                if diagnostics.len() >= limit {
+                    break;
+                }
+                diagnostics.push(json!({
                     "path": document.display,
                     "kind": diagnostic_kind_id(&diagnostic.kind),
                     "nodeKind": diagnostic.node_kind,
                     "span": span_json(&diagnostic.span),
                     "source": source_json(&document.summary)
-                }))
-            }).collect::<Vec<_>>(),
-            "trace": ast_trace_json(&config, &documents, false)
+                }));
+            }
+            if diagnostics.len() >= limit {
+                break;
+            }
+        }
+        let truncated = documents
+            .iter()
+            .map(|document| document.summary.diagnostics.len())
+            .sum::<usize>()
+            > diagnostics.len();
+        Ok(json!({
+            "diagnostics": diagnostics,
+            "limit": limit,
+            "trace": ast_trace_json(&config, &documents, truncated)
         }))
     })
     .await
@@ -5427,7 +5456,7 @@ Public memory concept.
             &config,
             json!({
                 "name": "code.ast.context",
-                "arguments": { "paths": ["src/lib.rs"], "limit": 5 }
+                "arguments": { "paths": ["src/lib.rs"], "symbols": ["function"], "limit": 5 }
             }),
         )
         .await
@@ -5644,6 +5673,11 @@ Public memory concept.
             "pub fn one() -> u8 { 1 }\npub fn two() -> u8 { 2 }\n",
         )
         .expect("source");
+        std::fs::write(
+            repo_root.join("src/more.rs"),
+            "pub fn three() -> u8 { 3 }\npub fn four() -> u8 { 4 }\n",
+        )
+        .expect("source");
         let config_path = repo_root.join("opensymphony-memory.yaml");
         std::fs::write(
             &config_path,
@@ -5664,6 +5698,73 @@ Public memory concept.
 
         assert_eq!(symbols["symbols"].as_array().expect("symbols").len(), 1);
         assert_eq!(symbols["limit"], 1);
+
+        let outline = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.outline",
+                "arguments": { "paths": ["src"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("outline");
+        let outline_symbol_count = outline["documents"]
+            .as_array()
+            .expect("documents")
+            .iter()
+            .map(|document| document["symbols"].as_array().expect("symbols").len())
+            .sum::<usize>();
+        assert_eq!(outline_symbol_count, 1);
+        assert_eq!(outline["limit"], 1);
+        assert!(
+            outline["trace"]
+                .as_array()
+                .expect("outline trace")
+                .iter()
+                .any(|line| line == "truncated by limit")
+        );
+    }
+
+    #[tokio::test]
+    async fn code_ast_diagnostics_enforces_request_limit() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/bad.rs"), "pub fn broken( {\n").expect("source");
+        std::fs::write(repo_root.join("src/worse.rs"), "pub fn worse( {\n").expect("source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_matches_per_request: 1\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let diagnostics = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.diagnostics",
+                "arguments": { "paths": ["src"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("diagnostics");
+
+        assert_eq!(
+            diagnostics["diagnostics"]
+                .as_array()
+                .expect("diagnostics")
+                .len(),
+            1
+        );
+        assert_eq!(diagnostics["limit"], 1);
+        assert!(
+            diagnostics["trace"]
+                .as_array()
+                .expect("diagnostics trace")
+                .iter()
+                .any(|line| line == "truncated by limit")
+        );
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -2095,8 +2095,14 @@ async fn call_code_ast_context_tool(
     let symbol_kinds = normalized_string_set_args(arguments, &["symbols"]);
     let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
     let scope_refs = scope_refs_for_context(&scope, &paths);
-    let artifacts = code_intel_artifacts_blocking(repo_root, paths, scope_refs, limit).await?;
-    let artifacts = filter_code_intel_artifacts_by_symbol_kinds(artifacts, &symbol_kinds);
+    let artifacts = code_intel_artifacts_with_symbol_kinds_blocking(
+        repo_root,
+        paths,
+        scope_refs,
+        limit,
+        symbol_kinds,
+    )
+    .await?;
     let trace = artifacts
         .iter()
         .filter(|artifact| artifact.kind == "trace")
@@ -2105,50 +2111,6 @@ async fn call_code_ast_context_tool(
     let mut markdown = String::from("## Structural Context\n\n");
     append_code_intel_artifacts(config, &mut markdown, artifacts);
     Ok(json!({ "markdown": markdown, "trace": trace }))
-}
-
-fn filter_code_intel_artifacts_by_symbol_kinds(
-    artifacts: Vec<CodeIntelArtifact>,
-    symbol_kinds: &BTreeSet<String>,
-) -> Vec<CodeIntelArtifact> {
-    if symbol_kinds.is_empty() {
-        return artifacts;
-    }
-    artifacts
-        .into_iter()
-        .filter_map(|mut artifact| {
-            if artifact.kind != "ast-symbols" {
-                return Some(artifact);
-            }
-            let lines = artifact.summary.lines().collect::<Vec<_>>();
-            let keep = lines
-                .iter()
-                .map(|line| {
-                    line.strip_prefix("- ")
-                        .and_then(|line| line.split_whitespace().next())
-                        .is_some_and(|kind| symbol_kinds.contains(kind))
-                })
-                .collect::<Vec<_>>();
-            let selected_lines = lines
-                .iter()
-                .zip(&keep)
-                .filter_map(|(line, keep)| keep.then_some(*line))
-                .collect::<Vec<_>>();
-            if selected_lines.is_empty() {
-                return None;
-            }
-            artifact.summary = selected_lines.join("\n");
-            if artifact.source_refs.len() == keep.len() {
-                artifact.source_refs = artifact
-                    .source_refs
-                    .into_iter()
-                    .zip(keep)
-                    .filter_map(|(source_ref, keep)| keep.then_some(source_ref))
-                    .collect();
-            }
-            Some(artifact)
-        })
-        .collect()
 }
 
 async fn call_code_ast_diagnostics_tool(
@@ -2269,9 +2231,6 @@ fn collect_ast_files(
     max_files: usize,
     files: &mut Vec<PathBuf>,
 ) -> Result<(), MemoryError> {
-    if files.len() >= max_files {
-        return Ok(());
-    }
     let candidate = if path.is_absolute() {
         path.to_path_buf()
     } else {
@@ -2290,13 +2249,15 @@ fn collect_ast_files(
         });
     }
     if resolved.is_file() {
-        if !ast_file_is_supported(repo_root, &resolved)? {
-            return Ok(());
+        if ast_file_is_supported(repo_root, &resolved)? && files.len() < max_files {
+            files.push(resolved);
         }
-        files.push(resolved);
         return Ok(());
     }
     if !resolved.is_dir() {
+        return Ok(());
+    }
+    if files.len() >= max_files {
         return Ok(());
     }
     let mut entries = fs::read_dir(&resolved)
@@ -3393,6 +3354,27 @@ async fn code_intel_artifacts_blocking(
 ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
     tokio::task::spawn_blocking(move || {
         CompositeCodeIntelProvider::new(repo_root).code_context(&paths, &scope_refs, limit)
+    })
+    .await
+    .map_err(|error| {
+        MemoryError::InvalidInput(format!("code-intelligence analysis task failed: {error}"))
+    })?
+}
+
+async fn code_intel_artifacts_with_symbol_kinds_blocking(
+    repo_root: PathBuf,
+    paths: Vec<PathBuf>,
+    scope_refs: Vec<KnowledgeScope>,
+    limit: usize,
+    symbol_kinds: BTreeSet<String>,
+) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    tokio::task::spawn_blocking(move || {
+        CompositeCodeIntelProvider::new(repo_root).code_context_with_symbol_kinds(
+            &paths,
+            &scope_refs,
+            limit,
+            &symbol_kinds,
+        )
     })
     .await
     .map_err(|error| {
@@ -5894,6 +5876,32 @@ Public memory concept.
     }
 
     #[tokio::test]
+    async fn code_ast_query_accepts_custom_capture_names() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let query = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.query",
+                "arguments": {
+                    "paths": ["src/lib.rs"],
+                    "language": "rust",
+                    "query": "(function_item name: (identifier) @my_capture)"
+                }
+            }),
+        )
+        .await
+        .expect("query");
+
+        assert_eq!(query["matches"][0]["captures"][0]["name"], "my_capture");
+        assert_eq!(query["matches"][0]["captures"][0]["text"], "answer");
+    }
+
+    #[tokio::test]
     async fn code_ast_tools_reject_paths_outside_repo() {
         let repo = TempDir::new().expect("temp repo");
         let outside = TempDir::new().expect("outside repo");
@@ -5910,6 +5918,36 @@ Public memory concept.
         )
         .await
         .expect_err("outside path should fail");
+
+        assert!(matches!(error, MemoryError::PathOutsideRepo { .. }));
+    }
+
+    #[tokio::test]
+    async fn code_ast_tools_validate_all_requested_paths_before_budget_skip() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        let outside = TempDir::new().expect("outside repo");
+        let outside_path = outside.path().join("lib.rs");
+        std::fs::write(&outside_path, "pub fn outside() {}\n").expect("outside source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_files_per_request: 1\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let error = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": { "paths": ["src", outside_path] }
+            }),
+        )
+        .await
+        .expect_err("outside path should fail even after file budget is full");
 
         assert!(matches!(error, MemoryError::PathOutsideRepo { .. }));
     }

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1549,7 +1549,7 @@ async fn memory_server_mcp(
             "capabilities": { "tools": {} }
         })),
         "tools/list" => Ok(json!({
-            "tools": memory_tool_descriptors(&state.config)
+            "tools": memory_tool_descriptors(&state.config, &state.auth)
         })),
         "tools/call" => match tokio::time::timeout(
             MEMORY_MCP_TOOL_TIMEOUT,
@@ -1601,7 +1601,7 @@ fn required_access_for_request(
     }
 }
 
-fn memory_tool_descriptors(config: &MemoryConfig) -> Vec<Value> {
+fn memory_tool_descriptors(config: &MemoryConfig, auth: &MemoryServerAuth) -> Vec<Value> {
     let mut tools = vec![
         json!({ "name": "memory.context", "description": "Build a pre-implementation memory context bundle", "access": "read" }),
         json!({ "name": "memory.search", "description": "Search captured issue memory", "access": "read" }),
@@ -1619,7 +1619,14 @@ fn memory_tool_descriptors(config: &MemoryConfig) -> Vec<Value> {
     ];
     if ast_tools_enabled(config) {
         tools.extend(AST_MCP_TOOL_NAMES.iter().map(|name| {
-            json!({ "name": name, "description": "Read-only Tree-sitter AST code intelligence", "access": "read" })
+            json!({
+                "name": name,
+                "description": "Read-only Tree-sitter AST code intelligence",
+                "access": match required_access_for_tool(name, auth) {
+                    MemoryServerAccess::Read => "read",
+                    MemoryServerAccess::Admin => "admin",
+                }
+            })
         }));
     }
     tools
@@ -4517,11 +4524,11 @@ fn print_search_results(
 mod tests {
     use super::{
         LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, MemoryMcpRequest, MemoryServerAccess,
-        MemoryServerAuth, authorize_memory_request, call_memory_ingest_code_intel_tool,
-        call_memory_tool, context_source_from_mcp, memory_server_health_payload,
-        memory_tool_descriptors, origin_is_localhost, parse_remote_memory_response,
-        remote_memory_tool_token, replace_or_append_managed_section, required_access_for_request,
-        resolve_code_intel_repo, trim_auto_memory_status_log,
+        MemoryServerAuth, RUST_QUERY_PACK_VERSION, authorize_memory_request,
+        call_memory_ingest_code_intel_tool, call_memory_tool, context_source_from_mcp,
+        memory_server_health_payload, memory_tool_descriptors, origin_is_localhost,
+        parse_remote_memory_response, remote_memory_tool_token, replace_or_append_managed_section,
+        required_access_for_request, resolve_code_intel_repo, trim_auto_memory_status_log,
     };
     use crate::opensymphony_memory::{
         CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
@@ -4537,7 +4544,7 @@ mod tests {
     fn mcp_tool_list_exposes_context_admin_and_ast_tools_when_enabled() {
         let repo = TempDir::new().expect("temp repo");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
-        let names = memory_tool_descriptors(&config)
+        let names = memory_tool_descriptors(&config, &MemoryServerAuth::default())
             .into_iter()
             .filter_map(|tool| {
                 tool.get("name")
@@ -4571,7 +4578,7 @@ mod tests {
         )
         .expect("config");
         let config = MemoryConfig::load(repo.path(), Some(&config_path)).expect("memory config");
-        let names = memory_tool_descriptors(&config)
+        let names = memory_tool_descriptors(&config, &MemoryServerAuth::default())
             .into_iter()
             .filter_map(|tool| {
                 tool.get("name")
@@ -4582,6 +4589,30 @@ mod tests {
 
         assert!(names.contains(&"memory.context".to_string()));
         assert!(!names.iter().any(|name| name.starts_with("code.ast.")));
+    }
+
+    #[test]
+    fn mcp_tool_list_marks_ast_query_admin_when_admin_token_is_configured() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let tools = memory_tool_descriptors(
+            &config,
+            &MemoryServerAuth {
+                read_token: Some("read-token".to_string()),
+                admin_token: Some("admin-token".to_string()),
+            },
+        );
+        let query_tool = tools
+            .iter()
+            .find(|tool| tool["name"] == "code.ast.query")
+            .expect("query tool");
+        let outline_tool = tools
+            .iter()
+            .find(|tool| tool["name"] == "code.ast.outline")
+            .expect("outline tool");
+
+        assert_eq!(query_tool["access"], "admin");
+        assert_eq!(outline_tool["access"], "read");
     }
 
     #[test]
@@ -5319,7 +5350,7 @@ Public memory concept.
         assert_eq!(symbols["symbols"][0]["name"], "answer");
         assert_eq!(
             symbols["symbols"][0]["source"]["queryPackVersion"],
-            "rust-query-pack-v2"
+            RUST_QUERY_PACK_VERSION
         );
 
         let query = call_memory_tool(
@@ -5344,6 +5375,61 @@ Public memory concept.
                 .as_str()
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn code_ast_references_returns_span_and_source_citation() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "fn helper() -> u8 { 42 }\npub fn answer() -> u8 { helper() }\n",
+        )
+        .expect("source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let references = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.references",
+                "arguments": { "paths": ["src/lib.rs"], "symbol": "helper" }
+            }),
+        )
+        .await
+        .expect("references");
+        let first = &references["references"][0];
+
+        assert_eq!(first["path"], "src/lib.rs");
+        assert_eq!(first["kind"], "reference.call");
+        assert_eq!(first["span"]["startLine"], 2);
+        assert!(first["source"]["contentSha256"].as_str().is_some());
+        assert_eq!(first["source"]["queryPackVersion"], RUST_QUERY_PACK_VERSION);
+    }
+
+    #[tokio::test]
+    async fn code_ast_diagnostics_returns_parser_diagnostics_with_source() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn broken( {\n").expect("source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let diagnostics = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.diagnostics",
+                "arguments": { "paths": ["src/lib.rs"] }
+            }),
+        )
+        .await
+        .expect("diagnostics");
+        let first = &diagnostics["diagnostics"][0];
+
+        assert_eq!(first["path"], "src/lib.rs");
+        assert!(first["span"]["startLine"].as_u64().expect("line") >= 1);
+        assert!(first["source"]["contentSha256"].as_str().is_some());
+        assert_eq!(first["source"]["queryPackVersion"], RUST_QUERY_PACK_VERSION);
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1897,6 +1897,10 @@ async fn call_code_ast_outline_tool(
 ) -> Result<Value, MemoryError> {
     ast_mcp_tool_blocking("code.ast.outline", move || {
         let documents = ast_documents(&config, &arguments)?;
+        let limit = ast_limit(&config, &arguments);
+        let truncated = documents
+            .iter()
+            .any(|document| document.summary.symbols.len() > limit);
         Ok(json!({
             "documents": documents.iter().map(|document| json!({
                 "path": document.display,
@@ -1904,7 +1908,7 @@ async fn call_code_ast_outline_tool(
                 "contentSha256": document.summary.source.sha256,
                 "parserVersion": parser_version_string(&document.summary),
                 "queryPackVersion": document.summary.versions.query_pack,
-                "symbols": document.summary.symbols.iter().take(ast_limit(&config, &arguments)).map(|symbol| json!({
+                "symbols": document.summary.symbols.iter().take(limit).map(|symbol| json!({
                     "kind": symbol_kind_id(&symbol.kind),
                     "name": symbol.name,
                     "span": span_json(&symbol.span),
@@ -1914,7 +1918,8 @@ async fn call_code_ast_outline_tool(
                 })).collect::<Vec<_>>(),
                 "diagnostics": diagnostics_json(&document.summary)
             })).collect::<Vec<_>>(),
-            "trace": ast_trace_json(&config, &documents, false)
+            "limit": limit,
+            "trace": ast_trace_json(&config, &documents, truncated)
         }))
     })
     .await
@@ -4656,6 +4661,24 @@ mod tests {
 
         assert!(names.contains(&"memory.context".to_string()));
         assert!(!names.iter().any(|name| name.starts_with("code.ast.")));
+
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  enabled: true\n  ast:\n    enabled: false\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(repo.path(), Some(&config_path)).expect("memory config");
+        let names = memory_tool_descriptors(&config, &MemoryServerAuth::default())
+            .into_iter()
+            .filter_map(|tool| {
+                tool.get("name")
+                    .and_then(|name| name.as_str())
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"memory.context".to_string()));
+        assert!(!names.iter().any(|name| name.starts_with("code.ast.")));
     }
 
     #[test]
@@ -5389,6 +5412,52 @@ Public memory concept.
     }
 
     #[tokio::test]
+    async fn code_ast_context_returns_markdown_and_trace() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let context = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.context",
+                "arguments": { "paths": ["src/lib.rs"], "limit": 5 }
+            }),
+        )
+        .await
+        .expect("context");
+
+        assert!(
+            context["markdown"]
+                .as_str()
+                .expect("markdown")
+                .contains("## Structural Context")
+        );
+        assert!(
+            context["markdown"]
+                .as_str()
+                .expect("markdown")
+                .contains("ast-summary: src/lib.rs")
+        );
+        assert!(
+            context["trace"]
+                .as_array()
+                .expect("trace")
+                .iter()
+                .any(|line| line
+                    .as_str()
+                    .expect("trace line")
+                    .contains("fallback: CodebaseAnalyzer not used"))
+        );
+    }
+
+    #[tokio::test]
     async fn code_ast_outline_symbols_and_query_return_source_citations() {
         let repo = TempDir::new().expect("temp repo");
         let repo_root = repo.path().canonicalize().expect("canonical repo");
@@ -5404,7 +5473,7 @@ Public memory concept.
             &config,
             json!({
                 "name": "code.ast.outline",
-                "arguments": { "paths": ["src/lib.rs"], "limit": 10 }
+                "arguments": { "paths": ["src/lib.rs"], "limit": 1 }
             }),
         )
         .await
@@ -5427,6 +5496,14 @@ Public memory concept.
         assert_eq!(
             outline["documents"][0]["symbols"][0]["span"]["startLine"],
             1
+        );
+        assert_eq!(outline["limit"], 1);
+        assert!(
+            outline["trace"]
+                .as_array()
+                .expect("outline trace")
+                .iter()
+                .any(|line| line == "truncated by limit")
         );
 
         let symbols = call_memory_tool(

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -2092,9 +2092,11 @@ async fn call_code_ast_context_tool(
     let scope = scope_filter_from_mcp(arguments, true);
     let paths = ast_path_args(arguments)?;
     let limit = ast_limit(config, arguments);
+    let symbol_kinds = normalized_string_set_args(arguments, &["symbols"]);
     let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
     let scope_refs = scope_refs_for_context(&scope, &paths);
     let artifacts = code_intel_artifacts_blocking(repo_root, paths, scope_refs, limit).await?;
+    let artifacts = filter_code_intel_artifacts_by_symbol_kinds(artifacts, &symbol_kinds);
     let trace = artifacts
         .iter()
         .filter(|artifact| artifact.kind == "trace")
@@ -2103,6 +2105,50 @@ async fn call_code_ast_context_tool(
     let mut markdown = String::from("## Structural Context\n\n");
     append_code_intel_artifacts(config, &mut markdown, artifacts);
     Ok(json!({ "markdown": markdown, "trace": trace }))
+}
+
+fn filter_code_intel_artifacts_by_symbol_kinds(
+    artifacts: Vec<CodeIntelArtifact>,
+    symbol_kinds: &BTreeSet<String>,
+) -> Vec<CodeIntelArtifact> {
+    if symbol_kinds.is_empty() {
+        return artifacts;
+    }
+    artifacts
+        .into_iter()
+        .filter_map(|mut artifact| {
+            if artifact.kind != "ast-symbols" {
+                return Some(artifact);
+            }
+            let lines = artifact.summary.lines().collect::<Vec<_>>();
+            let keep = lines
+                .iter()
+                .map(|line| {
+                    line.strip_prefix("- ")
+                        .and_then(|line| line.split_whitespace().next())
+                        .is_some_and(|kind| symbol_kinds.contains(kind))
+                })
+                .collect::<Vec<_>>();
+            let selected_lines = lines
+                .iter()
+                .zip(&keep)
+                .filter_map(|(line, keep)| keep.then_some(*line))
+                .collect::<Vec<_>>();
+            if selected_lines.is_empty() {
+                return None;
+            }
+            artifact.summary = selected_lines.join("\n");
+            if artifact.source_refs.len() == keep.len() {
+                artifact.source_refs = artifact
+                    .source_refs
+                    .into_iter()
+                    .zip(keep)
+                    .filter_map(|(source_ref, keep)| keep.then_some(source_ref))
+                    .collect();
+            }
+            Some(artifact)
+        })
+        .collect()
 }
 
 async fn call_code_ast_diagnostics_tool(
@@ -5447,7 +5493,7 @@ Public memory concept.
         std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
         std::fs::write(
             repo_root.join("src/lib.rs"),
-            "pub fn answer() -> u8 { 42 }\n",
+            "pub struct Thing {\n    value: u8,\n}\npub fn answer() -> u8 { 42 }\n",
         )
         .expect("source");
         let config = MemoryConfig::load(&repo_root, None).expect("config");
@@ -5456,7 +5502,7 @@ Public memory concept.
             &config,
             json!({
                 "name": "code.ast.context",
-                "arguments": { "paths": ["src/lib.rs"], "symbols": ["function"], "limit": 5 }
+                "arguments": { "paths": ["src/lib.rs"], "symbols": ["struct"], "limit": 5 }
             }),
         )
         .await
@@ -5472,7 +5518,13 @@ Public memory concept.
             context["markdown"]
                 .as_str()
                 .expect("markdown")
-                .contains("ast-summary: src/lib.rs")
+                .contains("struct `Thing`")
+        );
+        assert!(
+            !context["markdown"]
+                .as_str()
+                .expect("markdown")
+                .contains("function `answer`")
         );
         assert!(
             context["trace"]
@@ -5658,6 +5710,13 @@ Public memory concept.
         let first = &diagnostics["diagnostics"][0];
 
         assert_eq!(first["path"], "src/lib.rs");
+        assert!(
+            matches!(
+                first["kind"].as_str().expect("diagnostic kind"),
+                "error" | "missing"
+            ),
+            "diagnostic kind should use the serialized AST diagnostic vocabulary"
+        );
         assert!(first["span"]["startLine"].as_u64().expect("line") >= 1);
         assert!(first["source"]["contentSha256"].as_str().is_some());
         assert_eq!(first["source"]["queryPackVersion"], RUST_QUERY_PACK_VERSION);

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1930,7 +1930,8 @@ async fn call_code_ast_symbols_tool(
         let kinds = normalized_string_set_args(&arguments, &["kinds"]);
         let limit = ast_limit(&config, &arguments);
         let mut symbols = Vec::new();
-        for document in ast_documents(&config, &arguments)? {
+        let documents = ast_documents(&config, &arguments)?;
+        for document in &documents {
             for symbol in document.summary.symbols.iter().filter(|symbol| {
                 query
                     .as_ref()
@@ -1954,7 +1955,11 @@ async fn call_code_ast_symbols_tool(
                 break;
             }
         }
-        Ok(json!({ "symbols": symbols, "limit": limit }))
+        Ok(json!({
+            "symbols": symbols,
+            "limit": limit,
+            "trace": ast_trace_json(&config, &documents, symbols.len() >= limit)
+        }))
     })
     .await
 }
@@ -1967,22 +1972,26 @@ async fn call_code_ast_references_tool(
         let symbol = required_string_arg(&arguments, "symbol")?;
         let limit = ast_limit(&config, &arguments);
         let mut references = Vec::new();
-        for document in ast_documents(&config, &arguments)? {
+        let documents = ast_documents(&config, &arguments)?;
+        for document in &documents {
             for capture in document
                 .summary
                 .captures
                 .iter()
                 .filter(|capture| capture.capture_name.starts_with("reference."))
-                .filter(|capture| capture.text.contains(&symbol))
+                .filter(|capture| capture_matches_symbol(&capture.text, &symbol))
             {
                 if references.len() >= limit {
                     break;
                 }
+                let (snippet, truncated) =
+                    truncate_capture(&capture.text, config.code_intel.ast.max_capture_bytes);
                 references.push(json!({
                     "kind": capture.capture_name,
                     "path": document.display,
                     "span": span_json(&capture.span),
-                    "snippet": truncate_capture(&capture.text, config.code_intel.ast.max_capture_bytes).0,
+                    "snippet": snippet,
+                    "truncated": truncated,
                     "source": source_json(&document.summary)
                 }));
             }
@@ -1990,7 +1999,12 @@ async fn call_code_ast_references_tool(
                 break;
             }
         }
-        Ok(json!({ "references": references, "confidence": "syntactic", "limit": limit }))
+        Ok(json!({
+            "references": references,
+            "confidence": "syntactic",
+            "limit": limit,
+            "trace": ast_trace_json(&config, &documents, references.len() >= limit)
+        }))
     })
     .await
 }
@@ -2130,9 +2144,6 @@ fn ast_documents(
                 repo_root: repo_root.clone(),
             })?
             .to_path_buf();
-        if crate::opensymphony_code_intel::detect_language(&relative).is_none() {
-            continue;
-        }
         let metadata = fs::metadata(&path).map_err(|source| MemoryError::ReadFile {
             path: path.clone(),
             source,
@@ -2199,6 +2210,9 @@ fn collect_ast_files(
         });
     }
     if resolved.is_file() {
+        if !ast_file_is_supported(repo_root, &resolved)? {
+            return Ok(());
+        }
         files.push(resolved);
         return Ok(());
     }
@@ -2226,15 +2240,39 @@ fn collect_ast_files(
         })?;
         if file_type.is_dir() {
             collect_ast_files(repo_root, &entry.path(), max_files, files)?;
-        } else if file_type.is_file() {
+        } else if file_type.is_file() && ast_file_is_supported(repo_root, &entry.path())? {
             files.push(entry.path());
         }
     }
     Ok(())
 }
 
+fn ast_file_is_supported(repo_root: &Path, path: &Path) -> Result<bool, MemoryError> {
+    let relative = path
+        .strip_prefix(repo_root)
+        .map_err(|_| MemoryError::PathOutsideRepo {
+            path: path.to_path_buf(),
+            repo_root: repo_root.to_path_buf(),
+        })?;
+    Ok(crate::opensymphony_code_intel::detect_language(relative).is_some())
+}
+
+fn capture_matches_symbol(capture_text: &str, symbol: &str) -> bool {
+    capture_text.match_indices(symbol).any(|(start, value)| {
+        let end = start + value.len();
+        let before = capture_text[..start].chars().next_back();
+        let after = capture_text[end..].chars().next();
+        before.is_none_or(|value| !is_identifier_char(value))
+            && after.is_none_or(|value| !is_identifier_char(value))
+    })
+}
+
+fn is_identifier_char(value: char) -> bool {
+    value == '_' || value.is_alphanumeric()
+}
+
 fn ast_limit(config: &MemoryConfig, arguments: &Value) -> usize {
-    usize_arg(arguments, "limit", 50).min(config.code_intel.ast.max_matches_per_file)
+    usize_arg(arguments, "limit", 50).min(config.code_intel.ast.max_matches_per_request)
 }
 
 fn ast_language_ids() -> Vec<&'static str> {
@@ -2256,7 +2294,7 @@ fn ast_limits_json(config: &MemoryConfig) -> Value {
     json!({
         "maxFileBytes": config.code_intel.ast.max_file_bytes,
         "maxFilesPerRequest": config.code_intel.ast.max_files_per_request,
-        "maxMatchesPerFile": config.code_intel.ast.max_matches_per_file,
+        "maxMatchesPerRequest": config.code_intel.ast.max_matches_per_request,
         "maxCaptureBytes": config.code_intel.ast.max_capture_bytes
     })
 }
@@ -2273,8 +2311,8 @@ fn ast_trace_json(
             config.code_intel.ast.max_files_per_request
         ),
         format!(
-            "max matches per file {}",
-            config.code_intel.ast.max_matches_per_file
+            "max matches per request {}",
+            config.code_intel.ast.max_matches_per_request
         ),
     ];
     if truncated {
@@ -5322,6 +5360,35 @@ Public memory concept.
     }
 
     #[tokio::test]
+    async fn code_ast_status_returns_provider_versions_and_limits() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let status = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.status",
+                "arguments": {}
+            }),
+        )
+        .await
+        .expect("status");
+
+        assert_eq!(status["provider"], "tree-sitter-ast");
+        assert_eq!(status["available"], true);
+        assert!(
+            status["languages"]
+                .as_array()
+                .expect("languages")
+                .iter()
+                .any(|language| language == "rust")
+        );
+        assert_eq!(status["queryPackVersions"]["rust"], RUST_QUERY_PACK_VERSION);
+        assert_eq!(status["limits"]["maxMatchesPerRequest"], 2000);
+    }
+
+    #[tokio::test]
     async fn code_ast_outline_symbols_and_query_return_source_citations() {
         let repo = TempDir::new().expect("temp repo");
         let repo_root = repo.path().canonicalize().expect("canonical repo");
@@ -5381,6 +5448,13 @@ Public memory concept.
             symbols["symbols"][0]["source"]["queryPackVersion"],
             RUST_QUERY_PACK_VERSION
         );
+        assert!(
+            symbols["trace"]
+                .as_array()
+                .expect("symbols trace")
+                .iter()
+                .any(|line| line.as_str().expect("trace line").contains("src/lib.rs"))
+        );
 
         let query = call_memory_tool(
             &config,
@@ -5413,10 +5487,16 @@ Public memory concept.
         std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
         std::fs::write(
             repo_root.join("src/lib.rs"),
-            "fn helper() -> u8 { 42 }\npub fn answer() -> u8 { helper() }\n",
+            "fn helper() {}\nfn myhelper() {}\npub fn answer() { helper(); myhelper(); }\n",
         )
         .expect("source");
-        let config = MemoryConfig::load(&repo_root, None).expect("config");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_capture_bytes: 3\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
 
         let references = call_memory_tool(
             &config,
@@ -5427,13 +5507,29 @@ Public memory concept.
         )
         .await
         .expect("references");
+        assert_eq!(
+            references["references"]
+                .as_array()
+                .expect("references")
+                .len(),
+            1
+        );
         let first = &references["references"][0];
 
         assert_eq!(first["path"], "src/lib.rs");
         assert_eq!(first["kind"], "reference.call");
-        assert_eq!(first["span"]["startLine"], 2);
+        assert_eq!(first["span"]["startLine"], 3);
+        assert_eq!(first["snippet"], "hel");
+        assert_eq!(first["truncated"], true);
         assert!(first["source"]["contentSha256"].as_str().is_some());
         assert_eq!(first["source"]["queryPackVersion"], RUST_QUERY_PACK_VERSION);
+        assert!(
+            references["trace"]
+                .as_array()
+                .expect("references trace")
+                .iter()
+                .any(|line| line.as_str().expect("trace line").contains("src/lib.rs"))
+        );
     }
 
     #[tokio::test]
@@ -5474,7 +5570,7 @@ Public memory concept.
         let config_path = repo_root.join("opensymphony-memory.yaml");
         std::fs::write(
             &config_path,
-            "code_intel:\n  ast:\n    max_matches_per_file: 1\n",
+            "code_intel:\n  ast:\n    max_matches_per_request: 1\n",
         )
         .expect("config");
         let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
@@ -5491,6 +5587,41 @@ Public memory concept.
 
         assert_eq!(symbols["symbols"].as_array().expect("symbols").len(), 1);
         assert_eq!(symbols["limit"], 1);
+    }
+
+    #[tokio::test]
+    async fn code_ast_file_limit_counts_supported_source_files() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/aaa.bin"), b"notes").expect("notes");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_files_per_request: 1\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let symbols = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": { "paths": ["src"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("symbols");
+
+        assert_eq!(symbols["symbols"][0]["name"], "answer");
+        assert!(
+            symbols["trace"]
+                .as_array()
+                .expect("trace")
+                .iter()
+                .any(|line| line.as_str().expect("trace line").contains("parsed 1 file"))
+        );
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1850,12 +1850,16 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
             }))
         }
         "code.ast.status" => call_code_ast_status_tool(config),
-        "code.ast.outline" => call_code_ast_outline_tool(config, &arguments),
-        "code.ast.symbols" => call_code_ast_symbols_tool(config, &arguments),
-        "code.ast.references" => call_code_ast_references_tool(config, &arguments),
-        "code.ast.query" => call_code_ast_query_tool(config, &arguments),
+        "code.ast.outline" => call_code_ast_outline_tool(config.clone(), arguments.clone()).await,
+        "code.ast.symbols" => call_code_ast_symbols_tool(config.clone(), arguments.clone()).await,
+        "code.ast.references" => {
+            call_code_ast_references_tool(config.clone(), arguments.clone()).await
+        }
+        "code.ast.query" => call_code_ast_query_tool(config.clone(), arguments.clone()).await,
         "code.ast.context" => call_code_ast_context_tool(config, &arguments).await,
-        "code.ast.diagnostics" => call_code_ast_diagnostics_tool(config, &arguments),
+        "code.ast.diagnostics" => {
+            call_code_ast_diagnostics_tool(config.clone(), arguments.clone()).await
+        }
         "memory.capture" => call_memory_capture_tool(config, &arguments).await,
         "memory.sync_docs" => call_memory_sync_docs_tool(config, &arguments),
         "memory.lint" => call_memory_lint_tool(config, &arguments),
@@ -1887,154 +1891,167 @@ fn call_code_ast_status_tool(config: &MemoryConfig) -> Result<Value, MemoryError
     }))
 }
 
-fn call_code_ast_outline_tool(
-    config: &MemoryConfig,
-    arguments: &Value,
+async fn call_code_ast_outline_tool(
+    config: MemoryConfig,
+    arguments: Value,
 ) -> Result<Value, MemoryError> {
-    let documents = ast_documents(config, arguments)?;
-    Ok(json!({
-        "documents": documents.iter().map(|document| json!({
-            "path": document.display,
-            "language": document.summary.source.language.id(),
-            "contentSha256": document.summary.source.sha256,
-            "parserVersion": parser_version_string(&document.summary),
-            "queryPackVersion": document.summary.versions.query_pack,
-            "symbols": document.summary.symbols.iter().take(ast_limit(config, arguments)).map(|symbol| json!({
-                "kind": symbol_kind_id(&symbol.kind),
-                "name": symbol.name,
-                "span": span_json(&symbol.span),
-                "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
-                "parserVersion": symbol.parser_version,
-                "queryPackVersion": symbol.query_pack_version
+    ast_mcp_tool_blocking("code.ast.outline", move || {
+        let documents = ast_documents(&config, &arguments)?;
+        Ok(json!({
+            "documents": documents.iter().map(|document| json!({
+                "path": document.display,
+                "language": document.summary.source.language.id(),
+                "contentSha256": document.summary.source.sha256,
+                "parserVersion": parser_version_string(&document.summary),
+                "queryPackVersion": document.summary.versions.query_pack,
+                "symbols": document.summary.symbols.iter().take(ast_limit(&config, &arguments)).map(|symbol| json!({
+                    "kind": symbol_kind_id(&symbol.kind),
+                    "name": symbol.name,
+                    "span": span_json(&symbol.span),
+                    "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
+                    "parserVersion": symbol.parser_version,
+                    "queryPackVersion": symbol.query_pack_version
+                })).collect::<Vec<_>>(),
+                "diagnostics": diagnostics_json(&document.summary)
             })).collect::<Vec<_>>(),
-            "diagnostics": diagnostics_json(&document.summary)
-        })).collect::<Vec<_>>(),
-        "trace": ast_trace_json(config, &documents, false)
-    }))
+            "trace": ast_trace_json(&config, &documents, false)
+        }))
+    })
+    .await
 }
 
-fn call_code_ast_symbols_tool(
-    config: &MemoryConfig,
-    arguments: &Value,
+async fn call_code_ast_symbols_tool(
+    config: MemoryConfig,
+    arguments: Value,
 ) -> Result<Value, MemoryError> {
-    let query = optional_string_arg(arguments, "query").map(|value| value.to_ascii_lowercase());
-    let kinds = normalized_string_set_args(arguments, &["kinds"]);
-    let limit = ast_limit(config, arguments);
-    let mut symbols = Vec::new();
-    for document in ast_documents(config, arguments)? {
-        for symbol in document.summary.symbols.iter().filter(|symbol| {
-            query
-                .as_ref()
-                .is_none_or(|query| symbol.name.to_ascii_lowercase().contains(query))
-                && (kinds.is_empty() || kinds.contains(symbol_kind_id(&symbol.kind)))
-        }) {
+    ast_mcp_tool_blocking("code.ast.symbols", move || {
+        let query =
+            optional_string_arg(&arguments, "query").map(|value| value.to_ascii_lowercase());
+        let kinds = normalized_string_set_args(&arguments, &["kinds"]);
+        let limit = ast_limit(&config, &arguments);
+        let mut symbols = Vec::new();
+        for document in ast_documents(&config, &arguments)? {
+            for symbol in document.summary.symbols.iter().filter(|symbol| {
+                query
+                    .as_ref()
+                    .is_none_or(|query| symbol.name.to_ascii_lowercase().contains(query))
+                    && (kinds.is_empty() || kinds.contains(symbol_kind_id(&symbol.kind)))
+            }) {
+                if symbols.len() >= limit {
+                    break;
+                }
+                symbols.push(json!({
+                    "id": format!("{}:{}:{}", document.display, symbol.name, symbol.rendered_span),
+                    "kind": symbol_kind_id(&symbol.kind),
+                    "name": symbol.name,
+                    "path": document.display,
+                    "span": span_json(&symbol.span),
+                    "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
+                    "source": source_json(&document.summary)
+                }));
+            }
             if symbols.len() >= limit {
                 break;
             }
-            symbols.push(json!({
-                "id": format!("{}:{}:{}", document.display, symbol.name, symbol.rendered_span),
-                "kind": symbol_kind_id(&symbol.kind),
-                "name": symbol.name,
-                "path": document.display,
-                "span": span_json(&symbol.span),
-                "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
-                "source": source_json(&document.summary)
-            }));
         }
-        if symbols.len() >= limit {
-            break;
-        }
-    }
-    Ok(json!({ "symbols": symbols, "limit": limit }))
+        Ok(json!({ "symbols": symbols, "limit": limit }))
+    })
+    .await
 }
 
-fn call_code_ast_references_tool(
-    config: &MemoryConfig,
-    arguments: &Value,
+async fn call_code_ast_references_tool(
+    config: MemoryConfig,
+    arguments: Value,
 ) -> Result<Value, MemoryError> {
-    let symbol = required_string_arg(arguments, "symbol")?;
-    let limit = ast_limit(config, arguments);
-    let mut references = Vec::new();
-    for document in ast_documents(config, arguments)? {
-        for capture in document
-            .summary
-            .captures
-            .iter()
-            .filter(|capture| capture.capture_name.starts_with("reference."))
-            .filter(|capture| capture.text.contains(&symbol))
-        {
+    ast_mcp_tool_blocking("code.ast.references", move || {
+        let symbol = required_string_arg(&arguments, "symbol")?;
+        let limit = ast_limit(&config, &arguments);
+        let mut references = Vec::new();
+        for document in ast_documents(&config, &arguments)? {
+            for capture in document
+                .summary
+                .captures
+                .iter()
+                .filter(|capture| capture.capture_name.starts_with("reference."))
+                .filter(|capture| capture.text.contains(&symbol))
+            {
+                if references.len() >= limit {
+                    break;
+                }
+                references.push(json!({
+                    "kind": capture.capture_name,
+                    "path": document.display,
+                    "span": span_json(&capture.span),
+                    "snippet": truncate_capture(&capture.text, config.code_intel.ast.max_capture_bytes).0,
+                    "source": source_json(&document.summary)
+                }));
+            }
             if references.len() >= limit {
                 break;
             }
-            references.push(json!({
-                "kind": capture.capture_name,
-                "path": document.display,
-                "span": span_json(&capture.span),
-                "snippet": truncate_capture(&capture.text, config.code_intel.ast.max_capture_bytes).0,
-                "source": source_json(&document.summary)
-            }));
         }
-        if references.len() >= limit {
-            break;
-        }
-    }
-    Ok(json!({ "references": references, "confidence": "syntactic", "limit": limit }))
+        Ok(json!({ "references": references, "confidence": "syntactic", "limit": limit }))
+    })
+    .await
 }
 
-fn call_code_ast_query_tool(
-    config: &MemoryConfig,
-    arguments: &Value,
+async fn call_code_ast_query_tool(
+    config: MemoryConfig,
+    arguments: Value,
 ) -> Result<Value, MemoryError> {
-    let language = required_string_arg(arguments, "language")?.to_ascii_lowercase();
-    let language = SourceLanguage::from_id(&language).ok_or_else(|| {
-        MemoryError::InvalidInput(format!("unsupported AST query language `{language}`"))
-    })?;
-    if !language.supports_ast_queries() {
-        return Err(MemoryError::InvalidInput(format!(
-            "language `{}` does not support Tree-sitter ad hoc queries",
-            language.id()
-        )));
-    }
-    let query = required_string_arg(arguments, "query")?;
-    let limit = ast_limit(config, arguments);
-    let documents = ast_documents(config, arguments)?;
-    let mut matches = Vec::new();
-    for document in documents
-        .iter()
-        .filter(|document| document.summary.source.language == language)
-    {
-        let query_matches = run_ad_hoc_query(language, &document.source, &query, limit)
-            .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
-        for query_match in query_matches {
+    ast_mcp_tool_blocking("code.ast.query", move || {
+        let language = required_string_arg(&arguments, "language")?.to_ascii_lowercase();
+        let language = SourceLanguage::from_id(&language).ok_or_else(|| {
+            MemoryError::InvalidInput(format!("unsupported AST query language `{language}`"))
+        })?;
+        if !language.supports_ast_queries() {
+            return Err(MemoryError::InvalidInput(format!(
+                "language `{}` does not support Tree-sitter ad hoc queries",
+                language.id()
+            )));
+        }
+        let query = required_string_arg(&arguments, "query")?;
+        let limit = ast_limit(&config, &arguments);
+        let documents = ast_documents(&config, &arguments)?;
+        let mut matches = Vec::new();
+        for document in documents
+            .iter()
+            .filter(|document| document.summary.source.language == language)
+        {
+            let query_matches = run_ad_hoc_query(language, &document.source, &query, limit)
+                .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
+            for query_match in query_matches {
+                if matches.len() >= limit {
+                    break;
+                }
+                matches.push(json!({
+                    "path": document.display,
+                    "captures": query_match.captures.iter().map(|capture| {
+                        let (text, truncated) = truncate_capture(
+                            &capture.text,
+                            config.code_intel.ast.max_capture_bytes,
+                        );
+                        json!({
+                            "name": capture.capture_name,
+                            "text": text,
+                            "truncated": truncated,
+                            "span": span_json(&capture.span)
+                        })
+                    }).collect::<Vec<_>>(),
+                    "source": source_json(&document.summary)
+                }));
+            }
             if matches.len() >= limit {
                 break;
             }
-            matches.push(json!({
-                "path": document.display,
-                "captures": query_match.captures.iter().map(|capture| {
-                    let (text, truncated) = truncate_capture(
-                        &capture.text,
-                        config.code_intel.ast.max_capture_bytes,
-                    );
-                    json!({
-                        "name": capture.capture_name,
-                        "text": text,
-                        "truncated": truncated,
-                        "span": span_json(&capture.span)
-                    })
-                }).collect::<Vec<_>>(),
-                "source": source_json(&document.summary)
-            }));
         }
-        if matches.len() >= limit {
-            break;
-        }
-    }
-    Ok(json!({
-        "matches": matches,
-        "limit": limit,
-        "trace": ast_trace_json(config, &documents, matches.len() >= limit)
-    }))
+        Ok(json!({
+            "matches": matches,
+            "limit": limit,
+            "trace": ast_trace_json(&config, &documents, matches.len() >= limit)
+        }))
+    })
+    .await
 }
 
 async fn call_code_ast_context_tool(
@@ -2057,23 +2074,35 @@ async fn call_code_ast_context_tool(
     Ok(json!({ "markdown": markdown, "trace": trace }))
 }
 
-fn call_code_ast_diagnostics_tool(
-    config: &MemoryConfig,
-    arguments: &Value,
+async fn call_code_ast_diagnostics_tool(
+    config: MemoryConfig,
+    arguments: Value,
 ) -> Result<Value, MemoryError> {
-    let documents = ast_documents(config, arguments)?;
-    Ok(json!({
-        "diagnostics": documents.iter().flat_map(|document| {
-            document.summary.diagnostics.iter().map(|diagnostic| json!({
-                "path": document.display,
-                "kind": diagnostic_kind_id(&diagnostic.kind),
-                "nodeKind": diagnostic.node_kind,
-                "span": span_json(&diagnostic.span),
-                "source": source_json(&document.summary)
-            }))
-        }).collect::<Vec<_>>(),
-        "trace": ast_trace_json(config, &documents, false)
-    }))
+    ast_mcp_tool_blocking("code.ast.diagnostics", move || {
+        let documents = ast_documents(&config, &arguments)?;
+        Ok(json!({
+            "diagnostics": documents.iter().flat_map(|document| {
+                document.summary.diagnostics.iter().map(|diagnostic| json!({
+                    "path": document.display,
+                    "kind": diagnostic_kind_id(&diagnostic.kind),
+                    "nodeKind": diagnostic.node_kind,
+                    "span": span_json(&diagnostic.span),
+                    "source": source_json(&document.summary)
+                }))
+            }).collect::<Vec<_>>(),
+            "trace": ast_trace_json(&config, &documents, false)
+        }))
+    })
+    .await
+}
+
+async fn ast_mcp_tool_blocking<F>(tool_name: &'static str, task: F) -> Result<Value, MemoryError>
+where
+    F: FnOnce() -> Result<Value, MemoryError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(task).await.map_err(|error| {
+        MemoryError::InvalidInput(format!("{tool_name} analysis task failed: {error}"))
+    })?
 }
 
 fn ast_documents(

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -15,8 +15,11 @@ use tokio::task::JoinHandle;
 
 use crate::{
     opensymphony_code_intel::{
-        AstDiagnosticKind, CaptureRecord, CompositeCodeIntelProvider, PROVIDER_NAME,
-        ParsedDocumentSummary, SourceLanguage, SymbolKind, parse_path,
+        AstDiagnosticKind, CaptureRecord, CompositeCodeIntelProvider,
+        JAVASCRIPT_QUERY_PACK_VERSION, JSX_QUERY_PACK_VERSION, PROVIDER_NAME,
+        PYTHON_QUERY_PACK_VERSION, ParsedDocumentSummary, RUST_QUERY_PACK_VERSION, SourceLanguage,
+        SymbolKind, TREE_SITTER_VERSION, TSX_QUERY_PACK_VERSION, TYPESCRIPT_QUERY_PACK_VERSION,
+        parse_path, run_ad_hoc_query,
     },
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
@@ -45,6 +48,15 @@ use crate::{
 
 const MEMORY_MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
 const REMOTE_MEMORY_TOOL_TIMEOUT: Duration = Duration::from_secs(330);
+const AST_MCP_TOOL_NAMES: &[&str] = &[
+    "code.ast.status",
+    "code.ast.outline",
+    "code.ast.symbols",
+    "code.ast.references",
+    "code.ast.query",
+    "code.ast.context",
+    "code.ast.diagnostics",
+];
 
 #[derive(Debug, Args)]
 pub struct MemoryArgs {
@@ -1522,9 +1534,11 @@ async fn memory_server_mcp(
     headers: axum::http::HeaderMap,
     axum::Json(request): axum::Json<MemoryMcpRequest>,
 ) -> (axum::http::StatusCode, axum::Json<Value>) {
-    if let Err(response) =
-        authorize_memory_request(&headers, &state.auth, required_access_for_request(&request))
-    {
+    if let Err(response) = authorize_memory_request(
+        &headers,
+        &state.auth,
+        required_access_for_request(&request, &state.auth),
+    ) {
         return response;
     }
     let id = request.id.clone();
@@ -1535,7 +1549,7 @@ async fn memory_server_mcp(
             "capabilities": { "tools": {} }
         })),
         "tools/list" => Ok(json!({
-            "tools": memory_tool_descriptors()
+            "tools": memory_tool_descriptors(&state.config)
         })),
         "tools/call" => match tokio::time::timeout(
             MEMORY_MCP_TOOL_TIMEOUT,
@@ -1570,13 +1584,16 @@ async fn memory_server_mcp(
     }
 }
 
-fn required_access_for_request(request: &MemoryMcpRequest) -> MemoryServerAccess {
+fn required_access_for_request(
+    request: &MemoryMcpRequest,
+    auth: &MemoryServerAuth,
+) -> MemoryServerAccess {
     if request.method == "tools/call"
         && request
             .params
             .get("name")
             .and_then(Value::as_str)
-            .is_some_and(is_admin_memory_tool)
+            .is_some_and(|name| required_access_for_tool(name, auth) == MemoryServerAccess::Admin)
     {
         MemoryServerAccess::Admin
     } else {
@@ -1584,8 +1601,8 @@ fn required_access_for_request(request: &MemoryMcpRequest) -> MemoryServerAccess
     }
 }
 
-fn memory_tool_descriptors() -> Vec<Value> {
-    vec![
+fn memory_tool_descriptors(config: &MemoryConfig) -> Vec<Value> {
+    let mut tools = vec![
         json!({ "name": "memory.context", "description": "Build a pre-implementation memory context bundle", "access": "read" }),
         json!({ "name": "memory.search", "description": "Search captured issue memory", "access": "read" }),
         json!({ "name": "memory.related", "description": "Find related issue memory by issue, area, or paths", "access": "read" }),
@@ -1599,7 +1616,13 @@ fn memory_tool_descriptors() -> Vec<Value> {
         json!({ "name": "memory.export_okf", "description": "Export an OKF memory bundle", "access": "admin" }),
         json!({ "name": "memory.import_okf", "description": "Import an OKF memory bundle", "access": "admin" }),
         json!({ "name": "memory.ingest_code_intel", "description": "Generate code-intelligence artifacts for future ingestion", "access": "admin" }),
-    ]
+    ];
+    if ast_tools_enabled(config) {
+        tools.extend(AST_MCP_TOOL_NAMES.iter().map(|name| {
+            json!({ "name": name, "description": "Read-only Tree-sitter AST code intelligence", "access": "read" })
+        }));
+    }
+    tools
 }
 
 fn is_admin_memory_tool(name: &str) -> bool {
@@ -1613,6 +1636,20 @@ fn is_admin_memory_tool(name: &str) -> bool {
             | "memory.import_okf"
             | "memory.ingest_code_intel"
     )
+}
+
+fn required_access_for_tool(name: &str, auth: &MemoryServerAuth) -> MemoryServerAccess {
+    if is_admin_memory_tool(name)
+        || (name == "code.ast.query" && non_empty_str(auth.admin_token.as_deref()).is_some())
+    {
+        MemoryServerAccess::Admin
+    } else {
+        MemoryServerAccess::Read
+    }
+}
+
+fn ast_tools_enabled(config: &MemoryConfig) -> bool {
+    config.code_intel.enabled && config.code_intel.ast.enabled
 }
 
 fn authorize_memory_request(
@@ -1705,6 +1742,11 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
         .and_then(Value::as_str)
         .ok_or_else(|| MemoryError::InvalidInput("tools/call requires params.name".to_string()))?;
     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+    if AST_MCP_TOOL_NAMES.contains(&name) && !ast_tools_enabled(config) {
+        return Err(MemoryError::InvalidInput(
+            "AST code-intelligence tools are disabled".to_string(),
+        ));
+    }
     match name {
         "memory.context" => {
             let issue = required_string_arg(&arguments, "issue")?;
@@ -1800,6 +1842,13 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
                 })).collect::<Vec<_>>()
             }))
         }
+        "code.ast.status" => call_code_ast_status_tool(config),
+        "code.ast.outline" => call_code_ast_outline_tool(config, &arguments),
+        "code.ast.symbols" => call_code_ast_symbols_tool(config, &arguments),
+        "code.ast.references" => call_code_ast_references_tool(config, &arguments),
+        "code.ast.query" => call_code_ast_query_tool(config, &arguments),
+        "code.ast.context" => call_code_ast_context_tool(config, &arguments).await,
+        "code.ast.diagnostics" => call_code_ast_diagnostics_tool(config, &arguments),
         "memory.capture" => call_memory_capture_tool(config, &arguments).await,
         "memory.sync_docs" => call_memory_sync_docs_tool(config, &arguments),
         "memory.lint" => call_memory_lint_tool(config, &arguments),
@@ -1811,6 +1860,459 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
             "unsupported memory tool `{other}`"
         ))),
     }
+}
+
+struct AstDocument {
+    display: String,
+    source: String,
+    summary: ParsedDocumentSummary,
+}
+
+fn call_code_ast_status_tool(config: &MemoryConfig) -> Result<Value, MemoryError> {
+    let _ = resolve_code_intel_repo(config, None)?;
+    Ok(json!({
+        "provider": "tree-sitter-ast",
+        "available": true,
+        "languages": ast_language_ids(),
+        "parserVersion": TREE_SITTER_VERSION,
+        "queryPackVersions": ast_query_pack_versions(),
+        "limits": ast_limits_json(config)
+    }))
+}
+
+fn call_code_ast_outline_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let documents = ast_documents(config, arguments)?;
+    Ok(json!({
+        "documents": documents.iter().map(|document| json!({
+            "path": document.display,
+            "language": document.summary.source.language.id(),
+            "contentSha256": document.summary.source.sha256,
+            "parserVersion": parser_version_string(&document.summary),
+            "queryPackVersion": document.summary.versions.query_pack,
+            "symbols": document.summary.symbols.iter().take(ast_limit(config, arguments)).map(|symbol| json!({
+                "kind": symbol_kind_id(&symbol.kind),
+                "name": symbol.name,
+                "span": span_json(&symbol.span),
+                "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
+                "parserVersion": symbol.parser_version,
+                "queryPackVersion": symbol.query_pack_version
+            })).collect::<Vec<_>>(),
+            "diagnostics": diagnostics_json(&document.summary)
+        })).collect::<Vec<_>>(),
+        "trace": ast_trace_json(config, &documents, false)
+    }))
+}
+
+fn call_code_ast_symbols_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let query = optional_string_arg(arguments, "query").map(|value| value.to_ascii_lowercase());
+    let kinds = normalized_string_set_args(arguments, &["kinds"]);
+    let limit = ast_limit(config, arguments);
+    let mut symbols = Vec::new();
+    for document in ast_documents(config, arguments)? {
+        for symbol in document.summary.symbols.iter().filter(|symbol| {
+            query
+                .as_ref()
+                .is_none_or(|query| symbol.name.to_ascii_lowercase().contains(query))
+                && (kinds.is_empty() || kinds.contains(symbol_kind_id(&symbol.kind)))
+        }) {
+            if symbols.len() >= limit {
+                break;
+            }
+            symbols.push(json!({
+                "id": format!("{}:{}:{}", document.display, symbol.name, symbol.rendered_span),
+                "kind": symbol_kind_id(&symbol.kind),
+                "name": symbol.name,
+                "path": document.display,
+                "span": span_json(&symbol.span),
+                "selectionSpan": line_span_json(symbol.span.start_line, symbol.span.end_line),
+                "source": source_json(&document.summary)
+            }));
+        }
+        if symbols.len() >= limit {
+            break;
+        }
+    }
+    Ok(json!({ "symbols": symbols, "limit": limit }))
+}
+
+fn call_code_ast_references_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let symbol = required_string_arg(arguments, "symbol")?;
+    let limit = ast_limit(config, arguments);
+    let mut references = Vec::new();
+    for document in ast_documents(config, arguments)? {
+        for capture in document
+            .summary
+            .captures
+            .iter()
+            .filter(|capture| capture.capture_name.starts_with("reference."))
+            .filter(|capture| capture.text.contains(&symbol))
+        {
+            if references.len() >= limit {
+                break;
+            }
+            references.push(json!({
+                "kind": capture.capture_name,
+                "path": document.display,
+                "span": span_json(&capture.span),
+                "snippet": truncate_capture(&capture.text, config.code_intel.ast.max_capture_bytes).0,
+                "source": source_json(&document.summary)
+            }));
+        }
+        if references.len() >= limit {
+            break;
+        }
+    }
+    Ok(json!({ "references": references, "confidence": "syntactic", "limit": limit }))
+}
+
+fn call_code_ast_query_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let language = required_string_arg(arguments, "language")?.to_ascii_lowercase();
+    let language = SourceLanguage::from_id(&language).ok_or_else(|| {
+        MemoryError::InvalidInput(format!("unsupported AST query language `{language}`"))
+    })?;
+    if !language.supports_ast_queries() {
+        return Err(MemoryError::InvalidInput(format!(
+            "language `{}` does not support Tree-sitter ad hoc queries",
+            language.id()
+        )));
+    }
+    let query = required_string_arg(arguments, "query")?;
+    let limit = ast_limit(config, arguments);
+    let documents = ast_documents(config, arguments)?;
+    let mut matches = Vec::new();
+    for document in documents
+        .iter()
+        .filter(|document| document.summary.source.language == language)
+    {
+        let query_matches = run_ad_hoc_query(language, &document.source, &query, limit)
+            .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
+        for query_match in query_matches {
+            if matches.len() >= limit {
+                break;
+            }
+            matches.push(json!({
+                "path": document.display,
+                "captures": query_match.captures.iter().map(|capture| {
+                    let (text, truncated) = truncate_capture(
+                        &capture.text,
+                        config.code_intel.ast.max_capture_bytes,
+                    );
+                    json!({
+                        "name": capture.capture_name,
+                        "text": text,
+                        "truncated": truncated,
+                        "span": span_json(&capture.span)
+                    })
+                }).collect::<Vec<_>>(),
+                "source": source_json(&document.summary)
+            }));
+        }
+        if matches.len() >= limit {
+            break;
+        }
+    }
+    Ok(json!({
+        "matches": matches,
+        "limit": limit,
+        "trace": ast_trace_json(config, &documents, matches.len() >= limit)
+    }))
+}
+
+async fn call_code_ast_context_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let scope = scope_filter_from_mcp(arguments, true);
+    let paths = ast_path_args(arguments)?;
+    let limit = ast_limit(config, arguments);
+    let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
+    let scope_refs = scope_refs_for_context(&scope, &paths);
+    let artifacts = code_intel_artifacts_blocking(repo_root, paths, scope_refs, limit).await?;
+    let trace = artifacts
+        .iter()
+        .filter(|artifact| artifact.kind == "trace")
+        .flat_map(|artifact| artifact.summary.lines().map(str::to_string))
+        .collect::<Vec<_>>();
+    let mut markdown = String::from("## Structural Context\n\n");
+    append_code_intel_artifacts(config, &mut markdown, artifacts);
+    Ok(json!({ "markdown": markdown, "trace": trace }))
+}
+
+fn call_code_ast_diagnostics_tool(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Value, MemoryError> {
+    let documents = ast_documents(config, arguments)?;
+    Ok(json!({
+        "diagnostics": documents.iter().flat_map(|document| {
+            document.summary.diagnostics.iter().map(|diagnostic| json!({
+                "path": document.display,
+                "kind": diagnostic_kind_id(&diagnostic.kind),
+                "nodeKind": diagnostic.node_kind,
+                "span": span_json(&diagnostic.span),
+                "source": source_json(&document.summary)
+            }))
+        }).collect::<Vec<_>>(),
+        "trace": ast_trace_json(config, &documents, false)
+    }))
+}
+
+fn ast_documents(
+    config: &MemoryConfig,
+    arguments: &Value,
+) -> Result<Vec<AstDocument>, MemoryError> {
+    let scope = scope_filter_from_mcp(arguments, false);
+    let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
+    let paths = ast_path_args(arguments)?;
+    let mut files = Vec::new();
+    for path in paths {
+        collect_ast_files(
+            &repo_root,
+            &path,
+            config.code_intel.ast.max_files_per_request,
+            &mut files,
+        )?;
+    }
+    let mut documents = Vec::new();
+    for path in files {
+        let relative = path
+            .strip_prefix(&repo_root)
+            .map_err(|_| MemoryError::PathOutsideRepo {
+                path: path.clone(),
+                repo_root: repo_root.clone(),
+            })?
+            .to_path_buf();
+        if crate::opensymphony_code_intel::detect_language(&relative).is_none() {
+            continue;
+        }
+        let metadata = fs::metadata(&path).map_err(|source| MemoryError::ReadFile {
+            path: path.clone(),
+            source,
+        })?;
+        if metadata.len() > config.code_intel.ast.max_file_bytes {
+            return Err(MemoryError::InvalidInput(format!(
+                "{} exceeds AST max_file_bytes {}",
+                relative.display(),
+                config.code_intel.ast.max_file_bytes
+            )));
+        }
+        let source = fs::read_to_string(&path).map_err(|source| MemoryError::ReadFile {
+            path: path.clone(),
+            source,
+        })?;
+        let summary = parse_path(&relative, &source)
+            .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
+        documents.push(AstDocument {
+            display: relative.display().to_string(),
+            source,
+            summary,
+        });
+    }
+    Ok(documents)
+}
+
+fn ast_path_args(arguments: &Value) -> Result<Vec<PathBuf>, MemoryError> {
+    let paths = string_list_arg(arguments, "paths")
+        .into_iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    if paths.is_empty() {
+        return Err(MemoryError::InvalidInput(
+            "code.ast tools require at least one path".to_string(),
+        ));
+    }
+    Ok(paths)
+}
+
+fn collect_ast_files(
+    repo_root: &Path,
+    path: &Path,
+    max_files: usize,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), MemoryError> {
+    if files.len() >= max_files {
+        return Ok(());
+    }
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo_root.join(path)
+    };
+    let resolved = candidate
+        .canonicalize()
+        .map_err(|source| MemoryError::ResolvePath {
+            path: candidate.clone(),
+            source,
+        })?;
+    if !resolved.starts_with(repo_root) {
+        return Err(MemoryError::PathOutsideRepo {
+            path: resolved,
+            repo_root: repo_root.to_path_buf(),
+        });
+    }
+    if resolved.is_file() {
+        files.push(resolved);
+        return Ok(());
+    }
+    if !resolved.is_dir() {
+        return Ok(());
+    }
+    let mut entries = fs::read_dir(&resolved)
+        .map_err(|source| MemoryError::ReadFile {
+            path: resolved.clone(),
+            source,
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| MemoryError::ReadFile {
+            path: resolved.clone(),
+            source,
+        })?;
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        if files.len() >= max_files {
+            break;
+        }
+        let file_type = entry.file_type().map_err(|source| MemoryError::ReadFile {
+            path: entry.path(),
+            source,
+        })?;
+        if file_type.is_dir() {
+            collect_ast_files(repo_root, &entry.path(), max_files, files)?;
+        } else if file_type.is_file() {
+            files.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+fn ast_limit(config: &MemoryConfig, arguments: &Value) -> usize {
+    usize_arg(arguments, "limit", 50).min(config.code_intel.ast.max_matches_per_file)
+}
+
+fn ast_language_ids() -> Vec<&'static str> {
+    vec!["rust", "typescript", "tsx", "javascript", "jsx", "python"]
+}
+
+fn ast_query_pack_versions() -> Value {
+    json!({
+        "rust": RUST_QUERY_PACK_VERSION,
+        "typescript": TYPESCRIPT_QUERY_PACK_VERSION,
+        "tsx": TSX_QUERY_PACK_VERSION,
+        "javascript": JAVASCRIPT_QUERY_PACK_VERSION,
+        "jsx": JSX_QUERY_PACK_VERSION,
+        "python": PYTHON_QUERY_PACK_VERSION
+    })
+}
+
+fn ast_limits_json(config: &MemoryConfig) -> Value {
+    json!({
+        "maxFileBytes": config.code_intel.ast.max_file_bytes,
+        "maxFilesPerRequest": config.code_intel.ast.max_files_per_request,
+        "maxMatchesPerFile": config.code_intel.ast.max_matches_per_file,
+        "maxCaptureBytes": config.code_intel.ast.max_capture_bytes
+    })
+}
+
+fn ast_trace_json(
+    config: &MemoryConfig,
+    documents: &[AstDocument],
+    truncated: bool,
+) -> Vec<String> {
+    let mut trace = vec![
+        format!("parsed {} file(s)", documents.len()),
+        format!(
+            "max files per request {}",
+            config.code_intel.ast.max_files_per_request
+        ),
+        format!(
+            "max matches per file {}",
+            config.code_intel.ast.max_matches_per_file
+        ),
+    ];
+    if truncated {
+        trace.push("truncated by limit".to_string());
+    }
+    trace.extend(documents.iter().map(|document| {
+        format!(
+            "{} lines {}-{} parser {} query-pack {} content sha256:{}",
+            document.display,
+            1,
+            document.source.lines().count().max(1),
+            parser_version_string(&document.summary),
+            document.summary.versions.query_pack,
+            document.summary.source.sha256
+        )
+    }));
+    trace
+}
+
+fn source_json(summary: &ParsedDocumentSummary) -> Value {
+    json!({
+        "contentSha256": summary.source.sha256,
+        "parserVersion": parser_version_string(summary),
+        "queryPackVersion": summary.versions.query_pack
+    })
+}
+
+fn parser_version_string(summary: &ParsedDocumentSummary) -> String {
+    format!(
+        "{}:{}",
+        summary.versions.grammar, summary.versions.tree_sitter
+    )
+}
+
+fn diagnostics_json(summary: &ParsedDocumentSummary) -> Vec<Value> {
+    summary
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            json!({
+                "kind": diagnostic_kind_id(&diagnostic.kind),
+                "nodeKind": diagnostic.node_kind,
+                "span": span_json(&diagnostic.span)
+            })
+        })
+        .collect()
+}
+
+fn span_json(span: &crate::opensymphony_code_intel::SourceSpan) -> Value {
+    json!({
+        "startLine": span.start_line,
+        "startColumn": span.start_column,
+        "endLine": span.end_line,
+        "endColumn": span.end_column,
+        "startByte": span.start_byte,
+        "endByte": span.end_byte
+    })
+}
+
+fn line_span_json(start_line: usize, end_line: usize) -> Value {
+    json!({ "startLine": start_line, "endLine": end_line })
+}
+
+fn truncate_capture(text: &str, max_bytes: usize) -> (String, bool) {
+    if text.len() <= max_bytes {
+        return (text.to_string(), false);
+    }
+    let end = text
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    (text[..end].to_string(), true)
 }
 
 async fn call_memory_capture_tool(
@@ -2469,6 +2971,13 @@ fn symbol_kind_id(kind: &SymbolKind) -> &'static str {
         SymbolKind::Constant => "constant",
         SymbolKind::Test => "test",
         SymbolKind::Document => "document",
+    }
+}
+
+fn diagnostic_kind_id(kind: &AstDiagnosticKind) -> &'static str {
+    match kind {
+        AstDiagnosticKind::Error => "error",
+        AstDiagnosticKind::Missing => "missing",
     }
 }
 
@@ -4025,8 +4534,10 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn mcp_tool_list_exposes_context_and_admin_tools_without_code_context() {
-        let names = memory_tool_descriptors()
+    fn mcp_tool_list_exposes_context_admin_and_ast_tools_when_enabled() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let names = memory_tool_descriptors(&config)
             .into_iter()
             .filter_map(|tool| {
                 tool.get("name")
@@ -4041,8 +4552,36 @@ mod tests {
         assert!(names.contains(&"memory.reindex".to_string()));
         assert!(names.contains(&"memory.export_okf".to_string()));
         assert!(names.contains(&"memory.import_okf".to_string()));
-        assert!(!names.iter().any(|name| name.contains("code_context")));
-        assert!(!names.iter().any(|name| name.contains("code-context")));
+        assert!(names.contains(&"code.ast.status".to_string()));
+        assert!(names.contains(&"code.ast.outline".to_string()));
+        assert!(names.contains(&"code.ast.symbols".to_string()));
+        assert!(names.contains(&"code.ast.references".to_string()));
+        assert!(names.contains(&"code.ast.query".to_string()));
+        assert!(names.contains(&"code.ast.context".to_string()));
+        assert!(names.contains(&"code.ast.diagnostics".to_string()));
+    }
+
+    #[test]
+    fn mcp_tool_list_hides_ast_tools_when_code_intel_disabled() {
+        let repo = TempDir::new().expect("temp repo");
+        let config_path = repo.path().join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  enabled: false\n  ast:\n    enabled: true\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(repo.path(), Some(&config_path)).expect("memory config");
+        let names = memory_tool_descriptors(&config)
+            .into_iter()
+            .filter_map(|tool| {
+                tool.get("name")
+                    .and_then(|name| name.as_str())
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"memory.context".to_string()));
+        assert!(!names.iter().any(|name| name.starts_with("code.ast.")));
     }
 
     #[test]
@@ -4072,19 +4611,51 @@ mod tests {
         };
 
         assert_eq!(
-            required_access_for_request(&read_request),
+            required_access_for_request(&read_request, &MemoryServerAuth::default()),
             MemoryServerAccess::Read
         );
         assert_eq!(
-            required_access_for_request(&admin_request),
+            required_access_for_request(&admin_request, &MemoryServerAuth::default()),
             MemoryServerAccess::Admin
         );
         assert_eq!(
-            required_access_for_request(&okf_export_request),
+            required_access_for_request(&okf_export_request, &MemoryServerAuth::default()),
             MemoryServerAccess::Admin
         );
         assert_eq!(
-            required_access_for_request(&persistent_code_ingest_request),
+            required_access_for_request(
+                &persistent_code_ingest_request,
+                &MemoryServerAuth::default()
+            ),
+            MemoryServerAccess::Admin
+        );
+
+        let ast_outline_request = MemoryMcpRequest {
+            id: json!("test"),
+            method: "tools/call".to_string(),
+            params: json!({ "name": "code.ast.outline" }),
+        };
+        let ast_query_request = MemoryMcpRequest {
+            id: json!("test"),
+            method: "tools/call".to_string(),
+            params: json!({ "name": "code.ast.query" }),
+        };
+        assert_eq!(
+            required_access_for_request(&ast_outline_request, &MemoryServerAuth::default()),
+            MemoryServerAccess::Read
+        );
+        assert_eq!(
+            required_access_for_request(&ast_query_request, &MemoryServerAuth::default()),
+            MemoryServerAccess::Read
+        );
+        assert_eq!(
+            required_access_for_request(
+                &ast_query_request,
+                &MemoryServerAuth {
+                    read_token: Some("read-token".to_string()),
+                    admin_token: Some("admin-token".to_string()),
+                },
+            ),
             MemoryServerAccess::Admin
         );
     }
@@ -4688,6 +5259,200 @@ Public memory concept.
         assert!(text.contains("ast-summary: src/lib.rs"));
         assert!(text.contains("function `answer`"));
         assert!(text.contains("fallback: CodebaseAnalyzer not used"));
+    }
+
+    #[tokio::test]
+    async fn code_ast_outline_symbols_and_query_return_source_citations() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "pub fn answer() -> u8 { helper() }\nfn helper() -> u8 { 42 }\n",
+        )
+        .expect("source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let outline = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.outline",
+                "arguments": { "paths": ["src/lib.rs"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("outline");
+        assert_eq!(outline["documents"][0]["path"], "src/lib.rs");
+        assert_eq!(outline["documents"][0]["language"], "rust");
+        assert!(outline["documents"][0]["contentSha256"].as_str().is_some());
+        assert!(
+            outline["documents"][0]["parserVersion"]
+                .as_str()
+                .expect("parser version")
+                .contains("tree-sitter-rust")
+        );
+        assert!(
+            outline["documents"][0]["queryPackVersion"]
+                .as_str()
+                .expect("query pack")
+                .starts_with("rust-query-pack")
+        );
+        assert_eq!(
+            outline["documents"][0]["symbols"][0]["span"]["startLine"],
+            1
+        );
+
+        let symbols = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": {
+                    "paths": ["src/lib.rs"],
+                    "query": "answer",
+                    "kinds": ["function"],
+                    "limit": 10
+                }
+            }),
+        )
+        .await
+        .expect("symbols");
+        assert_eq!(symbols["symbols"][0]["name"], "answer");
+        assert_eq!(
+            symbols["symbols"][0]["source"]["queryPackVersion"],
+            "rust-query-pack-v2"
+        );
+
+        let query = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.query",
+                "arguments": {
+                    "paths": ["src/lib.rs"],
+                    "language": "rust",
+                    "query": "(function_item name: (identifier) @definition.function)",
+                    "limit": 1
+                }
+            }),
+        )
+        .await
+        .expect("query");
+        assert_eq!(query["matches"].as_array().expect("matches").len(), 1);
+        assert_eq!(query["matches"][0]["captures"][0]["text"], "answer");
+        assert_eq!(query["matches"][0]["captures"][0]["span"]["startLine"], 1);
+        assert!(
+            query["matches"][0]["source"]["contentSha256"]
+                .as_str()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn code_ast_tools_enforce_configured_match_limits() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "pub fn one() -> u8 { 1 }\npub fn two() -> u8 { 2 }\n",
+        )
+        .expect("source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_matches_per_file: 1\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let symbols = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": { "paths": ["src/lib.rs"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("symbols");
+
+        assert_eq!(symbols["symbols"].as_array().expect("symbols").len(), 1);
+        assert_eq!(symbols["limit"], 1);
+    }
+
+    #[tokio::test]
+    async fn code_ast_query_truncates_large_captures() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_capture_bytes: 3\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let query = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.query",
+                "arguments": {
+                    "paths": ["src/lib.rs"],
+                    "language": "rust",
+                    "query": "(function_item name: (identifier) @definition.function)"
+                }
+            }),
+        )
+        .await
+        .expect("query");
+
+        assert_eq!(query["matches"][0]["captures"][0]["text"], "ans");
+        assert_eq!(query["matches"][0]["captures"][0]["truncated"], true);
+    }
+
+    #[tokio::test]
+    async fn code_ast_tools_reject_paths_outside_repo() {
+        let repo = TempDir::new().expect("temp repo");
+        let outside = TempDir::new().expect("outside repo");
+        let outside_path = outside.path().join("lib.rs");
+        std::fs::write(&outside_path, "pub fn outside() {}\n").expect("outside source");
+        let config = MemoryConfig::load(repo.path(), None).expect("config");
+
+        let error = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.outline",
+                "arguments": { "paths": [outside_path] }
+            }),
+        )
+        .await
+        .expect_err("outside path should fail");
+
+        assert!(matches!(error, MemoryError::PathOutsideRepo { .. }));
+    }
+
+    #[tokio::test]
+    async fn code_ast_tool_calls_fail_when_disabled() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(&config_path, "code_intel:\n  ast:\n    enabled: false\n").expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let error = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.outline",
+                "arguments": { "paths": ["src/lib.rs"] }
+            }),
+        )
+        .await
+        .expect_err("disabled AST tools should fail");
+
+        assert!(matches!(error, MemoryError::InvalidInput(message)
+            if message.contains("AST code-intelligence tools are disabled")));
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     fs,
     io::{ErrorKind, Read},
     path::{Component, Path, PathBuf},
@@ -462,6 +462,17 @@ impl AstCodeIntelProvider {
         scope_refs: &[KnowledgeScope],
         limit: usize,
     ) -> Result<AstCodeIntelReport, MemoryError> {
+        let symbol_kinds = BTreeSet::new();
+        self.code_context_report_with_symbols(paths, scope_refs, limit, &symbol_kinds)
+    }
+
+    fn code_context_report_with_symbols(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+        symbol_kinds: &BTreeSet<String>,
+    ) -> Result<AstCodeIntelReport, MemoryError> {
         let repo_root = self.canonical_root()?;
         let commit_sha = git_commit_sha(&repo_root);
         let mut report = AstCodeIntelReport::default();
@@ -528,6 +539,7 @@ impl AstCodeIntelProvider {
                 scope_refs,
                 commit_sha.clone(),
                 remaining_symbols,
+                symbol_kinds,
             );
             remaining_symbols = remaining_symbols.saturating_sub(used_symbols);
             report.used_symbols += used_symbols;
@@ -713,6 +725,44 @@ impl CompositeCodeIntelProvider {
             fallback: CodebaseAnalyzer::new(root),
         }
     }
+
+    pub fn code_context_with_symbol_kinds(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+        symbol_kinds: &BTreeSet<String>,
+    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+        let mut report =
+            self.ast
+                .code_context_report_with_symbols(paths, scope_refs, limit, symbol_kinds)?;
+        let use_fallback = !report.fallback_reasons.is_empty();
+        let mut artifacts = std::mem::take(&mut report.artifacts);
+        let fallback_paths = if paths.is_empty() {
+            paths
+        } else {
+            &report.fallback_paths
+        };
+        let has_fallback_target = paths.is_empty() || !fallback_paths.is_empty();
+        let fallback_limit = limit.saturating_sub(report.used_symbols);
+        let mut fallback_used = false;
+
+        if use_fallback && has_fallback_target {
+            artifacts.extend(self.fallback.code_context(
+                fallback_paths,
+                scope_refs,
+                fallback_limit,
+            )?);
+            fallback_used = true;
+        }
+        let trace = report.trace_artifact(
+            scope_refs,
+            "composite-code-intel",
+            report.composite_fallback(fallback_used),
+        );
+        artifacts.push(trace);
+        Ok(artifacts)
+    }
 }
 
 impl CodeIntelIndex for CompositeCodeIntelProvider {
@@ -817,6 +867,7 @@ fn ast_artifacts_for_summary(
     scope_refs: &[KnowledgeScope],
     commit_sha: Option<String>,
     symbol_limit: usize,
+    symbol_kinds: &BTreeSet<String>,
 ) -> (Vec<CodeIntelArtifact>, usize) {
     let diagnostic_summary = diagnostics_summary(&summary.diagnostics);
     let mut artifacts = vec![CodeIntelArtifact {
@@ -844,11 +895,20 @@ fn ast_artifacts_for_summary(
 
     if !summary.symbols.is_empty() && symbol_limit > 0 {
         let max_symbols = symbol_limit;
-        let used_symbols = summary.symbols.len().min(max_symbols);
-        let symbols = summary
+        let selected_symbols = summary
             .symbols
             .iter()
+            .filter(|symbol| {
+                symbol_kinds.is_empty() || symbol_kinds.contains(symbol_kind_label(&symbol.kind))
+            })
             .take(max_symbols)
+            .collect::<Vec<_>>();
+        let used_symbols = selected_symbols.len();
+        if selected_symbols.is_empty() {
+            return (artifacts, 0);
+        }
+        let symbols = selected_symbols
+            .iter()
             .map(|symbol| {
                 format!(
                     "- {} `{}` at {}:{}",
@@ -864,10 +924,8 @@ fn ast_artifacts_for_summary(
             provider: PROVIDER_NAME.to_string(),
             kind: "ast-symbols".to_string(),
             scope_refs: scope_refs.to_vec(),
-            source_refs: summary
-                .symbols
+            source_refs: selected_symbols
                 .iter()
-                .take(max_symbols)
                 .map(|symbol| MemorySourceRef {
                     kind: "code-symbol".to_string(),
                     id: format!("{relative_display}:{}", symbol.rendered_span),
@@ -1048,13 +1106,11 @@ pub fn run_ad_hoc_query(
     let mut parser = Parser::new();
     parser.set_language(&parser_language)?;
     let tree = parser.parse(source, None).ok_or(CodeIntelError::Parse)?;
-    let metadata = load_metadata(config)?;
     let query =
         Query::new(&parser_language, query_source).map_err(|source| CodeIntelError::Query {
             query_name: "ad_hoc".to_string(),
             source,
         })?;
-    validate_capture_names("ad_hoc", &query, &metadata)?;
 
     let mut results = Vec::new();
     let mut cursor = QueryCursor::new();

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -196,7 +196,7 @@ pub enum SourceLanguage {
 }
 
 impl SourceLanguage {
-    fn id(self) -> &'static str {
+    pub fn id(self) -> &'static str {
         match self {
             SourceLanguage::Rust => "rust",
             SourceLanguage::TypeScript => "typescript",
@@ -209,6 +209,26 @@ impl SourceLanguage {
             SourceLanguage::Toml => "toml",
             SourceLanguage::Markdown => "markdown",
         }
+    }
+
+    pub fn from_id(value: &str) -> Option<Self> {
+        match value {
+            "rust" => Some(SourceLanguage::Rust),
+            "typescript" => Some(SourceLanguage::TypeScript),
+            "tsx" => Some(SourceLanguage::Tsx),
+            "javascript" => Some(SourceLanguage::JavaScript),
+            "jsx" => Some(SourceLanguage::Jsx),
+            "python" => Some(SourceLanguage::Python),
+            "json" => Some(SourceLanguage::Json),
+            "yaml" => Some(SourceLanguage::Yaml),
+            "toml" => Some(SourceLanguage::Toml),
+            "markdown" => Some(SourceLanguage::Markdown),
+            _ => None,
+        }
+    }
+
+    pub fn supports_ast_queries(self) -> bool {
+        !self.is_lightweight()
     }
 
     fn display_name(self) -> &'static str {
@@ -324,6 +344,11 @@ pub struct CaptureRecord {
     pub text: String,
     pub span: SourceSpan,
     pub rendered_span: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdHocQueryMatch {
+    pub captures: Vec<CaptureRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1007,6 +1032,57 @@ pub fn parse_source(
     })
 }
 
+pub fn run_ad_hoc_query(
+    language: SourceLanguage,
+    source: &str,
+    query_source: &str,
+    limit: usize,
+) -> Result<Vec<AdHocQueryMatch>, CodeIntelError> {
+    if !language.supports_ast_queries() {
+        return Err(CodeIntelError::UnsupportedLanguage {
+            path: language.id().to_string(),
+        });
+    }
+    let config = language_config(language);
+    let parser_language = (config.parser)();
+    let mut parser = Parser::new();
+    parser.set_language(&parser_language)?;
+    let tree = parser.parse(source, None).ok_or(CodeIntelError::Parse)?;
+    let metadata = load_metadata(config)?;
+    let query =
+        Query::new(&parser_language, query_source).map_err(|source| CodeIntelError::Query {
+            query_name: "ad_hoc".to_string(),
+            source,
+        })?;
+    validate_capture_names("ad_hoc", &query, &metadata)?;
+
+    let mut results = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+    while let Some(query_match) = matches.next() {
+        if results.len() >= limit {
+            break;
+        }
+        let captures = query_match
+            .captures
+            .iter()
+            .map(|capture| {
+                let span = one_based_span(capture.node);
+                let rendered_span = span.render();
+                Ok(CaptureRecord {
+                    query_name: "ad_hoc".to_string(),
+                    capture_name: query.capture_names()[capture.index as usize].to_string(),
+                    text: capture.node.utf8_text(source.as_bytes())?.to_string(),
+                    span,
+                    rendered_span,
+                })
+            })
+            .collect::<Result<Vec<_>, CodeIntelError>>()?;
+        results.push(AdHocQueryMatch { captures });
+    }
+    Ok(results)
+}
+
 fn language_config(language: SourceLanguage) -> LanguageConfig {
     match language {
         SourceLanguage::Rust => LanguageConfig {
@@ -1127,7 +1203,7 @@ fn compile_query<'a>(
         query_name: asset.name.to_string(),
         source,
     })?;
-    validate_capture_names(asset, &query, metadata)?;
+    validate_capture_names(asset.name, &query, metadata)?;
     Ok(CompiledQuery {
         asset,
         query,
@@ -1136,20 +1212,20 @@ fn compile_query<'a>(
 }
 
 fn validate_capture_names(
-    asset: QueryAsset,
+    query_name: &str,
     query: &Query,
     metadata: &QueryPackMetadata,
 ) -> Result<(), CodeIntelError> {
     for capture_name in query.capture_names().iter().copied() {
         if !STANDARD_CAPTURE_NAMES.contains(&capture_name) {
             return Err(CodeIntelError::NonstandardCapture {
-                query_name: asset.name.to_string(),
+                query_name: query_name.to_string(),
                 capture_name: capture_name.to_string(),
             });
         }
         if !metadata.captures.contains_key(capture_name) {
             return Err(CodeIntelError::UndocumentedCapture {
-                query_name: asset.name.to_string(),
+                query_name: query_name.to_string(),
                 capture_name: capture_name.to_string(),
             });
         }

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -71,8 +71,21 @@ impl MemoryConfig {
             );
         }
 
+        let code_intel = parsed.code_intel.unwrap_or_default();
+        let ast = code_intel.ast.unwrap_or_default();
+
         Ok(Self {
             enabled: parsed.enabled.unwrap_or(true),
+            code_intel: CodeIntelConfig {
+                enabled: code_intel.enabled.unwrap_or(true),
+                ast: AstCodeIntelConfig {
+                    enabled: ast.enabled.unwrap_or(true),
+                    max_file_bytes: ast.max_file_bytes.unwrap_or(2_097_152),
+                    max_files_per_request: ast.max_files_per_request.unwrap_or(200),
+                    max_matches_per_file: ast.max_matches_per_file.unwrap_or(2_000),
+                    max_capture_bytes: ast.max_capture_bytes.unwrap_or(4_096),
+                },
+            },
             config_path: resolved_config_path,
             repo_root,
             memory_root,
@@ -222,6 +235,16 @@ fn write_memory_config(config: &MemoryConfig) -> Result<(), MemoryError> {
     }
     let file = MemoryConfigFile {
         enabled: Some(config.enabled),
+        code_intel: Some(CodeIntelConfigFile {
+            enabled: Some(config.code_intel.enabled),
+            ast: Some(AstCodeIntelConfigFile {
+                enabled: Some(config.code_intel.ast.enabled),
+                max_file_bytes: Some(config.code_intel.ast.max_file_bytes),
+                max_files_per_request: Some(config.code_intel.ast.max_files_per_request),
+                max_matches_per_file: Some(config.code_intel.ast.max_matches_per_file),
+                max_capture_bytes: Some(config.code_intel.ast.max_capture_bytes),
+            }),
+        }),
         memory_root: Some(PathBuf::from(path_relative_to(
             &config.repo_root,
             &config.memory_root,
@@ -274,6 +297,16 @@ fn render_memory_init_config(repo_root: &Path) -> Result<String, MemoryError> {
         );
     }
     let config = MemoryConfigFile {
+        code_intel: Some(CodeIntelConfigFile {
+            enabled: Some(true),
+            ast: Some(AstCodeIntelConfigFile {
+                enabled: Some(true),
+                max_file_bytes: Some(2_097_152),
+                max_files_per_request: Some(200),
+                max_matches_per_file: Some(2_000),
+                max_capture_bytes: Some(4_096),
+            }),
+        }),
         memory_root: Some(PathBuf::from(DEFAULT_MEMORY_ROOT)),
         visibility: Some(MemoryVisibility::Private),
         index_path: Some(PathBuf::from(format!(

--- a/crates/opensymphony-memory/src/config.rs
+++ b/crates/opensymphony-memory/src/config.rs
@@ -82,7 +82,10 @@ impl MemoryConfig {
                     enabled: ast.enabled.unwrap_or(true),
                     max_file_bytes: ast.max_file_bytes.unwrap_or(2_097_152),
                     max_files_per_request: ast.max_files_per_request.unwrap_or(200),
-                    max_matches_per_file: ast.max_matches_per_file.unwrap_or(2_000),
+                    max_matches_per_request: ast
+                        .max_matches_per_request
+                        .or(ast.max_matches_per_file)
+                        .unwrap_or(2_000),
                     max_capture_bytes: ast.max_capture_bytes.unwrap_or(4_096),
                 },
             },
@@ -241,7 +244,8 @@ fn write_memory_config(config: &MemoryConfig) -> Result<(), MemoryError> {
                 enabled: Some(config.code_intel.ast.enabled),
                 max_file_bytes: Some(config.code_intel.ast.max_file_bytes),
                 max_files_per_request: Some(config.code_intel.ast.max_files_per_request),
-                max_matches_per_file: Some(config.code_intel.ast.max_matches_per_file),
+                max_matches_per_request: Some(config.code_intel.ast.max_matches_per_request),
+                max_matches_per_file: None,
                 max_capture_bytes: Some(config.code_intel.ast.max_capture_bytes),
             }),
         }),
@@ -303,7 +307,8 @@ fn render_memory_init_config(repo_root: &Path) -> Result<String, MemoryError> {
                 enabled: Some(true),
                 max_file_bytes: Some(2_097_152),
                 max_files_per_request: Some(200),
-                max_matches_per_file: Some(2_000),
+                max_matches_per_request: Some(2_000),
+                max_matches_per_file: None,
                 max_capture_bytes: Some(4_096),
             }),
         }),

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -392,7 +392,7 @@ pub struct AstCodeIntelConfig {
     pub enabled: bool,
     pub max_file_bytes: u64,
     pub max_files_per_request: usize,
-    pub max_matches_per_file: usize,
+    pub max_matches_per_request: usize,
     pub max_capture_bytes: usize,
 }
 
@@ -527,6 +527,8 @@ struct AstCodeIntelConfigFile {
     max_file_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     max_files_per_request: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_matches_per_request: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     max_matches_per_file: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -367,6 +367,7 @@ pub enum SourceSnapshotPolicy {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryConfig {
     pub enabled: bool,
+    pub code_intel: CodeIntelConfig,
     pub config_path: PathBuf,
     pub repo_root: PathBuf,
     pub memory_root: PathBuf,
@@ -378,6 +379,21 @@ pub struct MemoryConfig {
     pub docs: DocsConfig,
     pub areas: BTreeMap<String, AreaConfig>,
     pub redaction: RedactionConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeIntelConfig {
+    pub enabled: bool,
+    pub ast: AstCodeIntelConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AstCodeIntelConfig {
+    pub enabled: bool,
+    pub max_file_bytes: u64,
+    pub max_files_per_request: usize,
+    pub max_matches_per_file: usize,
+    pub max_capture_bytes: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -474,6 +490,8 @@ struct MemoryConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    code_intel: Option<CodeIntelConfigFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     memory_root: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     visibility: Option<MemoryVisibility>,
@@ -491,6 +509,28 @@ struct MemoryConfigFile {
     areas: BTreeMap<String, AreaConfigFile>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     redaction: Option<RedactionConfigFile>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct CodeIntelConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ast: Option<AstCodeIntelConfigFile>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct AstCodeIntelConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_file_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_files_per_request: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_matches_per_file: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_capture_bytes: Option<usize>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -531,7 +531,7 @@ code_intel:
     enabled: true
     max_file_bytes: 2097152
     max_files_per_request: 200
-    max_matches_per_file: 2000
+    max_matches_per_request: 2000
     max_capture_bytes: 4096
 docs:
   public_root: docs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -525,6 +525,14 @@ visibility: private
 index_path: .opensymphony/memory/memory.duckdb
 confidence_threshold: 75
 markdown_indexes: true
+code_intel:
+  enabled: true
+  ast:
+    enabled: true
+    max_file_bytes: 2097152
+    max_files_per_request: 200
+    max_matches_per_file: 2000
+    max_capture_bytes: 4096
 docs:
   public_root: docs
   default_visibility: public

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -410,7 +410,12 @@ Startup and write paths own schema creation or migration.
 Streamable HTTP JSON-RPC endpoint at `/mcp`. CLI commands call that endpoint
 when `OPENSYMPHONY_MEMORY_ENDPOINT` is set; otherwise they use offline direct
 mode. Read tools are `memory.context`, `memory.search`, `memory.related`,
-`memory.brief`, `memory.docs`, and `memory.status`. Admin tools are
+`memory.brief`, `memory.docs`, `memory.status`, and, when
+`code_intel.ast.enabled` is true, `code.ast.status`, `code.ast.outline`,
+`code.ast.symbols`, `code.ast.references`, `code.ast.context`, and
+`code.ast.diagnostics`. `code.ast.query` is also local read-only by default,
+but requires the admin token when an admin token is configured so hosted or
+token-gated deployments can restrict ad hoc query execution. Admin tools are
 `memory.capture`, `memory.sync_docs`, `memory.lint`, `memory.reindex`,
 `memory.export_okf`, `memory.import_okf`, and `memory.ingest_code_intel`; these
 require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or `--admin-token` on
@@ -424,6 +429,9 @@ languages, parser diagnostics, oversized files, and calls without requested
 paths use the existing `CodebaseAnalyzer` repository-summary fallback; mixed
 supported and unsupported requests can include both AST artifacts and fallback
 artifacts. The trace section records parse/query counts and the fallback reason.
+The direct `code.ast.*` tools return JSON with path, line range, content hash,
+parser version, query-pack version, trace, and truncation metadata for targeted
+agent inspection. `memory.context` remains the recommended kickoff path.
 `memory.ingest_code_intel` generates code-intelligence artifacts without
 persistence by default. Admin callers can pass `persist=true` to write derived
 DuckDB rows for code documents, symbols, query-pack edges, and parser

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -426,7 +426,10 @@ pass `--token` to require bearer-token access for read tools. Admin tools
 `memory.export_okf`, `memory.import_okf`, and `memory.ingest_code_intel`)
 require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or `--admin-token`. When only the
 admin token is configured, it also gates read tools; do not inject that token
-into ordinary worker environments.
+into ordinary worker environments. When `code_intel.ast.enabled` is true,
+`tools/list` also exposes read-only `code.ast.*` inspection tools. The ad hoc
+`code.ast.query` tool is available for local trusted use without tokens, and is
+admin-gated when an admin token is configured.
 
 Linear archival is a separate command and is guarded by captured memory:
 

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -867,7 +867,7 @@ Response:
   "diagnostics": [
     {
       "path": "crates/opensymphony-cli/src/memory.rs",
-      "kind": "parse-error",
+      "kind": "error",
       "nodeKind": "ERROR",
       "span": { "startLine": 954, "endLine": 954 },
       "source": {
@@ -885,6 +885,9 @@ Response:
   ]
 }
 ```
+
+Diagnostic `kind` values are the AST diagnostic vocabulary currently emitted by
+the parser bridge: `error` and `missing`.
 
 ### 9.4 CLI surface
 

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -634,6 +634,8 @@ Rationale: agents keep `memory.context` as their main context-loading path, whil
 
 ### 9.3 MCP tool contracts
 
+Response-level `limit` fields are request-wide caps across all returned files.
+
 #### `code.ast.status`
 
 Request:
@@ -822,13 +824,16 @@ Request:
   "repo": ".",
   "issue": "COE-123",
   "paths": ["crates/opensymphony-cli/src/memory.rs"],
-  "symbols": ["run_context"],
+  "symbols": ["function"],
   "includeCallers": true,
   "includeCallees": true,
   "includeTests": true,
   "limit": 40
 }
 ```
+
+The current MCP-backed implementation treats `symbols` as a symbol-kind filter
+that reuses the same provider path as `memory.context --include-code-intel`.
 
 Response:
 
@@ -839,6 +844,44 @@ Response:
     "parsed crates/opensymphony-cli/src/memory.rs",
     "ran rust definitions/references/calls/tests/diagnostics",
     "selected 8 symbols and 3 call edges"
+  ]
+}
+```
+
+#### `code.ast.diagnostics`
+
+Request:
+
+```json
+{
+  "repo": ".",
+  "paths": ["crates/opensymphony-cli/src/memory.rs"],
+  "limit": 50
+}
+```
+
+Response:
+
+```json
+{
+  "diagnostics": [
+    {
+      "path": "crates/opensymphony-cli/src/memory.rs",
+      "kind": "parse-error",
+      "nodeKind": "ERROR",
+      "span": { "startLine": 954, "endLine": 954 },
+      "source": {
+        "contentSha256": "...",
+        "parserVersion": "tree-sitter-rust:...",
+        "queryPackVersion": "rust-query-pack-v2"
+      }
+    }
+  ],
+  "limit": 50,
+  "trace": [
+    "parsed 1 file(s)",
+    "max files per request 200",
+    "max matches per request 2000"
   ]
 }
 ```

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -477,7 +477,7 @@ captures:
   import.path: Import path or module use path
   test.case: Test function or test block
 limits:
-  max_matches_per_file: 2000
+  max_matches_per_request: 2000
   max_capture_bytes: 4096
 ```
 
@@ -689,6 +689,13 @@ Response:
       ],
       "diagnostics": []
     }
+  ],
+  "limit": 20,
+  "trace": [
+    "parsed 1 file(s)",
+    "max files per request 200",
+    "max matches per request 2000",
+    "crates/opensymphony-cli/src/memory.rs lines 1-1400 parser tree-sitter-rust@... query-pack rust@1 content sha256:..."
   ]
 }
 ```
@@ -751,10 +758,23 @@ Response:
       "kind": "reference.call",
       "path": "crates/opensymphony-cli/src/memory.rs",
       "span": { "startLine": 1258, "endLine": 1258 },
-      "snippet": "run_context(&repo_root, &config, args).await"
+      "snippet": "run_context",
+      "truncated": false,
+      "source": {
+        "commitSha": "...",
+        "contentSha256": "...",
+        "queryPackVersion": "rust@1"
+      }
     }
   ],
-  "confidence": "syntactic"
+  "confidence": "syntactic",
+  "limit": 50,
+  "trace": [
+    "parsed 1 file(s)",
+    "max files per request 200",
+    "max matches per request 2000",
+    "crates/opensymphony-cli/src/memory.rs lines 1-1400 parser tree-sitter-rust@... query-pack rust@1 content sha256:..."
+  ]
 }
 ```
 
@@ -1161,7 +1181,7 @@ code_intel:
     persist_by_default: false
     max_file_bytes: 2097152
     max_files_per_request: 200
-    max_matches_per_file: 2000
+    max_matches_per_request: 2000
     query_timeout_ms: 5000
     parsed_tree_cache_entries: 256
     document_cache_bytes: 134217728

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -729,9 +729,9 @@ Response:
       "span": { "startLine": 954, "endLine": 990 },
       "selectionSpan": { "startLine": 954, "endLine": 954 },
       "source": {
-        "commitSha": "...",
         "contentSha256": "...",
-        "queryPackVersion": "rust@1"
+        "parserVersion": "tree-sitter-rust:...",
+        "queryPackVersion": "rust-query-pack-v2"
       }
     }
   ]
@@ -763,9 +763,9 @@ Response:
       "snippet": "run_context",
       "truncated": false,
       "source": {
-        "commitSha": "...",
         "contentSha256": "...",
-        "queryPackVersion": "rust@1"
+        "parserVersion": "tree-sitter-rust:...",
+        "queryPackVersion": "rust-query-pack-v2"
       }
     }
   ],
@@ -807,7 +807,12 @@ Response:
           "text": "run_context",
           "span": { "startLine": 954, "endLine": 954 }
         }
-      ]
+      ],
+      "source": {
+        "contentSha256": "...",
+        "parserVersion": "tree-sitter-rust:...",
+        "queryPackVersion": "rust-query-pack-v2"
+      }
     }
   ]
 }
@@ -1228,9 +1233,7 @@ code_intel:
     max_file_bytes: 2097152
     max_files_per_request: 200
     max_matches_per_request: 2000
-    query_timeout_ms: 5000
-    parsed_tree_cache_entries: 256
-    document_cache_bytes: 134217728
+    max_capture_bytes: 4096
     languages:
       rust: true
       typescript: true
@@ -1509,7 +1512,6 @@ These are engineering targets for local mode and should be measured with reposit
 | File too large | Skip file and return warning. |
 | Stale persisted record | Reparse if file is available, otherwise return stale only when requested. |
 | Path outside repo | Reject request. |
-| Query timeout | Return partial results with truncation warning. |
 | Too many matches | Truncate with trace entry and deterministic ordering. |
 
 ## 20. Documentation updates


### PR DESCRIPTION
## Summary

Expose read-only Tree-sitter AST exploration through the memory MCP server for COE-502.

## Changes

- Added `code_intel.ast` memory config defaults and conditional `code.ast.*` MCP tool descriptors.
- Implemented `code.ast.status`, `outline`, `symbols`, `references`, `query`, `context`, and `diagnostics` handlers with path containment, auth, source citations, trace metadata, and deterministic request limits.
- Aligned `tools/list` access metadata with the effective `code.ast.query` admin-token policy.
- Offloaded non-context AST file I/O, parsing, and ad hoc query work through `spawn_blocking` so MCP requests do not block the Tokio executor.
- Tightened reference matching to identifier boundaries, exposed reference truncation metadata, and made source-file limits count parseable source files.
- Renamed the canonical AST match limit to `max_matches_per_request` while still accepting legacy `max_matches_per_file` YAML.
- Added focused contract tests and documented the new config/MCP auth behavior.
- Moved `code.ast.context` symbol-kind filtering into the structured provider path, allowed custom ad hoc query capture names, and ensured invalid requested paths are rejected before file-budget skips.

## Evidence

### Test output

```
cargo test-system-duckdb code_ast -- --nocapture
# 13 passed; 0 failed

cargo test-system-duckdb mcp_tool_list -- --nocapture
# 3 passed; 0 failed

cargo test-system-duckdb mcp_admin_tools_require_admin_access -- --nocapture
# 1 passed; 0 failed

cargo test-system-duckdb --test memory
# 46 passed; 0 failed

cargo clippy-system-duckdb
# passed

cargo fmt --check
# passed
```

### End-to-end MCP proof

Started the actual memory server with system DuckDB linking:

```
cargo --config "env.DUCKDB_LIB_DIR='/opt/homebrew/opt/duckdb/lib'"   --config "env.DUCKDB_INCLUDE_DIR='/opt/homebrew/opt/duckdb/include'"   --config "env.DYLD_LIBRARY_PATH='/opt/homebrew/opt/duckdb/lib'"   run --no-default-features --features duckdb-prebuilt --   memory serve --addr 127.0.0.1:18765
```

Then verified real HTTP `/mcp` requests:

```
curl -sS -X POST http://127.0.0.1:18765/mcp   -H 'content-type: application/json'   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
# 20 tools; all 7 code.ast.* tools listed; code.ast.query access=read in local no-token mode

curl -sS -X POST http://127.0.0.1:18765/mcp   -H 'content-type: application/json'   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"code.ast.status","arguments":{}}}'
# provider=tree-sitter-ast; available=true; rust_query_pack=rust-query-pack-v2; maxMatchesPerRequest=2000

curl -sS -X POST http://127.0.0.1:18765/mcp   -H 'content-type: application/json'   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"code.ast.outline","arguments":{"paths":["crates/opensymphony-cli/src/memory.rs"],"limit":1}}}'
# documents=1; first_path=crates/opensymphony-cli/src/memory.rs; first_symbol=MemoryArgs; trace includes parsed file and source hash
```

### Verification

Reproduced the pre-change MCP descriptor gap with the existing descriptor test, then verified the new enabled/disabled tool listing, normal read access for read-only AST tools, AST-specific disable toggle, admin-gated ad hoc query policy when an admin token is configured, path containment, request match limits, source-file limit behavior, capture truncation, exact/boundary reference matching, references, diagnostics, context wrapper JSON shape, structured context symbol-kind filtering, custom ad hoc capture names, global outline limit semantics, diagnostics request limits, all-requested-path containment validation before file-budget skips, source citation fields, spec examples for source metadata, implemented AST config fields, executor offload for AST analysis handlers, and real HTTP MCP dispatch.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None. `max_matches_per_file` remains accepted as a legacy YAML alias for `max_matches_per_request`.

## Related issues

COE-502

## Additional notes

Skipped optional standalone `opensymphony code ast ...` debug commands because `memory.context --include-code-intel` remains the recommended CLI kickoff/debug path and the new MCP handlers reuse the existing provider path.




