### PR TITLE
feat(code-intel): harden AST limits and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,8 @@ When changing the pinned OpenHands assumptions, update `docs/sources.md`.
 - `docs/linear-and-tools.md`: Linear integration and GraphQL helper assets
 - `docs/memory.md`: project memory capture, DuckDB indexing, documentation sync,
   and archive guard design
+- `docs/code-intelligence.md`: agent and operator workflow for AST-backed code
+  intelligence
 - `docs/ui-frankentui.md`: operator UI design
 - `docs/repository-layout.md`: crate ownership
 - `docs/deployment-modes.md`: local MVP and hosted follow-on

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ OpenSymphony automates software development workflows by:
 - **GraphQL-only Linear integration**: Agent-side Linear reads and writes through checked-in helper/query assets
 - **Conversation reuse policies**: Default per-issue reuse with optional fresh-per-run resets
 - **Harness selection**: Default OpenHands agent-server execution, plus local Codex app-server support for ChatGPT subscription-backed runs
+- **Tree-sitter code intelligence**: Local AST parsing, symbols, diagnostics, and source-cited structural context for agents
 - **Local-first MVP**: Trusted-machine deployment with optional hosted mode
 
 OpenSymphony `1.0.0` is the compatibility boundary for the GraphQL-only Linear

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -201,7 +201,7 @@ workflow.
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
 8.  Run a principal-style self-review of the plan and refine it in the comment.
 9.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-10. After initial file discovery, re-run `opensymphony memory context --issue {{ issue.identifier }} --paths <path1>,<path2> --include-code-intel` for touched areas when memory is configured, and record useful references in the workpad.
+10. After initial file discovery, re-run `opensymphony memory context --issue {{ issue.identifier }} --paths <path1>,<path2> --include-code-intel` for touched areas when memory is configured, record useful references in the workpad, and treat current source files and tests as authoritative over generated context.
 11. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -2279,7 +2279,7 @@ fn collect_ast_files(
         })?;
     if let Some(component) = skipped_directory_name(&resolved) {
         warnings.push(format!(
-            "{} skipped directory `{component}` (generated/vendor/build list)",
+            "{} skipped directory `{component}`",
             relative.display()
         ));
         return Ok(());
@@ -5915,17 +5915,17 @@ Public memory concept.
         assert!(trace.iter().any(|line| {
             line.as_str()
                 .expect("trace line")
-                .contains("warning: node_modules skipped directory `node_modules` (generated/vendor/build list)")
-        }));
-        assert!(trace.iter().any(|line| {
-            line.as_str().expect("trace line").contains(
-                "warning: vendor skipped directory `vendor` (generated/vendor/build list)",
-            )
+                .contains("warning: node_modules skipped directory `node_modules`")
         }));
         assert!(trace.iter().any(|line| {
             line.as_str()
                 .expect("trace line")
-                .contains("warning: src/generated skipped directory `generated` (generated/vendor/build list)")
+                .contains("warning: vendor skipped directory `vendor`")
+        }));
+        assert!(trace.iter().any(|line| {
+            line.as_str()
+                .expect("trace line")
+                .contains("warning: src/generated skipped directory `generated`")
         }));
 
         let explicit_generated = call_memory_tool(
@@ -5947,7 +5947,7 @@ Public memory concept.
                 .any(|line| line
                     .as_str()
                     .expect("trace line")
-                    .contains("generated/vendor/build list"))
+                    .contains("skipped directory"))
         );
     }
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5822,11 +5822,12 @@ Public memory concept.
         .await
         .expect("diagnostics");
 
-        assert!(
-            !diagnostics["diagnostics"]
+        assert_eq!(
+            diagnostics["diagnostics"]
                 .as_array()
                 .expect("diagnostics")
-                .is_empty()
+                .len(),
+            1
         );
         assert_eq!(diagnostics["limit"], 1);
         assert!(

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -19,7 +19,7 @@ use crate::{
         JAVASCRIPT_QUERY_PACK_VERSION, JSX_QUERY_PACK_VERSION, PROVIDER_NAME,
         PYTHON_QUERY_PACK_VERSION, ParsedDocumentSummary, RUST_QUERY_PACK_VERSION, SourceLanguage,
         SymbolKind, TREE_SITTER_VERSION, TSX_QUERY_PACK_VERSION, TYPESCRIPT_QUERY_PACK_VERSION,
-        parse_path, run_ad_hoc_query,
+        parse_path, run_ad_hoc_query, skipped_directory_component,
     },
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
@@ -1879,6 +1879,11 @@ struct AstDocument {
     summary: ParsedDocumentSummary,
 }
 
+struct AstDocuments {
+    documents: Vec<AstDocument>,
+    warnings: Vec<String>,
+}
+
 fn call_code_ast_status_tool(config: &MemoryConfig) -> Result<Value, MemoryError> {
     let _ = resolve_code_intel_repo(config, None)?;
     Ok(json!({
@@ -1896,12 +1901,12 @@ async fn call_code_ast_outline_tool(
     arguments: Value,
 ) -> Result<Value, MemoryError> {
     ast_mcp_tool_blocking("code.ast.outline", move || {
-        let documents = ast_documents(&config, &arguments)?;
+        let ast_documents = ast_documents(&config, &arguments)?;
         let limit = ast_limit(&config, &arguments);
         let mut remaining = limit;
         let mut truncated = false;
         let mut response_documents = Vec::new();
-        for document in &documents {
+        for document in &ast_documents.documents {
             let selected_symbols = document
                 .summary
                 .symbols
@@ -1931,7 +1936,7 @@ async fn call_code_ast_outline_tool(
         Ok(json!({
             "documents": response_documents,
             "limit": limit,
-            "trace": ast_trace_json(&config, &documents, truncated)
+            "trace": ast_trace_json(&config, &ast_documents, truncated)
         }))
     })
     .await
@@ -1947,8 +1952,8 @@ async fn call_code_ast_symbols_tool(
         let kinds = normalized_string_set_args(&arguments, &["kinds"]);
         let limit = ast_limit(&config, &arguments);
         let mut symbols = Vec::new();
-        let documents = ast_documents(&config, &arguments)?;
-        for document in &documents {
+        let ast_documents = ast_documents(&config, &arguments)?;
+        for document in &ast_documents.documents {
             for symbol in document.summary.symbols.iter().filter(|symbol| {
                 query
                     .as_ref()
@@ -1975,7 +1980,7 @@ async fn call_code_ast_symbols_tool(
         Ok(json!({
             "symbols": symbols,
             "limit": limit,
-            "trace": ast_trace_json(&config, &documents, symbols.len() >= limit)
+            "trace": ast_trace_json(&config, &ast_documents, symbols.len() >= limit)
         }))
     })
     .await
@@ -1989,8 +1994,8 @@ async fn call_code_ast_references_tool(
         let symbol = required_string_arg(&arguments, "symbol")?;
         let limit = ast_limit(&config, &arguments);
         let mut references = Vec::new();
-        let documents = ast_documents(&config, &arguments)?;
-        for document in &documents {
+        let ast_documents = ast_documents(&config, &arguments)?;
+        for document in &ast_documents.documents {
             for capture in document
                 .summary
                 .captures
@@ -2020,7 +2025,7 @@ async fn call_code_ast_references_tool(
             "references": references,
             "confidence": "syntactic",
             "limit": limit,
-            "trace": ast_trace_json(&config, &documents, references.len() >= limit)
+            "trace": ast_trace_json(&config, &ast_documents, references.len() >= limit)
         }))
     })
     .await
@@ -2043,9 +2048,10 @@ async fn call_code_ast_query_tool(
         }
         let query = required_string_arg(&arguments, "query")?;
         let limit = ast_limit(&config, &arguments);
-        let documents = ast_documents(&config, &arguments)?;
+        let ast_documents = ast_documents(&config, &arguments)?;
         let mut matches = Vec::new();
-        for document in documents
+        for document in ast_documents
+            .documents
             .iter()
             .filter(|document| document.summary.source.language == language)
         {
@@ -2079,7 +2085,7 @@ async fn call_code_ast_query_tool(
         Ok(json!({
             "matches": matches,
             "limit": limit,
-            "trace": ast_trace_json(&config, &documents, matches.len() >= limit)
+            "trace": ast_trace_json(&config, &ast_documents, matches.len() >= limit)
         }))
     })
     .await
@@ -2118,10 +2124,10 @@ async fn call_code_ast_diagnostics_tool(
     arguments: Value,
 ) -> Result<Value, MemoryError> {
     ast_mcp_tool_blocking("code.ast.diagnostics", move || {
-        let documents = ast_documents(&config, &arguments)?;
+        let ast_documents = ast_documents(&config, &arguments)?;
         let limit = ast_limit(&config, &arguments);
         let mut diagnostics = Vec::new();
-        for document in &documents {
+        for document in &ast_documents.documents {
             for diagnostic in &document.summary.diagnostics {
                 if diagnostics.len() >= limit {
                     break;
@@ -2138,7 +2144,8 @@ async fn call_code_ast_diagnostics_tool(
                 break;
             }
         }
-        let truncated = documents
+        let truncated = ast_documents
+            .documents
             .iter()
             .map(|document| document.summary.diagnostics.len())
             .sum::<usize>()
@@ -2146,7 +2153,7 @@ async fn call_code_ast_diagnostics_tool(
         Ok(json!({
             "diagnostics": diagnostics,
             "limit": limit,
-            "trace": ast_trace_json(&config, &documents, truncated)
+            "trace": ast_trace_json(&config, &ast_documents, truncated)
         }))
     })
     .await
@@ -2161,20 +2168,19 @@ where
     })?
 }
 
-fn ast_documents(
-    config: &MemoryConfig,
-    arguments: &Value,
-) -> Result<Vec<AstDocument>, MemoryError> {
+fn ast_documents(config: &MemoryConfig, arguments: &Value) -> Result<AstDocuments, MemoryError> {
     let scope = scope_filter_from_mcp(arguments, false);
     let repo_root = resolve_code_intel_repo(config, scope.repo.as_deref())?;
     let paths = ast_path_args(arguments)?;
     let mut files = Vec::new();
+    let mut warnings = Vec::new();
     for path in paths {
         collect_ast_files(
             &repo_root,
             &path,
             config.code_intel.ast.max_files_per_request,
             &mut files,
+            &mut warnings,
         )?;
     }
     let mut documents = Vec::new();
@@ -2191,11 +2197,12 @@ fn ast_documents(
             source,
         })?;
         if metadata.len() > config.code_intel.ast.max_file_bytes {
-            return Err(MemoryError::InvalidInput(format!(
+            warnings.push(format!(
                 "{} exceeds AST max_file_bytes {}",
                 relative.display(),
                 config.code_intel.ast.max_file_bytes
-            )));
+            ));
+            continue;
         }
         let source = fs::read_to_string(&path).map_err(|source| MemoryError::ReadFile {
             path: path.clone(),
@@ -2209,7 +2216,10 @@ fn ast_documents(
             summary,
         });
     }
-    Ok(documents)
+    Ok(AstDocuments {
+        documents,
+        warnings,
+    })
 }
 
 fn ast_path_args(arguments: &Value) -> Result<Vec<PathBuf>, MemoryError> {
@@ -2230,6 +2240,7 @@ fn collect_ast_files(
     path: &Path,
     max_files: usize,
     files: &mut Vec<PathBuf>,
+    warnings: &mut Vec<String>,
 ) -> Result<(), MemoryError> {
     let candidate = if path.is_absolute() {
         path.to_path_buf()
@@ -2247,6 +2258,19 @@ fn collect_ast_files(
             path: resolved,
             repo_root: repo_root.to_path_buf(),
         });
+    }
+    let relative = resolved
+        .strip_prefix(repo_root)
+        .map_err(|_| MemoryError::PathOutsideRepo {
+            path: resolved.clone(),
+            repo_root: repo_root.to_path_buf(),
+        })?;
+    if let Some(component) = skipped_directory_component(relative) {
+        warnings.push(format!(
+            "{} skipped generated/vendor directory component `{component}`",
+            relative.display()
+        ));
+        return Ok(());
     }
     if resolved.is_file() {
         if ast_file_is_supported(repo_root, &resolved)? && files.len() < max_files {
@@ -2280,7 +2304,7 @@ fn collect_ast_files(
             source,
         })?;
         if file_type.is_dir() {
-            collect_ast_files(repo_root, &entry.path(), max_files, files)?;
+            collect_ast_files(repo_root, &entry.path(), max_files, files, warnings)?;
         } else if file_type.is_file() && ast_file_is_supported(repo_root, &entry.path())? {
             files.push(entry.path());
         }
@@ -2342,9 +2366,10 @@ fn ast_limits_json(config: &MemoryConfig) -> Value {
 
 fn ast_trace_json(
     config: &MemoryConfig,
-    documents: &[AstDocument],
+    ast_documents: &AstDocuments,
     truncated: bool,
 ) -> Vec<String> {
+    let documents = &ast_documents.documents;
     let mut trace = vec![
         format!("parsed {} file(s)", documents.len()),
         format!(
@@ -2359,6 +2384,12 @@ fn ast_trace_json(
     if truncated {
         trace.push("truncated by limit".to_string());
     }
+    trace.extend(
+        ast_documents
+            .warnings
+            .iter()
+            .map(|warning| format!("warning: {warning}")),
+    );
     trace.extend(documents.iter().map(|document| {
         format!(
             "{} lines {}-{} parser {} query-pack {} content sha256:{}",
@@ -5791,12 +5822,11 @@ Public memory concept.
         .await
         .expect("diagnostics");
 
-        assert_eq!(
-            diagnostics["diagnostics"]
+        assert!(
+            !diagnostics["diagnostics"]
                 .as_array()
                 .expect("diagnostics")
-                .len(),
-            1
+                .is_empty()
         );
         assert_eq!(diagnostics["limit"], 1);
         assert!(
@@ -5840,6 +5870,165 @@ Public memory concept.
                 .expect("trace")
                 .iter()
                 .any(|line| line.as_str().expect("trace line").contains("parsed 1 file"))
+        );
+    }
+
+    #[tokio::test]
+    async fn code_ast_tools_skip_generated_and_vendor_directories_with_trace() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::create_dir_all(repo_root.join("node_modules/pkg")).expect("node_modules");
+        std::fs::create_dir_all(repo_root.join("vendor/pkg")).expect("vendor");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        std::fs::write(
+            repo_root.join("node_modules/pkg/lib.rs"),
+            "pub fn generated_dep() {}\n",
+        )
+        .expect("generated source");
+        std::fs::write(
+            repo_root.join("vendor/pkg/lib.rs"),
+            "pub fn vendored() {}\n",
+        )
+        .expect("vendor source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let symbols = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": { "paths": ["src", "node_modules", "vendor"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("symbols");
+
+        assert_eq!(symbols["symbols"][0]["name"], "answer");
+        assert_eq!(symbols["symbols"].as_array().expect("symbols").len(), 1);
+        let trace = symbols["trace"].as_array().expect("trace");
+        assert!(trace.iter().any(|line| {
+            line.as_str()
+                .expect("trace line")
+                .contains("warning: node_modules skipped generated/vendor")
+        }));
+        assert!(trace.iter().any(|line| {
+            line.as_str()
+                .expect("trace line")
+                .contains("warning: vendor skipped generated/vendor")
+        }));
+    }
+
+    #[tokio::test]
+    async fn code_ast_tools_skip_oversized_files_with_trace() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(repo_root.join("src/big.rs"), "pub fn oversized() {}\n")
+            .expect("big source");
+        std::fs::write(repo_root.join("src/small.rs"), "pub fn ok() {}\n").expect("small source");
+        let config_path = repo_root.join("opensymphony-memory.yaml");
+        std::fs::write(
+            &config_path,
+            "code_intel:\n  ast:\n    max_file_bytes: 15\n",
+        )
+        .expect("config");
+        let config = MemoryConfig::load(&repo_root, Some(&config_path)).expect("config");
+
+        let symbols = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": { "paths": ["src"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("symbols");
+
+        assert_eq!(symbols["symbols"][0]["name"], "ok");
+        assert_eq!(symbols["symbols"].as_array().expect("symbols").len(), 1);
+        assert!(
+            symbols["trace"]
+                .as_array()
+                .expect("trace")
+                .iter()
+                .any(|line| line
+                    .as_str()
+                    .expect("trace line")
+                    .contains("warning: src/big.rs exceeds AST max_file_bytes 15"))
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_code_ast_tool_calls_do_not_share_parser_or_query_state() {
+        let repo = TempDir::new().expect("temp repo");
+        let repo_root = repo.path().canonicalize().expect("canonical repo");
+        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "pub fn answer() -> u8 { helper() }\nfn helper() -> u8 { 42 }\n",
+        )
+        .expect("source");
+        std::fs::write(repo_root.join("src/bad.rs"), "pub fn broken( {\n").expect("bad source");
+        let config = MemoryConfig::load(&repo_root, None).expect("config");
+
+        let symbols_config = config.clone();
+        let diagnostics_config = config.clone();
+        let query_config = config.clone();
+        let (symbols, diagnostics, query) = tokio::join!(
+            call_memory_tool(
+                &symbols_config,
+                json!({
+                    "name": "code.ast.symbols",
+                    "arguments": { "paths": ["src/lib.rs"], "limit": 10 }
+                }),
+            ),
+            call_memory_tool(
+                &diagnostics_config,
+                json!({
+                    "name": "code.ast.diagnostics",
+                    "arguments": { "paths": ["src/bad.rs"], "limit": 10 }
+                }),
+            ),
+            call_memory_tool(
+                &query_config,
+                json!({
+                    "name": "code.ast.query",
+                    "arguments": {
+                        "paths": ["src/lib.rs"],
+                        "language": "rust",
+                        "query": "(function_item name: (identifier) @definition.function)",
+                        "limit": 10
+                    }
+                }),
+            )
+        );
+
+        let symbols = symbols.expect("symbols");
+        let diagnostics = diagnostics.expect("diagnostics");
+        let query = query.expect("query");
+        assert!(
+            symbols["symbols"]
+                .as_array()
+                .expect("symbols")
+                .iter()
+                .any(|symbol| symbol["name"] == "answer")
+        );
+        assert_eq!(
+            diagnostics["diagnostics"]
+                .as_array()
+                .expect("diagnostics")
+                .len(),
+            1
+        );
+        assert_eq!(
+            query["matches"]
+                .as_array()
+                .expect("matches")
+                .iter()
+                .flat_map(|item| item["captures"].as_array().expect("captures"))
+                .filter(|capture| capture["name"] == "definition.function")
+                .count(),
+            2
         );
     }
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -2279,7 +2279,7 @@ fn collect_ast_files(
         })?;
     if let Some(component) = skipped_directory_name(&resolved) {
         warnings.push(format!(
-            "{} skipped generated/vendor directory `{component}`",
+            "{} skipped directory `{component}` (generated/vendor/build list)",
             relative.display()
         ));
         return Ok(());
@@ -5915,17 +5915,17 @@ Public memory concept.
         assert!(trace.iter().any(|line| {
             line.as_str()
                 .expect("trace line")
-                .contains("warning: node_modules skipped generated/vendor")
+                .contains("warning: node_modules skipped directory `node_modules` (generated/vendor/build list)")
+        }));
+        assert!(trace.iter().any(|line| {
+            line.as_str().expect("trace line").contains(
+                "warning: vendor skipped directory `vendor` (generated/vendor/build list)",
+            )
         }));
         assert!(trace.iter().any(|line| {
             line.as_str()
                 .expect("trace line")
-                .contains("warning: vendor skipped generated/vendor")
-        }));
-        assert!(trace.iter().any(|line| {
-            line.as_str()
-                .expect("trace line")
-                .contains("warning: src/generated skipped generated/vendor")
+                .contains("warning: src/generated skipped directory `generated` (generated/vendor/build list)")
         }));
 
         let explicit_generated = call_memory_tool(
@@ -5947,7 +5947,7 @@ Public memory concept.
                 .any(|line| line
                     .as_str()
                     .expect("trace line")
-                    .contains("skipped generated/vendor"))
+                    .contains("generated/vendor/build list"))
         );
     }
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -19,7 +19,7 @@ use crate::{
         JAVASCRIPT_QUERY_PACK_VERSION, JSX_QUERY_PACK_VERSION, PROVIDER_NAME,
         PYTHON_QUERY_PACK_VERSION, ParsedDocumentSummary, RUST_QUERY_PACK_VERSION, SourceLanguage,
         SymbolKind, TREE_SITTER_VERSION, TSX_QUERY_PACK_VERSION, TYPESCRIPT_QUERY_PACK_VERSION,
-        parse_path, run_ad_hoc_query, skipped_directory_component,
+        parse_path, run_ad_hoc_query, skipped_directory_name,
     },
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
@@ -2259,19 +2259,6 @@ fn collect_ast_files(
             repo_root: repo_root.to_path_buf(),
         });
     }
-    let relative = resolved
-        .strip_prefix(repo_root)
-        .map_err(|_| MemoryError::PathOutsideRepo {
-            path: resolved.clone(),
-            repo_root: repo_root.to_path_buf(),
-        })?;
-    if let Some(component) = skipped_directory_component(relative) {
-        warnings.push(format!(
-            "{} skipped generated/vendor directory component `{component}`",
-            relative.display()
-        ));
-        return Ok(());
-    }
     if resolved.is_file() {
         if ast_file_is_supported(repo_root, &resolved)? && files.len() < max_files {
             files.push(resolved);
@@ -2282,6 +2269,19 @@ fn collect_ast_files(
         return Ok(());
     }
     if files.len() >= max_files {
+        return Ok(());
+    }
+    let relative = resolved
+        .strip_prefix(repo_root)
+        .map_err(|_| MemoryError::PathOutsideRepo {
+            path: resolved.clone(),
+            repo_root: repo_root.to_path_buf(),
+        })?;
+    if let Some(component) = skipped_directory_name(&resolved) {
+        warnings.push(format!(
+            "{} skipped generated/vendor directory `{component}`",
+            relative.display()
+        ));
         return Ok(());
     }
     let mut entries = fs::read_dir(&resolved)
@@ -5877,10 +5877,15 @@ Public memory concept.
     async fn code_ast_tools_skip_generated_and_vendor_directories_with_trace() {
         let repo = TempDir::new().expect("temp repo");
         let repo_root = repo.path().canonicalize().expect("canonical repo");
-        std::fs::create_dir_all(repo_root.join("src")).expect("src dir");
+        std::fs::create_dir_all(repo_root.join("src/generated")).expect("src dir");
         std::fs::create_dir_all(repo_root.join("node_modules/pkg")).expect("node_modules");
         std::fs::create_dir_all(repo_root.join("vendor/pkg")).expect("vendor");
         std::fs::write(repo_root.join("src/lib.rs"), "pub fn answer() {}\n").expect("source");
+        std::fs::write(
+            repo_root.join("src/generated/mod.rs"),
+            "pub fn generated_mod() {}\n",
+        )
+        .expect("explicit generated source");
         std::fs::write(
             repo_root.join("node_modules/pkg/lib.rs"),
             "pub fn generated_dep() {}\n",
@@ -5916,6 +5921,33 @@ Public memory concept.
                 .expect("trace line")
                 .contains("warning: vendor skipped generated/vendor")
         }));
+        assert!(trace.iter().any(|line| {
+            line.as_str()
+                .expect("trace line")
+                .contains("warning: src/generated skipped generated/vendor")
+        }));
+
+        let explicit_generated = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.ast.symbols",
+                "arguments": { "paths": ["src/generated/mod.rs"], "limit": 10 }
+            }),
+        )
+        .await
+        .expect("explicit generated symbols");
+
+        assert_eq!(explicit_generated["symbols"][0]["name"], "generated_mod");
+        assert!(
+            !explicit_generated["trace"]
+                .as_array()
+                .expect("trace")
+                .iter()
+                .any(|line| line
+                    .as_str()
+                    .expect("trace line")
+                    .contains("skipped generated/vendor"))
+        );
     }
 
     #[tokio::test]
@@ -5986,7 +6018,7 @@ Public memory concept.
                 &diagnostics_config,
                 json!({
                     "name": "code.ast.diagnostics",
-                    "arguments": { "paths": ["src/bad.rs"], "limit": 10 }
+                    "arguments": { "paths": ["src/bad.rs"], "limit": 1 }
                 }),
             ),
             call_memory_tool(

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -58,7 +58,7 @@ const TSX_METADATA: &str = include_str!("../queries/tsx/metadata.toml");
 const JAVASCRIPT_METADATA: &str = include_str!("../queries/javascript/metadata.toml");
 const JSX_METADATA: &str = include_str!("../queries/jsx/metadata.toml");
 const PYTHON_METADATA: &str = include_str!("../queries/python/metadata.toml");
-const DEFAULT_MAX_FILE_BYTES: u64 = 1_000_000;
+const DEFAULT_MAX_FILE_BYTES: u64 = 2_097_152;
 
 const STANDARD_CAPTURE_NAMES: &[&str] = &[
     "definition.module",
@@ -515,13 +515,6 @@ impl AstCodeIntelProvider {
                 .to_path_buf();
             let relative_display = relative_path.to_string_lossy().to_string();
 
-            if let Some(component) = skipped_directory_component(&relative_path) {
-                report.fallback_reasons.push(format!(
-                    "{relative_display} skipped generated/vendor directory component `{component}`"
-                ));
-                continue;
-            }
-
             let Some(source) = self.read_limited_source(&resolved, &relative_display, &mut report)
             else {
                 continue;
@@ -696,17 +689,12 @@ impl AstCodeIntelProvider {
     }
 }
 
-pub fn skipped_directory_component(path: impl AsRef<Path>) -> Option<&'static str> {
-    path.as_ref().components().find_map(|component| {
-        let Component::Normal(value) = component else {
-            return None;
-        };
-        let value = value.to_str()?;
-        SKIPPED_DIRECTORY_COMPONENTS
-            .iter()
-            .copied()
-            .find(|skipped| value == *skipped)
-    })
+pub fn skipped_directory_name(path: impl AsRef<Path>) -> Option<&'static str> {
+    let value = path.as_ref().file_name()?.to_str()?;
+    SKIPPED_DIRECTORY_COMPONENTS
+        .iter()
+        .copied()
+        .find(|skipped| value == *skipped)
 }
 
 fn requested_candidate(repo_root: &Path, path: &Path) -> PathBuf {
@@ -2401,7 +2389,10 @@ mod tests {
         fs::create_dir_all(repo.path().join("src")).expect("src dir");
         fs::write(
             repo.path().join("src/lib.rs"),
-            format!("pub const LARGE: &str = \"{}\";\n", "x".repeat(1_000_001)),
+            format!(
+                "pub const LARGE: &str = \"{}\";\n",
+                "x".repeat(DEFAULT_MAX_FILE_BYTES as usize + 1)
+            ),
         )
         .expect("large rust");
 
@@ -2423,63 +2414,30 @@ mod tests {
     }
 
     #[test]
-    fn composite_skips_generated_and_vendor_directories_with_trace() {
+    fn composite_parses_explicit_files_under_generated_directories() {
         let repo = TempDir::new().expect("temp repo");
-        fs::create_dir_all(repo.path().join("src")).expect("src dir");
-        fs::create_dir_all(repo.path().join("node_modules/pkg")).expect("node_modules dir");
-        fs::create_dir_all(repo.path().join("vendor/pkg")).expect("vendor dir");
+        fs::create_dir_all(repo.path().join("src/generated")).expect("generated dir");
         fs::write(
-            repo.path().join("src/lib.rs"),
-            "pub fn answer() -> u8 { 42 }\n",
+            repo.path().join("src/generated/mod.rs"),
+            "pub fn answer() {}\n",
         )
-        .expect("rust file");
-        fs::write(
-            repo.path().join("node_modules/pkg/lib.rs"),
-            "pub fn generated_dep() {}\n",
-        )
-        .expect("generated file");
-        fs::write(
-            repo.path().join("vendor/pkg/lib.rs"),
-            "pub fn vendored() {}\n",
-        )
-        .expect("vendor file");
+        .expect("generated module");
 
         let artifacts = CompositeCodeIntelProvider::new(repo.path())
-            .code_context(
-                &[
-                    PathBuf::from("src/lib.rs"),
-                    PathBuf::from("node_modules/pkg/lib.rs"),
-                    PathBuf::from("vendor/pkg/lib.rs"),
-                ],
-                &[],
-                20,
-            )
+            .code_context(&[PathBuf::from("src/generated/mod.rs")], &[], 20)
             .expect("code context");
 
         assert!(
             artifacts
                 .iter()
-                .any(|artifact| artifact.title == "src/lib.rs")
+                .any(|artifact| artifact.title == "src/generated/mod.rs")
         );
         assert!(
-            !artifacts
+            artifacts
                 .iter()
-                .any(|artifact| artifact.title.contains("node_modules"))
+                .any(|artifact| artifact.kind == "ast-symbols"
+                    && artifact.summary.contains("function `answer`"))
         );
-        assert!(
-            !artifacts
-                .iter()
-                .any(|artifact| artifact.title.contains("vendor"))
-        );
-        assert!(artifacts.iter().any(|artifact| {
-            artifact.kind == "trace"
-                && artifact
-                    .summary
-                    .contains("node_modules/pkg/lib.rs skipped generated/vendor")
-                && artifact
-                    .summary
-                    .contains("vendor/pkg/lib.rs skipped generated/vendor")
-        }));
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -515,6 +515,20 @@ impl AstCodeIntelProvider {
                 .to_path_buf();
             let relative_display = relative_path.to_string_lossy().to_string();
 
+            if resolved.is_dir() {
+                if let Some(component) = skipped_directory_name(&resolved) {
+                    report.fallback_reasons.push(format!(
+                        "{relative_display} skipped directory `{component}`"
+                    ));
+                    continue;
+                }
+                report
+                    .fallback_reasons
+                    .push(format!("{relative_display} is a directory"));
+                report.fallback_paths.push(relative_path);
+                continue;
+            }
+
             let Some(source) = self.read_limited_source(&resolved, &relative_display, &mut report)
             else {
                 continue;
@@ -2438,6 +2452,30 @@ mod tests {
                 .any(|artifact| artifact.kind == "ast-symbols"
                     && artifact.summary.contains("function `answer`"))
         );
+    }
+
+    #[test]
+    fn composite_skips_requested_generated_directories_with_trace() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("generated")).expect("generated dir");
+        fs::write(repo.path().join("generated/mod.rs"), "pub fn hidden() {}\n")
+            .expect("generated module");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(&[PathBuf::from("generated")], &[], 20)
+            .expect("code context");
+
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.title.contains("generated/mod.rs"))
+        );
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace"
+                && artifact
+                    .summary
+                    .contains("generated skipped directory `generated`")
+        }));
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -37,6 +37,20 @@ pub const JAVASCRIPT_QUERY_PACK_VERSION: &str = "javascript-query-pack-v1";
 pub const JSX_QUERY_PACK_VERSION: &str = "jsx-query-pack-v1";
 pub const PYTHON_QUERY_PACK_VERSION: &str = "python-query-pack-v1";
 const MARKDOWN_FENCE_QUERY_NAME: &str = "markdown_fences";
+const SKIPPED_DIRECTORY_COMPONENTS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".venv",
+    "__pycache__",
+    "coverage",
+    ".next",
+    ".turbo",
+    "vendor",
+    "generated",
+];
 
 const RUST_METADATA: &str = include_str!("../queries/rust/metadata.toml");
 const TYPESCRIPT_METADATA: &str = include_str!("../queries/typescript/metadata.toml");
@@ -501,6 +515,13 @@ impl AstCodeIntelProvider {
                 .to_path_buf();
             let relative_display = relative_path.to_string_lossy().to_string();
 
+            if let Some(component) = skipped_directory_component(&relative_path) {
+                report.fallback_reasons.push(format!(
+                    "{relative_display} skipped generated/vendor directory component `{component}`"
+                ));
+                continue;
+            }
+
             let Some(source) = self.read_limited_source(&resolved, &relative_display, &mut report)
             else {
                 continue;
@@ -673,6 +694,19 @@ impl AstCodeIntelProvider {
             .unwrap_or(&candidate)
             .to_path_buf())
     }
+}
+
+pub fn skipped_directory_component(path: impl AsRef<Path>) -> Option<&'static str> {
+    path.as_ref().components().find_map(|component| {
+        let Component::Normal(value) = component else {
+            return None;
+        };
+        let value = value.to_str()?;
+        SKIPPED_DIRECTORY_COMPONENTS
+            .iter()
+            .copied()
+            .find(|skipped| value == *skipped)
+    })
 }
 
 fn requested_candidate(repo_root: &Path, path: &Path) -> PathBuf {
@@ -2385,6 +2419,66 @@ mod tests {
         }));
         assert!(artifacts.iter().any(|artifact| {
             artifact.kind == "trace" && artifact.summary.contains("max AST file size")
+        }));
+    }
+
+    #[test]
+    fn composite_skips_generated_and_vendor_directories_with_trace() {
+        let repo = TempDir::new().expect("temp repo");
+        fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        fs::create_dir_all(repo.path().join("node_modules/pkg")).expect("node_modules dir");
+        fs::create_dir_all(repo.path().join("vendor/pkg")).expect("vendor dir");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("rust file");
+        fs::write(
+            repo.path().join("node_modules/pkg/lib.rs"),
+            "pub fn generated_dep() {}\n",
+        )
+        .expect("generated file");
+        fs::write(
+            repo.path().join("vendor/pkg/lib.rs"),
+            "pub fn vendored() {}\n",
+        )
+        .expect("vendor file");
+
+        let artifacts = CompositeCodeIntelProvider::new(repo.path())
+            .code_context(
+                &[
+                    PathBuf::from("src/lib.rs"),
+                    PathBuf::from("node_modules/pkg/lib.rs"),
+                    PathBuf::from("vendor/pkg/lib.rs"),
+                ],
+                &[],
+                20,
+            )
+            .expect("code context");
+
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.title == "src/lib.rs")
+        );
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.title.contains("node_modules"))
+        );
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.title.contains("vendor"))
+        );
+        assert!(artifacts.iter().any(|artifact| {
+            artifact.kind == "trace"
+                && artifact
+                    .summary
+                    .contains("node_modules/pkg/lib.rs skipped generated/vendor")
+                && artifact
+                    .summary
+                    .contains("vendor/pkg/lib.rs skipped generated/vendor")
         }));
     }
 

--- a/crates/opensymphony-planning/src/codebase.rs
+++ b/crates/opensymphony-planning/src/codebase.rs
@@ -311,8 +311,13 @@ impl RepoWalker {
             "target",
             ".venv",
             "__pycache__",
+            "coverage",
+            ".next",
+            ".turbo",
             "dist",
             "build",
+            "vendor",
+            "generated",
         ] {
             exclude_dirs.insert(dir.to_string());
         }

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -53,8 +53,10 @@ read the cited files and run the relevant tests before changing behavior.
 
 Generated and vendor directories such as `node_modules`, `target`, `dist`,
 `build`, `.venv`, `.next`, `.turbo`, `vendor`, and `generated` are skipped with
-trace warnings. Oversized files are skipped with trace warnings rather than
-failing the whole request.
+trace warnings during directory traversal. Explicitly requested files inside
+those directories are still parsed when they stay inside the repo root and pass
+the configured limits. Oversized files are skipped with trace warnings rather
+than failing the whole request.
 
 ## MCP Tools
 

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -1,0 +1,94 @@
+# Code Intelligence
+
+OpenSymphony code intelligence is local, read-only context for agents. It parses
+current source files with pinned Tree-sitter grammars, extracts symbols,
+diagnostics, references, and source-cited spans, then renders that evidence
+through `memory.context` and the read-only `code.ast.*` MCP tools.
+
+Code intelligence does not replace source inspection or tests. Current files,
+repository docs, and test results remain authoritative.
+
+## Configuration
+
+Code intelligence is enabled by default when memory is configured:
+
+```yaml
+code_intel:
+  enabled: true
+  ast:
+    enabled: true
+    max_file_bytes: 2097152
+    max_files_per_request: 200
+    max_matches_per_request: 2000
+    max_capture_bytes: 4096
+```
+
+The AST provider only loads built-in pinned grammar crates. Target repositories
+cannot supply native grammar binaries.
+
+## Freshness
+
+AST context is generated from the current worktree. Rendered artifacts include
+content hash, parser version, query-pack version, path, and line range so agents
+can tell what file state produced the context. Persisted code-intelligence rows
+store metadata, hashes, spans, freshness, and snippet hashes; source snippets
+are rendered from local files on demand.
+
+There is no filesystem watcher in V1. Re-run `memory.context` after editing
+source files.
+
+## Agent Workflow
+
+Use memory first, then code-intelligence context after file discovery:
+
+```bash
+opensymphony memory context --issue COE-123
+opensymphony memory context --issue COE-123 \
+  --paths crates/opensymphony-cli/src/memory.rs \
+  --include-code-intel
+```
+
+Use the output to find likely symbols, diagnostics, and related tests. Then
+read the cited files and run the relevant tests before changing behavior.
+
+Generated and vendor directories such as `node_modules`, `target`, `dist`,
+`build`, `.venv`, `.next`, `.turbo`, `vendor`, and `generated` are skipped with
+trace warnings. Oversized files are skipped with trace warnings rather than
+failing the whole request.
+
+## MCP Tools
+
+When `code_intel.ast.enabled` is true, `tools/list` exposes these read-only
+tools:
+
+- `code.ast.status`
+- `code.ast.outline`
+- `code.ast.symbols`
+- `code.ast.references`
+- `code.ast.query`
+- `code.ast.context`
+- `code.ast.diagnostics`
+
+`code.ast.query` accepts ad hoc Tree-sitter query text for local trusted use.
+When an admin token is configured, it is admin-gated. All tools enforce the
+configured file, match, and capture limits and run AST work off the async server
+thread.
+
+## Security
+
+- Relative paths resolve under the configured repo root.
+- Absolute paths and symlinks must canonicalize inside the repo root.
+- Only built-in pinned grammars are trusted.
+- The provider parses text and runs Tree-sitter queries only; it does not
+  execute target-repo source, build scripts, package manager scripts, tests, or
+  macros.
+- Public docs should cite paths and line ranges, not private source snippets.
+
+## Troubleshooting
+
+- Empty AST output with a trace fallback usually means no paths were requested,
+  the language is unsupported, or every requested file was skipped by limits.
+- Parser diagnostics mean Tree-sitter recovered partial syntax; inspect the
+  cited file before trusting symbol shape.
+- Stale-looking context usually means the agent edited files after loading
+  context. Re-run `memory.context --include-code-intel` for the touched paths.

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -51,12 +51,12 @@ opensymphony memory context --issue COE-123 \
 Use the output to find likely symbols, diagnostics, and related tests. Then
 read the cited files and run the relevant tests before changing behavior.
 
-Generated and vendor directories such as `node_modules`, `target`, `dist`,
-`build`, `.venv`, `.next`, `.turbo`, `vendor`, and `generated` are skipped with
-trace warnings during directory traversal. Explicitly requested files inside
-those directories are still parsed when they stay inside the repo root and pass
-the configured limits. Oversized files are skipped with trace warnings rather
-than failing the whole request.
+Generated, vendor, build, and cache directories such as `node_modules`,
+`target`, `dist`, `build`, `.venv`, `.next`, `.turbo`, `vendor`, and
+`generated` are skipped with trace warnings during directory traversal.
+Explicitly requested files inside those directories are still parsed when they
+stay inside the repo root and pass the configured limits. Oversized files are
+skipped with trace warnings rather than failing the whole request.
 
 ## MCP Tools
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -555,11 +555,11 @@ areas:
 
 `code_intel.ast.max_file_bytes`, `max_files_per_request`,
 `max_matches_per_request`, and `max_capture_bytes` bound AST reads, query
-results, and rendered snippets. Generated and vendor directories (`.git`,
-`node_modules`, `target`, `dist`, `build`, `.venv`, `__pycache__`, `coverage`,
-`.next`, `.turbo`, `vendor`, and `generated`) are skipped with trace warnings
-during directory traversal; explicitly requested files inside them can still be
-parsed when they pass path containment and resource limits.
+results, and rendered snippets. Generated, vendor, build, and cache directories
+(`.git`, `node_modules`, `target`, `dist`, `build`, `.venv`, `__pycache__`,
+`coverage`, `.next`, `.turbo`, `vendor`, and `generated`) are skipped with
+trace warnings during directory traversal; explicitly requested files inside
+them can still be parsed when they pass path containment and resource limits.
 
 Private memory should stay out of source control. Commit
 `.opensymphony/memory/memory.yaml` and generated public docs when appropriate;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -557,7 +557,9 @@ areas:
 `max_matches_per_request`, and `max_capture_bytes` bound AST reads, query
 results, and rendered snippets. Generated and vendor directories (`.git`,
 `node_modules`, `target`, `dist`, `build`, `.venv`, `__pycache__`, `coverage`,
-`.next`, `.turbo`, `vendor`, and `generated`) are skipped with trace warnings.
+`.next`, `.turbo`, `vendor`, and `generated`) are skipped with trace warnings
+during directory traversal; explicitly requested files inside them can still be
+parsed when they pass path containment and resource limits.
 
 Private memory should stay out of source control. Commit
 `.opensymphony/memory/memory.yaml` and generated public docs when appropriate;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -553,6 +553,12 @@ areas:
         - runtime
 ```
 
+`code_intel.ast.max_file_bytes`, `max_files_per_request`,
+`max_matches_per_request`, and `max_capture_bytes` bound AST reads, query
+results, and rendered snippets. Generated and vendor directories (`.git`,
+`node_modules`, `target`, `dist`, `build`, `.venv`, `__pycache__`, `coverage`,
+`.next`, `.turbo`, `vendor`, and `generated`) are skipped with trace warnings.
+
 Private memory should stay out of source control. Commit
 `.opensymphony/memory/memory.yaml` and generated public docs when appropriate;
 do not commit issue capsules, markdown indexes, DuckDB, source snapshots, or

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -444,10 +444,12 @@ provenance on the current rows; a clean re-ingest with identical content,
 parser version, and query-pack version updates that provenance without reporting
 phantom stale rows.
 
-Generated and vendor directories are skipped by default with trace warnings, as
-are files over `code_intel.ast.max_file_bytes`. The AST tools only use built-in
-pinned grammar crates and never execute target-repo source, build scripts,
-package manager scripts, tests, or macros. See
+Generated and vendor directories are skipped during directory traversal with
+trace warnings, as are files over `code_intel.ast.max_file_bytes`. Explicit file
+requests inside generated or vendor directory names still parse when they pass
+path containment and resource limits. The AST tools only use built-in pinned
+grammar crates and never execute target-repo source, build scripts, package
+manager scripts, tests, or macros. See
 [`docs/code-intelligence.md`](code-intelligence.md) for the operator and agent
 workflow.
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -444,9 +444,9 @@ provenance on the current rows; a clean re-ingest with identical content,
 parser version, and query-pack version updates that provenance without reporting
 phantom stale rows.
 
-Generated and vendor directories are skipped during directory traversal with
-trace warnings, as are files over `code_intel.ast.max_file_bytes`. Explicit file
-requests inside generated or vendor directory names still parse when they pass
+Generated, vendor, build, and cache directories are skipped during directory
+traversal with trace warnings, as are files over `code_intel.ast.max_file_bytes`.
+Explicit file requests inside skipped directory names still parse when they pass
 path containment and resource limits. The AST tools only use built-in pinned
 grammar crates and never execute target-repo source, build scripts, package
 manager scripts, tests, or macros. See

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -443,6 +443,14 @@ writing current rows. Commit SHA and dirty-worktree state are stored as
 provenance on the current rows; a clean re-ingest with identical content,
 parser version, and query-pack version updates that provenance without reporting
 phantom stale rows.
+
+Generated and vendor directories are skipped by default with trace warnings, as
+are files over `code_intel.ast.max_file_bytes`. The AST tools only use built-in
+pinned grammar crates and never execute target-repo source, build scripts,
+package manager scripts, tests, or macros. See
+[`docs/code-intelligence.md`](code-intelligence.md) for the operator and agent
+workflow.
+
 `opensymphony memory reindex --from-okf [bundle-root]` rebuilds the derived
 DuckDB catalog from OKF concept documents, defaulting to the configured memory
 root. Broken links and unknown concept types are indexed as warnings; malformed

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -431,8 +431,8 @@ into ordinary worker environments. When `code_intel.ast.enabled` is true,
 `code.ast.query` tool is available for local trusted use without tokens, and is
 admin-gated when an admin token is configured. AST work runs off the async
 server thread, enforces configured file/match/capture limits, rejects paths and
-symlinks outside the repo root, skips generated/vendor directories during
-traversal and oversized files with trace warnings, and never executes
+symlinks outside the repo root, skips generated/vendor/build/cache directories
+during traversal and oversized files with trace warnings, and never executes
 target-repo code. Direct file requests inside skipped directory names still pass
 through containment and resource checks. See
 [`docs/code-intelligence.md`](code-intelligence.md) for agent and operator

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -429,7 +429,12 @@ admin token is configured, it also gates read tools; do not inject that token
 into ordinary worker environments. When `code_intel.ast.enabled` is true,
 `tools/list` also exposes read-only `code.ast.*` inspection tools. The ad hoc
 `code.ast.query` tool is available for local trusted use without tokens, and is
-admin-gated when an admin token is configured.
+admin-gated when an admin token is configured. AST work runs off the async
+server thread, enforces configured file/match/capture limits, rejects paths and
+symlinks outside the repo root, skips generated/vendor directories and oversized
+files with trace warnings, and never executes target-repo code. See
+[`docs/code-intelligence.md`](code-intelligence.md) for agent and operator
+usage.
 
 Linear archival is a separate command and is guarded by captured memory:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -431,8 +431,10 @@ into ordinary worker environments. When `code_intel.ast.enabled` is true,
 `code.ast.query` tool is available for local trusted use without tokens, and is
 admin-gated when an admin token is configured. AST work runs off the async
 server thread, enforces configured file/match/capture limits, rejects paths and
-symlinks outside the repo root, skips generated/vendor directories and oversized
-files with trace warnings, and never executes target-repo code. See
+symlinks outside the repo root, skips generated/vendor directories during
+traversal and oversized files with trace warnings, and never executes
+target-repo code. Direct file requests inside skipped directory names still pass
+through containment and resource checks. See
 [`docs/code-intelligence.md`](code-intelligence.md) for agent and operator
 usage.
 

--- a/docs/tasks/multi-repo-memory-server-with-code-intelligence.md
+++ b/docs/tasks/multi-repo-memory-server-with-code-intelligence.md
@@ -61,7 +61,9 @@ Keep **MCP over Streamable HTTP** as the canonical agent/CLI protocol. It still 
 ## Code Intelligence Integration
 
 - Treat DeepWiki/Codemaps as inspiration for a clean-room OpenSymphony capability: generated architecture docs, code maps, source links, summaries, dependency/call graphs, and queryable code understanding.
-- Add `CodeIntelProvider` with initial implementation wrapping the existing repository `CodebaseAnalyzer`.
+- Use the concrete Tree-sitter AST provider as the first structural code-intelligence implementation. It feeds `memory.context --include-code-intel` and the read-only `code.ast.*` MCP tools with source-cited symbols, diagnostics, references, parser/query-pack versions, and content hashes.
+- Keep `CodebaseAnalyzer` as the repository-summary fallback for unsupported languages, no requested paths, parser diagnostics, oversized files, and mixed-path requests.
+- Run parse/query work from async paths through `spawn_blocking`, keep parser/query cursor state local to each task, and rely on configured file, match, and capture limits before adding any cache.
 - Future providers:
   - Qdrant-backed multi-vector embeddings.
   - Colleague code graph adapter.


### PR DESCRIPTION
## Summary

Hardens Tree-sitter code intelligence resource behavior and documents the V1 agent/operator workflow.

## Changes

- Skip generated/vendor directories during MCP traversal with trace warnings while still parsing explicit files under those path components.
- Skip oversized AST MCP files with trace warnings instead of failing the whole tool call.
- Add focused concurrency, skip, query-limit, path-containment, and provider trace coverage.
- Add `docs/code-intelligence.md` and update README, AGENTS.md, memory, operations, configuration, workflow, and planning docs.

## Evidence

### Test output

```
cargo fmt --check
cargo test-system-duckdb code_ast
cargo test-system-duckdb composite_parses_explicit_files_under_generated_directories
cargo test-system-duckdb composite_skips_requested_generated_directories_with_trace
cargo test-system-duckdb code_ast_diagnostics_enforces_request_limit
cargo test-system-duckdb
cargo clippy-system-duckdb
target/debug/opensymphony memory lint --public-docs
```

### Verification

- Reproduced the missing generated/vendor traversal policy with `rg` over the AST provider and MCP collector before editing.
- Timing checks with `target/debug/opensymphony memory context --include-code-intel`:
  - Rust path `crates/opensymphony-code-intel/src/lib.rs`: 3.72s debug run.
  - Mixed Rust/TypeScript paths `crates/opensymphony-code-intel/src/lib.rs,apps/web/src/index.ts`: 4.37s debug run.
  - Warm mixed repeat: 3.49s debug run.
- Verified rendered context included `ast-summary`, `ast-symbols`, and `Code-intelligence trace` sections for requested Rust and TypeScript paths.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- COE-503

## Additional notes

No custom cache layer was added. The current measured debug timings and existing per-call parser/query-cursor isolation did not justify one for V1; configured file, match, capture, and generated/vendor traversal skip limits now bound the resource surface.

