### PR TITLE
feat(init): add Codex code review as a PR review provider option

### DIFF
--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -117,8 +117,10 @@ echo "**DO NOT MERGE** - the user reviews and merges."
 
 ## Review Handling
 
-This repo uses the OpenHands PR Review plugin for automated reviews. Reviews
-post as inline comments on specific lines of code.
+This repo uses an automated AI review provider configured under
+`Automated AI PR review` in `WORKFLOW.md`: either the OpenHands PR Review
+plugin (GitHub Actions) or Codex code review (Codex GitHub integration).
+Reviews post as inline comments on specific lines of code.
 
 Before inspecting GitHub review comments, fetch the latest Linear issue comments
 with `.agents/skills/linear/queries/issue_comments.graphql`. Treat unresolved,
@@ -127,8 +129,10 @@ has no new GitHub comments.
 
 ### AI Review Comments
 
-AI reviews are posted by GitHub Actions with `openhands-review` as the job name.
-They are advisory only and do not count as required approvals.
+AI reviews are posted by GitHub Actions with `openhands-review` as the job
+name (openhands provider) or by the Codex connector bot
+(`chatgpt-codex-connector`, codex provider). They are advisory only and do not
+count as required approvals.
 
 To address AI review feedback:
 1. Read the inline comment on the specific line
@@ -136,7 +140,14 @@ To address AI review feedback:
    is correct), or push back (disagree with reasoning)
 3. Reply inline to the review comment explaining your action
 4. If accepting, implement the fix, commit, and push
-5. Optionally re-trigger AI review by adding the `review-this` label
+5. After pushing follow-up commits, re-trigger AI review per the active
+   provider: add the `review-this` label (openhands) or post a comment that is
+   exactly `@codex review` (codex)
+
+Never ask the review bot to make code changes. In particular, never mention
+`@codex` with any text other than the exact phrase `@codex review`; other
+mentions start a Codex cloud task that bills general Codex usage and edits
+code outside this workspace.
 
 Use the explicit review-comment reply endpoint for inline AI review threads:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,12 +364,19 @@ When changing the pinned OpenHands assumptions, update `docs/sources.md`.
 
 ## AI PR Review Overlay
 
-This repository uses an automated AI PR review system via OpenHands.
+This repository uses an automated AI PR review system. The active provider is
+recorded under `Automated AI PR review` in `WORKFLOW.md`: the OpenHands PR
+Review plugin (current) or Codex code review (see
+`docs/codex-code-review-setup.md`).
 
 ### How it works
 
-- The `.github/workflows/ai-pr-review.yml` workflow runs on PR events
-- It uses the OpenHands PR review plugin with repository-specific guidance
+- OpenHands provider: the `.github/workflows/ai-pr-review.yml` workflow runs
+  on PR events using the OpenHands PR review plugin with repository-specific
+  guidance
+- Codex provider: the Codex GitHub integration reviews PRs on open and on an
+  exact `@codex review` comment, applying the `## Review guidelines` guidance
+  in the closest `AGENTS.md`
 - Reviews focus on correctness, security, and maintainability
 - The AI reviewer is **advisory only** and does not count as a human approval
 
@@ -395,10 +402,15 @@ Substantive PRs should include an `Evidence` section showing:
 
 ### Triggering review
 
-The AI review runs automatically on:
+With the OpenHands provider, the AI review runs automatically on:
 - PR opened (non-draft, same-repo)
 - PR synchronized (new commits)
 - PR marked ready for review
 - `review-this` label added
 
 To manually retrigger, add the `review-this` label.
+
+With the Codex provider, the initial review runs automatically on PR open;
+retrigger by posting a comment that is exactly `@codex review`. Never mention
+`@codex` with any other text (it starts a cloud task billed to general Codex
+usage, outside the orchestration), and never ask Codex to fix or push changes.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -209,6 +209,53 @@ workflow.
       - resulting `HEAD` short SHA.
 12. Compact context and proceed to execution.
 
+## Automated AI PR review
+
+Active review provider: `openhands`
+
+<!-- Valid values: `openhands`, `codex`, `none`.
+     openhands = OpenHands PR Review plugin via GitHub Actions (pay-per-token,
+                 uses the AI_REVIEW_API_KEY repository secret).
+     codex     = Codex code review via the Codex GitHub integration (included
+                 with a ChatGPT subscription; GitHub-triggered reviews draw
+                 from a separate code-review usage pool, so they never compete
+                 with implementation runs for quota).
+     To switch providers, edit the value above and follow
+     docs/codex-code-review-setup.md -->
+
+Both providers post standard GitHub reviews with inline comments, and both are
+re-triggered after every follow-up push so each fix round gets a fresh review
+pass. Treat findings from either provider identically under the PR feedback
+sweep protocol below.
+
+Whenever this workflow says "re-trigger AI review", perform the action that
+matches the active provider:
+
+- `openhands`: add the `review-this` label to the PR
+  (`gh pr edit <pr> --add-label review-this`).
+- `codex`: post a top-level PR comment whose entire body is exactly
+  `@codex review` (`gh pr comment <pr> --body '@codex review'`). Codex reacts
+  with 👀 and posts a fresh review.
+- `none`: skip re-trigger steps; only human and CI feedback apply.
+
+Never re-trigger at PR creation time for either provider: the initial review
+runs automatically when the PR is opened (`pull_request.opened` for
+`openhands`, automatic reviews for `codex`).
+
+Codex guardrails (mandatory whenever the active provider is `codex`):
+
+- The re-trigger phrase must be exactly `@codex review` with no other text.
+  Mentioning `@codex` with anything else starts a Codex cloud task that bills
+  against general Codex usage limits (not the separate code-review pool) and
+  operates outside this orchestration.
+- Never ask Codex to fix, implement, or push changes. All code changes happen
+  in this orchestrated workspace through the normal implementation flow; the
+  review bot only reviews.
+
+AI review comments are posted by `github-actions[bot]` (openhands, job name
+`openhands-review`) or by the Codex connector bot (`chatgpt-codex-connector`).
+Treat both as actionable AI feedback in the sweep protocol.
+
 ## PR feedback sweep protocol (required)
 
 When a ticket has an attached PR, run this protocol before moving to `Human Review`:
@@ -253,8 +300,8 @@ When a ticket has an attached PR, run this protocol before moving to `Human Revi
 5. Update the workpad plan/checklist to include each feedback item and its resolution status.
 6. Re-run validation after feedback-driven changes and push updates.
 7. Repeat this sweep until there are no outstanding actionable comments.
-8. If you pushed follow-up commits to an existing PR, add the `review-this` label after the push to re-trigger automated AI PR review.
-   - Do **not** add `review-this` when the PR is first created; the `pull_request.opened` event already triggers the initial AI review pass.
+8. If you pushed follow-up commits to an existing PR, re-trigger AI review after the push (see `Automated AI PR review`) so the new commits get a fresh review pass.
+   - Do **not** re-trigger when the PR is first created; the initial AI review pass already runs automatically on PR open.
 
 ## Blocked-access escape hatch (required behavior)
 
@@ -291,8 +338,8 @@ Use this only when completion is blocked by missing required tools or missing au
 7.  Before every `git push` attempt, run the required validation for your scope and confirm it passes; if it fails, address issues and rerun until green, then commit and push changes.
 8.  Attach the PR URL to the Linear issue through the repo-local `linear` skill using `attachmentLinkGitHubPR` (preferred) or `attachmentLinkURL` when the target is not a GitHub PR. This is REQUIRED - do not rely on mentioning the PR URL in comments alone. The PR must appear in the issue's Links/Attachments section.
     - Ensure the GitHub PR has label `symphony` (add it if missing).
-    - Do **not** add `review-this` when this push created the PR; the initial PR open already triggered AI review.
-    - If this push updated an existing PR with new commits, add `review-this` after the push to request a fresh AI review pass.
+    - Do **not** re-trigger AI review when this push created the PR; the PR open already triggered the initial review.
+    - If this push updated an existing PR with new commits, re-trigger AI review after the push (see `Automated AI PR review`) to request a fresh review pass.
 9.  Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
@@ -332,7 +379,7 @@ Use this only when completion is blocked by missing required tools or missing au
    - a new top-level PR comment is actionable feedback
    - a failing required PR check is actionable feedback even if no human comment was left
 5. If any actionable feedback or failing required check is present, move the issue to `Rework` and follow the rework flow.
-   - Before leaving `Human Review` to address new feedback, remove any pre-existing `review-this` label from the PR so the next rerun request is an explicit new edge.
+   - Before leaving `Human Review` to address new feedback with the `openhands` provider, remove any pre-existing `review-this` label from the PR so the next rerun request is an explicit new edge. (With the `codex` provider there is nothing to clean up; each `@codex review` comment is a fresh request.)
    - Do not wait for an inline review comment when a Linear comment, top-level PR comment, or failing check already requires action.
 6. If approved, human moves the issue to `Merging`.
 7. When the issue is in `Merging`, first inspect the attached PR state.
@@ -368,7 +415,7 @@ For most code review feedback (addressing comments, small fixes, requested tweak
 5. Re-run validation/tests to ensure changes are correct.
    - Always inspect current PR checks (`gh pr view --json statusCheckRollup`) before declaring feedback addressed.
    - If any required check is failing, treat that as unfinished rework even if the latest review text is positive.
-6. After pushing follow-up commits to the existing PR, add the `review-this` label to re-trigger automated AI PR review.
+6. After pushing follow-up commits to the existing PR, re-trigger AI review (see `Automated AI PR review`) so the rework gets a fresh review pass.
 7. Move the issue back to `Human Review` once all feedback is addressed.
 
 **Preserve review history**: Keeping the same PR preserves all discussion context, review threads, and decision history. Reviewers can see incremental changes rather than starting from scratch.
@@ -390,7 +437,7 @@ For major rework:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
    - Create a new bootstrap `## Agent Harness Workpad` comment.
    - Build a fresh plan/checklist and execute end-to-end.
-6. Do **not** add `review-this` immediately after creating the new PR; the initial PR open already triggered automated AI review.
+6. Do **not** re-trigger AI review immediately after creating the new PR; the initial PR open already triggered the automated review.
 
 **Default assumption**: Treat `Rework` as minor feedback unless there is clear evidence that the approach is fundamentally broken. Preserve PR history and discussion context as the default behavior.
 
@@ -419,6 +466,8 @@ For major rework:
   title/description/acceptance criteria, same-project assignment, a `related`
   link to the current issue, and `blockedBy` when the follow-up depends on
   the current issue.
+- Never mention `@codex` in any comment except the exact re-trigger phrase `@codex review`, and only when the active review provider is `codex`.
+- Never ask a review bot (Codex or OpenHands) to implement, fix, or push changes; implement all fixes in this workspace through the normal flow.
 - Do not move to `Human Review` unless the `Completion bar before Human Review` is satisfied.
 - **Never merge or allow merge of a PR with outstanding critical feedback or failing checks.** This includes not moving to `Merging` if feedback sweep shows unresolved comments.
 - In `Human Review`, do not make changes; wait and poll.

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -1900,7 +1900,7 @@ where
         "2. In Codex settings, install the Codex GitHub app for {repo_label}."
     ))?;
     ui.line(format!(
-        "3. Create a Codex cloud environment for {repo_label} (Codex settings -> Environments -> Create environment). Code review needs no custom setup; the default universal image works. Without an environment, Codex only comments \"To use Codex here, create an environment for this repo\" instead of reviewing."
+        "3. Create a Codex cloud environment for {repo_label} at https://chatgpt.com/codex/cloud/settings/environments. Code review needs no custom setup; the default universal image works. Without an environment, Codex only comments \"To use Codex here, create an environment for this repo\" instead of reviewing."
     ))?;
     ui.line(format!(
         "4. Enable Code review for {repo_label} and turn on automatic reviews so every newly opened PR gets an initial review."

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -1900,13 +1900,16 @@ where
         "2. In Codex settings, install the Codex GitHub app for {repo_label}."
     ))?;
     ui.line(format!(
-        "3. Enable Code review for {repo_label} and turn on automatic reviews so every newly opened PR gets an initial review."
+        "3. Create a Codex cloud environment for {repo_label} (Codex settings -> Environments -> Create environment). Code review needs no custom setup; the default universal image works. Without an environment, Codex only comments \"To use Codex here, create an environment for this repo\" instead of reviewing."
+    ))?;
+    ui.line(format!(
+        "4. Enable Code review for {repo_label} and turn on automatic reviews so every newly opened PR gets an initial review."
     ))?;
     ui.line(
-        "4. Keep review guidance current: Codex applies the `## Review guidelines` section in `AGENTS.md`, which points at `.agents/skills/custom-codereview-guide.md`.",
+        "5. Keep review guidance current: Codex applies the `## Review guidelines` section in `AGENTS.md`, which points at `.agents/skills/custom-codereview-guide.md`.",
     )?;
     ui.line(
-        "5. Verify: open a test PR; Codex should react with 👀 and post a review. If nothing happens and no error appears, disconnect and reconnect the GitHub connector in Codex settings.",
+        "6. Verify: open a test PR; Codex should react with 👀 and post a review. If nothing happens and no error appears, disconnect and reconnect the GitHub connector in Codex settings.",
     )?;
     ui.blank_line()?;
     ui.line(

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -38,6 +38,10 @@ const AI_REVIEW_LABEL_NAME: &str = "review-this";
 const AGENTS_EXAMPLE_PATH: &str = "AGENTS-example.md";
 const WORKFLOW_PROJECT_SLUG_PLACEHOLDER: &str = "\"YOUR-PROJECT-SLUG\"";
 const WORKFLOW_GIT_REMOTE_PLACEHOLDER: &str = "https://github.com/YOUR-ORG/YOUR-REPO.git";
+const WORKFLOW_REVIEW_PROVIDER_PLACEHOLDER: &str = "YOUR-REVIEW-PROVIDER";
+const CODEX_CODE_REVIEW_SETUP_GUIDE_URL: &str =
+    "https://github.com/kumanday/OpenSymphony/blob/main/docs/codex-code-review-setup.md";
+const CODEX_CODE_REVIEW_DOCS_URL: &str = "https://developers.openai.com/codex/integrations/github";
 
 #[derive(Debug, Args, Clone, Default)]
 pub struct InitArgs {
@@ -48,7 +52,14 @@ pub struct InitArgs {
     non_interactive: bool,
     #[arg(
         long,
-        help = "Scaffold automated OpenHands AI PR review without prompting"
+        value_enum,
+        value_name = "PROVIDER",
+        help = "Automated PR review provider: openhands (GitHub Actions plugin, pay-per-token), codex (Codex code review via ChatGPT subscription), or none"
+    )]
+    review_provider: Option<ReviewProviderArg>,
+    #[arg(
+        long,
+        help = "Scaffold automated OpenHands AI PR review without prompting (same as --review-provider openhands)"
     )]
     ai_pr_review: bool,
     #[arg(
@@ -155,6 +166,23 @@ impl AiReviewProviderKindArg {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum ReviewProviderArg {
+    Openhands,
+    Codex,
+    None,
+}
+
+impl ReviewProviderArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Openhands => "openhands",
+            Self::Codex => "codex",
+            Self::None => "none",
+        }
+    }
+}
+
 impl InitArgs {
     fn validate(&self) -> Result<(), InitCommandError> {
         let secret_sources = [
@@ -181,8 +209,28 @@ impl InitArgs {
                     .to_string(),
             ));
         }
+        if matches!(
+            self.review_provider,
+            Some(ReviewProviderArg::Codex | ReviewProviderArg::None)
+        ) && self.ai_pr_review_requested_by_flags()
+        {
+            return Err(InitCommandError::InvalidArgument(
+                "OpenHands review flags (--ai-pr-review, --configure-github, --ai-review-*) can only be used with --review-provider openhands"
+                    .to_string(),
+            ));
+        }
 
         Ok(())
+    }
+
+    fn resolved_review_provider_from_flags(&self) -> Option<ReviewProviderArg> {
+        if let Some(provider) = self.review_provider {
+            Some(provider)
+        } else if self.ai_pr_review_requested_by_flags() {
+            Some(ReviewProviderArg::Openhands)
+        } else {
+            None
+        }
     }
 
     fn ai_pr_review_requested_by_flags(&self) -> bool {
@@ -589,17 +637,14 @@ where
         "Initializing OpenSymphony files in {}",
         target_repo.display()
     ))?;
-    let enable_ai_pr_review = if args.ai_pr_review_requested_by_flags() {
-        true
+    let review_provider = if let Some(provider) = args.resolved_review_provider_from_flags() {
+        provider
     } else if args.non_interactive {
-        false
+        ReviewProviderArg::None
     } else {
-        prompt_yes_no(
-            ui,
-            "Also scaffold automated OpenHands AI PR review? [y/N]: ",
-            false,
-        )?
+        prompt_review_provider(ui)?
     };
+    let enable_ai_pr_review = review_provider == ReviewProviderArg::Openhands;
     let ai_review_config = if enable_ai_pr_review {
         Some(
             if args.non_interactive || args.ai_pr_review_requested_by_flags() {
@@ -623,6 +668,8 @@ where
     if ai_review_config.is_some() {
         fetched_assets
             .extend(fetch_template_assets(&client, AI_REVIEW_TEMPLATE_ASSETS, &[]).await?);
+    }
+    if review_provider != ReviewProviderArg::None {
         fetched_assets.extend(generated_ai_review_assets());
     }
     let mut planned_assets = plan_assets(&target_repo, fetched_assets)?;
@@ -696,6 +743,7 @@ where
             planned,
             git_remote_url(&git_remote),
             linear_project_slug.as_deref(),
+            review_provider,
         )?;
 
         match final_result {
@@ -754,6 +802,9 @@ where
 
     if let Some(config) = ai_review_config.as_ref() {
         handle_ai_pr_review_setup(ui, env_lookup, &target_repo, &git_remote, config, &args)?;
+    }
+    if review_provider == ReviewProviderArg::Codex {
+        handle_codex_review_setup(ui, &git_remote)?;
     }
 
     prompt_for_missing_llm_env(env_lookup, ui, &args)?;
@@ -1083,6 +1134,7 @@ fn apply_asset(
     planned: PlannedAsset,
     git_remote_url: Option<&str>,
     linear_project_slug: Option<&str>,
+    review_provider: ReviewProviderArg,
 ) -> Result<AppliedChange, InitCommandError> {
     let existing = planned.existing.as_deref();
 
@@ -1091,6 +1143,7 @@ fn apply_asset(
         &planned.action,
         git_remote_url,
         linear_project_slug,
+        review_provider,
     ) else {
         return Ok(match planned.action {
             PlannedAction::Skip => AppliedChange::Skipped,
@@ -1141,18 +1194,23 @@ fn build_final_contents(
     action: &PlannedAction,
     git_remote_url: Option<&str>,
     linear_project_slug: Option<&str>,
+    review_provider: ReviewProviderArg,
 ) -> Option<String> {
     match action {
         PlannedAction::Create | PlannedAction::Overwrite => Some(match asset.kind {
-            AssetKind::Workflow => {
-                customize_workflow(&asset.contents, git_remote_url, linear_project_slug)
-            }
+            AssetKind::Workflow => customize_workflow(
+                &asset.contents,
+                git_remote_url,
+                linear_project_slug,
+                review_provider,
+            ),
             _ => asset.contents.clone(),
         }),
         PlannedAction::CustomizeWorkflow => Some(customize_workflow(
             &asset.contents,
             git_remote_url,
             linear_project_slug,
+            review_provider,
         )),
         PlannedAction::Skip | PlannedAction::Unchanged => None,
         PlannedAction::Prompt => None,
@@ -1453,6 +1511,36 @@ where
     }
 }
 
+fn prompt_review_provider<R, W>(
+    ui: &mut PromptUi<R, W>,
+) -> Result<ReviewProviderArg, InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    ui.blank_line()?;
+    ui.line("Configure automated AI PR code review for this repository?")?;
+    ui.line(
+        "  codex     - Codex code review via the Codex GitHub integration. Included with a ChatGPT subscription; GitHub-triggered reviews draw from a separate code-review usage pool, so they never compete with implementation runs for quota.",
+    )?;
+    ui.line(
+        "  openhands - OpenHands PR Review plugin via GitHub Actions. Pay-per-token with your own LLM API key.",
+    )?;
+    ui.line("  none      - skip automated PR review for now.")?;
+    loop {
+        let response = ui.prompt("Review provider [codex/openhands/none] (default none): ")?;
+        match response.trim().to_ascii_lowercase().as_str() {
+            "" | "none" | "skip" | "n" | "no" => return Ok(ReviewProviderArg::None),
+            "codex" => return Ok(ReviewProviderArg::Codex),
+            // `y`/`yes` preserved from the previous yes/no OpenHands prompt.
+            "openhands" | "y" | "yes" => return Ok(ReviewProviderArg::Openhands),
+            _ => {
+                ui.line("Please answer with `codex`, `openhands`, or `none`.")?;
+            }
+        }
+    }
+}
+
 fn prompt_ai_review_config<R, W>(
     ui: &mut PromptUi<R, W>,
 ) -> Result<AiReviewConfig, InitCommandError>
@@ -1609,6 +1697,7 @@ fn customize_workflow(
     template: &str,
     git_remote_url: Option<&str>,
     linear_project_slug: Option<&str>,
+    review_provider: ReviewProviderArg,
 ) -> String {
     let mut customized = template.to_string();
 
@@ -1624,7 +1713,10 @@ fn customize_workflow(
             customized.replace(WORKFLOW_PROJECT_SLUG_PLACEHOLDER, &yaml_double_quote(slug));
     }
 
-    customized
+    customized.replace(
+        WORKFLOW_REVIEW_PROVIDER_PLACEHOLDER,
+        review_provider.as_str(),
+    )
 }
 
 fn comparable_text(value: &str) -> String {
@@ -1644,12 +1736,12 @@ fn custom_codereview_guide_contents() -> String {
 name: custom-codereview-guide
 description: |
   Repository-specific code review guidance for this project.
-  Update this file so OpenHands PR review focuses on the right risks.
+  Update this file so automated PR review focuses on the right risks.
 ---
 
 # Custom Code Review Guide
 
-OpenHands PR review will load this file when it is present. Replace this starter content with repository-specific expectations.
+Automated PR review reads this guidance: the OpenHands PR Review plugin loads this file directly, and Codex code review reaches it through the `## Review guidelines` section in `AGENTS.md`. Replace this starter content with repository-specific expectations.
 
 ## Default Priorities
 
@@ -1773,6 +1865,55 @@ where
     }
 
     print_ai_review_setup_links(ui)?;
+    Ok(())
+}
+
+fn handle_codex_review_setup<R, W>(
+    ui: &mut PromptUi<R, W>,
+    git_remote: &GitRemoteDetection,
+) -> Result<(), InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    let repo_label = git_remote_url(git_remote)
+        .and_then(github_repo_slug_from_remote)
+        .map(|slug| format!("`{slug}`"))
+        .unwrap_or_else(|| "this repository".to_string());
+
+    ui.blank_line()?;
+    ui.line(
+        "Codex code review selected. Reviews run through the Codex GitHub integration using a ChatGPT subscription and draw from a separate code-review usage pool, so they never compete with agent implementation runs for quota.",
+    )?;
+    ui.line(
+        "No GitHub Actions workflow, repository secret, or `review-this` label is needed for this provider.",
+    )?;
+    ui.blank_line()?;
+    ui.line("Finish the one-time Codex setup in a browser:")?;
+    ui.line(
+        "1. Sign in at https://chatgpt.com/codex with the ChatGPT account that should fund reviews.",
+    )?;
+    ui.line(
+        "   If your GitHub identity is linked to more than one ChatGPT account (for example personal + a workspace), connect from the intended account last; the most recently connected account is used.",
+    )?;
+    ui.line(format!(
+        "2. In Codex settings, install the Codex GitHub app for {repo_label}."
+    ))?;
+    ui.line(format!(
+        "3. Enable Code review for {repo_label} and turn on automatic reviews so every newly opened PR gets an initial review."
+    ))?;
+    ui.line(
+        "4. Keep review guidance current: Codex applies the `## Review guidelines` section in `AGENTS.md`, which points at `.agents/skills/custom-codereview-guide.md`.",
+    )?;
+    ui.line(
+        "5. Verify: open a test PR; Codex should react with 👀 and post a review. If nothing happens and no error appears, disconnect and reconnect the GitHub connector in Codex settings.",
+    )?;
+    ui.blank_line()?;
+    ui.line(
+        "`WORKFLOW.md` records `codex` as the active review provider: agents re-request review after every follow-up push by commenting exactly `@codex review`, and never ask Codex to make code changes.",
+    )?;
+    ui.line(format!("Setup guide: {CODEX_CODE_REVIEW_SETUP_GUIDE_URL}"))?;
+    ui.line(format!("Codex docs: {CODEX_CODE_REVIEW_DOCS_URL}"))?;
     Ok(())
 }
 
@@ -2217,10 +2358,11 @@ mod tests {
     use super::{
         AiReviewConfig, AiReviewProviderKindArg, DEFAULT_AI_REVIEW_MODEL_ID, DEFAULT_LLM_BASE_URL,
         DEFAULT_LLM_MODEL, DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS, GitRemoteDetection, InitArgs,
-        InitCommandError, PromptUi, comparable_text, custom_codereview_guide_contents,
-        customize_workflow, git_remote_url, github_repo_slug_from_remote,
-        normalize_github_repo_slug, prompt_ai_review_config, prompt_for_missing_llm_env,
-        prompt_yes_no, resolve_ai_review_secret, select_remote_name, shell_single_quote,
+        InitCommandError, PromptUi, ReviewProviderArg, comparable_text,
+        custom_codereview_guide_contents, customize_workflow, git_remote_url,
+        github_repo_slug_from_remote, normalize_github_repo_slug, prompt_ai_review_config,
+        prompt_for_missing_llm_env, prompt_review_provider, prompt_yes_no,
+        resolve_ai_review_secret, select_remote_name, shell_single_quote,
         template_fetch_timeout_from_env,
     };
 
@@ -2243,16 +2385,35 @@ hooks:
   after_create: |
     git clone --depth 1 https://github.com/YOUR-ORG/YOUR-REPO.git .
 ---
+
+Active review provider: `YOUR-REVIEW-PROVIDER`
 "#;
 
         let customized = customize_workflow(
             workflow,
             Some("git@github.com:kumanday/demo.git"),
             Some("demo-project"),
+            ReviewProviderArg::Openhands,
         );
 
         assert!(customized.contains("project_slug: \"demo-project\""));
         assert!(customized.contains("git clone --depth 1 'git@github.com:kumanday/demo.git' ."));
+        assert!(customized.contains("Active review provider: `openhands`"));
+    }
+
+    #[test]
+    fn customize_workflow_replaces_review_provider_for_codex_and_none() {
+        let workflow = "Active review provider: `YOUR-REVIEW-PROVIDER`\n";
+
+        let codex = customize_workflow(workflow, None, None, ReviewProviderArg::Codex);
+        assert!(codex.contains("Active review provider: `codex`"));
+
+        let none = customize_workflow(workflow, None, None, ReviewProviderArg::None);
+        assert!(none.contains("Active review provider: `none`"));
+
+        let without_placeholder =
+            customize_workflow("no marker here\n", None, None, ReviewProviderArg::Codex);
+        assert_eq!(without_placeholder, "no marker here\n");
     }
 
     #[test]
@@ -2270,6 +2431,7 @@ hooks:
             workflow,
             Some("https://github.com/example/demo.git"),
             Some("demo-project"),
+            ReviewProviderArg::None,
         );
 
         assert!(customized.contains("project_slug:    \"demo-project\""));
@@ -2600,6 +2762,79 @@ hooks:
                 if name == "LLM_API_KEY"
                     && flag == "--reuse-llm-api-key-for-ai-review-secret"
         ));
+    }
+
+    #[test]
+    fn prompt_review_provider_accepts_named_choices_and_default() {
+        for (input, expected) in [
+            (&b"codex\n"[..], ReviewProviderArg::Codex),
+            (&b"openhands\n"[..], ReviewProviderArg::Openhands),
+            (&b"none\n"[..], ReviewProviderArg::None),
+            (&b"\n"[..], ReviewProviderArg::None),
+            // Legacy answers from the previous yes/no OpenHands prompt.
+            (&b"yes\n"[..], ReviewProviderArg::Openhands),
+            (&b"n\n"[..], ReviewProviderArg::None),
+        ] {
+            let mut output = Vec::new();
+            let mut ui = PromptUi::new(input, &mut output);
+            let provider = prompt_review_provider(&mut ui).expect("prompt should succeed");
+            assert_eq!(provider, expected, "input {input:?}");
+        }
+    }
+
+    #[test]
+    fn prompt_review_provider_reprompts_on_invalid_answer() {
+        let mut output = Vec::new();
+        let mut ui = PromptUi::new(&b"copilot\ncodex\n"[..], &mut output);
+
+        let provider = prompt_review_provider(&mut ui).expect("prompt should succeed");
+
+        assert_eq!(provider, ReviewProviderArg::Codex);
+        let rendered = String::from_utf8(output).expect("prompt output should be utf-8");
+        assert!(rendered.contains("Please answer with `codex`, `openhands`, or `none`."));
+    }
+
+    #[test]
+    fn init_args_reject_openhands_flags_with_codex_provider() {
+        let args = InitArgs {
+            review_provider: Some(ReviewProviderArg::Codex),
+            ai_pr_review: true,
+            ..InitArgs::default()
+        };
+
+        let error = args.validate().expect_err("flag mix should be rejected");
+
+        assert!(matches!(
+            error,
+            InitCommandError::InvalidArgument(message)
+                if message.contains("--review-provider openhands")
+        ));
+    }
+
+    #[test]
+    fn review_provider_resolution_prefers_explicit_flag_then_openhands_flags() {
+        let explicit = InitArgs {
+            review_provider: Some(ReviewProviderArg::Codex),
+            ..InitArgs::default()
+        };
+        assert_eq!(
+            explicit.resolved_review_provider_from_flags(),
+            Some(ReviewProviderArg::Codex)
+        );
+
+        let legacy = InitArgs {
+            ai_pr_review: true,
+            ..InitArgs::default()
+        };
+        assert_eq!(
+            legacy.resolved_review_provider_from_flags(),
+            Some(ReviewProviderArg::Openhands)
+        );
+
+        assert_eq!(
+            InitArgs::default().resolved_review_provider_from_flags(),
+            None
+        );
     }
 
     #[test]

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -81,6 +81,7 @@ fn init_help_explains_non_interactive_automation_flags() {
         "--non-interactive",
         "--linear-project-slug",
         "--conflict-policy",
+        "--review-provider",
         "--ai-pr-review",
         "--configure-github",
         "--commit-and-push",

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -36,6 +36,10 @@ async fn init_copies_template_files_and_customizes_workflow() {
     let config = fs::read_to_string(repo.path().join("config.yaml")).expect("config should exist");
     assert!(workflow.contains("project_slug: \"demo-project\""));
     assert!(workflow.contains("git clone --depth 1 'https://github.com/example/demo.git' ."));
+    assert!(
+        workflow.contains("Active review provider: `none`"),
+        "declining review setup should record provider `none`: {workflow}",
+    );
     assert!(config.contains("tool_dir: ~/.opensymphony/openhands-server"));
 
     assert!(
@@ -183,7 +187,7 @@ async fn init_non_interactive_succeeds_with_flags_and_closed_stdin() {
         "non-interactive init should skip commit/push without prompting: {stdout}",
     );
     assert!(
-        !stdout.contains("Also scaffold automated OpenHands AI PR review?"),
+        !stdout.contains("Configure automated AI PR code review"),
         "non-interactive init should not print prompt text: {stdout}",
     );
     assert!(
@@ -344,7 +348,7 @@ async fn init_can_scaffold_ai_pr_review_and_print_fallback_commands_when_gh_cann
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "yes\n\n\n\n\n\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "openhands\n\n\n\n\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()
@@ -368,6 +372,12 @@ async fn init_can_scaffold_ai_pr_review_and_print_fallback_commands_when_gh_cann
             .join(".agents/skills/custom-codereview-guide.md")
             .is_file(),
         "starter review guide should be created"
+    );
+    let workflow =
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+    assert!(
+        workflow.contains("Active review provider: `openhands`"),
+        "openhands provider should be recorded in WORKFLOW.md: {workflow}",
     );
     assert!(
         !repo
@@ -471,6 +481,160 @@ async fn init_non_interactive_scaffolds_ai_review_from_flags() {
 }
 
 #[tokio::test]
+async fn init_interactive_codex_review_provider_skips_openhands_scaffolding() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
+    write_stdin(&mut child, "codex\ndemo-project\nno\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "codex review init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        !repo
+            .path()
+            .join(".github/workflows/ai-pr-review.yml")
+            .exists(),
+        "codex provider should not scaffold the OpenHands Actions workflow"
+    );
+    assert!(
+        repo.path()
+            .join(".agents/skills/custom-codereview-guide.md")
+            .is_file(),
+        "codex provider should still write the shared review guide"
+    );
+    let workflow =
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+    assert!(
+        workflow.contains("Active review provider: `codex`"),
+        "codex provider should be recorded in WORKFLOW.md: {workflow}",
+    );
+    assert!(
+        stdout.contains("https://chatgpt.com/codex"),
+        "stdout should print the Codex setup checklist: {stdout}",
+    );
+    assert!(
+        stdout.contains("@codex review"),
+        "stdout should explain the re-review trigger comment: {stdout}",
+    );
+    assert!(
+        stdout.contains("separate code-review usage pool"),
+        "stdout should explain the separate review quota: {stdout}",
+    );
+    assert!(
+        !stdout.contains("gh variable set AI_REVIEW_MODEL_ID"),
+        "codex provider should not configure OpenHands Actions variables: {stdout}",
+    );
+    assert!(
+        !stdout.contains("Configure the default AI PR review provider"),
+        "codex provider should not prompt for OpenHands provider settings: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_non_interactive_codex_review_provider_from_flag() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(
+        repo.path(),
+        server.base_url(),
+        &[
+            "--non-interactive",
+            "--review-provider",
+            "codex",
+            "--linear-project-slug",
+            "demo-project",
+        ],
+    );
+    write_stdin(&mut child, "").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "non-interactive codex init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        !repo
+            .path()
+            .join(".github/workflows/ai-pr-review.yml")
+            .exists(),
+        "codex provider should not scaffold the OpenHands Actions workflow"
+    );
+    assert!(
+        repo.path()
+            .join(".agents/skills/custom-codereview-guide.md")
+            .is_file(),
+        "codex provider should still write the shared review guide"
+    );
+    let workflow =
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+    assert!(
+        workflow.contains("Active review provider: `codex`"),
+        "codex provider should be recorded in WORKFLOW.md: {workflow}",
+    );
+    assert!(
+        stdout.contains("https://chatgpt.com/codex"),
+        "stdout should print the Codex setup checklist: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_rejects_openhands_flags_with_codex_provider() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(
+        repo.path(),
+        server.base_url(),
+        &[
+            "--non-interactive",
+            "--review-provider",
+            "codex",
+            "--ai-pr-review",
+        ],
+    );
+    write_stdin(&mut child, "").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "mixing codex provider with OpenHands flags should fail: {stdout}",
+    );
+    assert!(
+        stdout.contains("--review-provider openhands"),
+        "failure should explain the conflicting flags: {stdout}",
+    );
+    assert!(
+        !repo.path().join("WORKFLOW.md").exists(),
+        "failed validation should not write bootstrap files"
+    );
+}
+
+#[tokio::test]
 async fn init_can_scaffold_ai_pr_review_and_configure_github_with_gh() {
     let server = TemplateServer::start().await;
     let repo = TempDir::new().expect("temp repo should exist");
@@ -489,7 +653,11 @@ async fn init_can_scaffold_ai_pr_review_and_configure_github_with_gh() {
             ),
         ],
     );
-    write_stdin(&mut child, "yes\n\n\n\n\n\ndemo-project\nyes\nyes\nno\n").await;
+    write_stdin(
+        &mut child,
+        "openhands\n\n\n\n\n\ndemo-project\nyes\nyes\nno\n",
+    )
+    .await;
 
     let output = child
         .wait_with_output()
@@ -1075,6 +1243,10 @@ openhands:
       llm:
         model: ${LLM_MODEL}
 ---
+
+## Automated AI PR review
+
+Active review provider: `YOUR-REVIEW-PROVIDER`
 "#
             .to_string(),
         ),

--- a/docs/ai-pr-review-human-setup.md
+++ b/docs/ai-pr-review-human-setup.md
@@ -3,6 +3,12 @@
 This document covers the remaining human checks for the OpenHands PR review
 workflow.
 
+> **Using a ChatGPT subscription instead?** OpenSymphony also supports Codex
+> code review as the PR review provider — no GitHub Actions workflow, no
+> per-token API key, and a separate code-review usage pool. See
+> [codex-code-review-setup.md](codex-code-review-setup.md), including
+> instructions for switching an existing repo between providers.
+
 `opensymphony init` now tries to configure the GitHub Actions variables and
 label automatically when `gh` is installed and can access the target repository.
 It also prompts you to commit and push the generated OpenSymphony files so this

--- a/docs/codex-code-review-setup.md
+++ b/docs/codex-code-review-setup.md
@@ -1,0 +1,122 @@
+# Codex Code Review - Setup and Switching Guide
+
+OpenSymphony supports two automated PR review providers:
+
+| | OpenHands PR Review plugin | Codex code review |
+|---|---|---|
+| Runs on | GitHub Actions in your repo | OpenAI infrastructure via the Codex GitHub app |
+| Cost | Pay-per-token via `AI_REVIEW_API_KEY` | Included with a ChatGPT subscription |
+| Quota | Your LLM provider account | A **separate Code Review usage pool** — GitHub-triggered reviews never compete with Codex implementation runs for quota |
+| Initial review | `pull_request.opened` workflow event | Codex **Automatic reviews** setting |
+| Re-review after a push | Agent adds the `review-this` label | Agent comments exactly `@codex review` |
+| Review guidance | `.agents/skills/custom-codereview-guide.md` | `## Review guidelines` section in `AGENTS.md` (which points at the same guide) |
+
+The active provider is recorded in the target repo's `WORKFLOW.md` under
+`## Automated AI PR review` (`Active review provider:`), set by
+`opensymphony init --review-provider <openhands|codex|none>` or the matching
+interactive prompt.
+
+With either provider the review loop is intentionally iterative: the initial
+review runs when the PR opens, and the agent re-triggers a fresh review after
+**every** follow-up push, addressing findings in-thread until none remain.
+Expect many rounds per PR; that is the designed behavior, not waste. This is
+one reason Codex code review pairs well with the Codex harness: review rounds
+bill the separate code-review pool, while implementation turns bill the
+general pool. Note that only **GitHub-triggered** reviews get the separate
+pool; `codex /review` in the CLI or review-via-cloud-task bills general usage.
+
+## Setting up Codex code review
+
+Prerequisites: a ChatGPT subscription (any paid tier) and admin access to the
+GitHub repository.
+
+1. Sign in at <https://chatgpt.com/codex> with the ChatGPT account that should
+   fund reviews.
+
+   > ⚠️ **Multi-account caveat**: if your GitHub identity is linked to more
+   > than one ChatGPT account (for example personal Pro + a Business
+   > workspace — workspaces count as separate accounts), the most recently
+   > connected account is used for reviews. Connect from the intended account
+   > **last**. This is also the most common cause of "quota available but
+   > reviews report limit reached".
+
+2. In Codex settings, install the Codex GitHub app and grant it access to the
+   repository (or organization).
+3. Enable **Code review** for the repository.
+4. Turn on **Automatic reviews** so every newly opened PR gets an initial
+   review without any agent action. Re-reviews after follow-up pushes are
+   requested by the agent per `WORKFLOW.md` (an exact `@codex review`
+   comment), so each fix round still gets reviewed.
+5. Keep review guidance current. Codex applies the `## Review guidelines`
+   section of the closest `AGENTS.md`; `opensymphony init` seeds that section
+   and the fuller `.agents/skills/custom-codereview-guide.md` it points to.
+6. Verify: open a trivial test PR. Codex should react with 👀 within about a
+   minute and post a standard GitHub review. Then push a follow-up commit and
+   comment `@codex review` to confirm re-review works.
+
+### Agent-facing rules (enforced by `WORKFLOW.md`)
+
+- The re-review trigger must be **exactly** `@codex review`. Mentioning
+  `@codex` with any other text starts a Codex **cloud task** that bills
+  against general usage limits (not the review pool) and operates outside the
+  OpenSymphony workspace.
+- Never ask Codex to fix, implement, or push changes — even though the Codex
+  product supports "@codex fix the P1 issue". That path bypasses the
+  orchestrated loop, pushes commits from outside the managed workspace, and
+  bills general usage. All fixes are implemented by the OpenSymphony agent in
+  its workspace; Codex only reviews.
+
+## Switching an existing repo: OpenHands → Codex
+
+1. Complete the Codex setup above for the repository.
+2. In the target repo's `WORKFLOW.md`, change the marker under
+   `## Automated AI PR review`:
+
+   ```
+   Active review provider: `codex`
+   ```
+
+   If the repo was initialized before this section existed, re-run
+   `opensymphony init` (accepting the WORKFLOW.md update) or copy the section
+   from the current template.
+3. Disable the OpenHands review workflow — keep the file so switching back is
+   trivial:
+
+   ```bash
+   gh workflow disable ai-pr-review
+   ```
+
+   (Alternative: delete `.github/workflows/ai-pr-review.yml`, or unset the
+   `AI_REVIEW_MODEL_ID` repository variable — the workflow self-skips when its
+   variables are missing.)
+4. Commit and push the `WORKFLOW.md` change.
+5. Optional cleanup: the `review-this` label and `AI_REVIEW_API_KEY` secret
+   are unused by Codex and can stay for an easy switch back.
+
+## Switching back: Codex → OpenHands
+
+1. Set `Active review provider:` back to `openhands` in `WORKFLOW.md`.
+2. Re-enable the Actions workflow:
+
+   ```bash
+   gh workflow enable ai-pr-review
+   ```
+
+3. In Codex settings, disable Code review (or at least Automatic reviews) for
+   the repository — otherwise every PR gets two competing AI reviews.
+4. Verify the `AI_REVIEW_*` variables, the `AI_REVIEW_API_KEY` secret, and the
+   `review-this` label still exist (see
+   [ai-pr-review-human-setup.md](ai-pr-review-human-setup.md)).
+
+## Troubleshooting
+
+- **No review, no error**: usually stale connector state — disconnect and
+  reconnect the GitHub connector in Codex settings.
+- **Reviews report limit reached while the dashboard shows quota**: the wrong
+  linked ChatGPT account is funding reviews; see the multi-account caveat
+  above.
+- **A `@codex` comment started a cloud task instead of a review**: the comment
+  contained more than the exact phrase `@codex review`. This is the documented
+  Codex behavior; the workflow guardrails exist to prevent it.
+- **Both providers reviewed a PR**: the OpenHands workflow was left enabled
+  while Codex Automatic reviews were on. Disable one (steps above).

--- a/docs/codex-code-review-setup.md
+++ b/docs/codex-code-review-setup.md
@@ -42,15 +42,22 @@ GitHub repository.
 
 2. In Codex settings, install the Codex GitHub app and grant it access to the
    repository (or organization).
-3. Enable **Code review** for the repository.
-4. Turn on **Automatic reviews** so every newly opened PR gets an initial
+3. Create a **Codex cloud environment** for the repository: Codex settings →
+   **Environments** → **Create environment**, then select the repo. This is
+   the "Codex cloud set up for the repository" prerequisite in OpenAI's docs —
+   until an environment exists, Codex responds to PRs with
+   *"To use Codex here, create an environment for this repo"* instead of
+   reviewing. For review-only use the defaults are fine (universal container
+   image, no setup script, internet off during the agent phase).
+4. Enable **Code review** for the repository.
+5. Turn on **Automatic reviews** so every newly opened PR gets an initial
    review without any agent action. Re-reviews after follow-up pushes are
    requested by the agent per `WORKFLOW.md` (an exact `@codex review`
    comment), so each fix round still gets reviewed.
-5. Keep review guidance current. Codex applies the `## Review guidelines`
+6. Keep review guidance current. Codex applies the `## Review guidelines`
    section of the closest `AGENTS.md`; `opensymphony init` seeds that section
    and the fuller `.agents/skills/custom-codereview-guide.md` it points to.
-6. Verify: open a trivial test PR. Codex should react with 👀 within about a
+7. Verify: open a trivial test PR. Codex should react with 👀 within about a
    minute and post a standard GitHub review. Then push a follow-up commit and
    comment `@codex review` to confirm re-review works.
 
@@ -110,6 +117,10 @@ GitHub repository.
 
 ## Troubleshooting
 
+- **Codex comments "To use Codex here, create an environment for this repo"**:
+  the GitHub app is installed but the repository has no Codex cloud
+  environment. Create one (setup step 3), then re-trigger with an exact
+  `@codex review` comment.
 - **No review, no error**: usually stale connector state — disconnect and
   reconnect the GitHub connector in Codex settings.
 - **Reviews report limit reached while the dashboard shows quota**: the wrong

--- a/docs/codex-code-review-setup.md
+++ b/docs/codex-code-review-setup.md
@@ -42,8 +42,9 @@ GitHub repository.
 
 2. In Codex settings, install the Codex GitHub app and grant it access to the
    repository (or organization).
-3. Create a **Codex cloud environment** for the repository: Codex settings →
-   **Environments** → **Create environment**, then select the repo. This is
+3. Create a **Codex cloud environment** for the repository at
+   <https://chatgpt.com/codex/cloud/settings/environments> (**Create
+   environment**, then select the repo). This is
    the "Codex cloud set up for the repository" prerequisite in OpenAI's docs —
    until an environment exists, Codex responds to PRs with
    *"To use Codex here, create an environment for this repo"* instead of

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,20 +78,33 @@ It does not:
 - copy `.github/*` bootstrap files
 - delete repo-local extra skills that are not in the template tree
 
-Optional AI PR review scaffolding:
+Optional AI PR review scaffolding, controlled by the review provider choice
+(`--review-provider <openhands|codex|none>` or the interactive prompt):
 
-- `.github/workflows/ai-pr-review.yml`
-- `.agents/skills/custom-codereview-guide.md`
+- `openhands`: `.github/workflows/ai-pr-review.yml` and
+  `.agents/skills/custom-codereview-guide.md`
+- `codex`: `.agents/skills/custom-codereview-guide.md` only — reviews run
+  through the Codex GitHub integration with a ChatGPT subscription, so no
+  Actions workflow, secret, or label is scaffolded. `init` prints the
+  one-time browser setup checklist; see
+  [codex-code-review-setup.md](codex-code-review-setup.md).
+
+The chosen provider is recorded in `WORKFLOW.md` as
+`Active review provider:` under `## Automated AI PR review`, which tells
+agents how to re-trigger review after follow-up pushes (`review-this` label
+for openhands, an exact `@codex review` comment for codex).
 
 ## Labels
 
-If you enable AI PR review and `gh` is available with repository access,
-`opensymphony init` can create the `review-this` label for you. If automation is
-skipped, create it once per repository:
+If you choose the `openhands` review provider and `gh` is available with
+repository access, `opensymphony init` can create the `review-this` label for
+you. If automation is skipped, create it once per repository:
 
 ```bash
 gh label create "review-this" --description "Trigger AI PR review" --color "d73a4a" --force
 ```
+
+The `codex` provider does not use the `review-this` label.
 
 ## Review The Generated Workflow
 


### PR DESCRIPTION
## Summary

Gives users with a ChatGPT subscription an automated PR review path that costs no per-token API spend: Codex code review via the Codex GitHub integration, whose GitHub-triggered reviews are metered against a **separate code-review usage pool** — so review rounds never compete with Codex-harness implementation runs for quota.

- `opensymphony init` now prompts **Review provider [codex/openhands/none]** (default `none`, matching the old default; legacy `y`/`yes`/`n` answers still work). New `--review-provider <openhands|codex|none>` flag for non-interactive runs; `--ai-pr-review` and friends remain as openhands aliases, and mixing OpenHands-specific flags with `--review-provider codex|none` fails validation.
- **codex path**: skips `.github/workflows/ai-pr-review.yml`, `AI_REVIEW_*` variables/secret, and the `review-this` label; still writes the shared `.agents/skills/custom-codereview-guide.md`; prints the one-time chatgpt.com/codex checklist (connector install, enable Code review + Automatic reviews, multi-account caveat, verification, stale-connector troubleshooting).
- The chosen provider is recorded in `WORKFLOW.md` via the new `YOUR-REVIEW-PROVIDER` template placeholder (companion PR: [OpenSymphony-template#5](https://github.com/kumanday/OpenSymphony-template/pull/5)). Substitution is a no-op on older templates.
- This repo's own `WORKFLOW.md`, `AGENTS.md`, and `land` skill switch to provider-neutral "re-trigger AI review" language (active provider stays `openhands` here). The iterative loop is preserved exactly: initial review on PR open, fresh review after **every** follow-up push — `review-this` label for openhands, an exact `@codex review` comment for codex.
- Guardrails: never mention `@codex` with anything but the exact phrase `@codex review` (anything else starts a cloud task billed to general usage, outside the orchestration); never ask a review bot to implement/push fixes — all fixes happen in the orchestrated workspace.
- New `docs/codex-code-review-setup.md` covers setup, quota semantics, and switching an existing repo between providers in both directions.

## Test plan

- `cargo test-system-duckdb --lib opensymphony_cli::init_repo` — 28 passed (new coverage: provider prompt choices/defaults/reprompt, flag-conflict validation, provider resolution precedence, placeholder substitution incl. no-placeholder no-op)
- `cargo test-system-duckdb --test init` — 19 passed (new: interactive codex flow, non-interactive `--review-provider codex`, codex+openhands flag rejection; existing openhands flows updated to assert the recorded provider)
- `cargo test-system-duckdb --test help` — 11 passed (`--review-provider` in init help)
- `cargo clippy-system-duckdb` and `cargo fmt --check` clean