### PR TITLE
fix(init): keep /codereview trigger in generated review guide

### DIFF
--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -1737,11 +1737,15 @@ name: custom-codereview-guide
 description: |
   Repository-specific code review guidance for this project.
   Update this file so automated PR review focuses on the right risks.
+triggers:
+  - /codereview
 ---
 
 # Custom Code Review Guide
 
-Automated PR review reads this guidance: the OpenHands PR Review plugin loads this file directly, and Codex code review reaches it through the `## Review guidelines` section in `AGENTS.md`. Replace this starter content with repository-specific expectations.
+Automated PR review reads this guidance: the OpenHands PR Review plugin loads it via the `/codereview` trigger, and Codex code review reaches it through the `## Review guidelines` section in `AGENTS.md`. Keep the `triggers` frontmatter: it scopes this content to review conversations so implementation agents do not carry it in context. Replace this starter content with repository-specific expectations.
+
+**This is a durable, shared document.** Never add PR-specific or ticket-specific content here — no "already resolved, do not re-flag" lists, no per-PR evidence dumps. Respond to review feedback in the PR's review threads instead. Only add guidance that applies to all future reviews.
 
 ## Default Priorities
 
@@ -2845,6 +2849,14 @@ hooks:
         let guide = custom_codereview_guide_contents();
 
         assert!(guide.contains("name: custom-codereview-guide"));
+        assert!(
+            guide.contains("triggers:\n  - /codereview"),
+            "guide must keep the /codereview trigger so review guidance stays scoped to review conversations: {guide}",
+        );
+        assert!(
+            guide.contains("durable, shared document"),
+            "guide must warn against PR-specific content: {guide}",
+        );
         assert!(guide.contains("Default Priorities"));
         assert!(guide.contains("Evidence Expectations"));
     }


### PR DESCRIPTION
## Summary

Two fixes to the `custom-codereview-guide.md` that `opensymphony init` generates:

1. **Restore `triggers: [/codereview]` frontmatter.** The generated guide dropped it relative to real-world guides. Per OpenHands SDK skill semantics ([skill.py](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context/skills/skill.py) — with triggers: injected when the trigger keyword appears; without: always in `<REPO_CONTEXT>`), a trigger-less guide is injected into **every** OpenHands conversation, including implementation runs. The pr-review plugin's prompt always contains `/codereview`, so the trigger costs reviews nothing while keeping review guidance out of implementation agents' context. Codex code review is unaffected either way (it reads the guide via the `## Review guidelines` pointer in `AGENTS.md`).
2. **Add a durability warning.** Observed in the wild: agents appended per-PR "already resolved, do not re-flag" sections to the shared guide across several review rounds. The generated starter now states the document is durable and task-agnostic, and review feedback belongs in PR threads. (Matching WORKFLOW.md guardrail: [OpenSymphony-template#7](https://github.com/kumanday/OpenSymphony-template/pull/7).)

## Test plan

- `cargo test-system-duckdb --lib opensymphony_cli::init_repo` — 28 passed; the guide-metadata test now asserts the trigger frontmatter and durability warning.