### PR TITLE
Invert code-intel provider trait ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,9 +195,10 @@ AST evidence and fallback trace visibility without changing the public
 keep path containment, file/match/capture limits, parser/query-pack/source
 citations, and trace output intact. `code.ast.query` is local read-only by
 default and becomes admin-gated whenever a memory admin token is configured.
-The current `opensymphony_code_intel` adapter still implements
-`opensymphony_memory::CodeIntelIndex`; keep that bridge narrow until a follow-up
-inverts trait ownership into the code-intelligence module.
+The rendered code-intelligence provider trait and artifact types live in
+`opensymphony_code_intel`; memory may re-export compatibility aliases and convert
+provider errors for `memory.context`, but AST/composite providers must not import
+memory internals.
 
 ### Separate Symphony hooks from OpenHands hooks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,10 +195,11 @@ AST evidence and fallback trace visibility without changing the public
 keep path containment, file/match/capture limits, parser/query-pack/source
 citations, and trace output intact. `code.ast.query` is local read-only by
 default and becomes admin-gated whenever a memory admin token is configured.
-The rendered code-intelligence provider trait and artifact types live in
-`opensymphony_code_intel`; memory may re-export compatibility aliases and convert
-provider errors for `memory.context`, but AST/composite providers must not import
-memory internals.
+The rendered code-intelligence provider trait and provider artifact types live in
+`opensymphony_code_intel`; memory keeps its legacy `CodeIntelIndex` and
+`CodeIntelArtifact` compatibility surface as an adapter around the provider
+contract and converts provider errors for `memory.context`, but AST/composite
+providers must not import memory internals.
 
 ### Separate Symphony hooks from OpenHands hooks
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -15,7 +15,8 @@ use tokio::task::JoinHandle;
 
 use crate::{
     opensymphony_code_intel::{
-        AstDiagnosticKind, CaptureRecord, CompositeCodeIntelProvider,
+        AstDiagnosticKind, CaptureRecord, CodeIntelArtifact, CodeIntelProvider, CodeIntelScope,
+        CodeIntelScopeKind, CodeIntelSourceRef, CompositeCodeIntelProvider,
         JAVASCRIPT_QUERY_PACK_VERSION, JSX_QUERY_PACK_VERSION, PROVIDER_NAME,
         PYTHON_QUERY_PACK_VERSION, ParsedDocumentSummary, RUST_QUERY_PACK_VERSION, SourceLanguage,
         SymbolKind, TREE_SITTER_VERSION, TSX_QUERY_PACK_VERSION, TYPESCRIPT_QUERY_PACK_VERSION,
@@ -24,12 +25,11 @@ use crate::{
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
     opensymphony_memory::{
-        ArchivePlan, CodeIntelArtifact, CodeIntelDiagnosticInput, CodeIntelDocumentInput,
-        CodeIntelEdgeInput, CodeIntelIndex, CodeIntelPersistBatch, CodeIntelSymbolInput,
-        CommentEvidence, DocsSyncPlan, IssueEvidence, IssueLinkEvidence, IssueSelection,
-        KnowledgeScope, KnowledgeScopeKind, LintSeverity, MemoryConfig, MemoryContextOptions,
-        MemoryError, MemoryReindexReport, MemoryScopeFilter, MemorySourceRef, MemoryVisibility,
-        SourceFile, archive_blocking_warning_count, brief, context_for_issue_with_options,
+        ArchivePlan, CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
+        CodeIntelPersistBatch, CodeIntelSymbolInput, CommentEvidence, DocsSyncPlan, IssueEvidence,
+        IssueLinkEvidence, IssueSelection, LintSeverity, MemoryConfig, MemoryContextOptions,
+        MemoryError, MemoryReindexReport, MemoryScopeFilter, MemoryVisibility, SourceFile,
+        archive_blocking_warning_count, brief, context_for_issue_with_options,
         docs_for_area_with_scope, expand_issue_range, export_okf_bundle, import_okf_bundle, lint,
         lint_okf_bundle, load_source_file, mark_archived, persist_code_intel_documents,
         plan_archive, plan_capture, plan_docs_sync, plan_memory_init, refresh_memory_index,
@@ -2692,7 +2692,7 @@ struct CodeIntelPersistRequest {
     config: MemoryConfig,
     scope: MemoryScopeFilter,
     paths: Vec<PathBuf>,
-    scope_refs: Vec<KnowledgeScope>,
+    scope_refs: Vec<CodeIntelScope>,
     limit: usize,
     languages: BTreeSet<String>,
     symbols: BTreeSet<String>,
@@ -2831,7 +2831,7 @@ fn code_intel_artifacts_for_summary(
     summary: &ParsedDocumentSummary,
     relative_path: &Path,
     relative_display: &str,
-    scope_refs: &[KnowledgeScope],
+    scope_refs: &[CodeIntelScope],
     commit_sha: Option<String>,
     symbols: &BTreeSet<String>,
     symbol_limit: usize,
@@ -2841,7 +2841,7 @@ fn code_intel_artifacts_for_summary(
         provider: summary.versions.provider.clone(),
         kind: "ast-summary".to_string(),
         scope_refs: scope_refs.to_vec(),
-        source_refs: vec![MemorySourceRef {
+        source_refs: vec![CodeIntelSourceRef {
             kind: "path".to_string(),
             id: relative_display.to_string(),
             url: None,
@@ -2891,7 +2891,7 @@ fn code_intel_artifacts_for_summary(
         scope_refs: scope_refs.to_vec(),
         source_refs: selected_symbols
             .iter()
-            .map(|symbol| MemorySourceRef {
+            .map(|symbol| CodeIntelSourceRef {
                 kind: "code-symbol".to_string(),
                 id: format!("{relative_display}:{}", symbol.rendered_span),
                 url: None,
@@ -2918,7 +2918,7 @@ fn diagnostics_summary(diagnostics: &[crate::opensymphony_code_intel::AstDiagnos
 }
 
 fn code_intel_trace_artifact(
-    scope_refs: &[KnowledgeScope],
+    scope_refs: &[CodeIntelScope],
     parsed_files: usize,
     query_runs: usize,
     skipped_files: &[String],
@@ -3380,7 +3380,7 @@ async fn append_code_intel_context_blocking(
 async fn code_intel_artifacts_blocking(
     repo_root: PathBuf,
     paths: Vec<PathBuf>,
-    scope_refs: Vec<KnowledgeScope>,
+    scope_refs: Vec<CodeIntelScope>,
     limit: usize,
 ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
     tokio::task::spawn_blocking(move || {
@@ -3390,12 +3390,13 @@ async fn code_intel_artifacts_blocking(
     .map_err(|error| {
         MemoryError::InvalidInput(format!("code-intelligence analysis task failed: {error}"))
     })?
+    .map_err(MemoryError::from)
 }
 
 async fn code_intel_artifacts_with_symbol_kinds_blocking(
     repo_root: PathBuf,
     paths: Vec<PathBuf>,
-    scope_refs: Vec<KnowledgeScope>,
+    scope_refs: Vec<CodeIntelScope>,
     limit: usize,
     symbol_kinds: BTreeSet<String>,
 ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
@@ -3411,6 +3412,7 @@ async fn code_intel_artifacts_with_symbol_kinds_blocking(
     .map_err(|error| {
         MemoryError::InvalidInput(format!("code-intelligence analysis task failed: {error}"))
     })?
+    .map_err(MemoryError::from)
 }
 
 fn append_code_intel_artifacts(
@@ -3464,37 +3466,37 @@ fn resolve_code_intel_repo(
     Ok(resolved)
 }
 
-fn scope_refs_for_context(scope: &MemoryScopeFilter, paths: &[PathBuf]) -> Vec<KnowledgeScope> {
+fn scope_refs_for_context(scope: &MemoryScopeFilter, paths: &[PathBuf]) -> Vec<CodeIntelScope> {
     let mut refs = Vec::new();
     push_scope_ref(
         &mut refs,
-        KnowledgeScopeKind::ProjectSet,
+        CodeIntelScopeKind::ProjectSet,
         scope.project_set.as_deref(),
     );
     push_scope_ref(
         &mut refs,
-        KnowledgeScopeKind::Project,
+        CodeIntelScopeKind::Project,
         scope.project.as_deref(),
     );
     push_scope_ref(
         &mut refs,
-        KnowledgeScopeKind::Milestone,
+        CodeIntelScopeKind::Milestone,
         scope.milestone.as_deref(),
     );
     push_scope_ref(
         &mut refs,
-        KnowledgeScopeKind::WorkItem,
+        CodeIntelScopeKind::WorkItem,
         scope.issue.as_deref(),
     );
     push_scope_ref(
         &mut refs,
-        KnowledgeScopeKind::Repository,
+        CodeIntelScopeKind::Repository,
         scope.repo.as_deref(),
     );
-    push_scope_ref(&mut refs, KnowledgeScopeKind::Area, scope.area.as_deref());
+    push_scope_ref(&mut refs, CodeIntelScopeKind::Area, scope.area.as_deref());
     for path in paths {
-        refs.push(KnowledgeScope {
-            kind: KnowledgeScopeKind::CodePath,
+        refs.push(CodeIntelScope {
+            kind: CodeIntelScopeKind::CodePath,
             id: path.display().to_string(),
             label: None,
         });
@@ -3502,9 +3504,9 @@ fn scope_refs_for_context(scope: &MemoryScopeFilter, paths: &[PathBuf]) -> Vec<K
     refs
 }
 
-fn push_scope_ref(refs: &mut Vec<KnowledgeScope>, kind: KnowledgeScopeKind, id: Option<&str>) {
+fn push_scope_ref(refs: &mut Vec<CodeIntelScope>, kind: CodeIntelScopeKind, id: Option<&str>) {
     if let Some(id) = id.and_then(non_empty) {
-        refs.push(KnowledgeScope {
+        refs.push(CodeIntelScope {
             kind,
             id,
             label: None,

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -101,7 +101,7 @@ pub struct CodeIntelArtifact {
     pub summary: String,
 }
 
-pub trait CodeIntelProvider {
+pub trait CodeIntelProvider: Send + Sync {
     fn code_context(
         &self,
         paths: &[PathBuf],

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -10,16 +10,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator};
 
-// TODO(COE-506): invert this adapter so memory consumes a code-intel owned
-// provider trait after the AST integration is stable.
-// COE-499 keeps the existing memory CodeIntelIndex contract so memory.context
-// gains AST evidence without adding a new public tool surface.
-use crate::{
-    opensymphony_memory::{
-        CodeIntelArtifact, CodeIntelIndex, KnowledgeScope, MemoryError, MemorySourceRef,
-    },
-    opensymphony_planning::CodebaseAnalyzer,
-};
+// Rendered code-intelligence context is owned here so memory can consume it
+// without the AST provider importing memory internals.
+use crate::opensymphony_planning::CodebaseAnalyzer;
 
 pub const PROVIDER_NAME: &str = "tree-sitter";
 pub const TREE_SITTER_VERSION: &str = "0.26.9";
@@ -59,6 +52,63 @@ const JAVASCRIPT_METADATA: &str = include_str!("../queries/javascript/metadata.t
 const JSX_METADATA: &str = include_str!("../queries/jsx/metadata.toml");
 const PYTHON_METADATA: &str = include_str!("../queries/python/metadata.toml");
 const DEFAULT_MAX_FILE_BYTES: u64 = 2_097_152;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeIntelScopeKind {
+    LocalInstance,
+    Organization,
+    ProjectSet,
+    Project,
+    Milestone,
+    WorkItem,
+    Repository,
+    CodePath,
+    Area,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeIntelScope {
+    pub kind: CodeIntelScopeKind,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeIntelSourceRef {
+    pub kind: String,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeIntelArtifact {
+    pub provider: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scope_refs: Vec<CodeIntelScope>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<CodeIntelSourceRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub summary: String,
+}
+
+pub trait CodeIntelProvider {
+    fn code_context(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[CodeIntelScope],
+        limit: usize,
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError>;
+}
 
 const STANDARD_CAPTURE_NAMES: &[&str] = &[
     "definition.module",
@@ -384,8 +434,18 @@ pub struct AstDiagnostic {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum CodeIntelError {
+    #[error("{0}")]
+    InvalidInput(String),
     #[error("unsupported source language for {path}")]
     UnsupportedLanguage { path: String },
+    #[error("failed to resolve {path}: {source}")]
+    ResolvePath {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("{path} is outside the repository root {repo_root}")]
+    PathOutsideRepo { path: PathBuf, repo_root: PathBuf },
     #[error("failed to load parser: {0}")]
     Language(#[from] tree_sitter::LanguageError),
     #[error("failed to parse source")]
@@ -473,9 +533,9 @@ impl AstCodeIntelProvider {
     fn code_context_report(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
-    ) -> Result<AstCodeIntelReport, MemoryError> {
+    ) -> Result<AstCodeIntelReport, CodeIntelError> {
         let symbol_kinds = BTreeSet::new();
         self.code_context_report_with_symbols(paths, scope_refs, limit, &symbol_kinds)
     }
@@ -483,10 +543,10 @@ impl AstCodeIntelProvider {
     fn code_context_report_with_symbols(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
         symbol_kinds: &BTreeSet<String>,
-    ) -> Result<AstCodeIntelReport, MemoryError> {
+    ) -> Result<AstCodeIntelReport, CodeIntelError> {
         let repo_root = self.canonical_root()?;
         let commit_sha = git_commit_sha(&repo_root);
         let mut report = AstCodeIntelReport::default();
@@ -641,10 +701,10 @@ impl AstCodeIntelProvider {
         }
     }
 
-    fn canonical_root(&self) -> Result<PathBuf, MemoryError> {
+    fn canonical_root(&self) -> Result<PathBuf, CodeIntelError> {
         self.root
             .canonicalize()
-            .map_err(|source| MemoryError::ResolvePath {
+            .map_err(|source| CodeIntelError::ResolvePath {
                 path: self.root.clone(),
                 source,
             })
@@ -654,14 +714,14 @@ impl AstCodeIntelProvider {
         &self,
         repo_root: &Path,
         path: &Path,
-    ) -> Result<Option<PathBuf>, MemoryError> {
+    ) -> Result<Option<PathBuf>, CodeIntelError> {
         let candidate = requested_candidate(repo_root, path);
         let resolved = match candidate.canonicalize() {
             Ok(resolved) => resolved,
             Err(source) if source.kind() == ErrorKind::NotFound => {
                 let normalized = normalize_lexical(&candidate);
                 if !normalized.starts_with(repo_root) {
-                    return Err(MemoryError::PathOutsideRepo {
+                    return Err(CodeIntelError::PathOutsideRepo {
                         path: normalized,
                         repo_root: repo_root.to_path_buf(),
                     });
@@ -669,14 +729,14 @@ impl AstCodeIntelProvider {
                 return Ok(None);
             }
             Err(source) => {
-                return Err(MemoryError::ResolvePath {
+                return Err(CodeIntelError::ResolvePath {
                     path: candidate.clone(),
                     source,
                 });
             }
         };
         if !resolved.starts_with(repo_root) {
-            return Err(MemoryError::PathOutsideRepo {
+            return Err(CodeIntelError::PathOutsideRepo {
                 path: resolved,
                 repo_root: repo_root.to_path_buf(),
             });
@@ -688,10 +748,10 @@ impl AstCodeIntelProvider {
         &self,
         repo_root: &Path,
         path: &Path,
-    ) -> Result<PathBuf, MemoryError> {
+    ) -> Result<PathBuf, CodeIntelError> {
         let candidate = normalize_lexical(&requested_candidate(repo_root, path));
         if !candidate.starts_with(repo_root) {
-            return Err(MemoryError::PathOutsideRepo {
+            return Err(CodeIntelError::PathOutsideRepo {
                 path: candidate.clone(),
                 repo_root: repo_root.to_path_buf(),
             });
@@ -733,13 +793,13 @@ fn normalize_lexical(path: &Path) -> PathBuf {
     normalized
 }
 
-impl CodeIntelIndex for AstCodeIntelProvider {
+impl CodeIntelProvider for AstCodeIntelProvider {
     fn code_context(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError> {
         let report = self.code_context_report(paths, scope_refs, limit)?;
         let trace = report.trace_artifact(scope_refs, PROVIDER_NAME, report.ast_only_fallback());
         let mut artifacts = report.artifacts;
@@ -765,10 +825,10 @@ impl CompositeCodeIntelProvider {
     pub fn code_context_with_symbol_kinds(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
         symbol_kinds: &BTreeSet<String>,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError> {
         let mut report =
             self.ast
                 .code_context_report_with_symbols(paths, scope_refs, limit, symbol_kinds)?;
@@ -801,13 +861,13 @@ impl CompositeCodeIntelProvider {
     }
 }
 
-impl CodeIntelIndex for CompositeCodeIntelProvider {
+impl CodeIntelProvider for CompositeCodeIntelProvider {
     fn code_context(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError> {
         let mut report = self.ast.code_context_report(paths, scope_refs, limit)?;
         let use_fallback = !report.fallback_reasons.is_empty();
         let mut artifacts = std::mem::take(&mut report.artifacts);
@@ -851,7 +911,7 @@ struct AstCodeIntelReport {
 impl AstCodeIntelReport {
     fn trace_artifact(
         &self,
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         provider: &str,
         fallback: String,
     ) -> CodeIntelArtifact {
@@ -900,7 +960,7 @@ fn ast_artifacts_for_summary(
     summary: ParsedDocumentSummary,
     relative_path: &Path,
     relative_display: &str,
-    scope_refs: &[KnowledgeScope],
+    scope_refs: &[CodeIntelScope],
     commit_sha: Option<String>,
     symbol_limit: usize,
     symbol_kinds: &BTreeSet<String>,
@@ -910,7 +970,7 @@ fn ast_artifacts_for_summary(
         provider: PROVIDER_NAME.to_string(),
         kind: "ast-summary".to_string(),
         scope_refs: scope_refs.to_vec(),
-        source_refs: vec![MemorySourceRef {
+        source_refs: vec![CodeIntelSourceRef {
             kind: "path".to_string(),
             id: relative_display.to_string(),
             url: None,
@@ -962,7 +1022,7 @@ fn ast_artifacts_for_summary(
             scope_refs: scope_refs.to_vec(),
             source_refs: selected_symbols
                 .iter()
-                .map(|symbol| MemorySourceRef {
+                .map(|symbol| CodeIntelSourceRef {
                     kind: "code-symbol".to_string(),
                     id: format!("{relative_display}:{}", symbol.rendered_span),
                     url: None,
@@ -1864,7 +1924,6 @@ fn source_span_for_text(source: &str) -> SourceSpan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::opensymphony_memory::CodeIntelIndex;
     use tempfile::TempDir;
 
     const RUST_COMPLETE: &str = include_str!("../fixtures/rust/complete.rs");
@@ -2528,7 +2587,7 @@ mod tests {
             .code_context(&[PathBuf::from("src/outside.rs")], &[], 20)
             .expect_err("outside symlink should be rejected");
 
-        assert!(matches!(error, MemoryError::PathOutsideRepo { .. }));
+        assert!(matches!(error, CodeIntelError::PathOutsideRepo { .. }));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -87,6 +87,19 @@ pub enum MemoryError {
     },
 }
 
+impl From<CodeIntelError> for MemoryError {
+    fn from(error: CodeIntelError) -> Self {
+        match error {
+            CodeIntelError::InvalidInput(message) => Self::InvalidInput(message),
+            CodeIntelError::ResolvePath { path, source } => Self::ResolvePath { path, source },
+            CodeIntelError::PathOutsideRepo { path, repo_root } => {
+                Self::PathOutsideRepo { path, repo_root }
+            }
+            error => Self::InvalidInput(error.to_string()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryVisibility {
@@ -193,23 +206,10 @@ pub struct ProviderStatus {
     pub detail: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeIntelArtifact {
-    pub provider: String,
-    pub kind: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub scope_refs: Vec<KnowledgeScope>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub source_refs: Vec<MemorySourceRef>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<PathBuf>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub commit_sha: Option<String>,
-    #[serde(default)]
-    pub title: String,
-    #[serde(default)]
-    pub summary: String,
-}
+pub use crate::opensymphony_code_intel::{
+    CodeIntelArtifact, CodeIntelError, CodeIntelProvider as CodeIntelIndex, CodeIntelScope,
+    CodeIntelScopeKind, CodeIntelSourceRef,
+};
 
 pub trait MemoryCatalog {
     fn provider_status(&self) -> ProviderStatus;
@@ -230,15 +230,6 @@ pub trait VectorIndex {
         scope_refs: &[KnowledgeScope],
         limit: usize,
     ) -> Result<Vec<SearchResult>, MemoryError>;
-}
-
-pub trait CodeIntelIndex {
-    fn code_context(
-        &self,
-        paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
-        limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,9 +339,9 @@ impl CodeIntelIndex for NoopCodeIntelIndex {
     fn code_context(
         &self,
         _paths: &[PathBuf],
-        _scope_refs: &[KnowledgeScope],
+        _scope_refs: &[CodeIntelScope],
         _limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError> {
         Ok(Vec::new())
     }
 }

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -209,9 +209,129 @@ pub struct ProviderStatus {
 }
 
 pub use crate::opensymphony_code_intel::{
-    CodeIntelArtifact, CodeIntelError, CodeIntelProvider as CodeIntelIndex, CodeIntelScope,
-    CodeIntelScopeKind, CodeIntelSourceRef,
+    CodeIntelArtifact as ProviderCodeIntelArtifact, CodeIntelError, CodeIntelProvider,
+    CodeIntelScope, CodeIntelScopeKind, CodeIntelSourceRef,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodeIntelArtifact {
+    pub provider: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scope_refs: Vec<KnowledgeScope>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<MemorySourceRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub summary: String,
+}
+
+impl From<ProviderCodeIntelArtifact> for CodeIntelArtifact {
+    fn from(artifact: ProviderCodeIntelArtifact) -> Self {
+        Self {
+            provider: artifact.provider,
+            kind: artifact.kind,
+            scope_refs: artifact.scope_refs.into_iter().map(Into::into).collect(),
+            source_refs: artifact.source_refs.into_iter().map(Into::into).collect(),
+            path: artifact.path,
+            commit_sha: artifact.commit_sha,
+            title: artifact.title,
+            summary: artifact.summary,
+        }
+    }
+}
+
+impl From<CodeIntelArtifact> for ProviderCodeIntelArtifact {
+    fn from(artifact: CodeIntelArtifact) -> Self {
+        Self {
+            provider: artifact.provider,
+            kind: artifact.kind,
+            scope_refs: artifact.scope_refs.into_iter().map(Into::into).collect(),
+            source_refs: artifact.source_refs.into_iter().map(Into::into).collect(),
+            path: artifact.path,
+            commit_sha: artifact.commit_sha,
+            title: artifact.title,
+            summary: artifact.summary,
+        }
+    }
+}
+
+impl From<CodeIntelScopeKind> for KnowledgeScopeKind {
+    fn from(kind: CodeIntelScopeKind) -> Self {
+        match kind {
+            CodeIntelScopeKind::LocalInstance => Self::LocalInstance,
+            CodeIntelScopeKind::Organization => Self::Organization,
+            CodeIntelScopeKind::ProjectSet => Self::ProjectSet,
+            CodeIntelScopeKind::Project => Self::Project,
+            CodeIntelScopeKind::Milestone => Self::Milestone,
+            CodeIntelScopeKind::WorkItem => Self::WorkItem,
+            CodeIntelScopeKind::Repository => Self::Repository,
+            CodeIntelScopeKind::CodePath => Self::CodePath,
+            CodeIntelScopeKind::Area => Self::Area,
+        }
+    }
+}
+
+impl From<KnowledgeScopeKind> for CodeIntelScopeKind {
+    fn from(kind: KnowledgeScopeKind) -> Self {
+        match kind {
+            KnowledgeScopeKind::LocalInstance => Self::LocalInstance,
+            KnowledgeScopeKind::Organization => Self::Organization,
+            KnowledgeScopeKind::ProjectSet => Self::ProjectSet,
+            KnowledgeScopeKind::Project => Self::Project,
+            KnowledgeScopeKind::Milestone => Self::Milestone,
+            KnowledgeScopeKind::WorkItem => Self::WorkItem,
+            KnowledgeScopeKind::Repository => Self::Repository,
+            KnowledgeScopeKind::CodePath => Self::CodePath,
+            KnowledgeScopeKind::Area => Self::Area,
+        }
+    }
+}
+
+impl From<CodeIntelScope> for KnowledgeScope {
+    fn from(scope: CodeIntelScope) -> Self {
+        Self {
+            kind: scope.kind.into(),
+            id: scope.id,
+            label: scope.label,
+        }
+    }
+}
+
+impl From<KnowledgeScope> for CodeIntelScope {
+    fn from(scope: KnowledgeScope) -> Self {
+        Self {
+            kind: scope.kind.into(),
+            id: scope.id,
+            label: scope.label,
+        }
+    }
+}
+
+impl From<CodeIntelSourceRef> for MemorySourceRef {
+    fn from(source_ref: CodeIntelSourceRef) -> Self {
+        Self {
+            kind: source_ref.kind,
+            id: source_ref.id,
+            url: source_ref.url,
+        }
+    }
+}
+
+impl From<MemorySourceRef> for CodeIntelSourceRef {
+    fn from(source_ref: MemorySourceRef) -> Self {
+        Self {
+            kind: source_ref.kind,
+            id: source_ref.id,
+            url: source_ref.url,
+        }
+    }
+}
 
 pub trait MemoryCatalog {
     fn provider_status(&self) -> ProviderStatus;
@@ -232,6 +352,56 @@ pub trait VectorIndex {
         scope_refs: &[KnowledgeScope],
         limit: usize,
     ) -> Result<Vec<SearchResult>, MemoryError>;
+}
+
+pub trait CodeIntelIndex {
+    fn code_context(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+    ) -> Result<Vec<CodeIntelArtifact>, MemoryError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct CodeIntelProviderAdapter<P> {
+    provider: P,
+}
+
+impl<P> CodeIntelProviderAdapter<P> {
+    pub fn new(provider: P) -> Self {
+        Self { provider }
+    }
+
+    pub fn provider(&self) -> &P {
+        &self.provider
+    }
+
+    pub fn into_inner(self) -> P {
+        self.provider
+    }
+}
+
+impl<P> CodeIntelIndex for CodeIntelProviderAdapter<P>
+where
+    P: CodeIntelProvider,
+{
+    fn code_context(
+        &self,
+        paths: &[PathBuf],
+        scope_refs: &[KnowledgeScope],
+        limit: usize,
+    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+        let provider_scope_refs = scope_refs
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .collect::<Vec<_>>();
+        self.provider
+            .code_context(paths, &provider_scope_refs, limit)
+            .map(|artifacts| artifacts.into_iter().map(Into::into).collect())
+            .map_err(MemoryError::from)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -341,9 +511,9 @@ impl CodeIntelIndex for NoopCodeIntelIndex {
     fn code_context(
         &self,
         _paths: &[PathBuf],
-        _scope_refs: &[CodeIntelScope],
+        _scope_refs: &[KnowledgeScope],
         _limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError> {
+    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
         Ok(Vec::new())
     }
 }
@@ -912,6 +1082,86 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[derive(Debug)]
+    struct EchoCodeIntelProvider;
+
+    impl CodeIntelProvider for EchoCodeIntelProvider {
+        fn code_context(
+            &self,
+            paths: &[PathBuf],
+            scope_refs: &[CodeIntelScope],
+            limit: usize,
+        ) -> Result<Vec<ProviderCodeIntelArtifact>, CodeIntelError> {
+            assert_eq!(
+                paths,
+                &[PathBuf::from("crates/opensymphony-memory/src/lib.rs")]
+            );
+            assert_eq!(limit, 7);
+            Ok(vec![ProviderCodeIntelArtifact {
+                provider: "echo".to_string(),
+                kind: "summary".to_string(),
+                scope_refs: scope_refs.to_vec(),
+                source_refs: vec![CodeIntelSourceRef {
+                    kind: "path".to_string(),
+                    id: "crates/opensymphony-memory/src/lib.rs".to_string(),
+                    url: None,
+                }],
+                path: Some(PathBuf::from("crates/opensymphony-memory/src/lib.rs")),
+                commit_sha: Some("abc123".to_string()),
+                title: "Memory boundary".to_string(),
+                summary: "Adapter converted provider artifacts into memory artifacts.".to_string(),
+            }])
+        }
+    }
+
+    #[test]
+    fn code_intel_provider_adapter_preserves_memory_index_contract() {
+        let adapter = CodeIntelProviderAdapter::new(EchoCodeIntelProvider);
+        let scope = KnowledgeScope {
+            kind: KnowledgeScopeKind::WorkItem,
+            id: "COE-506".to_string(),
+            label: Some("Trait inversion".to_string()),
+        };
+
+        let artifacts = adapter
+            .code_context(
+                &[PathBuf::from("crates/opensymphony-memory/src/lib.rs")],
+                std::slice::from_ref(&scope),
+                7,
+            )
+            .expect("adapter should convert provider output");
+
+        assert_eq!(artifacts.len(), 1);
+        let artifact = &artifacts[0];
+        assert_eq!(artifact.provider, "echo");
+        assert_eq!(artifact.scope_refs, vec![scope]);
+        assert_eq!(
+            artifact.source_refs,
+            vec![MemorySourceRef {
+                kind: "path".to_string(),
+                id: "crates/opensymphony-memory/src/lib.rs".to_string(),
+                url: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn noop_code_intel_index_keeps_memory_contract() {
+        let artifacts = NoopCodeIntelIndex
+            .code_context(
+                &[],
+                &[KnowledgeScope {
+                    kind: KnowledgeScopeKind::Repository,
+                    id: "repo".to_string(),
+                    label: None,
+                }],
+                1,
+            )
+            .expect("noop index should not fail");
+
+        assert!(artifacts.is_empty());
+    }
 
     #[test]
     fn ensure_memory_initialized_creates_config_and_gitignore_policy_once() {

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -85,6 +85,8 @@ pub enum MemoryError {
         source: Box<MemoryError>,
         cleanup: Box<MemoryError>,
     },
+    #[error("code-intelligence operation failed: {0}")]
+    CodeIntel(#[source] CodeIntelError),
 }
 
 impl From<CodeIntelError> for MemoryError {
@@ -95,7 +97,7 @@ impl From<CodeIntelError> for MemoryError {
             CodeIntelError::PathOutsideRepo { path, repo_root } => {
                 Self::PathOutsideRepo { path, repo_root }
             }
-            error => Self::InvalidInput(error.to_string()),
+            error => Self::CodeIntel(error),
         }
     }
 }

--- a/crates/opensymphony-planning/src/codebase.rs
+++ b/crates/opensymphony-planning/src/codebase.rs
@@ -6,8 +6,8 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
-use crate::opensymphony_memory::{
-    CodeIntelArtifact, CodeIntelIndex, KnowledgeScope, MemoryError, MemorySourceRef,
+use crate::opensymphony_code_intel::{
+    CodeIntelArtifact, CodeIntelError, CodeIntelProvider, CodeIntelScope, CodeIntelSourceRef,
 };
 
 /// Result of scanning a repository for structural analysis.
@@ -183,15 +183,15 @@ impl CodebaseAnalyzer {
     }
 }
 
-impl CodeIntelIndex for CodebaseAnalyzer {
+impl CodeIntelProvider for CodebaseAnalyzer {
     fn code_context(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError> {
         let analysis = self.analyze().map_err(|error| {
-            MemoryError::InvalidInput(format!("codebase analysis failed: {error}"))
+            CodeIntelError::InvalidInput(format!("codebase analysis failed: {error}"))
         })?;
         let requested_paths = paths
             .iter()
@@ -214,7 +214,7 @@ impl CodeIntelIndex for CodebaseAnalyzer {
                 provider: "codebase-analyzer".to_string(),
                 kind: "package".to_string(),
                 scope_refs: scope_refs.to_vec(),
-                source_refs: vec![MemorySourceRef {
+                source_refs: vec![CodeIntelSourceRef {
                     kind: "path".to_string(),
                     id: package.relative_path.clone(),
                     url: None,
@@ -243,7 +243,7 @@ impl CodeIntelIndex for CodebaseAnalyzer {
                 provider: "codebase-analyzer".to_string(),
                 kind: "convention".to_string(),
                 scope_refs: scope_refs.to_vec(),
-                source_refs: vec![MemorySourceRef {
+                source_refs: vec![CodeIntelSourceRef {
                     kind: "path".to_string(),
                     id: convention.evidence_path.clone(),
                     url: None,
@@ -260,7 +260,7 @@ impl CodeIntelIndex for CodebaseAnalyzer {
                 provider: "codebase-analyzer".to_string(),
                 kind: "repository-summary".to_string(),
                 scope_refs: scope_refs.to_vec(),
-                source_refs: vec![MemorySourceRef {
+                source_refs: vec![CodeIntelSourceRef {
                     kind: "codebase-analysis".to_string(),
                     id: analysis.root_path.clone(),
                     url: None,

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -26,6 +26,15 @@ code_intel:
 The AST provider only loads built-in pinned grammar crates. Target repositories
 cannot supply native grammar binaries.
 
+## Provider Boundary
+
+`opensymphony_code_intel` owns the rendered provider contract:
+`CodeIntelProvider`, `CodeIntelArtifact`, `CodeIntelScope`, and
+`CodeIntelSourceRef`. `opensymphony_memory` may consume and re-export those types
+for compatibility and convert provider errors into `MemoryError`, but AST and
+composite providers do not import memory internals. `CodebaseAnalyzer`
+implements the same provider trait as the repository-summary fallback.
+
 ## Freshness
 
 AST context is generated from the current worktree. Rendered artifacts include

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -30,11 +30,12 @@ cannot supply native grammar binaries.
 
 `opensymphony_code_intel` owns the rendered provider contract:
 `CodeIntelProvider`, `CodeIntelArtifact`, `CodeIntelScope`, and
-`CodeIntelSourceRef`. `opensymphony_memory` may consume and re-export those types
-for compatibility and convert provider errors into `MemoryError`, but AST and
-composite providers do not import memory internals. The provider trait is
-`Send + Sync` for async actor use. `CodebaseAnalyzer` implements the same
-provider trait as the repository-summary fallback.
+`CodeIntelSourceRef`. `opensymphony_memory` keeps its legacy `CodeIntelIndex`
+and `CodeIntelArtifact` compatibility surface as an adapter around that contract
+and converts provider errors into `MemoryError`, but AST and composite providers
+do not import memory internals. The provider trait is `Send + Sync` for async
+actor use. `CodebaseAnalyzer` implements the same provider trait as the
+repository-summary fallback.
 
 ## Freshness
 

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -32,8 +32,9 @@ cannot supply native grammar binaries.
 `CodeIntelProvider`, `CodeIntelArtifact`, `CodeIntelScope`, and
 `CodeIntelSourceRef`. `opensymphony_memory` may consume and re-export those types
 for compatibility and convert provider errors into `MemoryError`, but AST and
-composite providers do not import memory internals. `CodebaseAnalyzer`
-implements the same provider trait as the repository-summary fallback.
+composite providers do not import memory internals. The provider trait is
+`Send + Sync` for async actor use. `CodebaseAnalyzer` implements the same
+provider trait as the repository-summary fallback.
 
 ## Freshness
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -429,6 +429,9 @@ languages, parser diagnostics, oversized files, and calls without requested
 paths use the existing `CodebaseAnalyzer` repository-summary fallback; mixed
 supported and unsupported requests can include both AST artifacts and fallback
 artifacts. The trace section records parse/query counts and the fallback reason.
+The rendered artifact/provider contract is owned by `opensymphony_code_intel`;
+memory consumes and re-exports that contract for compatibility instead of
+owning the provider trait.
 The direct `code.ast.*` tools return JSON with path, line range, content hash,
 parser version, query-pack version, trace, and truncation metadata for targeted
 agent inspection. `memory.context` remains the recommended kickoff path.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -430,8 +430,9 @@ paths use the existing `CodebaseAnalyzer` repository-summary fallback; mixed
 supported and unsupported requests can include both AST artifacts and fallback
 artifacts. The trace section records parse/query counts and the fallback reason.
 The rendered artifact/provider contract is owned by `opensymphony_code_intel`;
-memory consumes and re-exports that contract for compatibility instead of
-owning the provider trait.
+memory keeps the legacy `CodeIntelIndex` and `CodeIntelArtifact` surface as an
+adapter around that provider contract instead of requiring code-intelligence
+providers to import memory internals.
 The direct `code.ast.*` tools return JSON with path, line range, content hash,
 parser version, query-pack version, trace, and truncation metadata for targeted
 agent inspection. `memory.context` remains the recommended kickoff path.

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -153,7 +153,7 @@ Implementation note: pin exact versions in `Cargo.lock` and prefer crates mainta
 The rendered context provider trait lives in `opensymphony_code_intel`. `opensymphony_memory` consumes and may re-export this contract for compatibility, but AST and composite providers do not import memory internals.
 
 ```rust
-pub trait CodeIntelProvider {
+pub trait CodeIntelProvider: Send + Sync {
     fn code_context(
         &self,
         paths: &[PathBuf],

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -52,7 +52,7 @@ Implication: OpenSymphony can use Tree-sitter for fast, language-aware, range-ci
 The current OpenSymphony repository already has the right seams:
 
 - Packaging is flat, but subsystem boundaries are explicit. The root crate includes internal module trees through `#[path = "../crates/.../src/lib.rs"]` declarations.
-- `opensymphony_code_intel` owns `CodeIntelArtifact`, `CodeIntelProvider`, and rendered code-intelligence scope/source-reference types; `opensymphony_memory` consumes and may re-export them for compatibility.
+- `opensymphony_code_intel` owns `CodeIntelArtifact`, `CodeIntelProvider`, and rendered code-intelligence scope/source-reference types; `opensymphony_memory` keeps the legacy `CodeIntelIndex`/`CodeIntelArtifact` surface as a compatibility adapter.
 - `opensymphony_cli` already supports `memory context --include-code-intel`.
 - The memory MCP server already lists `memory.context`, `memory.search`, `memory.related`, `memory.docs`, and an admin `memory.ingest_code_intel` capability.
 - The current `CodebaseAnalyzer` is useful for high-level repository summaries, packages, build systems, integration signals, conventions, and risks, but it does not parse ASTs, symbols, references, or syntax diagnostics.
@@ -150,7 +150,7 @@ Implementation note: pin exact versions in `Cargo.lock` and prefer crates mainta
 
 ### 5.2 Provider model
 
-The rendered context provider trait lives in `opensymphony_code_intel`. `opensymphony_memory` consumes and may re-export this contract for compatibility, but AST and composite providers do not import memory internals.
+The rendered context provider trait lives in `opensymphony_code_intel`. `opensymphony_memory` keeps a compatibility adapter for the legacy `CodeIntelIndex` surface, but AST and composite providers do not import memory internals.
 
 ```rust
 pub trait CodeIntelProvider: Send + Sync {
@@ -1250,8 +1250,9 @@ Changes:
 1. Extend memory record kinds for code symbols, edges, and diagnostics.
 2. Add DuckDB migrations for code-intelligence tables.
 3. Add freshness helpers for code records.
-4. Consume/re-export `opensymphony_code_intel::CodeIntelProvider` and
-   `CodeIntelArtifact` for compatibility instead of owning the provider trait.
+4. Consume `opensymphony_code_intel::CodeIntelProvider` through a memory-local
+   compatibility adapter instead of requiring providers to import memory
+   internals.
 5. Convert `CodeIntelError` into `MemoryError` only at memory integration
    boundaries.
 

--- a/docs/specs/opensymphony_tree_sitter_ast_spec.md
+++ b/docs/specs/opensymphony_tree_sitter_ast_spec.md
@@ -10,7 +10,7 @@ Primary consumer: OpenSymphony agents through memory and MCP context surfaces
 
 OpenSymphony should integrate Tree-sitter as the structural parsing layer for its code intelligence suite. The integration should turn repository source files into queryable, source-cited, freshness-aware syntax artifacts that agents can use to navigate definitions, references, imports, calls, tests, and syntax boundaries during planning and implementation.
 
-The best fit is an internal module tree named `opensymphony_code_intel`, compiled into the existing single `opensymphony` package. The module should expose an `AstCodeIntelProvider` that implements and extends the existing `CodeIntelIndex` contract. It should replace the current heuristic-only `CodebaseAnalyzer` path for `memory.context --include-code-intel`, while preserving compatibility by keeping the current analyzer as a fallback and repository-summary provider.
+The best fit is an internal module tree named `opensymphony_code_intel`, compiled into the existing single `opensymphony` package. The module exposes an `AstCodeIntelProvider` that implements the code-intelligence-owned `CodeIntelProvider` contract. It replaces the current heuristic-only `CodebaseAnalyzer` path for `memory.context --include-code-intel`, while preserving compatibility by keeping the current analyzer as a fallback and repository-summary provider.
 
 The first production slice should be read-only and agent-facing:
 
@@ -52,7 +52,7 @@ Implication: OpenSymphony can use Tree-sitter for fast, language-aware, range-ci
 The current OpenSymphony repository already has the right seams:
 
 - Packaging is flat, but subsystem boundaries are explicit. The root crate includes internal module trees through `#[path = "../crates/.../src/lib.rs"]` declarations.
-- `opensymphony_memory` already defines `CodeIntelArtifact` and `CodeIntelIndex`.
+- `opensymphony_code_intel` owns `CodeIntelArtifact`, `CodeIntelProvider`, and rendered code-intelligence scope/source-reference types; `opensymphony_memory` consumes and may re-export them for compatibility.
 - `opensymphony_cli` already supports `memory context --include-code-intel`.
 - The memory MCP server already lists `memory.context`, `memory.search`, `memory.related`, `memory.docs`, and an admin `memory.ingest_code_intel` capability.
 - The current `CodebaseAnalyzer` is useful for high-level repository summaries, packages, build systems, integration signals, conventions, and risks, but it does not parse ASTs, symbols, references, or syntax diagnostics.
@@ -74,7 +74,7 @@ Implication: Tree-sitter should be introduced as a provider upgrade behind exist
 
 1. Add a Rust module tree `crates/opensymphony-code-intel` and expose it through `src/lib.rs` as `opensymphony_code_intel`.
 2. Keep parser loading trusted by default. Built-in grammar crates are allowed. Repo-supplied native parser code is disabled unless explicitly configured by an operator.
-3. Reuse the current `CodeIntelIndex` trait for initial compatibility, then add a richer provider trait for AST-specific operations.
+3. Preserve the current `memory.context` output contract while keeping rendered provider trait ownership in `opensymphony_code_intel`.
 4. Preserve current CLI and MCP contracts where possible.
 5. Add tests for query packs, source spans, freshness, concurrency, malformed code, generated files, and memory-context integration.
 6. Keep the current `CodebaseAnalyzer` as a fallback, summary source, and planning-stage repository analyzer.
@@ -150,57 +150,26 @@ Implementation note: pin exact versions in `Cargo.lock` and prefer crates mainta
 
 ### 5.2 Provider model
 
-Add a richer provider trait in `opensymphony_code_intel` and adapt it to `opensymphony_memory::CodeIntelIndex`.
+The rendered context provider trait lives in `opensymphony_code_intel`. `opensymphony_memory` consumes and may re-export this contract for compatibility, but AST and composite providers do not import memory internals.
 
 ```rust
-pub trait CodeIntelProvider: Send + Sync {
-    fn status(&self) -> CodeIntelProviderStatus;
-
-    fn repository_summary(
-        &self,
-        request: RepositorySummaryRequest,
-    ) -> Result<RepositorySummary, CodeIntelError>;
-
-    fn ast_context(
-        &self,
-        request: AstContextRequest,
-    ) -> Result<AstContextBundle, CodeIntelError>;
-
-    fn symbols(
-        &self,
-        request: SymbolQueryRequest,
-    ) -> Result<Vec<SymbolRecord>, CodeIntelError>;
-
-    fn references(
-        &self,
-        request: ReferenceQueryRequest,
-    ) -> Result<Vec<ReferenceRecord>, CodeIntelError>;
-
-    fn structural_query(
-        &self,
-        request: StructuralQueryRequest,
-    ) -> Result<Vec<StructuralMatch>, CodeIntelError>;
-
-    fn ingest(
-        &self,
-        request: IngestRequest,
-    ) -> Result<IngestReport, CodeIntelError>;
-}
-```
-
-Add an adapter:
-
-```rust
-impl opensymphony_memory::CodeIntelIndex for AstCodeIntelProvider {
+pub trait CodeIntelProvider {
     fn code_context(
         &self,
         paths: &[PathBuf],
-        scope_refs: &[KnowledgeScope],
+        scope_refs: &[CodeIntelScope],
         limit: usize,
-    ) -> Result<Vec<CodeIntelArtifact>, MemoryError> {
-        // Build AstContextRequest, map structural evidence into CodeIntelArtifact.
-    }
+    ) -> Result<Vec<CodeIntelArtifact>, CodeIntelError>;
 }
+```
+
+`AstCodeIntelProvider`, `CompositeCodeIntelProvider`, and the
+`CodebaseAnalyzer` repository-summary fallback implement this trait:
+
+```rust
+impl CodeIntelProvider for AstCodeIntelProvider { /* ... */ }
+impl CodeIntelProvider for CompositeCodeIntelProvider { /* ... */ }
+impl CodeIntelProvider for CodebaseAnalyzer { /* ... */ }
 ```
 
 ### 5.3 Provider composition
@@ -1281,8 +1250,10 @@ Changes:
 1. Extend memory record kinds for code symbols, edges, and diagnostics.
 2. Add DuckDB migrations for code-intelligence tables.
 3. Add freshness helpers for code records.
-4. Keep `CodeIntelIndex` for compatibility.
-5. Add optional richer provider trait imports only where needed to avoid tight coupling.
+4. Consume/re-export `opensymphony_code_intel::CodeIntelProvider` and
+   `CodeIntelArtifact` for compatibility instead of owning the provider trait.
+5. Convert `CodeIntelError` into `MemoryError` only at memory integration
+   boundaries.
 
 ### 15.2 `opensymphony_cli`
 
@@ -1357,7 +1328,7 @@ Acceptance criteria:
 
 Deliverables:
 
-- `AstCodeIntelProvider` implements `CodeIntelIndex`.
+- `AstCodeIntelProvider` implements `CodeIntelProvider`.
 - `CompositeCodeIntelProvider` uses AST first and `CodebaseAnalyzer` fallback.
 - `opensymphony memory context --include-code-intel` prints structural evidence.
 - Path containment and file-size limits are enforced.
@@ -1571,7 +1542,7 @@ Treat memory and code intelligence as context. Current source files and tests re
 ### Related edges
 
 - `run_context` -> `append_code_intel_context` with confidence `syntactic`
-- `append_code_intel_context` -> `CodeIntelIndex::code_context` with confidence `syntactic`
+- `append_code_intel_context` -> `CodeIntelProvider::code_context` with confidence `syntactic`
 
 ### Diagnostics
 
@@ -1587,12 +1558,11 @@ Treat memory and code intelligence as context. Current source files and tests re
 
 ## 22. Open decisions
 
-1. Whether `opensymphony_code_intel` should own all code-intelligence provider traits or whether richer traits should live in `opensymphony_memory`.
-2. Whether ad hoc Tree-sitter queries should be available to read-token local agents or only to admin/operator tools.
-3. Whether to support WASM grammar loading in hosted mode after a separate sandboxing review.
-4. How aggressively to persist snippets. Default should be metadata and hashes, with snippets rendered on demand from local files.
-5. Whether to use a filesystem watcher for local desktop mode or rely on lazy hash validation.
-6. How much call-graph inference to expose before LSP or compiler-backed providers are added.
+1. Whether ad hoc Tree-sitter queries should be available to read-token local agents or only to admin/operator tools.
+2. Whether to support WASM grammar loading in hosted mode after a separate sandboxing review.
+3. How aggressively to persist snippets. Default should be metadata and hashes, with snippets rendered on demand from local files.
+4. Whether to use a filesystem watcher for local desktop mode or rely on lazy hash validation.
+5. How much call-graph inference to expose before LSP or compiler-backed providers are added.
 7. Whether generated public docs should include AST source snippets or only path and line references.
 
 ## 23. Acceptance criteria for V1


### PR DESCRIPTION
## Summary

Moves rendered code-intelligence provider ownership into `opensymphony_code_intel` while preserving the existing `memory.context --include-code-intel` behavior and the legacy `opensymphony_memory::CodeIntelIndex` compatibility surface.

## Changes

- Adds code-intel-owned `CodeIntelProvider`, `CodeIntelArtifact`, `CodeIntelScope`, and `CodeIntelSourceRef` types.
- Updates `AstCodeIntelProvider`, `CompositeCodeIntelProvider`, and `CodebaseAnalyzer` to implement the code-intel-owned provider trait.
- Restores the memory-owned `CodeIntelIndex` and `CodeIntelArtifact` API shape and adds `CodeIntelProviderAdapter` to bridge code-intel providers into memory without reversing imports.
- Converts `CodeIntelError` at memory boundaries while preserving provider error source chains through `MemoryError::CodeIntel`.
- Adds `Send + Sync` to the provider trait for async actor use.
- Updates durable docs and repo guidance to describe the provider boundary and memory compatibility adapter.

## Evidence

### Test output

```text
cargo check-system-duckdb
  Finished `dev` profile [unoptimized + debuginfo] target(s)

cargo fmt --check
  passed

cargo test-system-duckdb opensymphony_code_intel -- --nocapture
  test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 671 filtered out

cargo test-system-duckdb memory_context_code_intelligence --test memory -- --nocapture
  test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 42 filtered out

cargo test-system-duckdb mcp_memory_context_can_include_ast_code_intelligence -- --nocapture
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 695 filtered out

cargo test-system-duckdb --test memory
  test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test-system-duckdb code_intel_provider_adapter_preserves_memory_index_contract -- --nocapture
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 695 filtered out

cargo test-system-duckdb noop_code_intel_index_keeps_memory_contract -- --nocapture
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 695 filtered out

cargo clippy-system-duckdb
  Finished `dev` profile [unoptimized + debuginfo] target(s)

git diff --check
  passed
```

### Verification

Runtime smoke used the just-built code path:

```text
DUCKDB_LIB_DIR=/opt/homebrew/opt/duckdb/lib DUCKDB_INCLUDE_DIR=/opt/homebrew/opt/duckdb/include DYLD_LIBRARY_PATH=/opt/homebrew/opt/duckdb/lib cargo run --quiet --no-default-features --features duckdb-prebuilt -- memory context --issue COE-506 --paths crates/opensymphony-code-intel/src/lib.rs,crates/opensymphony-memory/src/lib.rs,crates/opensymphony-planning/src/codebase.rs,crates/opensymphony-cli/src/memory.rs --include-code-intel
```

The output rendered AST summaries for all four requested Rust files, symbol output including `CodeIntelProvider`, and a composite trace with `parsed 4 file(s)`, `ran 4 Tree-sitter query pack(s)`, and `fallback: CodebaseAnalyzer not used`.

Import-direction proof:

```text
rg -n "opensymphony_memory|MemoryError|KnowledgeScope|MemorySourceRef|CodeIntelIndex" crates/opensymphony-code-intel/src/lib.rs
# no matches
```

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactoring
- [x] Documentation
- [ ] Other: N/A

## Breaking changes

None. The rendered `memory.context --include-code-intel` behavior and output shape remain stable, and `opensymphony_memory::CodeIntelIndex` keeps the memory-owned `KnowledgeScope`/`MemoryError` contract.

## Related issues

COE-506: https://linear.app/trilogy-ai-coe/issue/COE-506/invert-codeintelindex-trait-ownership-after-ast-memory-integration

## Additional notes

Follow-up commits `bb0a7cd` and `7ac5555` address all inline automated review feedback by preserving provider error sources, adding `Send + Sync`, and keeping the memory compatibility adapter contract intact.
