### PR TITLE
Fix desktop Knowledge Graph native loading

### DIFF
--- a/apps/desktop/__tests__/app-shell-render.test.ts
+++ b/apps/desktop/__tests__/app-shell-render.test.ts
@@ -26,6 +26,7 @@ import { MockGatewayTransport } from "@opensymphony/api-client";
 import { createModelProfile } from "@opensymphony/gateway-schema";
 import { createFixtureGraphAdapter } from "@opensymphony/graph";
 import {
+  createDesktopGraphAdapter,
   createDesktopModelProfileController,
   createDesktopProfileController,
   createDesktopTransport,
@@ -411,6 +412,99 @@ describe("desktop app shell render", () => {
       { command: "run_diffs", args: { runId: "run-1", filePath: "src/config.ts" } },
       { command: "run_validation", args: { runId: "run-1" } },
       { command: "run_approvals", args: { runId: "run-1" } },
+    ]);
+  });
+
+  it("uses native Tauri commands for desktop graph reads", async () => {
+    const calls: TauriInvokeCall[] = [];
+    (globalThis as unknown as { __TAURI__: unknown }).__TAURI__ = {
+      core: {
+        async invoke(command: string, args?: Record<string, unknown>) {
+          calls.push({ command, args });
+          switch (command) {
+            case "memory_bundles":
+              return {
+                schema_version: { major: 1, minor: 0, patch: 0 },
+                bundles: [{
+                  id: "local-default",
+                  title: "OpenSymphony Memory",
+                  okf_version: "0.1",
+                  visibility: "private",
+                  concept_count: 1,
+                }],
+              };
+            case "memory_graph":
+              return {
+                schema_version: { major: 1, minor: 0, patch: 0 },
+                bundle_id: args?.bundleId,
+                cursor: { sequence: 1, partition: "memory-graph:local-default" },
+                nodes: [],
+                edges: [],
+                communities: [],
+                metrics: {
+                  orphan_count: 0,
+                  broken_link_count: 0,
+                  stale_concept_count: 0,
+                  warning_count: 0,
+                },
+                filters_applied: [],
+                generated_at: "2026-07-02T00:00:00Z",
+              };
+            case "memory_concept_detail":
+              return {
+                schema_version: { major: 1, minor: 0, patch: 0 },
+                bundle_id: args?.bundleId,
+                concept_id: args?.conceptId,
+                title: "COE-465",
+                visibility: "public",
+                body_markdown: "",
+                links: [],
+                source_refs: [],
+              };
+            case "memory_communities":
+              return {
+                schema_version: { major: 1, minor: 0, patch: 0 },
+                bundle_id: args?.bundleId,
+                communities: [],
+              };
+            case "memory_search":
+              return {
+                schema_version: { major: 1, minor: 0, patch: 0 },
+                query: args?.query,
+                bundle_id: args?.bundleId,
+                results: [],
+              };
+            default:
+              throw new Error(`unexpected command ${command}`);
+          }
+        },
+      },
+    };
+
+    const graphAdapter = createDesktopGraphAdapter("http://127.0.0.1:2468");
+
+    await graphAdapter.listBundles();
+    await graphAdapter.getGraphSnapshot("local-default", { visibility: "all_accessible" });
+    await graphAdapter.getConceptDetail("local-default", "issues/COE-465", { visibility: "public" });
+    await graphAdapter.getCommunities("local-default");
+    await graphAdapter.search("graph", {
+      limit: 5,
+      bundleId: "local-default",
+      visibility: "all_accessible",
+    });
+
+    expect(calls).toEqual([
+      { command: "memory_bundles", args: { visibility: null } },
+      { command: "memory_graph", args: { bundleId: "local-default", visibility: "all_accessible" } },
+      {
+        command: "memory_concept_detail",
+        args: { bundleId: "local-default", conceptId: "issues/COE-465", visibility: "public" },
+      },
+      { command: "memory_communities", args: { bundleId: "local-default", visibility: null } },
+      {
+        command: "memory_search",
+        args: { query: "graph", limit: 5, bundleId: "local-default", visibility: "all_accessible" },
+      },
     ]);
   });
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -929,6 +929,27 @@ async fn gateway_get_json(
     Ok(value)
 }
 
+fn path_with_query(path: &str, params: &[String]) -> String {
+    if params.is_empty() {
+        path.to_string()
+    } else {
+        format!("{path}?{}", params.join("&"))
+    }
+}
+
+fn push_query_param(params: &mut Vec<String>, key: &str, value: Option<&str>) {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    params.push(format!("{key}={}", urlencoding::encode(value)));
+}
+
+fn push_query_param_value<T: ToString>(params: &mut Vec<String>, key: &str, value: Option<T>) {
+    if let Some(value) = value {
+        params.push(format!("{key}={}", urlencoding::encode(&value.to_string())));
+    }
+}
+
 /// Request to attach to a local gateway instance.
 #[derive(Debug, Deserialize)]
 pub struct AttachGatewayRequest {
@@ -977,6 +998,95 @@ pub async fn dashboard_snapshot(
     state: tauri::State<'_, RwLock<GatewayConnection>>,
 ) -> CommandResult<serde_json::Value> {
     gateway_get_json(state, "/api/v1/dashboard/snapshot").await
+}
+
+/// List memory graph bundles through the active gateway.
+#[command]
+pub async fn memory_bundles(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    visibility: Option<String>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "visibility", visibility.as_deref());
+    let path = path_with_query("/api/v1/memory/bundles", &params);
+    gateway_get_json(state, &path).await
+}
+
+/// Get a memory graph snapshot for a bundle through the active gateway.
+#[command]
+pub async fn memory_graph(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    bundle_id: String,
+    visibility: Option<String>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "visibility", visibility.as_deref());
+    let path = path_with_query(
+        &format!(
+            "/api/v1/memory/bundles/{}/graph",
+            urlencoding::encode(&bundle_id)
+        ),
+        &params,
+    );
+    gateway_get_json(state, &path).await
+}
+
+/// Get a memory graph concept detail through the active gateway.
+#[command]
+pub async fn memory_concept_detail(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    bundle_id: String,
+    concept_id: String,
+    visibility: Option<String>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "visibility", visibility.as_deref());
+    let path = path_with_query(
+        &format!(
+            "/api/v1/memory/bundles/{}/concepts/{}",
+            urlencoding::encode(&bundle_id),
+            urlencoding::encode(&concept_id)
+        ),
+        &params,
+    );
+    gateway_get_json(state, &path).await
+}
+
+/// Get memory graph communities through the active gateway.
+#[command]
+pub async fn memory_communities(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    bundle_id: String,
+    visibility: Option<String>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "visibility", visibility.as_deref());
+    let path = path_with_query(
+        &format!(
+            "/api/v1/memory/bundles/{}/communities",
+            urlencoding::encode(&bundle_id)
+        ),
+        &params,
+    );
+    gateway_get_json(state, &path).await
+}
+
+/// Search memory graph concepts through the active gateway.
+#[command]
+pub async fn memory_search(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    query: String,
+    limit: Option<u64>,
+    bundle_id: Option<String>,
+    visibility: Option<String>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "query", Some(&query));
+    push_query_param_value(&mut params, "limit", limit);
+    push_query_param(&mut params, "bundle_id", bundle_id.as_deref());
+    push_query_param(&mut params, "visibility", visibility.as_deref());
+    let path = path_with_query("/api/v1/memory/search", &params);
+    gateway_get_json(state, &path).await
 }
 
 /// Get task graph for a project.
@@ -1388,6 +1498,24 @@ mod tests {
             "loopback_http"
         );
         assert_eq!(gateway_profile_for_url("https://example.com"), "websocket");
+    }
+
+    #[test]
+    fn memory_graph_query_helpers_encode_non_empty_values() {
+        let mut params = Vec::new();
+        push_query_param(&mut params, "visibility", Some(" all_accessible "));
+        push_query_param(&mut params, "bundle_id", Some("local default"));
+        push_query_param(&mut params, "empty", Some(" "));
+        push_query_param_value(&mut params, "limit", Some(5_u64));
+
+        assert_eq!(
+            path_with_query("/api/v1/memory/search", &params),
+            "/api/v1/memory/search?visibility=all_accessible&bundle_id=local%20default&limit=5"
+        );
+        assert_eq!(
+            path_with_query("/api/v1/memory/bundles", &[]),
+            "/api/v1/memory/bundles"
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -62,6 +62,11 @@ pub fn run() {
             // COE-410: Gateway local stream transport commands
             commands::attach_gateway,
             commands::dashboard_snapshot,
+            commands::memory_bundles,
+            commands::memory_graph,
+            commands::memory_concept_detail,
+            commands::memory_communities,
+            commands::memory_search,
             commands::task_graph,
             commands::run_detail,
             commands::run_files,

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -8,6 +8,11 @@ import {
 import {
   createGatewayGraphAdapter,
   createTauriNativeGraphAdapter,
+  type MemoryBundleList,
+  type MemoryCommunityList,
+  type MemoryConceptDetail,
+  type MemoryGraphSnapshot,
+  type MemorySearchResponse,
   type NativeGraphApi,
 } from "@opensymphony/graph";
 import type { ConnectionProfile } from "@opensymphony/gateway-schema";
@@ -26,15 +31,19 @@ import {
 
 const DEFAULT_GATEWAY_URL = "http://127.0.0.1:2468";
 
+type TauriInvoke = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
+
 export function createDesktopGraphAdapter(gatewayUrl = DEFAULT_GATEWAY_URL) {
+  const invoke = getTauriInvoke();
+  if (invoke) {
+    return createDesktopNativeGraphAdapter(createDesktopNativeGraphApi(invoke));
+  }
   return createGatewayGraphAdapter(gatewayUrl);
 }
 
 export function createDesktopNativeGraphAdapter(api: NativeGraphApi) {
   return createTauriNativeGraphAdapter(api);
 }
-
-type TauriInvoke = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
 
 interface TauriGlobal {
   invoke?: TauriInvoke;
@@ -72,6 +81,35 @@ type NativeSettingValue =
   | { type: "Text"; value: string }
   | { type: "Flag"; value: boolean }
   | { type: "Number"; value: number };
+
+function createDesktopNativeGraphApi(invoke: TauriInvoke): NativeGraphApi {
+  return {
+    listBundles: () => invoke<MemoryBundleList>("memory_bundles", { visibility: null }),
+    getGraphSnapshot: (bundleId, options) =>
+      invoke<MemoryGraphSnapshot>("memory_graph", {
+        bundleId,
+        visibility: options?.visibility ?? null,
+      }),
+    getConceptDetail: (bundleId, conceptId, options) =>
+      invoke<MemoryConceptDetail>("memory_concept_detail", {
+        bundleId,
+        conceptId,
+        visibility: options?.visibility ?? null,
+      }),
+    getCommunities: (bundleId, options) =>
+      invoke<MemoryCommunityList>("memory_communities", {
+        bundleId,
+        visibility: options?.visibility ?? null,
+      }),
+    search: (query, options) =>
+      invoke<MemorySearchResponse>("memory_search", {
+        query,
+        limit: options?.limit ?? null,
+        bundleId: options?.bundleId ?? null,
+        visibility: options?.visibility ?? null,
+      }),
+  };
+}
 
 export interface TauriTransportAdapter extends ActionCapableTransport {
   attach(): Promise<void>;


### PR DESCRIPTION
## Summary

Fixes the desktop Knowledge Graph load path by routing memory graph reads through native Tauri gateway commands when running inside the desktop app.

## Changes

- Adds read-only Tauri commands for memory graph bundles, snapshots, concept details, communities, and search.
- Updates the desktop graph adapter to use native Tauri commands in desktop mode while preserving HTTP fallback for browser/dev contexts.
- Adds focused desktop tests for native graph command routing and query encoding.

## Evidence

### Test output

```
npm run type-check
# tsc --build tsconfig.projects.json

npx jest --config jest.config.js --runTestsByPath apps/desktop/__tests__/app-shell-render.test.ts
# Test Suites: 1 passed, 1 total
# Tests:       15 passed, 15 total

npm run build --workspace=@opensymphony/desktop
# vite v6.4.3 building for production...
# ✓ built in 712ms

cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
# test result: ok. 41 passed; 0 failed
# test result: ok. 5 passed; 0 failed

git diff --check
# clean
```

### Verification

Live gateway probing showed `/api/v1/memory/bundles` and `/api/v1/memory/bundles/local-default/graph` returned `200 OK`, while the desktop app showed `Graph unavailable: Load failed`. This PR keeps the graph DTO and renderer contracts intact and moves desktop graph reads onto the same native gateway bridge used by other desktop reads.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`)
- [ ] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- [COE-520](https://linear.app/trilogy-ai-coe/issue/COE-520/route-desktop-knowledge-graph-through-native-gateway-commands)

## Additional notes

The Linear task is intentionally in Backlog so the orchestrator will not pick it up automatically.
