### PR TITLE
Record workflow target branch marker

### DIFF
--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -198,9 +198,14 @@ impl TargetBranch {
                 "target branch must be a non-empty local branch name".to_string(),
             ));
         }
-        if branch.starts_with("origin/") || branch.starts_with("refs/heads/") {
+        if branch.starts_with("origin/") || branch.starts_with("refs/") {
             return Err(InitCommandError::InvalidArgument(format!(
                 "target branch `{branch}` must be a local branch name, not a remote or full ref"
+            )));
+        }
+        if branch.starts_with("@{-") {
+            return Err(InitCommandError::InvalidArgument(format!(
+                "target branch `{branch}` must be a stable local branch name, not checkout shorthand"
             )));
         }
 
@@ -1778,10 +1783,13 @@ fn customize_workflow(
     );
     customized = customized.replace(WORKFLOW_TARGET_BRANCH_PLACEHOLDER, target_branch.local());
     customized = ensure_target_branch_marker(customized, target_branch);
+    replace_legacy_target_remote_refs(customized, target_branch)
+}
 
-    customized.replace(
-        LEGACY_WORKFLOW_TARGET_REMOTE_REF,
-        &target_branch.remote_ref(),
+fn replace_legacy_target_remote_refs(workflow: String, target_branch: &TargetBranch) -> String {
+    workflow.replace(
+        &format!("`{LEGACY_WORKFLOW_TARGET_REMOTE_REF}`"),
+        &format!("`{}`", target_branch.remote_ref()),
     )
 }
 
@@ -2600,7 +2608,14 @@ Active review provider: `YOUR-REVIEW-PROVIDER`
 
     #[test]
     fn target_branch_parser_rejects_remote_and_full_refs() {
-        for branch in ["", "origin/develop", "refs/heads/develop", "bad..branch"] {
+        for branch in [
+            "",
+            "origin/develop",
+            "refs/heads/develop",
+            "refs/remotes/origin/develop",
+            "@{-1}",
+            "bad..branch",
+        ] {
             assert!(
                 TargetBranch::parse(branch).is_err(),
                 "{branch:?} should be rejected"
@@ -2629,6 +2644,30 @@ hooks:
 
         assert!(customized.contains("project_slug:    \"demo-project\""));
         assert!(customized.contains("git clone --depth 1 'https://github.com/example/demo.git' ."));
+    }
+
+    #[test]
+    fn customize_workflow_preserves_origin_main_inside_repo_url() {
+        let workflow = r#"---
+hooks:
+  after_create: |
+    git clone --depth 1 https://github.com/YOUR-ORG/YOUR-REPO.git .
+---
+
+Keep feature branches current with `origin/main`.
+"#;
+
+        let customized = customize_workflow(
+            workflow,
+            Some("https://github.com/origin/main.git"),
+            None,
+            ReviewProviderArg::None,
+            &TargetBranch::default(),
+        );
+
+        assert!(customized.contains("git clone --depth 1 'https://github.com/origin/main.git' ."));
+        assert!(customized.contains("`origin/develop`"));
+        assert!(!customized.contains("https://github.com/origin/develop.git"));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -39,6 +39,10 @@ const AGENTS_EXAMPLE_PATH: &str = "AGENTS-example.md";
 const WORKFLOW_PROJECT_SLUG_PLACEHOLDER: &str = "\"YOUR-PROJECT-SLUG\"";
 const WORKFLOW_GIT_REMOTE_PLACEHOLDER: &str = "https://github.com/YOUR-ORG/YOUR-REPO.git";
 const WORKFLOW_REVIEW_PROVIDER_PLACEHOLDER: &str = "YOUR-REVIEW-PROVIDER";
+const WORKFLOW_TARGET_BRANCH_PLACEHOLDER: &str = "YOUR-TARGET-BRANCH";
+const WORKFLOW_AUTOMATED_REVIEW_HEADING: &str = "## Automated AI PR review";
+const DEFAULT_TARGET_BRANCH: &str = "develop";
+const LEGACY_WORKFLOW_TARGET_REMOTE_REF: &str = "origin/main";
 const CODEX_CODE_REVIEW_SETUP_GUIDE_URL: &str =
     "https://github.com/kumanday/OpenSymphony/blob/main/docs/codex-code-review-setup.md";
 const CODEX_CODE_REVIEW_DOCS_URL: &str = "https://developers.openai.com/codex/integrations/github";
@@ -180,6 +184,51 @@ impl ReviewProviderArg {
             Self::Codex => "codex",
             Self::None => "none",
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TargetBranch(String);
+
+impl TargetBranch {
+    fn parse(value: &str) -> Result<Self, InitCommandError> {
+        let branch = value.trim();
+        if branch.is_empty() {
+            return Err(InitCommandError::InvalidArgument(
+                "target branch must be a non-empty local branch name".to_string(),
+            ));
+        }
+        if branch.starts_with("origin/") || branch.starts_with("refs/heads/") {
+            return Err(InitCommandError::InvalidArgument(format!(
+                "target branch `{branch}` must be a local branch name, not a remote or full ref"
+            )));
+        }
+
+        let output = std::process::Command::new("git")
+            .args(["check-ref-format", "--branch", branch])
+            .output()
+            .map_err(InitCommandError::GitCheckRefFormat)?;
+        if !output.status.success() {
+            return Err(InitCommandError::InvalidArgument(format!(
+                "target branch `{branch}` is not accepted by `git check-ref-format --branch`"
+            )));
+        }
+
+        Ok(Self(branch.to_string()))
+    }
+
+    fn local(&self) -> &str {
+        &self.0
+    }
+
+    fn remote_ref(&self) -> String {
+        format!("origin/{}", self.0)
+    }
+}
+
+impl Default for TargetBranch {
+    fn default() -> Self {
+        Self(DEFAULT_TARGET_BRANCH.to_string())
     }
 }
 
@@ -355,6 +404,8 @@ pub(crate) enum InitCommandError {
     },
     #[error("failed to read interactive input: {0}")]
     PromptIo(#[source] io::Error),
+    #[error("failed to validate target branch with git check-ref-format: {0}")]
+    GitCheckRefFormat(#[source] io::Error),
     #[error("input closed while waiting for a response")]
     PromptClosed,
     #[error(
@@ -644,6 +695,7 @@ where
     } else {
         prompt_review_provider(ui)?
     };
+    let target_branch = TargetBranch::parse(DEFAULT_TARGET_BRANCH)?;
     let enable_ai_pr_review = review_provider == ReviewProviderArg::Openhands;
     let ai_review_config = if enable_ai_pr_review {
         Some(
@@ -744,6 +796,7 @@ where
             git_remote_url(&git_remote),
             linear_project_slug.as_deref(),
             review_provider,
+            &target_branch,
         )?;
 
         match final_result {
@@ -1135,6 +1188,7 @@ fn apply_asset(
     git_remote_url: Option<&str>,
     linear_project_slug: Option<&str>,
     review_provider: ReviewProviderArg,
+    target_branch: &TargetBranch,
 ) -> Result<AppliedChange, InitCommandError> {
     let existing = planned.existing.as_deref();
 
@@ -1144,6 +1198,7 @@ fn apply_asset(
         git_remote_url,
         linear_project_slug,
         review_provider,
+        target_branch,
     ) else {
         return Ok(match planned.action {
             PlannedAction::Skip => AppliedChange::Skipped,
@@ -1195,6 +1250,7 @@ fn build_final_contents(
     git_remote_url: Option<&str>,
     linear_project_slug: Option<&str>,
     review_provider: ReviewProviderArg,
+    target_branch: &TargetBranch,
 ) -> Option<String> {
     match action {
         PlannedAction::Create | PlannedAction::Overwrite => Some(match asset.kind {
@@ -1203,6 +1259,7 @@ fn build_final_contents(
                 git_remote_url,
                 linear_project_slug,
                 review_provider,
+                target_branch,
             ),
             _ => asset.contents.clone(),
         }),
@@ -1211,6 +1268,7 @@ fn build_final_contents(
             git_remote_url,
             linear_project_slug,
             review_provider,
+            target_branch,
         )),
         PlannedAction::Skip | PlannedAction::Unchanged => None,
         PlannedAction::Prompt => None,
@@ -1698,6 +1756,7 @@ fn customize_workflow(
     git_remote_url: Option<&str>,
     linear_project_slug: Option<&str>,
     review_provider: ReviewProviderArg,
+    target_branch: &TargetBranch,
 ) -> String {
     let mut customized = template.to_string();
 
@@ -1713,10 +1772,34 @@ fn customize_workflow(
             customized.replace(WORKFLOW_PROJECT_SLUG_PLACEHOLDER, &yaml_double_quote(slug));
     }
 
-    customized.replace(
+    customized = customized.replace(
         WORKFLOW_REVIEW_PROVIDER_PLACEHOLDER,
         review_provider.as_str(),
+    );
+    customized = customized.replace(WORKFLOW_TARGET_BRANCH_PLACEHOLDER, target_branch.local());
+    customized = ensure_target_branch_marker(customized, target_branch);
+
+    customized.replace(
+        LEGACY_WORKFLOW_TARGET_REMOTE_REF,
+        &target_branch.remote_ref(),
     )
+}
+
+fn ensure_target_branch_marker(mut workflow: String, target_branch: &TargetBranch) -> String {
+    if workflow.contains("Target branch: `") {
+        return workflow;
+    }
+
+    let section = format!(
+        "## Branch target\n\nTarget branch: `{}`\n\n<!-- Set by `opensymphony init` or `opensymphony update --target-branch`.\n     Value is a local branch name, not an `origin/...` ref. Agents should use\n     `origin/<target-branch>` when syncing, creating replacement branches, and\n     preparing PRs. -->\n\n",
+        target_branch.local()
+    );
+
+    if let Some(index) = workflow.find(WORKFLOW_AUTOMATED_REVIEW_HEADING) {
+        workflow.insert_str(index, &section);
+    }
+
+    workflow
 }
 
 fn comparable_text(value: &str) -> String {
@@ -2365,7 +2448,7 @@ mod tests {
     use super::{
         AiReviewConfig, AiReviewProviderKindArg, DEFAULT_AI_REVIEW_MODEL_ID, DEFAULT_LLM_BASE_URL,
         DEFAULT_LLM_MODEL, DEFAULT_TEMPLATE_FETCH_TIMEOUT_MS, GitRemoteDetection, InitArgs,
-        InitCommandError, PromptUi, ReviewProviderArg, comparable_text,
+        InitCommandError, PromptUi, ReviewProviderArg, TargetBranch, comparable_text,
         custom_codereview_guide_contents, customize_workflow, git_remote_url,
         github_repo_slug_from_remote, normalize_github_repo_slug, prompt_ai_review_config,
         prompt_for_missing_llm_env, prompt_review_provider, prompt_yes_no,
@@ -2401,6 +2484,7 @@ Active review provider: `YOUR-REVIEW-PROVIDER`
             Some("git@github.com:kumanday/demo.git"),
             Some("demo-project"),
             ReviewProviderArg::Openhands,
+            &TargetBranch::default(),
         );
 
         assert!(customized.contains("project_slug: \"demo-project\""));
@@ -2412,15 +2496,116 @@ Active review provider: `YOUR-REVIEW-PROVIDER`
     fn customize_workflow_replaces_review_provider_for_codex_and_none() {
         let workflow = "Active review provider: `YOUR-REVIEW-PROVIDER`\n";
 
-        let codex = customize_workflow(workflow, None, None, ReviewProviderArg::Codex);
+        let codex = customize_workflow(
+            workflow,
+            None,
+            None,
+            ReviewProviderArg::Codex,
+            &TargetBranch::default(),
+        );
         assert!(codex.contains("Active review provider: `codex`"));
 
-        let none = customize_workflow(workflow, None, None, ReviewProviderArg::None);
+        let none = customize_workflow(
+            workflow,
+            None,
+            None,
+            ReviewProviderArg::None,
+            &TargetBranch::default(),
+        );
         assert!(none.contains("Active review provider: `none`"));
 
-        let without_placeholder =
-            customize_workflow("no marker here\n", None, None, ReviewProviderArg::Codex);
+        let without_placeholder = customize_workflow(
+            "no marker here\n",
+            None,
+            None,
+            ReviewProviderArg::Codex,
+            &TargetBranch::default(),
+        );
         assert_eq!(without_placeholder, "no marker here\n");
+    }
+
+    #[test]
+    fn customize_workflow_renders_target_branch_marker_and_guidance() {
+        let workflow = r#"## Branch target
+
+Target branch: `YOUR-TARGET-BRANCH`
+
+Keep feature branches current with `origin/main`.
+
+## Automated AI PR review
+
+Active review provider: `YOUR-REVIEW-PROVIDER`
+"#;
+
+        let default_branch = customize_workflow(
+            workflow,
+            None,
+            None,
+            ReviewProviderArg::None,
+            &TargetBranch::default(),
+        );
+        assert!(default_branch.contains("Target branch: `develop`"));
+        assert!(default_branch.contains("`origin/develop`"));
+        assert!(!default_branch.contains("Target branch: `origin/develop`"));
+
+        let release_branch = TargetBranch::parse("release/next").expect("valid branch");
+        let customized = customize_workflow(
+            workflow,
+            None,
+            None,
+            ReviewProviderArg::Codex,
+            &release_branch,
+        );
+        assert!(customized.contains("Target branch: `release/next`"));
+        assert!(customized.contains("`origin/release/next`"));
+        assert!(!customized.contains("Target branch: `origin/release/next`"));
+        assert!(!customized.contains("origin/main"));
+    }
+
+    #[test]
+    fn customize_workflow_inserts_default_target_branch_marker() {
+        let workflow = r#"## Automated AI PR review
+
+Active review provider: `YOUR-REVIEW-PROVIDER`
+"#;
+
+        let customized = customize_workflow(
+            workflow,
+            None,
+            None,
+            ReviewProviderArg::None,
+            &TargetBranch::default(),
+        );
+
+        assert!(customized.contains("## Branch target"));
+        assert!(customized.contains("Target branch: `develop`"));
+        assert!(customized.contains("Active review provider: `none`"));
+    }
+
+    #[test]
+    fn target_branch_parser_accepts_local_branch_names() {
+        assert_eq!(
+            TargetBranch::parse(" main ")
+                .expect("main should parse")
+                .local(),
+            "main"
+        );
+        assert_eq!(
+            TargetBranch::parse("release/next")
+                .expect("slash branch should parse")
+                .local(),
+            "release/next"
+        );
+    }
+
+    #[test]
+    fn target_branch_parser_rejects_remote_and_full_refs() {
+        for branch in ["", "origin/develop", "refs/heads/develop", "bad..branch"] {
+            assert!(
+                TargetBranch::parse(branch).is_err(),
+                "{branch:?} should be rejected"
+            );
+        }
     }
 
     #[test]
@@ -2439,6 +2624,7 @@ hooks:
             Some("https://github.com/example/demo.git"),
             Some("demo-project"),
             ReviewProviderArg::None,
+            &TargetBranch::default(),
         );
 
         assert!(customized.contains("project_slug:    \"demo-project\""));

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -188,10 +188,11 @@ impl ReviewProviderArg {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct TargetBranch(String);
+pub(crate) struct TargetBranch(String);
 
 impl TargetBranch {
-    fn parse(value: &str) -> Result<Self, InitCommandError> {
+    #[allow(dead_code)]
+    pub(crate) fn parse(value: &str) -> Result<Self, InitCommandError> {
         let branch = value.trim();
         if branch.is_empty() {
             return Err(InitCommandError::InvalidArgument(
@@ -409,6 +410,7 @@ pub(crate) enum InitCommandError {
     },
     #[error("failed to read interactive input: {0}")]
     PromptIo(#[source] io::Error),
+    #[allow(dead_code)]
     #[error("failed to validate target branch with git check-ref-format: {0}")]
     GitCheckRefFormat(#[source] io::Error),
     #[error("input closed while waiting for a response")]
@@ -700,7 +702,7 @@ where
     } else {
         prompt_review_provider(ui)?
     };
-    let target_branch = TargetBranch::parse(DEFAULT_TARGET_BRANCH)?;
+    let target_branch = TargetBranch::default();
     let enable_ai_pr_review = review_provider == ReviewProviderArg::Openhands;
     let ai_review_config = if enable_ai_pr_review {
         Some(
@@ -1788,14 +1790,24 @@ fn customize_workflow(
 
 fn replace_legacy_target_remote_refs(workflow: String, target_branch: &TargetBranch) -> String {
     let remote_ref = target_branch.remote_ref();
-    let workflow = workflow.replace(
+    let mut workflow = workflow.replace(
         &format!("`{LEGACY_WORKFLOW_TARGET_REMOTE_REF}`"),
         &format!("`{remote_ref}`"),
     );
-    workflow.replace(
+    for phrase in [
+        "latest origin/main before handoff",
+        "branch from origin/main and restart",
+        "sync with latest origin/main before",
+        "Merge latest origin/main into branch",
+        "Create a fresh branch from origin/main.",
         "merged origin/main clean",
-        &format!("merged {remote_ref} clean"),
-    )
+    ] {
+        workflow = workflow.replace(
+            phrase,
+            &phrase.replace(LEGACY_WORKFLOW_TARGET_REMOTE_REF, &remote_ref),
+        );
+    }
+    workflow
 }
 
 fn ensure_target_branch_marker(mut workflow: String, target_branch: &TargetBranch) -> String {
@@ -2661,6 +2673,11 @@ hooks:
 
 Keep feature branches current with `origin/main`.
 
+- `pull`: keep branch updated with latest origin/main before handoff.
+- For closed PRs, create a fresh branch from origin/main and restart execution flow.
+- Run the pull skill to sync with latest origin/main before any code edits.
+- Merge latest origin/main into branch, resolve conflicts, and rerun checks.
+- Create a fresh branch from origin/main.
 Pull skill: merged origin/main clean, HEAD now <short-sha>.
 "#;
 
@@ -2674,8 +2691,18 @@ Pull skill: merged origin/main clean, HEAD now <short-sha>.
 
         assert!(customized.contains("git clone --depth 1 'https://github.com/origin/main.git' ."));
         assert!(customized.contains("`origin/develop`"));
+        assert!(customized.contains("latest origin/develop before handoff"));
+        assert!(customized.contains("branch from origin/develop and restart"));
+        assert!(customized.contains("sync with latest origin/develop before"));
+        assert!(customized.contains("Merge latest origin/develop into branch"));
+        assert!(customized.contains("Create a fresh branch from origin/develop."));
         assert!(customized.contains("Pull skill: merged origin/develop clean"));
         assert!(!customized.contains("https://github.com/origin/develop.git"));
+        assert!(!customized.contains("latest origin/main before handoff"));
+        assert!(!customized.contains("branch from origin/main and restart"));
+        assert!(!customized.contains("sync with latest origin/main before"));
+        assert!(!customized.contains("Merge latest origin/main into branch"));
+        assert!(!customized.contains("Create a fresh branch from origin/main."));
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -1787,9 +1787,14 @@ fn customize_workflow(
 }
 
 fn replace_legacy_target_remote_refs(workflow: String, target_branch: &TargetBranch) -> String {
-    workflow.replace(
+    let remote_ref = target_branch.remote_ref();
+    let workflow = workflow.replace(
         &format!("`{LEGACY_WORKFLOW_TARGET_REMOTE_REF}`"),
-        &format!("`{}`", target_branch.remote_ref()),
+        &format!("`{remote_ref}`"),
+    );
+    workflow.replace(
+        "merged origin/main clean",
+        &format!("merged {remote_ref} clean"),
     )
 }
 
@@ -2655,6 +2660,8 @@ hooks:
 ---
 
 Keep feature branches current with `origin/main`.
+
+Pull skill: merged origin/main clean, HEAD now <short-sha>.
 "#;
 
         let customized = customize_workflow(
@@ -2667,6 +2674,7 @@ Keep feature branches current with `origin/main`.
 
         assert!(customized.contains("git clone --depth 1 'https://github.com/origin/main.git' ."));
         assert!(customized.contains("`origin/develop`"));
+        assert!(customized.contains("Pull skill: merged origin/develop clean"));
         assert!(!customized.contains("https://github.com/origin/develop.git"));
     }
 

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -40,6 +40,18 @@ async fn init_copies_template_files_and_customizes_workflow() {
         workflow.contains("Active review provider: `none`"),
         "declining review setup should record provider `none`: {workflow}",
     );
+    assert!(
+        workflow.contains("Target branch: `develop`"),
+        "init should record the default target branch: {workflow}",
+    );
+    assert!(
+        workflow.contains("Keep feature branches current with `origin/develop`."),
+        "init should patch generated branch guidance: {workflow}",
+    );
+    assert!(
+        !workflow.contains("Target branch: `origin/develop`"),
+        "stored marker must stay local-only: {workflow}",
+    );
     assert!(config.contains("tool_dir: ~/.opensymphony/openhands-server"));
 
     assert!(
@@ -182,6 +194,14 @@ async fn init_non_interactive_succeeds_with_flags_and_closed_stdin() {
         fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
     assert!(workflow.contains("project_slug: \"demo-project\""));
     assert!(workflow.contains("git clone --depth 1 'https://github.com/example/demo.git' ."));
+    assert!(
+        workflow.contains("Target branch: `develop`"),
+        "non-interactive init should record the default target branch: {workflow}",
+    );
+    assert!(
+        workflow.contains("Keep feature branches current with `origin/develop`."),
+        "non-interactive init should patch generated branch guidance: {workflow}",
+    );
     assert!(
         stdout.contains("Skipped automatic commit/push. Pass `--commit-and-push`"),
         "non-interactive init should skip commit/push without prompting: {stdout}",
@@ -326,6 +346,10 @@ async fn init_non_interactive_conflict_policy_overwrite_replaces_existing_files(
         workflow.contains("project_slug: \"demo-project\"")
             && workflow.contains("git clone --depth 1 'https://github.com/example/demo.git' ."),
         "overwrite should replace the workflow with customized template content: {workflow}",
+    );
+    assert!(
+        workflow.contains("Target branch: `develop`"),
+        "overwrite should render the default target branch: {workflow}",
     );
     assert!(
         !workflow.contains("user workflow"),
@@ -1243,6 +1267,12 @@ openhands:
       llm:
         model: ${LLM_MODEL}
 ---
+
+## Branch target
+
+Target branch: `YOUR-TARGET-BRANCH`
+
+Keep feature branches current with `origin/main`.
 
 ## Automated AI PR review
 

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -217,6 +217,40 @@ async fn init_non_interactive_succeeds_with_flags_and_closed_stdin() {
 }
 
 #[tokio::test]
+async fn init_non_interactive_default_target_branch_does_not_require_git_on_path() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child_with_env(
+        repo.path(),
+        server.base_url(),
+        &["--non-interactive", "--linear-project-slug", "demo-project"],
+        &[("PATH", "")],
+    );
+    write_stdin(&mut child, "").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "non-interactive init should not require git to validate the default branch: stdout={stdout}, stderr={stderr}",
+    );
+
+    let workflow =
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+    assert!(
+        workflow.contains("Target branch: `develop`"),
+        "init should record the static default target branch: {workflow}",
+    );
+}
+
+#[tokio::test]
 async fn init_non_interactive_fails_before_writing_without_conflict_policy() {
     let server = TemplateServer::start().await;
     let repo = TempDir::new().expect("temp repo should exist");


### PR DESCRIPTION
## Summary

Adds the minimal workflow target branch model for init-generated `WORKFLOW.md` without changing orchestrator scheduling state.

## Changes

- Add a strict local target branch helper that trims input, rejects remote/full refs and checkout shorthand, and validates explicit names with `git check-ref-format --branch`.
- Render a managed `Branch target` workflow marker with default `develop` during init customization, without requiring git for that static default.
- Replace generated target-branch guidance with `origin/<target-branch>` while keeping the stored marker local-only and preserving clone URLs, including known bare branch-control phrases.
- Add focused unit and init integration coverage for default `develop`, explicit local names, rejected remote/full refs, checkout shorthand, URL preservation, bare guidance patching, and default init without git on `PATH`.

## Evidence

### Test output

```
git diff --check
cargo fmt --check
cargo test-system-duckdb target_branch_parser
# 2 passed
cargo test-system-duckdb customize_workflow
# 6 passed
cargo test-system-duckdb --test init
# 20 passed
```

### Verification

Verified `opensymphony init --non-interactive` fixture output records `Target branch: develop` and patches generated guidance to `origin/develop`. Unit coverage verifies `main` and `release/next` render as local marker values, while `origin/develop`, `refs/heads/develop`, `refs/remotes/origin/develop`, `@{-1}`, empty input, and a git-invalid branch are rejected before workflow content is written. Rework coverage verifies the default branch path works without git on `PATH`, detected clone URLs containing `origin/main` are preserved, and known bare workflow branch-control phrases are patched to `origin/develop`.

## Checklist

- [x] Tests pass (focused commands above)
- [x] Code is formatted (`cargo fmt --check`)
- [ ] Clippy is clean (`cargo clippy` not run locally; CI rust job runs clippy)
- [x] Documentation updated (not required; behavior covered by existing spec/task docs)
- [x] `AGENTS.md` updated (not required)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

COE-521: https://linear.app/trilogy-ai-coe/issue/COE-521/workflow-target-branch-model-and-init-customization

## Additional notes

This intentionally does not add the public init prompt/flag or update settings mode; those are separate follow-up tickets in the M12.7 wave.
