### PR TITLE
feat(cli): add init target branch option

### DIFF
--- a/crates/opensymphony-cli/src/init_repo.rs
+++ b/crates/opensymphony-cli/src/init_repo.rs
@@ -74,6 +74,12 @@ pub struct InitArgs {
     linear_project_slug: Option<String>,
     #[arg(
         long,
+        value_name = "BRANCH",
+        help = "Target branch for feature PRs and syncs; examples: develop (default), main, release/next"
+    )]
+    target_branch: Option<String>,
+    #[arg(
+        long,
         value_enum,
         value_name = "POLICY",
         help = "Apply this policy for existing generated files instead of prompting"
@@ -276,6 +282,13 @@ impl InitArgs {
         }
 
         Ok(())
+    }
+
+    fn explicit_target_branch(&self) -> Result<Option<TargetBranch>, InitCommandError> {
+        self.target_branch
+            .as_deref()
+            .map(TargetBranch::parse)
+            .transpose()
     }
 
     fn resolved_review_provider_from_flags(&self) -> Option<ReviewProviderArg> {
@@ -688,6 +701,7 @@ where
     E: EnvLookup,
 {
     args.validate()?;
+    let explicit_target_branch = args.explicit_target_branch()?;
     ui.set_allow_prompts(!args.non_interactive);
 
     let target_repo = env::current_dir().map_err(InitCommandError::CurrentDir)?;
@@ -702,7 +716,6 @@ where
     } else {
         prompt_review_provider(ui)?
     };
-    let target_branch = TargetBranch::default();
     let enable_ai_pr_review = review_provider == ReviewProviderArg::Openhands;
     let ai_review_config = if enable_ai_pr_review {
         Some(
@@ -741,6 +754,13 @@ where
                 PlannedAction::Create | PlannedAction::Overwrite | PlannedAction::CustomizeWorkflow
             )
     });
+    let target_branch = if let Some(branch) = explicit_target_branch {
+        branch
+    } else if workflow_will_change && !args.non_interactive {
+        prompt_target_branch(ui)?
+    } else {
+        TargetBranch::default()
+    };
 
     let git_remote = detect_git_remote_url(&target_repo);
     match &git_remote {
@@ -1573,6 +1593,30 @@ where
         Ok(default.to_string())
     } else {
         Ok(trimmed.to_string())
+    }
+}
+
+fn prompt_target_branch<R, W>(ui: &mut PromptUi<R, W>) -> Result<TargetBranch, InitCommandError>
+where
+    R: BufRead,
+    W: Write,
+{
+    ui.blank_line()?;
+    ui.line("Choose the target branch for future feature PRs and syncs.")?;
+    ui.line("Examples: `develop` (default), `main`, `release/next`, etc.")?;
+    loop {
+        let response = prompt_with_default(
+            ui,
+            "Target branch for feature PRs and syncs (default develop): ",
+            DEFAULT_TARGET_BRANCH,
+        )?;
+        match TargetBranch::parse(&response) {
+            Ok(branch) => return Ok(branch),
+            Err(InitCommandError::InvalidArgument(message)) => {
+                ui.line(format!("Please enter a local branch name: {message}"))?;
+            }
+            Err(error) => return Err(error),
+        }
     }
 }
 

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -79,6 +79,8 @@ fn init_help_explains_non_interactive_automation_flags() {
     );
     for snippet in [
         "--non-interactive",
+        "--target-branch",
+        "develop (default), main, release/next",
         "--linear-project-slug",
         "--conflict-policy",
         "--review-provider",

--- a/crates/opensymphony-cli/tests/init.rs
+++ b/crates/opensymphony-cli/tests/init.rs
@@ -17,7 +17,7 @@ async fn init_copies_template_files_and_customizes_workflow() {
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()
@@ -122,6 +122,10 @@ async fn init_copies_template_files_and_customizes_workflow() {
         "stdout should contain a summary: {stdout}",
     );
     assert!(
+        stdout.contains("Examples: `develop` (default), `main`, `release/next`, etc."),
+        "stdout should show target branch examples: {stdout}",
+    );
+    assert!(
         stdout.contains("Created:")
             && stdout.contains("- .gitignore")
             && stdout.contains("- .opensymphony/memory/memory.yaml"),
@@ -136,7 +140,7 @@ async fn init_uses_template_memory_skill_when_template_provides_it() {
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()
@@ -213,6 +217,93 @@ async fn init_non_interactive_succeeds_with_flags_and_closed_stdin() {
     assert!(
         !stdout.contains("Enter your Linear project slug/key"),
         "non-interactive init should not prompt for Linear slug: {stdout}",
+    );
+    assert!(
+        !stdout.contains("Target branch for feature PRs and syncs"),
+        "non-interactive init should not prompt for target branch: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_non_interactive_accepts_explicit_target_branch() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(
+        repo.path(),
+        server.base_url(),
+        &[
+            "--non-interactive",
+            "--linear-project-slug",
+            "demo-project",
+            "--target-branch",
+            "main",
+        ],
+    );
+    write_stdin(&mut child, "").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "non-interactive init should succeed: stdout={stdout}, stderr={stderr}",
+    );
+
+    let workflow =
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should exist");
+    assert!(
+        workflow.contains("Target branch: `main`"),
+        "explicit target branch should be recorded: {workflow}",
+    );
+    assert!(
+        workflow.contains("Keep feature branches current with `origin/main`."),
+        "explicit target branch should drive generated guidance: {workflow}",
+    );
+    assert!(
+        !stdout.contains("Target branch for feature PRs and syncs"),
+        "non-interactive explicit branch should not prompt: {stdout}",
+    );
+}
+
+#[tokio::test]
+async fn init_rejects_remote_target_branch_before_writing() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+
+    let mut child = spawn_init_child(
+        repo.path(),
+        server.base_url(),
+        &["--target-branch", "origin/develop"],
+    );
+    write_stdin(&mut child, "").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "invalid target branch should fail: stdout={stdout}, stderr={stderr}",
+    );
+    assert!(
+        stdout.contains(
+            "target branch `origin/develop` must be a local branch name, not a remote or full ref"
+        ),
+        "failure should explain local branch requirement: {stdout}",
+    );
+    assert!(
+        !repo.path().join("WORKFLOW.md").exists(),
+        "failed validation should not write bootstrap files",
     );
 }
 
@@ -343,6 +434,39 @@ async fn init_non_interactive_conflict_policy_skip_preserves_existing_files() {
 }
 
 #[tokio::test]
+async fn init_interactive_skipped_workflow_does_not_prompt_for_target_branch() {
+    let server = TemplateServer::start().await;
+    let repo = TempDir::new().expect("temp repo should exist");
+    init_git_repo(repo.path(), "https://github.com/example/demo.git");
+    fs::write(repo.path().join("WORKFLOW.md"), "user workflow\n")
+        .expect("existing workflow should write");
+
+    let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
+    write_stdin(&mut child, "\nskip\nno\n").await;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("init command should finish");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "init should succeed after skipping workflow: stdout={stdout}, stderr={stderr}",
+    );
+    assert_eq!(
+        fs::read_to_string(repo.path().join("WORKFLOW.md")).expect("workflow should still exist"),
+        "user workflow\n",
+        "skipped workflow should stay untouched",
+    );
+    assert!(
+        !stdout.contains("Target branch for feature PRs and syncs"),
+        "skipping WORKFLOW.md should avoid target branch prompt: {stdout}",
+    );
+}
+
+#[tokio::test]
 async fn init_non_interactive_conflict_policy_overwrite_replaces_existing_files() {
     let server = TemplateServer::start().await;
     let repo = TempDir::new().expect("temp repo should exist");
@@ -406,7 +530,7 @@ async fn init_can_scaffold_ai_pr_review_and_print_fallback_commands_when_gh_cann
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "openhands\n\n\n\n\n\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "openhands\n\n\n\n\n\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()
@@ -545,7 +669,7 @@ async fn init_interactive_codex_review_provider_skips_openhands_scaffolding() {
     init_git_repo(repo.path(), "https://github.com/example/demo.git");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "codex\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "codex\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()
@@ -713,7 +837,7 @@ async fn init_can_scaffold_ai_pr_review_and_configure_github_with_gh() {
     );
     write_stdin(
         &mut child,
-        "openhands\n\n\n\n\n\ndemo-project\nyes\nyes\nno\n",
+        "openhands\n\n\n\n\n\n\ndemo-project\nyes\nyes\nno\n",
     )
     .await;
 
@@ -844,7 +968,7 @@ async fn init_can_commit_and_push_bootstrap_changes_when_prompt_confirmed() {
         .expect("scratch file should write");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "\ndemo-project\nyes\n").await;
+    write_stdin(&mut child, "\n\ndemo-project\nyes\n").await;
 
     let output = child
         .wait_with_output()
@@ -937,7 +1061,7 @@ async fn init_copies_agents_template_to_example_when_agents_already_exists() {
     .expect("existing PR template should write");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "\nskip\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "\nskip\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()
@@ -984,7 +1108,7 @@ async fn init_repairs_gitignore_for_memory_policy() {
     fs::write(repo.path().join(".gitignore"), "node_modules/\n").expect(".gitignore should write");
 
     let mut child = spawn_init_child(repo.path(), server.base_url(), &[]);
-    write_stdin(&mut child, "\ndemo-project\nno\n").await;
+    write_stdin(&mut child, "\n\ndemo-project\nno\n").await;
 
     let output = child
         .wait_with_output()


### PR DESCRIPTION
## Summary

Expose the workflow target branch in `opensymphony init` through a non-interactive flag and an interactive prompt scoped to workflow customization.

## Changes

- Added `opensymphony init --target-branch <BRANCH>` help and early explicit-value validation.
- Added the interactive target branch prompt with examples and `develop` as the empty-input default.
- Added init/help coverage for default `develop`, explicit `main`, invalid `origin/develop`, skipped workflow no-prompt behavior, and existing prompt flows.

## Evidence

### Test output

```
cargo fmt --check
cargo test-system-duckdb --test init
  test result: ok. 23 passed; 0 failed
cargo test-system-duckdb --test help
  test result: ok. 11 passed; 0 failed
```

### Verification

Baseline before the change showed `opensymphony init --help` omitted `--target-branch`, and `opensymphony init --target-branch main --non-interactive` failed with `unexpected argument '--target-branch'`. The new tests verify the flag, prompt default, explicit branch write, invalid remote-ref error, and no-prompt behavior for non-interactive and skipped-workflow paths.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`)
- [ ] Documentation updated (not in this ticket scope)
- [ ] `AGENTS.md` updated (not needed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other: not applicable

## Breaking changes

None.

## Related issues

COE-522

## Additional notes

Docs and template hardening are tracked separately by the downstream workflow-target-branch task.
