### PR TITLE
Harden workflow target branch docs and settings guidance

### DIFF
--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -10,7 +10,7 @@ description:
 
 ## Goals
 
-- Ensure the PR is conflict-free with main.
+- Ensure the PR is conflict-free with the configured target branch.
 - Keep CI green and fix failures when they occur.
 - Address all review feedback.
 - Confirm PR is ready for merge (green CI, no unresolved comments).
@@ -27,9 +27,9 @@ description:
 2. Confirm the full gauntlet is green locally before any push.
 3. If the working tree has uncommitted changes, commit with the `commit` skill
    and push with the `push` skill before proceeding.
-4. Check mergeability and conflicts against main.
-5. If conflicts exist, use the `pull` skill to fetch/merge `origin/main` and
-   resolve conflicts, then use the `push` skill to publish the updated branch.
+4. Check mergeability and conflicts against the configured target branch.
+5. If conflicts exist, use the `pull` skill to fetch/merge `origin/<target-branch>`
+   and resolve conflicts, then use the `push` skill to publish the updated branch.
 6. Address any Linear issue comments and PR review comments before merging
    (see Review Handling below).
 7. Watch checks until complete.
@@ -102,11 +102,12 @@ echo "**DO NOT MERGE** - the user reviews and merges."
 - Use judgment to identify flaky failures. If a failure is a flake (e.g., a
   timeout on only one platform), you may proceed without fixing it.
 - If CI pushes an auto-fix commit (authored by GitHub Actions), it does not
-  trigger a fresh CI run. Detect the updated PR head, pull locally, merge
-  `origin/main` if needed, add a real author commit, and force-push to retrigger
-  CI, then restart the checks loop.
+  trigger a fresh CI run. Detect the updated PR head, pull locally, merge the
+  configured target branch if needed, add a real author commit, and force-push
+  to retrigger CI, then restart the checks loop.
 - If all jobs fail with corrupted pnpm lockfile errors on the merge commit, the
-  remediation is to fetch latest `origin/main`, merge, force-push, and rerun CI.
+  remediation is to fetch latest `origin/<target-branch>`, merge, force-push,
+  and rerun CI.
 - If mergeability is `UNKNOWN`, wait and re-check.
 - Do not merge while review comments are outstanding.
 - Do not enable auto-merge; this repo has no required checks so auto-merge can

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -60,7 +60,7 @@ branch=$(git branch --show-current)
 pr_number=$(gh pr view --json number -q .number)
 pr_title=$(gh pr view --json title -q .title)
 pr_body=$(gh pr view --json body -q .body)
-target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)
+target_branch=$(awk -F': *' '/^Target branch:/ { branch=$2; gsub(/`/, "", branch); gsub(/\r/, "", branch); gsub(/^[ \t]+|[ \t]+$/, "", branch); print branch; exit }' WORKFLOW.md)
 if [ -z "$target_branch" ]; then
   echo "WORKFLOW.md is missing a Target branch marker; run opensymphony update --target-branch <branch> before landing." >&2
   exit 1

--- a/.agents/skills/land/SKILL.md
+++ b/.agents/skills/land/SKILL.md
@@ -60,6 +60,15 @@ branch=$(git branch --show-current)
 pr_number=$(gh pr view --json number -q .number)
 pr_title=$(gh pr view --json title -q .title)
 pr_body=$(gh pr view --json body -q .body)
+target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)
+if [ -z "$target_branch" ]; then
+  echo "WORKFLOW.md is missing a Target branch marker; run opensymphony update --target-branch <branch> before landing." >&2
+  exit 1
+fi
+current_base=$(gh pr view --json baseRefName -q .baseRefName)
+if [ "$current_base" != "$target_branch" ]; then
+  gh pr edit --base "$target_branch"
+fi
 
 # Check mergeability and conflicts
 mergeable=$(gh pr view --json mergeable -q .mergeable)

--- a/.agents/skills/pull/SKILL.md
+++ b/.agents/skills/pull/SKILL.md
@@ -28,7 +28,7 @@ description:
      before merging the configured target branch.
 6. Merge in order:
    - Extract the configured target branch before merging:
-     `target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)`
+     `target_branch=$(awk -F': *' '/^Target branch:/ { branch=$2; gsub(/`/, "", branch); gsub(/\r/, "", branch); gsub(/^[ \t]+|[ \t]+$/, "", branch); print branch; exit }' WORKFLOW.md)`
    - If the marker is missing, stop and ask for the target branch to be added
      to `WORKFLOW.md`; do not guess.
    - Prefer `git -c merge.conflictstyle=zdiff3 merge "origin/$target_branch"`

--- a/.agents/skills/pull/SKILL.md
+++ b/.agents/skills/pull/SKILL.md
@@ -27,7 +27,11 @@ description:
    - This pulls branch updates made remotely (for example, a GitHub auto-commit)
      before merging the configured target branch.
 6. Merge in order:
-   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/<target-branch>`
+   - Extract the configured target branch before merging:
+     `target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)`
+   - If the marker is missing, stop and ask for the target branch to be added
+     to `WORKFLOW.md`; do not guess.
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge "origin/$target_branch"`
      for clearer conflict context.
 7. If conflicts appear, resolve them (see conflict guidance below), then:
    - `git add <files>`

--- a/.agents/skills/pull/SKILL.md
+++ b/.agents/skills/pull/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pull
 description:
-  Pull latest origin/main into the current local branch and resolve merge
-  conflicts (aka update-branch). Use when syncing a feature branch with origin,
-  perform a merge-based update (not rebase), and guide conflict resolution
-  best practices.
+  Pull the latest configured target branch into the current local branch and
+  resolve merge conflicts (aka update-branch). Use when syncing a feature
+  branch with origin, perform a merge-based update (not rebase), and guide
+  conflict resolution best practices.
 ---
 
 # Pull
@@ -18,15 +18,17 @@ description:
 3. Confirm remotes and branches:
    - Ensure the `origin` remote exists.
    - Ensure the current branch is the one to receive the merge.
+   - Read `WORKFLOW.md` `Target branch:` and use `origin/<target-branch>` as
+     the merge source.
 4. Fetch latest refs:
    - `git fetch origin`
 5. Sync the remote feature branch first:
    - `git pull --ff-only origin $(git branch --show-current)`
    - This pulls branch updates made remotely (for example, a GitHub auto-commit)
-     before merging `origin/main`.
+     before merging the configured target branch.
 6. Merge in order:
-   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/main` for clearer
-     conflict context.
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/<target-branch>`
+     for clearer conflict context.
 7. If conflicts appear, resolve them (see conflict guidance below), then:
    - `git add <files>`
    - `git commit` (or `git merge --continue` if the merge is paused)

--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -90,7 +90,7 @@ git push -u origin HEAD
 git push --force-with-lease origin HEAD
 
 # Ensure a PR exists (create only if missing)
-target_branch=$(awk -F': *' '/^Target branch:/ { print $2; exit }' WORKFLOW.md)
+target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)
 target_branch=${target_branch:-develop}
 pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
 if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then

--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -47,8 +47,9 @@ description:
      rewriting remotes or switching protocols as a workaround.
 
 5. Ensure a PR exists for the branch:
-   - If no PR exists, create one.
-   - If a PR exists and is open, update it.
+   - Read `WORKFLOW.md` `Target branch:` and use it as the PR base.
+   - If no PR exists, create one against the configured target branch.
+   - If a PR exists and is open, update it and correct the base if needed.
    - If branch is tied to a closed/merged PR, create a new branch + PR.
    - Write a proper PR title that clearly describes the change outcome
    - For branch updates, explicitly reconsider whether current PR title still
@@ -89,6 +90,8 @@ git push -u origin HEAD
 git push --force-with-lease origin HEAD
 
 # Ensure a PR exists (create only if missing)
+target_branch=$(awk -F': *' '/^Target branch:/ { print $2; exit }' WORKFLOW.md)
+target_branch=${target_branch:-develop}
 pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
 if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
   echo "Current branch is tied to a closed PR; create a new branch + PR." >&2
@@ -98,8 +101,12 @@ fi
 # Write a clear, human-friendly title that summarizes the shipped change.
 pr_title="<clear PR title written for this change>"
 if [ -z "$pr_state" ]; then
-  gh pr create --title "$pr_title"
+  gh pr create --base "$target_branch" --title "$pr_title"
 else
+  current_base=$(gh pr view --json baseRefName -q .baseRefName)
+  if [ "$current_base" != "$target_branch" ]; then
+    gh pr edit --base "$target_branch"
+  fi
   # Reconsider title on every branch update; edit if scope shifted.
   gh pr edit --title "$pr_title"
 fi

--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -91,7 +91,10 @@ git push --force-with-lease origin HEAD
 
 # Ensure a PR exists (create only if missing)
 target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)
-target_branch=${target_branch:-develop}
+if [ -z "$target_branch" ]; then
+  echo "WORKFLOW.md is missing a Target branch marker; run opensymphony update --target-branch <branch> before creating or retargeting a PR." >&2
+  exit 1
+fi
 pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
 if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
   echo "Current branch is tied to a closed PR; create a new branch + PR." >&2

--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -90,7 +90,7 @@ git push -u origin HEAD
 git push --force-with-lease origin HEAD
 
 # Ensure a PR exists (create only if missing)
-target_branch=$(awk -F': *' '/^Target branch:/ { gsub(/`/, "", $2); print $2; exit }' WORKFLOW.md)
+target_branch=$(awk -F': *' '/^Target branch:/ { branch=$2; gsub(/`/, "", branch); gsub(/\r/, "", branch); gsub(/^[ \t]+|[ \t]+$/, "", branch); print branch; exit }' WORKFLOW.md)
 if [ -z "$target_branch" ]; then
   echo "WORKFLOW.md is missing a Target branch marker; run opensymphony update --target-branch <branch> before creating or retargeting a PR." >&2
   exit 1

--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -39,7 +39,8 @@ description:
    remote URL is already configured.
 4. If push is not clean/rejected:
    - If the failure is a non-fast-forward or sync problem, run the `pull`
-     skill to merge `origin/main`, resolve conflicts, and rerun validation.
+     skill to merge the configured target branch, resolve conflicts, and rerun
+     validation.
    - Push again; use `--force-with-lease` only when history was rewritten.
    - If the failure is due to auth, permissions, or workflow restrictions on
      the configured remote, stop and surface the exact error instead of

--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ opensymphony init
 
 `opensymphony init` guides the bootstrap flow, customizes `WORKFLOW.md`, and
 can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review), including GitHub setup through `gh` when it is installed and authorized for the target repo. It also ensures `.gitignore` ignores local OpenSymphony runtime state.
+The generated workflow records a target branch marker for feature PRs and syncs.
+The default is `develop`; non-interactive setup can choose a repository-specific
+branch:
+
+```bash
+opensymphony init --non-interactive --target-branch main
+opensymphony init --non-interactive --target-branch release/next
+```
+
 If `AGENTS.md` already exists during first-time setup, `init` leaves it alone
 and writes the starter guidance to `AGENTS-example.md` for review.
 It also initializes `.opensymphony/memory/memory.yaml`, the shared policy and
@@ -162,6 +171,21 @@ maintenance path: it refreshes changed or new template-owned skill files under
 `.agents/skills/` without touching `WORKFLOW.md`, `AGENTS.md`, or the broader
 bootstrap files. When run from an OpenSymphony target repo, `update` also
 initializes or repairs the memory config and `.gitignore` policy if needed.
+When `--target-branch` or `--code-review` is present, `update` enters workflow
+settings mode instead: it patches only the managed `WORKFLOW.md` markers and
+skips the CLI reinstall, template skill refresh, and memory bootstrap.
+
+```bash
+opensymphony update --target-branch develop
+opensymphony update --target-branch main
+opensymphony update --target-branch release/next
+opensymphony update --target-branch release/next --code-review openhands
+```
+
+`--code-review openhands` enables an existing OpenHands review workflow when
+`.github/workflows/ai-pr-review.yml` is already present. It does not install or
+repair a missing workflow file; `--code-review codex` and `--code-review none`
+disable an existing OpenHands review workflow.
 
 ### Running the Orchestrator
 

--- a/README.md
+++ b/README.md
@@ -182,10 +182,13 @@ opensymphony update --target-branch release/next
 opensymphony update --target-branch release/next --code-review openhands
 ```
 
-`--code-review openhands` enables an existing OpenHands review workflow when
+`--code-review openhands` records the marker and attempts to enable an existing
+OpenHands review workflow through `gh workflow` when
 `.github/workflows/ai-pr-review.yml` is already present. It does not install or
 repair a missing workflow file; `--code-review codex` and `--code-review none`
-disable an existing OpenHands review workflow.
+record the marker and attempt to disable that workflow. If `gh` is unavailable,
+unauthorized, or cannot access Actions, `update` warns and leaves the workflow
+state unchanged; verify or adjust the workflow state manually.
 
 ### Running the Orchestrator
 

--- a/README.md
+++ b/README.md
@@ -151,16 +151,18 @@ opensymphony init
 can optionally scaffold automated code review via the [OpenHands PR Review Plugin](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review), including GitHub setup through `gh` when it is installed and authorized for the target repo. It also ensures `.gitignore` ignores local OpenSymphony runtime state.
 The generated workflow records a target branch marker for feature PRs and syncs.
 The default is `develop`; non-interactive setup can choose a repository-specific
-branch:
+branch after the shared target-repo template has the same marker-aware
+`WORKFLOW.md` and `pull`/`push`/`land` guidance:
 
 ```bash
 opensymphony init --non-interactive --target-branch main
 opensymphony init --non-interactive --target-branch release/next
 ```
 
-Fresh init fetches target-repo assets from `kumanday/OpenSymphony-template`;
-that template's `WORKFLOW.md` and `pull`/`push`/`land` skills must carry the
-same marker-aware wording before these branch examples are release-ready.
+Fresh init fetches target-repo assets from `kumanday/OpenSymphony-template`.
+Until that template sync lands, treat the examples above as the intended
+post-sync form; otherwise fresh repos can record the marker while copied skills
+still use older branch guidance.
 
 If `AGENTS.md` already exists during first-time setup, `init` leaves it alone
 and writes the starter guidance to `AGENTS-example.md` for review.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ opensymphony init --non-interactive --target-branch main
 opensymphony init --non-interactive --target-branch release/next
 ```
 
+Fresh init fetches target-repo assets from `kumanday/OpenSymphony-template`;
+that template's `WORKFLOW.md` and `pull`/`push`/`land` skills must carry the
+same marker-aware wording before these branch examples are release-ready.
+
 If `AGENTS.md` already exists during first-time setup, `init` leaves it alone
 and writes the starter guidance to `AGENTS-example.md` for review.
 It also initializes `.opensymphony/memory/memory.yaml`, the shared policy and
@@ -172,8 +176,9 @@ maintenance path: it refreshes changed or new template-owned skill files under
 bootstrap files. When run from an OpenSymphony target repo, `update` also
 initializes or repairs the memory config and `.gitignore` policy if needed.
 When `--target-branch` or `--code-review` is present, `update` enters workflow
-settings mode instead: it patches only the managed `WORKFLOW.md` markers and
-skips the CLI reinstall, template skill refresh, and memory bootstrap.
+settings mode instead: it patches the managed `WORKFLOW.md` markers, rewrites
+known legacy branch-control phrases when the target branch changes, and skips
+the CLI reinstall, template skill refresh, and memory bootstrap.
 
 ```bash
 opensymphony update --target-branch develop

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -138,7 +138,7 @@ workflow.
 - `linear`: interact with Linear.
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
-- `pull`: keep branch updated with latest `origin/main` before handoff.
+- `pull`: keep branch updated with the configured target branch before handoff.
 - `land`: when ticket reaches `Merging`, explicitly open and follow `.agents/skills/land/SKILL.md`, which includes the `land` loop.
 
 ## Status map
@@ -167,7 +167,7 @@ workflow.
    - `Done` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
    - For `Todo`, `In Progress`, or `Rework`: if a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
-   - For `Todo`, `In Progress`, or `Rework`: create a fresh branch from `origin/main` and restart execution flow as a new attempt.
+   - For `Todo`, `In Progress`, or `Rework`: create a fresh branch from the configured target branch and restart execution flow as a new attempt.
    - For `Human Review` or `Merging`: if the attached PR is already `MERGED`, do **not** reset the branch; update the workpad/dashboard as needed and move the issue to `Done`.
 5. For `Todo` tickets, do startup sequencing in this exact order:
    - `update_issue(..., state: "In Progress")`
@@ -201,12 +201,21 @@ workflow.
 8.  Run a principal-style self-review of the plan and refine it in the comment.
 9.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
 10. After initial file discovery, re-run `opensymphony memory context --issue {{ issue.identifier }} --paths <path1>,<path2> --include-code-intel` for touched areas when memory is configured, record useful references in the workpad, and treat current source files and tests as authoritative over generated context.
-11. Run the `pull` skill to sync with latest `origin/main` before any code edits, then record the pull/sync result in the workpad `Notes`.
+11. Run the `pull` skill to sync with the latest configured target branch before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),
       - result (`clean` or `conflicts resolved`),
       - resulting `HEAD` short SHA.
 12. Compact context and proceed to execution.
+
+## Branch target
+
+Target branch: `main`
+
+<!-- Set by `opensymphony init` or `opensymphony update --target-branch`.
+     Value is a local branch name, not an `origin/...` ref. Agents should use
+     `origin/<target-branch>` when syncing, creating replacement branches, and
+     preparing PRs. -->
 
 ## Automated AI PR review
 
@@ -339,7 +348,7 @@ Use this only when completion is blocked by missing required tools or missing au
     - Ensure the GitHub PR has label `symphony` (add it if missing).
     - Do **not** re-trigger AI review when this push created the PR; the PR open already triggered the initial review.
     - If this push updated an existing PR with new commits, re-trigger AI review after the push (see `Automated AI PR review`) to request a fresh review pass.
-9.  Merge latest `origin/main` into branch, resolve conflicts, and rerun checks.
+9.  Merge latest configured target branch into branch, resolve conflicts, and rerun checks.
 10. Update the workpad comment with final checklist status and validation notes.
     - Mark completed plan/acceptance/validation checklist items as checked.
     - Add final handoff notes (commit + validation summary) in the same workpad comment.
@@ -431,7 +440,7 @@ For major rework:
 1. Document in the workpad **why** a reset is necessary before closing anything.
 2. Close the existing PR tied to the issue.
 3. Remove the existing `## Agent Harness Workpad` comment from the issue.
-4. Create a fresh branch from `origin/main`.
+4. Create a fresh branch from the configured target branch.
 5. Start over from the normal kickoff flow:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
    - Create a new bootstrap `## Agent Harness Workpad` comment.
@@ -452,7 +461,7 @@ For major rework:
 ## Guardrails
 
 - If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
-- For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
+- For closed/merged branch PRs, create a new branch from the configured target branch and restart from reproduction/planning as if starting fresh.
 - **Do not close an open PR for minor feedback or incremental changes** - address feedback in the same branch/PR to preserve review history and discussion context.
 - Only close a PR and start fresh for major rework (fundamentally flawed approach, unrecoverable branch, or completely changed scope).
 - If issue state is `Backlog`, do not modify it; wait for human to move it to `Todo`.
@@ -569,7 +578,7 @@ Use this exact structure for the persistent workpad comment and keep it updated 
 Timestamped audit log. Add an entry after every milestone (state change, reproduction captured, code change, validation run, PR event, review addressed). Use ISO format: `YYYY-MM-DD HH:MMZ: <action>`.
 
 - YYYY-MM-DD HH:MMZ: State transition: Todo → In Progress, created workpad
-- YYYY-MM-DD HH:MMZ: Pull skill: merged origin/main clean, HEAD now <short-sha>
+- YYYY-MM-DD HH:MMZ: Pull skill: merged origin/<target-branch> clean, HEAD now <short-sha>
 - YYYY-MM-DD HH:MMZ: Reproduction captured: <command or behavior observed>
 - YYYY-MM-DD HH:MMZ: Validation passed: <test command and result>
 - YYYY-MM-DD HH:MMZ: Committed <short-sha>: <commit message summary>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -247,12 +247,21 @@ Important rule:
 - keep `opensymphony init --non-interactive` aligned with the interactive
   bootstrap flow. Every prompt-driven decision should have an explicit flag,
   and unresolved file conflicts must fail before writing.
+- keep generated `WORKFLOW.md` branch-target guidance and template-managed
+  skills aligned with the `Target branch:` marker instead of hard-coding one
+  remote branch.
 
 When you change shared target-repo assets, update the template first and then
 make sure the `init` and `update` flows still copy the full tree.
+If the current PR cannot modify `OpenSymphony-template`, leave a follow-up that
+updates that repo's `WORKFLOW.md` plus `.agents/skills/pull/SKILL.md`,
+`.agents/skills/push/SKILL.md`, and `.agents/skills/land/SKILL.md` with the
+same branch-marker wording before relying on fresh template fetches.
 
-For the planned configurable target branch and marker-only workflow update
-flags, see [Workflow Target Branch And Update Settings Specification](specs/workflow-target-branch-update-spec.md).
+For configurable target branches and marker-only workflow update flags, see
+[Workflow Target Branch And Update Settings Specification](specs/workflow-target-branch-update-spec.md).
+The default target branch is `develop`, but automation should also cover
+explicit `main` and slash branch names such as `release/next`.
 
 Provisioning scripts can initialize a target repo without stdin prompts:
 
@@ -260,11 +269,29 @@ Provisioning scripts can initialize a target repo without stdin prompts:
 opensymphony init \
   --non-interactive \
   --linear-project-slug my-linear-project \
+  --target-branch release/next \
   --conflict-policy overwrite \
   --commit-and-push
 ```
 
-Use `cargo test-system-duckdb --test init` after changing the init flow.
+Existing target repos can patch only workflow settings without refreshing the
+template-managed skill tree:
+
+```bash
+opensymphony update --target-branch develop
+opensymphony update --target-branch main
+opensymphony update --target-branch release/next
+opensymphony update --target-branch release/next --code-review openhands
+```
+
+`--code-review openhands` toggles an existing
+`.github/workflows/ai-pr-review.yml`; update settings mode warns instead of
+installing or repairing that workflow when it is missing. `codex` and `none`
+disable an existing OpenHands review workflow.
+
+Use `cargo test-system-duckdb --test init`,
+`cargo test-system-duckdb --test update`, and
+`cargo test-system-duckdb --test help` after changing this flow.
 
 ## Linear development rules
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -284,10 +284,12 @@ opensymphony update --target-branch release/next
 opensymphony update --target-branch release/next --code-review openhands
 ```
 
-`--code-review openhands` toggles an existing
-`.github/workflows/ai-pr-review.yml`; update settings mode warns instead of
-installing or repairing that workflow when it is missing. `codex` and `none`
-disable an existing OpenHands review workflow.
+`--code-review openhands` records the marker and attempts to enable an existing
+`.github/workflows/ai-pr-review.yml` through `gh workflow`; update settings
+mode warns instead of installing or repairing that workflow when it is missing.
+`codex` and `none` record the marker and attempt to disable an existing
+OpenHands review workflow. If `gh` is unavailable, unauthorized, or cannot
+access Actions, verify or adjust the workflow state manually.
 
 Use `cargo test-system-duckdb --test init`,
 `cargo test-system-duckdb --test update`, and

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -257,6 +257,9 @@ If the current PR cannot modify `OpenSymphony-template`, leave a follow-up that
 updates that repo's `WORKFLOW.md` plus `.agents/skills/pull/SKILL.md`,
 `.agents/skills/push/SKILL.md`, and `.agents/skills/land/SKILL.md` with the
 same branch-marker wording before relying on fresh template fetches.
+The raw fetch URLs live in `crates/opensymphony-cli/src/init_repo.rs` as the
+`OpenSymphony-template` base and tree endpoints, so local repo-only guidance is
+not enough to make fresh init output fully consistent.
 
 For configurable target branches and marker-only workflow update flags, see
 [Workflow Target Branch And Update Settings Specification](specs/workflow-target-branch-update-spec.md).
@@ -275,7 +278,9 @@ opensymphony init \
 ```
 
 Existing target repos can patch only workflow settings without refreshing the
-template-managed skill tree:
+template-managed skill tree. Target-branch changes update the managed marker and
+known legacy branch-control phrases in `WORKFLOW.md`; they do not refresh
+template-owned skills:
 
 ```bash
 opensymphony update --target-branch develop

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,9 @@ opensymphony init
 - prompts before overwriting other conflicting files
 - fills the `WORKFLOW.md` clone hook from `git remote` when possible
 - offers to fill the Linear project slug/key in `WORKFLOW.md`
+- records the feature PR and sync target branch in `WORKFLOW.md` under
+  `## Branch target`; the default is `develop`, and `--target-branch main` or
+  `--target-branch release/next` can set another local branch name
 - creates or updates `.gitignore` so local OpenSymphony runtime state stays untracked
 - can optionally scaffold OpenHands AI PR review
 - can configure the GitHub Actions variables, label, and optional review secret
@@ -42,6 +45,18 @@ published `opensymphony` release and only runs `cargo install opensymphony`
 when it actually needs to. If the current directory already looks like an
 OpenSymphony target repo because it has both `WORKFLOW.md` and `config.yaml`,
 the command then refreshes changed or new files under `.agents/skills/`.
+
+When `--target-branch` or `--code-review` is present, `update` uses workflow
+settings mode instead of the normal maintenance path. It requires `WORKFLOW.md`
+and `config.yaml`, patches only the managed workflow markers, and skips Cargo
+self-update, template skill refresh, and memory bootstrap:
+
+```bash
+opensymphony update --target-branch develop
+opensymphony update --target-branch main
+opensymphony update --target-branch release/next
+opensymphony update --target-branch release/next --code-review openhands
+```
 
 The template repository is still the upstream source of those starter assets,
 but it is an implementation detail of `opensymphony init`, not a required
@@ -66,8 +81,8 @@ Core bootstrap payload:
 
 ## Refreshing Template Skills
 
-`opensymphony update` only refreshes template-managed files under
-`.agents/skills/`.
+Without workflow-setting flags, `opensymphony update` only refreshes
+template-managed files under `.agents/skills/`.
 
 It does not:
 
@@ -93,6 +108,12 @@ The chosen provider is recorded in `WORKFLOW.md` as
 `Active review provider:` under `## Automated AI PR review`, which tells
 agents how to re-trigger review after follow-up pushes (`review-this` label
 for openhands, an exact `@codex review` comment for codex).
+
+For initialized target repos, `opensymphony update --code-review openhands`
+updates the marker and enables an existing `.github/workflows/ai-pr-review.yml`.
+It does not create or repair that workflow when the file is missing. Switching
+with `--code-review codex` or `--code-review none` disables an existing
+OpenHands review workflow.
 
 ## Labels
 
@@ -121,6 +142,7 @@ Important fields:
 | Field | Description | Env Var | Example |
 |-------|-------------|---------|---------|
 | `tracker.project_slug` | Linear `Project.slugId` from the project URL | - | `my-project-5250e49b61f4` |
+| `WORKFLOW.md` `Target branch:` | Local branch name agents use as `origin/<target-branch>` for syncs and PR bases | - | `develop`, `main`, `release/next` |
 | `workspace.root` | Where to store per-issue workspaces | - | `~/.opensymphony/workspaces` |
 | `openhands.conversation.agent.llm.model` | LLM model to use | `LLM_MODEL` | `openai/accounts/fireworks/models/glm-5p1` |
 | `openhands.conversation.agent.llm.credential_mode` | LLM credential adapter | - | `api_key` or `openai_subscription` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,8 @@ the command then refreshes changed or new files under `.agents/skills/`.
 
 When `--target-branch` or `--code-review` is present, `update` uses workflow
 settings mode instead of the normal maintenance path. It requires `WORKFLOW.md`
-and `config.yaml`, patches only the managed workflow markers, and skips Cargo
+and `config.yaml`, patches the managed workflow markers, rewrites known legacy
+branch-control phrases when the target branch changes, and skips Cargo
 self-update, template skill refresh, and memory bootstrap:
 
 ```bash
@@ -64,6 +65,10 @@ manual setup step:
 
 - [kumanday/OpenSymphony-template](https://github.com/kumanday/OpenSymphony-template)
 - [Raw template base](https://raw.githubusercontent.com/kumanday/OpenSymphony-template/refs/heads/main/WORKFLOW.md)
+
+Fresh init branch-target behavior is fully consistent only when that template
+repo's `WORKFLOW.md` and `pull`/`push`/`land` skills have the same marker-aware
+wording as this repository's local copies.
 
 ## Files Added By `init`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,10 +110,13 @@ agents how to re-trigger review after follow-up pushes (`review-this` label
 for openhands, an exact `@codex review` comment for codex).
 
 For initialized target repos, `opensymphony update --code-review openhands`
-updates the marker and enables an existing `.github/workflows/ai-pr-review.yml`.
-It does not create or repair that workflow when the file is missing. Switching
-with `--code-review codex` or `--code-review none` disables an existing
-OpenHands review workflow.
+updates the marker and attempts to enable an existing
+`.github/workflows/ai-pr-review.yml` through `gh workflow`. It does not create
+or repair that workflow when the file is missing. Switching with
+`--code-review codex` or `--code-review none` records the marker and attempts
+to disable an existing OpenHands review workflow. If `gh` is unavailable,
+unauthorized, or cannot access Actions, `update` warns and leaves the workflow
+state unchanged; verify or adjust it manually.
 
 ## Labels
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -124,11 +124,13 @@ opensymphony update --target-branch release/next
 opensymphony update --target-branch release/next --code-review openhands
 ```
 
-Settings mode skips the CLI reinstall, template skill refresh, and memory
-bootstrap. `--code-review openhands` records the marker and attempts to enable
-an existing `.github/workflows/ai-pr-review.yml` through `gh workflow` but does
-not install or repair a missing workflow file; `codex` and `none` record the
-marker and attempt to disable an existing OpenHands review workflow. If `gh` is
+Settings mode updates managed `WORKFLOW.md` markers, rewrites known legacy
+branch-control phrases when the target branch changes, and skips the CLI
+reinstall, template skill refresh, and memory bootstrap. `--code-review
+openhands` records the marker and attempts to enable an existing
+`.github/workflows/ai-pr-review.yml` through `gh workflow` but does not install
+or repair a missing workflow file; `codex` and `none` record the marker and
+attempt to disable an existing OpenHands review workflow. If `gh` is
 unavailable, unauthorized, or cannot access Actions, verify or adjust the
 workflow state manually.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,9 +125,12 @@ opensymphony update --target-branch release/next --code-review openhands
 ```
 
 Settings mode skips the CLI reinstall, template skill refresh, and memory
-bootstrap. `--code-review openhands` enables an existing
-`.github/workflows/ai-pr-review.yml` but does not install or repair a missing
-workflow file; `codex` and `none` disable an existing OpenHands review workflow.
+bootstrap. `--code-review openhands` records the marker and attempts to enable
+an existing `.github/workflows/ai-pr-review.yml` through `gh workflow` but does
+not install or repair a missing workflow file; `codex` and `none` record the
+marker and attempt to disable an existing OpenHands review workflow. If `gh` is
+unavailable, unauthorized, or cannot access Actions, verify or adjust the
+workflow state manually.
 
 Normal user installs use bundled DuckDB. This keeps `cargo install
 opensymphony` and `opensymphony update` turnkey even when the memory database is

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -114,6 +114,21 @@ maintenance path:
 - leaves `WORKFLOW.md`, `AGENTS.md`, `.github/*`, and repo-local extra skills
   alone
 
+Use workflow settings mode when only the managed branch or review-provider
+markers need to change:
+
+```bash
+opensymphony update --target-branch develop
+opensymphony update --target-branch main
+opensymphony update --target-branch release/next
+opensymphony update --target-branch release/next --code-review openhands
+```
+
+Settings mode skips the CLI reinstall, template skill refresh, and memory
+bootstrap. `--code-review openhands` enables an existing
+`.github/workflows/ai-pr-review.yml` but does not install or repair a missing
+workflow file; `codex` and `none` disable an existing OpenHands review workflow.
+
 Normal user installs use bundled DuckDB. This keeps `cargo install
 opensymphony` and `opensymphony update` turnkey even when the memory database is
 enabled.

--- a/examples/target-repo/WORKFLOW.md
+++ b/examples/target-repo/WORKFLOW.md
@@ -19,6 +19,15 @@ openhands:
 
 Work the assigned issue inside this repository and keep changes small and reviewable.
 
+## Branch target
+
+Target branch: `develop`
+
+<!-- Set by `opensymphony init` or `opensymphony update --target-branch`.
+     Value is a local branch name, not an `origin/...` ref. Agents should use
+     `origin/<target-branch>` when syncing, creating replacement branches, and
+     preparing PRs. -->
+
 Repository context precedence for this example target repo:
 
 1. Follow this `WORKFLOW.md`.


### PR DESCRIPTION
## Summary

Harden target-repo workflow and documentation guidance around the managed target branch marker and marker-only update settings.

## Changes

- Add `## Branch target` markers to the current workflow and checked-in example target workflow.
- Update pull, push, and land skill guidance to sync against the configured target branch instead of a fixed remote branch.
- Update push guidance so new and corrected PRs use the configured target branch as the GitHub PR base, stripping Markdown code-span backticks before passing the branch to `gh`.
- Document `opensymphony init --target-branch`, marker-only `opensymphony update`, combined `--target-branch` plus `--code-review`, and the OpenHands workflow-file limitation.
- Clarify that review-provider workflow toggling is attempted through `gh workflow` and should be verified manually when `gh` cannot act.
- Clarify that settings mode rewrites known legacy branch-control phrases when the target branch changes, while skipping template skill refresh.
- Document that fresh init consistency depends on syncing the external `OpenSymphony-template` workflow and pull/push/land skills.
- Make missing target markers explicit errors in push/land guidance, make the pull merge command executable, and verify/correct PR base before land mergeability checks.
- Trim CRLF and surrounding whitespace from copied target-branch marker extractors.

## Evidence

### Test output

```
# initial pass
cargo fmt --check
cargo test-system-duckdb --test init      # 23 passed
cargo test-system-duckdb --test update    # 10 passed
cargo test-system-duckdb --test help      # 11 passed
git diff --check

# second rework pass
parser proof from WORKFLOW.md returned <main>
git diff --check
cargo fmt --check
cargo test-system-duckdb --test init      # 23 passed
cargo test-system-duckdb --test update    # 10 passed
cargo test-system-duckdb --test help      # 11 passed

# third rework pass
git diff --check
cargo fmt --check
cargo test-system-duckdb --test init      # 23 passed
cargo test-system-duckdb --test update    # 10 passed
cargo test-system-duckdb --test help      # 11 passed

# final parser-trim pass
CRLF parser proof returned <main>
git diff --check
cargo fmt --check
cargo test-system-duckdb --test init      # 23 passed
cargo test-system-duckdb --test update    # 10 passed
cargo test-system-duckdb --test help      # 11 passed
```

### Verification

- Confirmed the edited workflow and skill guidance no longer use a fixed `origin/main` operational branch.
- Confirmed README, development, configuration, and operations docs include examples for default `develop`, explicit `main`, `release/next`, and combined update usage.
- Confirmed push guidance creates and corrects PRs against the configured target branch and strips marker backticks before calling `gh`.
- Confirmed missing target markers now stop push/land guidance instead of guessing `develop`, and land guidance checks PR `baseRefName` against the configured target branch.
- Confirmed CRLF and trailing marker whitespace are trimmed before passing target branch names to GitHub CLI examples.
- Confirmed code-review update documentation now matches the warning path when `gh` is unavailable, unauthorized, or cannot access Actions.
- Confirmed settings-mode docs mention both marker updates and known legacy branch-control phrase rewrites.
- Confirmed the external `OpenSymphony-template` sync surface is documented because this PR only changes the provided repository copy.

## Checklist

- [x] Tests pass (targeted COE-524 test plan)
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`) - not run; docs/template guidance only
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (not needed; workflow and skill guidance updated)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

COE-524

## Additional notes

The canonical target-repo template assets are fetched from `kumanday/OpenSymphony-template`; this PR documents the exact template sync surface but does not modify that separate repository.