### PR TITLE
Define desktop installer metadata contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ be materialized with `--bundle-dir <path>` or
 `OPENSYMPHONY_DESKTOP_BUNDLE_DIR`; the bundle must include
 `opensymphony-desktop-manifest.json` with `version`, `platform`, `arch`,
 relative `executable`, and `sha256` fields.
+Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
+different install root; the launcher still creates the versioned bundle beneath
+that root. The downloadable release-index and update prompt contract is defined
+in [Desktop App Installer And Auto-Update Spec](docs/specs/desktop-app-installer-auto-update-spec.md).
 
 ### Further Details
 

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -27,6 +27,13 @@ pub struct AppArgs {
     bundle_dir: Option<PathBuf>,
     #[arg(
         long,
+        env = "OPENSYMPHONY_DESKTOP_INSTALL_PATH",
+        value_name = "DIR",
+        help = "Install root for versioned desktop bundles"
+    )]
+    install_path: Option<PathBuf>,
+    #[arg(
+        long,
         env = "OPENSYMPHONY_DESKTOP_CACHE_ROOT",
         hide = true,
         help = "Override the desktop cache root; primarily for smoke tests"
@@ -46,6 +53,40 @@ struct DesktopBundleManifest {
     arch: String,
     executable: PathBuf,
     sha256: String,
+}
+
+// ponytail: parsed contract lives ahead of download logic; remove allow once COE-528 uses it.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DesktopReleaseIndex {
+    schema_version: u32,
+    assets: Vec<DesktopReleaseAsset>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DesktopReleaseAsset {
+    version: String,
+    platform: String,
+    arch: String,
+    url: String,
+    checksum: DesktopReleaseChecksum,
+    launch_target: DesktopLaunchTarget,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DesktopReleaseChecksum {
+    algorithm: String,
+    value: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DesktopLaunchTarget {
+    executable: PathBuf,
+    #[serde(default)]
+    args: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -70,7 +111,11 @@ pub async fn run_command(args: AppArgs) -> ExitCode {
 }
 
 fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
-    let cache_root = normalize_cache_root(args.cache_root.unwrap_or(default_cache_root()?))?;
+    let cache_root = normalize_cache_root(
+        args.install_path
+            .or(args.cache_root)
+            .unwrap_or(default_cache_root()?),
+    )?;
     let cache_dir = cache_root.join(desktop_version());
     validate_cache_dir(&cache_root, &cache_dir)?;
     let bundle_dir = args.bundle_dir.as_deref();
@@ -170,6 +215,11 @@ fn read_manifest(path: &Path) -> Result<DesktopBundleManifest, DesktopLauncherEr
         path: path.to_path_buf(),
         source,
     })
+}
+
+#[allow(dead_code)]
+fn parse_release_index(contents: &str) -> Result<DesktopReleaseIndex, serde_json::Error> {
+    serde_json::from_str(contents)
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> Result<(), DesktopLauncherError> {
@@ -381,13 +431,13 @@ fn current_arch() -> &'static str {
 #[derive(Debug, Error)]
 enum DesktopLauncherError {
     #[error(
-        "could not find HOME; set OPENSYMPHONY_DESKTOP_CACHE_ROOT to choose a desktop cache directory"
+        "could not find HOME; pass --install-path or set OPENSYMPHONY_DESKTOP_INSTALL_PATH to choose a desktop install root"
     )]
     MissingHome,
-    #[error("failed to determine current directory for desktop cache root: {0}")]
+    #[error("failed to determine current directory for desktop install root: {0}")]
     CurrentDir(io::Error),
     #[error(
-        "refusing unsafe desktop cache root {path}\nRepair: choose a non-root cache directory under ~/.opensymphony/desktop or another app-owned directory."
+        "refusing unsafe desktop install root {path}\nRepair: choose a non-root install directory under ~/.opensymphony/desktop or another app-owned directory."
     )]
     DangerousCacheRoot { path: PathBuf },
     #[error(
@@ -482,6 +532,70 @@ mod tests {
                 desktop_version()
             ))
         );
+    }
+
+    #[test]
+    fn install_path_is_a_versioned_bundle_root() {
+        let cli = Cli::try_parse_from([
+            "opensymphony",
+            "app",
+            "--install-path",
+            "/tmp/opensymphony-desktop",
+            "--dry-run",
+        ])
+        .expect("app command should parse");
+        let CliCommand::App(args) = cli.command else {
+            panic!("app command expected");
+        };
+        let root = normalize_cache_root(args.install_path.expect("install path"))
+            .expect("install path should normalize");
+
+        assert_eq!(
+            root.join(desktop_version()),
+            PathBuf::from(format!("/tmp/opensymphony-desktop/{}", desktop_version()))
+        );
+    }
+
+    #[test]
+    fn release_index_parses_download_contract() {
+        let raw = r#"{
+            "schema_version": 1,
+            "assets": [
+                {
+                    "version": "2.7.0",
+                    "platform": "macos",
+                    "arch": "aarch64",
+                    "url": "https://downloads.example.invalid/opensymphony/2.7.0/macos-aarch64.zip",
+                    "checksum": {
+                        "algorithm": "sha256",
+                        "value": "0123456789abcdef"
+                    },
+                    "launch_target": {
+                        "executable": "OpenSymphony.app/Contents/MacOS/OpenSymphony",
+                        "args": []
+                    }
+                }
+            ]
+        }"#;
+
+        let index = parse_release_index(raw).expect("release index should parse");
+        let asset = &index.assets[0];
+
+        assert_eq!(index.schema_version, 1);
+        assert_eq!(asset.version, "2.7.0");
+        assert_eq!(asset.platform, "macos");
+        assert_eq!(asset.arch, "aarch64");
+        assert_eq!(
+            asset.url,
+            "https://downloads.example.invalid/opensymphony/2.7.0/macos-aarch64.zip"
+        );
+        assert_eq!(asset.checksum.algorithm, "sha256");
+        assert_eq!(asset.checksum.value, "0123456789abcdef");
+        assert_eq!(
+            asset.launch_target.executable,
+            PathBuf::from("OpenSymphony.app/Contents/MacOS/OpenSymphony")
+        );
+        assert!(asset.launch_target.args.is_empty());
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -111,11 +111,8 @@ pub async fn run_command(args: AppArgs) -> ExitCode {
 }
 
 fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
-    let cache_root = normalize_cache_root(
-        args.install_path
-            .or(args.cache_root)
-            .unwrap_or(default_cache_root()?),
-    )?;
+    let cache_root =
+        normalize_cache_root(selected_install_root(args.install_path, args.cache_root)?)?;
     let cache_dir = cache_root.join(desktop_version());
     validate_cache_dir(&cache_root, &cache_dir)?;
     let bundle_dir = args.bundle_dir.as_deref();
@@ -301,6 +298,16 @@ fn file_sha256(path: &Path) -> Result<String, DesktopLauncherError> {
 fn default_cache_root() -> Result<PathBuf, DesktopLauncherError> {
     let home = home_dir().ok_or(DesktopLauncherError::MissingHome)?;
     Ok(home.join(DEFAULT_CACHE_RELATIVE))
+}
+
+fn selected_install_root(
+    install_path: Option<PathBuf>,
+    cache_root: Option<PathBuf>,
+) -> Result<PathBuf, DesktopLauncherError> {
+    match install_path.or(cache_root) {
+        Some(path) => Ok(path),
+        None => default_cache_root(),
+    }
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -554,6 +561,14 @@ mod tests {
             root.join(desktop_version()),
             PathBuf::from(format!("/tmp/opensymphony-desktop/{}", desktop_version()))
         );
+    }
+
+    #[test]
+    fn explicit_install_path_skips_default_home_lookup() {
+        let root = selected_install_root(Some(PathBuf::from("/tmp/custom-desktop")), None)
+            .expect("explicit install path should be accepted before HOME lookup");
+
+        assert_eq!(root, PathBuf::from("/tmp/custom-desktop"));
     }
 
     #[test]

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -42,8 +42,9 @@ implemented by COE-488 / OSYM-811 as a lazy cached launcher. It verifies a
 versioned desktop bundle under `~/.opensymphony/desktop/<version>/` and can
 materialize an early local bundle from `--bundle-dir <path>` or
 `OPENSYMPHONY_DESKTOP_BUNDLE_DIR` without adding Tauri or npm dependencies to
-the normal Cargo install path. Signed or downloaded bundle distribution remains
-future installer work.
+the normal Cargo install path. `--install-path <dir>` selects a custom install
+root with versioned bundles beneath it. Signed or downloaded bundle
+distribution remains future installer work.
 
 For development from a clone, rebuild the desktop frontend when `apps/desktop`
 or shared frontend packages change:

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -36,6 +36,15 @@ launcher does not make `cargo install opensymphony` compile Tauri, npm, or
 platform desktop dependencies; signed/downloaded desktop bundle distribution is
 still future installer work.
 
+The desktop bundle contract is intentionally small and lives in
+[Desktop App Installer And Auto-Update Spec](specs/desktop-app-installer-auto-update-spec.md).
+The release index selects assets by OpenSymphony version, platform,
+architecture, URL, SHA-256 checksum metadata, and launch target. The install
+root defaults to `~/.opensymphony/desktop`, while `--install-path <dir>` and
+`OPENSYMPHONY_DESKTOP_INSTALL_PATH` choose a custom root with versioned bundles
+beneath it. Update prompts default to yes only for interactive TTY execution;
+non-TTY runs do not prompt and must not infer consent.
+
 Do not make downloaded prebuilt DuckDB the default `cargo install` path until a
 managed installer or equivalent runtime-library strategy owns native library
 placement, loader configuration, health checks, and rollback.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,6 +45,11 @@ the OpenSymphony version, platform, architecture, relative executable path, and
 executable SHA-256. Local bundle materialization copies regular files and
 directories; symlinked bundle entries should be packaged by a future signed or
 downloaded bundle format instead of this local smoke path.
+Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
+custom install root. That root contains versioned bundles such as
+`<dir>/<version>/`; it is not the bundle directory itself. Download metadata,
+auto-update prompting, fallback order, and path-safety rules are defined in
+[Desktop App Installer And Auto-Update Spec](specs/desktop-app-installer-auto-update-spec.md).
 
 Important `init` behavior:
 

--- a/docs/specs/desktop-app-installer-auto-update-spec.md
+++ b/docs/specs/desktop-app-installer-auto-update-spec.md
@@ -1,0 +1,139 @@
+# Desktop App Installer And Auto-Update Spec
+
+This spec defines the durable contract for `opensymphony app` desktop bundle
+installation and update discovery. It does not define signed installer
+packaging, real asset publication, download implementation, or source builds.
+
+## Release Index
+
+The release index is a small JSON document. It is the only contract the CLI
+needs before choosing a downloadable desktop asset.
+
+```json
+{
+  "schema_version": 1,
+  "assets": [
+    {
+      "version": "2.7.0",
+      "platform": "macos",
+      "arch": "aarch64",
+      "url": "https://downloads.example.invalid/opensymphony/2.7.0/macos-aarch64.zip",
+      "checksum": {
+        "algorithm": "sha256",
+        "value": "0123456789abcdef"
+      },
+      "launch_target": {
+        "executable": "OpenSymphony.app/Contents/MacOS/OpenSymphony",
+        "args": []
+      }
+    }
+  ]
+}
+```
+
+Fields:
+
+- `schema_version`: integer release-index schema version. The current schema is
+  `1`.
+- `version`: OpenSymphony version carried by the bundle.
+- `platform`: Rust target OS string used by the launcher, such as `macos`,
+  `linux`, or `windows`.
+- `arch`: Rust target architecture string used by the launcher, such as
+  `aarch64` or `x86_64`.
+- `url`: HTTPS URL for the downloadable bundle archive.
+- `checksum`: archive integrity metadata. Schema version `1` requires
+  `algorithm: "sha256"` and a lowercase or uppercase hex `value`.
+- `launch_target`: launch metadata copied into the installed manifest after the
+  bundle is materialized. `executable` is a bundle-relative path and `args`
+  defaults to an empty list when omitted.
+
+Unknown top-level and asset fields are ignored by the current contract so a
+future publisher can add metadata without breaking old clients. Required fields
+above must remain required for schema version `1`.
+
+## Installed Layout
+
+The default install root is:
+
+```text
+~/.opensymphony/desktop/
+```
+
+`opensymphony app --install-path <dir>` and
+`OPENSYMPHONY_DESKTOP_INSTALL_PATH=<dir>` set the install root. The value is not
+a bundle directory. The launcher installs or verifies versioned bundles under
+that root:
+
+```text
+<install-root>/<version>/
+  opensymphony-desktop-manifest.json
+  <launch-target executable and assets>
+```
+
+The hidden `OPENSYMPHONY_DESKTOP_CACHE_ROOT` override remains accepted for
+existing smoke tests, but new user-facing docs and scripts should use
+`--install-path` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH`.
+
+## Installed Manifest
+
+The installed manifest remains `opensymphony-desktop-manifest.json`. Existing
+local bundles stay compatible with the current fields:
+
+```json
+{
+  "version": "2.7.0",
+  "platform": "macos",
+  "arch": "aarch64",
+  "executable": "OpenSymphony.app/Contents/MacOS/OpenSymphony",
+  "sha256": "0123456789abcdef"
+}
+```
+
+The installed `executable` is the release-index `launch_target.executable`.
+`sha256` is the executable checksum used at launch time; the release index
+checksum covers the downloadable archive before installation. A future schema
+may add `schema_version`, `source_url`, or launch `args`, but schema version `1`
+must continue to read the manifest above so `--bundle-dir` remains compatible.
+
+## Update Prompt Policy
+
+When the installed version is older than a matching release-index asset:
+
+- TTY execution prompts before replacing the installed version and defaults to
+  yes when the operator presses Enter.
+- TTY execution accepts an explicit no and launches the cached installed bundle
+  when it still verifies.
+- Non-TTY execution does not prompt. It may update only when a future
+  non-interactive flag or config explicitly opts in; otherwise it launches the
+  cached verified bundle or follows the fallback order below.
+
+The launcher must never treat a failed prompt read as consent.
+
+## Fallback Order
+
+`opensymphony app` resolves a launch target in this order:
+
+1. Use the cached installed bundle for the requested OpenSymphony version when
+   the installed manifest verifies.
+2. Use a matching prebuilt download from the release index when download support
+   exists and update policy permits it.
+3. Use source-build fallback when that later feature is available and its
+   prerequisites pass.
+4. Fail with a clear repair message.
+
+Early local `--bundle-dir <dir>` and `OPENSYMPHONY_DESKTOP_BUNDLE_DIR=<dir>`
+remain a smoke-test materialization path. They copy a local expanded bundle into
+`<install-root>/<version>/` and then run the same installed manifest checks.
+
+## Path Safety
+
+Install roots and manifest launch paths preserve the existing launcher safety
+rules:
+
+- install roots must not contain parent-directory components and must not be
+  filesystem roots;
+- versioned bundle directories must stay beneath the install root;
+- install roots and versioned bundle directories must not be symlinks;
+- local `--bundle-dir` materialization refuses symlinked entries;
+- manifest executable paths must be relative and must canonicalize inside the
+  versioned bundle directory.


### PR DESCRIPTION
## Summary

Define the durable `opensymphony app` desktop installer contract and add the CLI test surface for release metadata and custom install roots.

## Changes

- Added `--install-path <dir>` / `OPENSYMPHONY_DESKTOP_INSTALL_PATH` as the public install-root selector for versioned desktop bundles.
- Added release-index metadata structs and focused parsing coverage for version, platform, architecture, URL, checksum, and launch target.
- Added `docs/specs/desktop-app-installer-auto-update-spec.md` and aligned README, operations, desktop, and installer docs.
- Fixed the explicit install-path branch so it does not eagerly read the default HOME-based install root.

## Evidence

### Test output

```text
cargo fmt --check
# passed

git diff --check
# passed

cargo test-system-duckdb desktop_launcher --lib
running 18 tests
...
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 701 filtered out; finished in 0.01s
```

### Verification

Baseline before edits: `cargo test-system-duckdb desktop_launcher --lib` passed with 15 launcher tests. After the change, the same focused suite passes with 18 tests, covering release metadata parsing, install-root normalization, and explicit install-path selection before HOME fallback.

## Checklist

- [x] Tests pass (`cargo test-system-duckdb desktop_launcher --lib`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (GitHub `rust` job clippy step passed on `73c1577`; latest CI pending after follow-up push)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None. Existing `--bundle-dir` and `OPENSYMPHONY_DESKTOP_BUNDLE_DIR` local bundle materialization remain compatible.

## Related issues

Linear: COE-525

## Additional notes

Download, source-build fallback, release asset publication, and signed installer work remain out of scope for this ticket.
