### PR TITLE
Package desktop release bundle assets

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensymphony/desktop",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "description": "OpenSymphony Tauri desktop app shell",
   "type": "module",
   "private": true,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "dev": "vite --host 127.0.0.1 --port 1420 --strictPort",
-    "build": "vite build"
+    "build": "vite build",
+    "package:release": "node ../../scripts/package_desktop_release.mjs"
   },
   "dependencies": {
     "@opensymphony/api-client": "*",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "opensymphony-desktop"
-version = "2.5.0"
+version = "2.7.0"
 dependencies = [
  "chrono",
  "directories",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensymphony-desktop"
-version = "2.5.0"
+version = "2.7.0"
 description = "OpenSymphony Tauri desktop application shell"
 license = "MIT"
 homepage = "https://opensymphony.dev"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "OpenSymphony",
   "mainBinaryName": "OpenSymphony",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "identifier": "dev.opensymphony.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -573,25 +573,7 @@ mod tests {
 
     #[test]
     fn release_index_parses_download_contract() {
-        let raw = r#"{
-            "schema_version": 1,
-            "assets": [
-                {
-                    "version": "2.7.0",
-                    "platform": "macos",
-                    "arch": "aarch64",
-                    "url": "https://downloads.example.invalid/opensymphony/2.7.0/macos-aarch64.zip",
-                    "checksum": {
-                        "algorithm": "sha256",
-                        "value": "0123456789abcdef"
-                    },
-                    "launch_target": {
-                        "executable": "OpenSymphony.app/Contents/MacOS/OpenSymphony",
-                        "args": []
-                    }
-                }
-            ]
-        }"#;
+        let raw = include_str!("../tests/fixtures/desktop-release-index.json");
 
         let index = parse_release_index(raw).expect("release index should parse");
         let asset = &index.assets[0];
@@ -602,13 +584,13 @@ mod tests {
         assert_eq!(asset.arch, "aarch64");
         assert_eq!(
             asset.url,
-            "https://downloads.example.invalid/opensymphony/2.7.0/macos-aarch64.zip"
+            "https://github.com/kumanday/OpenSymphony/releases/download/v2.7.0/opensymphony-desktop-v2.7.0-macos-aarch64.tar.gz"
         );
         assert_eq!(asset.checksum.algorithm, "sha256");
-        assert_eq!(asset.checksum.value, "0123456789abcdef");
+        assert_eq!(asset.checksum.value.len(), 64);
         assert_eq!(
             asset.launch_target.executable,
-            PathBuf::from("OpenSymphony.app/Contents/MacOS/OpenSymphony")
+            PathBuf::from("OpenSymphony")
         );
         assert!(asset.launch_target.args.is_empty());
     }

--- a/crates/opensymphony-cli/tests/fixtures/desktop-release-index.json
+++ b/crates/opensymphony-cli/tests/fixtures/desktop-release-index.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "assets": [
+    {
+      "version": "2.7.0",
+      "platform": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/kumanday/OpenSymphony/releases/download/v2.7.0/opensymphony-desktop-v2.7.0-macos-aarch64.tar.gz",
+      "checksum": {
+        "algorithm": "sha256",
+        "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "launch_target": {
+        "executable": "OpenSymphony",
+        "args": []
+      }
+    }
+  ]
+}

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -81,8 +81,9 @@ npm run package:release --workspace=@opensymphony/desktop
 The package step writes a stable archive name and release index under
 `dist/desktop-release/`. The archive includes
 `opensymphony-desktop-manifest.json` plus the launch target named in that
-manifest. Upload the archive before replacing
-`opensymphony-desktop-release-index.json`.
+manifest. If an index already exists, the package step keeps other
+platform/architecture entries and replaces only the current asset entry. Upload
+the archive before replacing `opensymphony-desktop-release-index.json`.
 
 ## Task Graph Project Groups
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -68,6 +68,22 @@ in one terminal and `cargo run` from `apps/desktop/src-tauri` in another.
 Plain `cargo run` rebuilds and reads the current `apps/desktop/dist` bundle; it
 does not start Vite.
 
+## Release Bundle
+
+The first release asset format is a tarball consumed by the lazy CLI launcher.
+Build and package it from the repository root:
+
+```bash
+npm run build --workspace=@opensymphony/desktop
+npm run package:release --workspace=@opensymphony/desktop
+```
+
+The package step writes a stable archive name and release index under
+`dist/desktop-release/`. The archive includes
+`opensymphony-desktop-manifest.json` plus the launch target named in that
+manifest. Upload the archive before replacing
+`opensymphony-desktop-release-index.json`.
+
 ## Task Graph Project Groups
 
 When the gateway task graph includes Linear project metadata, the desktop task

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -36,6 +36,36 @@ launcher does not make `cargo install opensymphony` compile Tauri, npm, or
 platform desktop dependencies; signed/downloaded desktop bundle distribution is
 still future installer work.
 
+Maintainers can produce the current early desktop release assets from a source
+checkout with the desktop workspace script:
+
+```bash
+npm run build --workspace=@opensymphony/desktop
+npm run package:release --workspace=@opensymphony/desktop
+```
+
+The package command builds the Tauri desktop binary for the current platform,
+then writes these files under `dist/desktop-release/`:
+
+- `opensymphony-desktop-v<VERSION>-<PLATFORM>-<ARCH>.tar.gz`
+- `opensymphony-desktop-release-index.json`
+
+`VERSION` is the root Cargo workspace package version, and `PLATFORM`/`ARCH`
+use the same strings the CLI verifies (`macos`, `linux`, `windows`, `aarch64`,
+`x86_64`, and so on). The archive contains:
+
+- `opensymphony-desktop-manifest.json`, with version, platform, architecture,
+  relative executable path, and executable SHA-256.
+- the launch target named by that manifest.
+
+The release index is the metadata asset consumed by the CLI download path. It
+uses schema version `1`, lists compatible assets by version/platform/arch, and
+records the archive URL, archive SHA-256, and launch target. Upload the archive
+asset first, then upload or replace `opensymphony-desktop-release-index.json`
+last. The packaging script follows the same rule locally: it stages all output,
+publishes the archive, and only then publishes the index, so a failed packaging
+run does not leave new metadata claiming an unavailable archive.
+
 The desktop bundle contract is intentionally small and lives in
 [Desktop App Installer And Auto-Update Spec](specs/desktop-app-installer-auto-update-spec.md).
 The release index selects assets by OpenSymphony version, platform,

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -55,7 +55,9 @@ fails before writing release metadata if `apps/desktop/package.json`,
 `apps/desktop/src-tauri/Cargo.toml`, or `apps/desktop/src-tauri/tauri.conf.json`
 declare a different desktop version. `PLATFORM`/`ARCH` use the same strings the
 CLI verifies (`macos`, `linux`, `windows`, `aarch64`, `x86_64`, and so on). The
-archive contains:
+desktop Cargo build runs with `--locked`, so lockfile drift fails packaging
+instead of producing a release from an uncommitted dependency graph. The archive
+contains:
 
 - `opensymphony-desktop-manifest.json`, with version, platform, architecture,
   relative executable path, and executable SHA-256.

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -56,8 +56,9 @@ fails before writing release metadata if `apps/desktop/package.json`,
 declare a different desktop version. `PLATFORM`/`ARCH` use the same strings the
 CLI verifies (`macos`, `linux`, `windows`, `aarch64`, `x86_64`, and so on). The
 desktop Cargo build runs with `--locked`, so lockfile drift fails packaging
-instead of producing a release from an uncommitted dependency graph. The archive
-contains:
+instead of producing a release from an uncommitted dependency graph. The same
+locked metadata preflight runs when `--skip-build` is used with an existing
+binary. The archive contains:
 
 - `opensymphony-desktop-manifest.json`, with version, platform, architecture,
   relative executable path, and executable SHA-256.
@@ -67,8 +68,8 @@ The release index is the metadata asset consumed by the CLI download path. It
 uses schema version `1`, lists compatible assets by version/platform/arch, and
 records the archive URL, archive SHA-256, and launch target. When an existing
 release index is present in the output directory, the package command preserves
-other assets and replaces only the matching version/platform/arch entry. Upload
-the archive asset first, then upload or replace
+other assets and unknown top-level metadata, then replaces only the matching
+version/platform/arch entry. Upload the archive asset first, then upload or replace
 `opensymphony-desktop-release-index.json` last. The packaging script follows the
 same rule locally: it stages all output, publishes the archive, and only then
 publishes the index, so a failed packaging run does not leave new metadata

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -50,9 +50,12 @@ then writes these files under `dist/desktop-release/`:
 - `opensymphony-desktop-v<VERSION>-<PLATFORM>-<ARCH>.tar.gz`
 - `opensymphony-desktop-release-index.json`
 
-`VERSION` is the root Cargo workspace package version, and `PLATFORM`/`ARCH`
-use the same strings the CLI verifies (`macos`, `linux`, `windows`, `aarch64`,
-`x86_64`, and so on). The archive contains:
+`VERSION` is the root Cargo workspace package version. The package command
+fails before writing release metadata if `apps/desktop/package.json`,
+`apps/desktop/src-tauri/Cargo.toml`, or `apps/desktop/src-tauri/tauri.conf.json`
+declare a different desktop version. `PLATFORM`/`ARCH` use the same strings the
+CLI verifies (`macos`, `linux`, `windows`, `aarch64`, `x86_64`, and so on). The
+archive contains:
 
 - `opensymphony-desktop-manifest.json`, with version, platform, architecture,
   relative executable path, and executable SHA-256.
@@ -60,11 +63,14 @@ use the same strings the CLI verifies (`macos`, `linux`, `windows`, `aarch64`,
 
 The release index is the metadata asset consumed by the CLI download path. It
 uses schema version `1`, lists compatible assets by version/platform/arch, and
-records the archive URL, archive SHA-256, and launch target. Upload the archive
-asset first, then upload or replace `opensymphony-desktop-release-index.json`
-last. The packaging script follows the same rule locally: it stages all output,
-publishes the archive, and only then publishes the index, so a failed packaging
-run does not leave new metadata claiming an unavailable archive.
+records the archive URL, archive SHA-256, and launch target. When an existing
+release index is present in the output directory, the package command preserves
+other assets and replaces only the matching version/platform/arch entry. Upload
+the archive asset first, then upload or replace
+`opensymphony-desktop-release-index.json` last. The packaging script follows the
+same rule locally: it stages all output, publishes the archive, and only then
+publishes the index, so a failed packaging run does not leave new metadata
+claiming an unavailable archive.
 
 The desktop bundle contract is intentionally small and lives in
 [Desktop App Installer And Auto-Update Spec](specs/desktop-app-installer-auto-update-spec.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -58,7 +58,11 @@ The package command writes
 and `dist/desktop-release/opensymphony-desktop-release-index.json`. Upload the
 archive first and the release index last. The index is the CLI-consumable
 metadata file; it should never be published before the referenced archive is
-available.
+available. If an index already exists in the output directory, the package
+command preserves entries for other platform/architecture assets and replaces
+only the current asset entry. It also fails before writing metadata when the
+desktop package, Tauri crate, or Tauri config version does not match the release
+version.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 custom install root. That root contains versioned bundles such as
 `<dir>/<version>/`; it is not the bundle directory itself. Download metadata,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,6 +45,20 @@ the OpenSymphony version, platform, architecture, relative executable path, and
 executable SHA-256. Local bundle materialization copies regular files and
 directories; symlinked bundle entries should be packaged by a future signed or
 downloaded bundle format instead of this local smoke path.
+
+Maintainers can build the current release bundle assets from a checkout:
+
+```bash
+npm run build --workspace=@opensymphony/desktop
+npm run package:release --workspace=@opensymphony/desktop
+```
+
+The package command writes
+`dist/desktop-release/opensymphony-desktop-v<VERSION>-<PLATFORM>-<ARCH>.tar.gz`
+and `dist/desktop-release/opensymphony-desktop-release-index.json`. Upload the
+archive first and the release index last. The index is the CLI-consumable
+metadata file; it should never be published before the referenced archive is
+available.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 custom install root. That root contains versioned bundles such as
 `<dir>/<version>/`; it is not the bundle directory itself. Download metadata,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -62,7 +62,7 @@ available. If an index already exists in the output directory, the package
 command preserves entries for other platform/architecture assets and replaces
 only the current asset entry. It also fails before writing metadata when the
 desktop package, Tauri crate, or Tauri config version does not match the release
-version.
+version, or when Cargo lockfile drift would change the desktop dependency graph.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 custom install root. That root contains versioned bundles such as
 `<dir>/<version>/`; it is not the bundle directory itself. Download metadata,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,9 +60,10 @@ archive first and the release index last. The index is the CLI-consumable
 metadata file; it should never be published before the referenced archive is
 available. If an index already exists in the output directory, the package
 command preserves entries for other platform/architecture assets and replaces
-only the current asset entry. It also fails before writing metadata when the
-desktop package, Tauri crate, or Tauri config version does not match the release
-version, or when Cargo lockfile drift would change the desktop dependency graph.
+only the current asset entry while keeping unknown top-level metadata. It also
+fails before writing metadata when the desktop package, Tauri crate, or Tauri
+config version does not match the release version, or when Cargo lockfile drift
+would change the desktop dependency graph.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 custom install root. That root contains versioned bundles such as
 `<dir>/<version>/`; it is not the bundle directory itself. Download metadata,

--- a/docs/specs/desktop-app-installer-auto-update-spec.md
+++ b/docs/specs/desktop-app-installer-auto-update-spec.md
@@ -2,7 +2,7 @@
 
 This spec defines the durable contract for `opensymphony app` desktop bundle
 installation and update discovery. It does not define signed installer
-packaging, real asset publication, download implementation, or source builds.
+packaging, download implementation, or source builds.
 
 ## Release Index
 
@@ -17,13 +17,13 @@ needs before choosing a downloadable desktop asset.
       "version": "2.7.0",
       "platform": "macos",
       "arch": "aarch64",
-      "url": "https://downloads.example.invalid/opensymphony/2.7.0/macos-aarch64.zip",
+      "url": "https://github.com/kumanday/OpenSymphony/releases/download/v2.7.0/opensymphony-desktop-v2.7.0-macos-aarch64.tar.gz",
       "checksum": {
         "algorithm": "sha256",
-        "value": "0123456789abcdef"
+        "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       },
       "launch_target": {
-        "executable": "OpenSymphony.app/Contents/MacOS/OpenSymphony",
+        "executable": "OpenSymphony",
         "args": []
       }
     }
@@ -84,8 +84,8 @@ local bundles stay compatible with the current fields:
   "version": "2.7.0",
   "platform": "macos",
   "arch": "aarch64",
-  "executable": "OpenSymphony.app/Contents/MacOS/OpenSymphony",
-  "sha256": "0123456789abcdef"
+  "executable": "OpenSymphony",
+  "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 }
 ```
 

--- a/scripts/package_desktop_release.mjs
+++ b/scripts/package_desktop_release.mjs
@@ -65,6 +65,7 @@ async function main(options) {
     run("cargo", [
       "build",
       "--release",
+      "--locked",
       "--manifest-path",
       "apps/desktop/src-tauri/Cargo.toml",
       "--target-dir",

--- a/scripts/package_desktop_release.mjs
+++ b/scripts/package_desktop_release.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+const manifestFile = "opensymphony-desktop-manifest.json";
+const indexFile = "opensymphony-desktop-release-index.json";
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+try {
+  await main(options);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+async function main(options) {
+  const version = options.version ?? (await readWorkspaceVersion());
+  const platform = rustPlatform(process.platform);
+  const arch = rustArch(process.arch);
+  const executableName = process.platform === "win32" ? "OpenSymphony.exe" : "OpenSymphony";
+  const outputDir = resolveFromRoot(options.outputDir);
+  const targetDir = resolveFromRoot(options.targetDir);
+  const binary = options.binary
+    ? resolveFromRoot(options.binary)
+    : join(targetDir, "release", executableName);
+  const assetName = `opensymphony-desktop-v${version}-${platform}-${arch}.tar.gz`;
+  const assetBaseUrl =
+    options.assetBaseUrl ?? `https://github.com/kumanday/OpenSymphony/releases/download/v${version}`;
+  const assetUrl = `${assetBaseUrl.replace(/\/+$/, "")}/${assetName}`;
+
+  if (options.dryRun) {
+    console.log(`Dry run: version ${version}`);
+    console.log(`Dry run: platform ${platform}`);
+    console.log(`Dry run: architecture ${arch}`);
+    console.log(`Dry run: ${options.skipBuild ? "skip" : "run"} desktop cargo build`);
+    console.log(`Dry run: package ${binary}`);
+    console.log(`Dry run: write ${join(outputDir, assetName)}`);
+    console.log(`Dry run: write ${join(outputDir, indexFile)}`);
+    return;
+  }
+
+  if (!options.skipBuild) {
+    run("cargo", [
+      "build",
+      "--release",
+      "--manifest-path",
+      "apps/desktop/src-tauri/Cargo.toml",
+      "--target-dir",
+      targetDir,
+    ]);
+  }
+
+  await assertExecutable(binary);
+  await mkdir(outputDir, { recursive: true });
+
+  const staging = join(outputDir, `.tmp-desktop-release-${process.pid}-${Date.now()}`);
+  const bundleDir = join(staging, "bundle");
+  const stagedArchive = join(staging, assetName);
+  const stagedIndex = join(staging, indexFile);
+  const finalArchive = join(outputDir, assetName);
+  const finalIndex = join(outputDir, indexFile);
+
+  try {
+    await mkdir(bundleDir, { recursive: true });
+    const stagedExecutable = join(bundleDir, executableName);
+    await copyFile(binary, stagedExecutable);
+    if (process.platform !== "win32") {
+      const mode = (await stat(binary)).mode;
+      await chmod(stagedExecutable, mode | 0o755);
+    }
+
+    const executableSha = await sha256(stagedExecutable);
+    await writeJson(join(bundleDir, manifestFile), {
+      version,
+      platform,
+      arch,
+      executable: executableName,
+      sha256: executableSha,
+    });
+
+    run("tar", [
+      "-czf",
+      stagedArchive,
+      "-C",
+      bundleDir,
+      manifestFile,
+      executableName,
+    ]);
+
+    const archiveSha = await sha256(stagedArchive);
+    await writeJson(stagedIndex, {
+      schema_version: 1,
+      assets: [
+        {
+          version,
+          platform,
+          arch,
+          url: assetUrl,
+          checksum: {
+            algorithm: "sha256",
+            value: archiveSha,
+          },
+          launch_target: {
+            executable: executableName,
+            args: [],
+          },
+        },
+      ],
+    });
+
+    await rm(finalArchive, { force: true });
+    await rename(stagedArchive, finalArchive);
+    await rm(finalIndex, { force: true });
+    await rename(stagedIndex, finalIndex);
+
+    console.log(`Wrote ${finalArchive}`);
+    console.log(`Wrote ${finalIndex}`);
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+function parseArgs(args) {
+  const parsed = {
+    outputDir: "dist/desktop-release",
+    targetDir: "apps/desktop/src-tauri/target",
+    assetBaseUrl: undefined,
+    binary: undefined,
+    version: undefined,
+    skipBuild: false,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--output-dir":
+        parsed.outputDir = takeValue(args, ++index, arg);
+        break;
+      case "--target-dir":
+        parsed.targetDir = takeValue(args, ++index, arg);
+        break;
+      case "--asset-base-url":
+        parsed.assetBaseUrl = takeValue(args, ++index, arg);
+        break;
+      case "--binary":
+        parsed.binary = takeValue(args, ++index, arg);
+        break;
+      case "--version":
+        parsed.version = takeValue(args, ++index, arg);
+        break;
+      case "--skip-build":
+        parsed.skipBuild = true;
+        break;
+      case "--dry-run":
+        parsed.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function takeValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+async function readWorkspaceVersion() {
+  const cargoToml = await readFile(join(repoRoot, "Cargo.toml"), "utf8");
+  const workspacePackage = cargoToml.match(/\[workspace\.package\][\s\S]*?^version\s*=\s*"([^"]+)"/m);
+  if (!workspacePackage) {
+    throw new Error("could not read [workspace.package] version from Cargo.toml");
+  }
+  return workspacePackage[1];
+}
+
+function rustPlatform(platform) {
+  if (platform === "darwin") {
+    return "macos";
+  }
+  if (platform === "win32") {
+    return "windows";
+  }
+  return platform;
+}
+
+function rustArch(arch) {
+  if (arch === "x64") {
+    return "x86_64";
+  }
+  if (arch === "arm64") {
+    return "aarch64";
+  }
+  return arch;
+}
+
+function resolveFromRoot(path) {
+  return resolve(repoRoot, path);
+}
+
+async function assertExecutable(path) {
+  const metadata = await stat(path).catch((source) => {
+    throw new Error(`desktop executable is missing at ${path}: ${source.message}`);
+  });
+  if (!metadata.isFile()) {
+    throw new Error(`desktop executable is not a file: ${path}`);
+  }
+}
+
+async function sha256(path) {
+  return new Promise((resolveHash, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolveHash(hash.digest("hex")));
+  });
+}
+
+async function writeJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (result.error) {
+    throw new Error(`failed to run ${command}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} exited with ${result.status}`);
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/package_desktop_release.mjs [options]
+
+Build and package the current-platform OpenSymphony desktop bundle.
+
+Options:
+  --output-dir <dir>       Output directory (default: dist/desktop-release)
+  --target-dir <dir>       Cargo target dir (default: apps/desktop/src-tauri/target)
+  --asset-base-url <url>   Release URL prefix for the archive
+  --binary <path>          Existing desktop binary to package
+  --version <version>      Override the Cargo workspace package version
+  --skip-build             Package --binary or the default target binary as-is
+  --dry-run                Print planned actions without building or writing
+  -h, --help               Show this help
+`);
+}

--- a/scripts/package_desktop_release.mjs
+++ b/scripts/package_desktop_release.mjs
@@ -36,6 +36,7 @@ try {
 
 async function main(options) {
   const version = options.version ?? (await readWorkspaceVersion());
+  await assertDesktopVersions(version);
   const platform = rustPlatform(process.platform);
   const arch = rustArch(process.arch);
   const executableName = process.platform === "win32" ? "OpenSymphony.exe" : "OpenSymphony";
@@ -109,29 +110,23 @@ async function main(options) {
     ]);
 
     const archiveSha = await sha256(stagedArchive);
-    await writeJson(stagedIndex, {
-      schema_version: 1,
-      assets: [
-        {
-          version,
-          platform,
-          arch,
-          url: assetUrl,
-          checksum: {
-            algorithm: "sha256",
-            value: archiveSha,
-          },
-          launch_target: {
-            executable: executableName,
-            args: [],
-          },
-        },
-      ],
+    const releaseIndex = await mergeReleaseIndex(finalIndex, {
+      version,
+      platform,
+      arch,
+      url: assetUrl,
+      checksum: {
+        algorithm: "sha256",
+        value: archiveSha,
+      },
+      launch_target: {
+        executable: executableName,
+        args: [],
+      },
     });
+    await writeJson(stagedIndex, releaseIndex);
 
-    await rm(finalArchive, { force: true });
     await rename(stagedArchive, finalArchive);
-    await rm(finalIndex, { force: true });
     await rename(stagedIndex, finalIndex);
 
     console.log(`Wrote ${finalArchive}`);
@@ -204,6 +199,63 @@ async function readWorkspaceVersion() {
     throw new Error("could not read [workspace.package] version from Cargo.toml");
   }
   return workspacePackage[1];
+}
+
+async function assertDesktopVersions(expectedVersion) {
+  const packageJson = JSON.parse(await readFile(join(repoRoot, "apps/desktop/package.json"), "utf8"));
+  const tauriConfig = JSON.parse(
+    await readFile(join(repoRoot, "apps/desktop/src-tauri/tauri.conf.json"), "utf8"),
+  );
+  const cargoToml = await readFile(join(repoRoot, "apps/desktop/src-tauri/Cargo.toml"), "utf8");
+  const cargoPackage = cargoToml.match(/\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m);
+  const versions = [
+    ["apps/desktop/package.json", packageJson.version],
+    ["apps/desktop/src-tauri/tauri.conf.json", tauriConfig.version],
+    ["apps/desktop/src-tauri/Cargo.toml", cargoPackage?.[1]],
+  ];
+  const mismatches = versions.filter(([, version]) => version !== expectedVersion);
+  if (mismatches.length > 0) {
+    throw new Error(
+      `desktop version mismatch for release ${expectedVersion}: ${mismatches
+        .map(([path, version]) => `${path} has ${version ?? "no version"}`)
+        .join(", ")}`,
+    );
+  }
+}
+
+async function mergeReleaseIndex(indexPath, asset) {
+  const existing = await readExistingIndex(indexPath);
+  return {
+    schema_version: 1,
+    assets: [
+      ...existing.assets.filter(
+        (candidate) =>
+          !(
+            candidate.version === asset.version &&
+            candidate.platform === asset.platform &&
+            candidate.arch === asset.arch
+          ),
+      ),
+      asset,
+    ],
+  };
+}
+
+async function readExistingIndex(indexPath) {
+  let raw;
+  try {
+    raw = await readFile(indexPath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { schema_version: 1, assets: [] };
+    }
+    throw error;
+  }
+  const parsed = JSON.parse(raw);
+  if (parsed.schema_version !== 1 || !Array.isArray(parsed.assets)) {
+    throw new Error(`${indexPath} is not a schema_version 1 desktop release index`);
+  }
+  return parsed;
 }
 
 function rustPlatform(platform) {

--- a/scripts/package_desktop_release.mjs
+++ b/scripts/package_desktop_release.mjs
@@ -37,6 +37,7 @@ try {
 async function main(options) {
   const version = options.version ?? (await readWorkspaceVersion());
   await assertDesktopVersions(version);
+  assertDesktopLockfile(version);
   const platform = rustPlatform(process.platform);
   const arch = rustArch(process.arch);
   const executableName = process.platform === "win32" ? "OpenSymphony.exe" : "OpenSymphony";
@@ -224,9 +225,45 @@ async function assertDesktopVersions(expectedVersion) {
   }
 }
 
+function assertDesktopLockfile(expectedVersion) {
+  const result = spawnSync(
+    "cargo",
+    [
+      "metadata",
+      "--locked",
+      "--format-version",
+      "1",
+      "--no-deps",
+      "--manifest-path",
+      "apps/desktop/src-tauri/Cargo.toml",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (result.error) {
+    throw new Error(`failed to run cargo metadata --locked: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`desktop Cargo.lock is stale: ${result.stderr.trim() || result.stdout.trim()}`);
+  }
+
+  const metadata = JSON.parse(result.stdout);
+  const desktopPackage = metadata.packages.find((pkg) => pkg.name === "opensymphony-desktop");
+  if (desktopPackage?.version !== expectedVersion) {
+    throw new Error(
+      `desktop Cargo.lock records opensymphony-desktop ${desktopPackage?.version ?? "unknown"}, expected ${expectedVersion}`,
+    );
+  }
+}
+
 async function mergeReleaseIndex(indexPath, asset) {
   const existing = await readExistingIndex(indexPath);
   return {
+    ...existing,
     schema_version: 1,
     assets: [
       ...existing.assets.filter(


### PR DESCRIPTION
## Summary

Adds the first maintainer-run desktop release bundle pipeline for `opensymphony app` assets.

## Changes

- Add `scripts/package_desktop_release.mjs` and the `@opensymphony/desktop` `package:release` command.
- Generate a tarball containing `opensymphony-desktop-manifest.json` plus the verified launch target, and publish `opensymphony-desktop-release-index.json` last.
- Preserve existing release-index entries for other platform/architecture assets, plus unknown top-level metadata, when packaging a new current-platform archive.
- Validate desktop package, Tauri crate, Tauri lockfile, and Tauri config versions before writing release metadata.
- Build the default desktop release bundle with Cargo `--locked`; `--skip-build --binary` runs the same locked metadata preflight before publishing metadata.
- Align the desktop app version declarations to `2.7.0` and update desktop installer/release docs.

## Evidence

### Test output

```
npm run build --workspace=@opensymphony/desktop
# passed

npm run package:release --workspace=@opensymphony/desktop -- --skip-build --binary target/coe-526-rework-metadata/bin/OpenSymphony --output-dir target/coe-526-rework-metadata/out --asset-base-url https://github.com/kumanday/OpenSymphony/releases/download/v2.7.0
# wrote opensymphony-desktop-v2.7.0-macos-aarch64.tar.gz
# wrote opensymphony-desktop-release-index.json

jq -r '.channel, (.assets[] | [.version,.platform,.arch] | @tsv)' target/coe-526-rework-metadata/out/opensymphony-desktop-release-index.json
# stable
# 2.7.0 linux x86_64
# 2.7.0 macos aarch64

tar -tzf target/coe-526-rework-metadata/out/opensymphony-desktop-v2.7.0-macos-aarch64.tar.gz
# opensymphony-desktop-manifest.json
# OpenSymphony

npm run package:release --workspace=@opensymphony/desktop -- --version 2.7.1 --skip-build --binary target/coe-526-version-fail-final/bin/OpenSymphony --output-dir target/coe-526-version-fail-final/out
# failed as expected with desktop version mismatch
# no opensymphony-desktop-release-index.json was written

npm run package:release --workspace=@opensymphony/desktop -- --dry-run
# printed planned v2.7.0 macos/aarch64 cargo build, archive, and index paths

cargo metadata --manifest-path apps/desktop/src-tauri/Cargo.toml --locked --format-version 1 --no-deps
# reported opensymphony-desktop 2.7.0 from the checked-in lockfile

node --check scripts/package_desktop_release.mjs
cargo fmt --check
git diff --check
cargo test-system-duckdb desktop_launcher --lib
# 18 passed; 0 failed; 701 filtered out
```

### Verification

The packaging script was run in local output mode with a fake executable to verify the archive and release index shape without requiring a full Tauri release build. The output directory started with a Linux release-index entry and a top-level `channel` field; after packaging, the index retained both and added the macOS asset. A mismatched-version run exited nonzero before writing release metadata. The desktop Cargo lockfile now records the same `2.7.0` package version as the desktop crate and Tauri config, the default Cargo release build uses `--locked`, and skip-build packaging runs a locked metadata preflight.

## Checklist

- [x] Tests pass (`cargo test`) - targeted desktop launcher and packaging checks passed
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`) - not run; scoped change is JS/docs/desktop metadata
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed) - not needed
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other: N/A

## Breaking changes

None.

## Related issues

COE-526

## Additional notes

The default package command builds the desktop crate for the current platform. The validation uses `--skip-build --binary` for a fast local packaging proof; signed native installers and hosted update channels remain out of scope.