### PR TITLE
Add desktop app bundle update prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ normal run would need to build from source.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 different install root; the launcher still creates the versioned bundle beneath
 that root. On a cache miss, the launcher downloads the release index from the
-latest GitHub release and installs the compatible asset; set
-`OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to point at a private or test index.
-When a cached bundle is already installed, the launcher checks the release
-index before launch, prompts `Update before launch? [Y/n]` in an interactive
-terminal when a newer compatible bundle is available, and updates by default in
-non-interactive runs. Pass `--no-update` to launch the cached bundle without
-checking first.
+versioned GitHub release matching the running CLI and installs the compatible
+asset; set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to point at a private or
+test index. When a cached bundle is already installed, the launcher checks the
+latest release index before launch, prompts `Update before launch? [Y/n]` in an
+interactive terminal when a newer compatible bundle is available, and updates
+by default in non-interactive runs. Pass `--no-update` to launch the cached
+bundle without checking first.
 The release-index and update prompt contract is defined in
 [Desktop App Installer And Auto-Update Spec](docs/specs/desktop-app-installer-auto-update-spec.md).
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ different install root; the launcher still creates the versioned bundle beneath
 that root. On a cache miss, the launcher downloads the release index from the
 matching GitHub release and installs the compatible asset; set
 `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to point at a private or test index.
+When a cached bundle is already installed, the launcher checks the release
+index before launch, prompts `Update before launch? [Y/n]` in an interactive
+terminal when a newer compatible bundle is available, and updates by default in
+non-interactive runs. Pass `--no-update` to launch the cached bundle without
+checking first.
 The release-index and update prompt contract is defined in
 [Desktop App Installer And Auto-Update Spec](docs/specs/desktop-app-installer-auto-update-spec.md).
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ normal run would need to build from source.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 different install root; the launcher still creates the versioned bundle beneath
 that root. On a cache miss, the launcher downloads the release index from the
-matching GitHub release and installs the compatible asset; set
+latest GitHub release and installs the compatible asset; set
 `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to point at a private or test index.
 When a cached bundle is already installed, the launcher checks the release
 index before launch, prompts `Update before launch? [Y/n]` in an interactive

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -1,10 +1,11 @@
 use std::{
+    cmp::Ordering,
     env,
     ffi::OsString,
     fs,
     fs::File,
     io,
-    io::Read,
+    io::{BufRead, IsTerminal, Read, Write},
     path::{Path, PathBuf},
     process::{Command, ExitCode, Stdio},
     time::Duration,
@@ -64,6 +65,11 @@ pub struct AppArgs {
         help = "Verify the bundle and print the launch target without starting it"
     )]
     dry_run: bool,
+    #[arg(
+        long,
+        help = "Launch the cached desktop bundle without checking for updates first"
+    )]
+    no_update: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -106,8 +112,54 @@ struct DesktopLaunchTarget {
 
 #[derive(Debug)]
 struct VerifiedBundle {
+    bundle_dir: PathBuf,
     executable: PathBuf,
     manifest: DesktopBundleManifest,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SemanticVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+}
+
+impl SemanticVersion {
+    fn parse(value: &str) -> Option<Self> {
+        let core = value.split_once('+').map_or(value, |(core, _)| core);
+        let core = core.split_once('-').map_or(core, |(core, _)| core);
+        let mut parts = core.split('.');
+        let major = parse_version_part(parts.next()?)?;
+        let minor = parse_version_part(parts.next()?)?;
+        let patch = parse_version_part(parts.next()?)?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl Ord for SemanticVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch))
+    }
+}
+
+impl PartialOrd for SemanticVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn parse_version_part(part: &str) -> Option<u64> {
+    if part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    part.parse().ok()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -234,6 +286,8 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
     let cache_dir = cache_root.join(desktop_version());
     validate_cache_dir(&cache_root, &cache_dir)?;
     let bundle_dir = args.bundle_dir.as_deref();
+    let no_update = args.no_update;
+    let skip_update = no_update || bundle_dir.is_some();
     if args.dry_run {
         let verified = dry_run_verified_bundle(&cache_dir, bundle_dir)?;
         println!(
@@ -253,8 +307,15 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
         true,
     )
     .await?;
+    let verified = maybe_update_verified_bundle(
+        &cache_root,
+        verified,
+        release_index_url.as_str(),
+        skip_update,
+    )
+    .await;
     Command::new(&verified.executable)
-        .current_dir(&cache_dir)
+        .current_dir(&verified.bundle_dir)
         .spawn()
         .map_err(|source| DesktopLauncherError::Launch {
             path: verified.executable.clone(),
@@ -299,6 +360,60 @@ async fn ensure_verified_bundle(
     .await
 }
 
+async fn maybe_update_verified_bundle(
+    cache_root: &Path,
+    verified: VerifiedBundle,
+    release_index_url: &str,
+    no_update: bool,
+) -> VerifiedBundle {
+    if no_update {
+        return verified;
+    }
+    let candidate = match latest_update_candidate(
+        release_index_url,
+        verified.manifest.version.as_str(),
+    )
+    .await
+    {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            eprintln!("Desktop update check failed; launching installed bundle: {error}");
+            return verified;
+        }
+    };
+    let Some(asset) = candidate else {
+        return verified;
+    };
+    let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+    if interactive {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        let mut reader = stdin.lock();
+        let mut writer = stdout.lock();
+        match prompt_update_decision(
+            &mut reader,
+            &mut writer,
+            true,
+            verified.manifest.version.as_str(),
+            asset.version.as_str(),
+        ) {
+            Ok(true) => {}
+            Ok(false) => return verified,
+            Err(source) => {
+                eprintln!("Desktop update prompt failed; launching installed bundle: {source}");
+                return verified;
+            }
+        }
+    }
+    match install_release_asset(cache_root, asset).await {
+        Ok(updated) => updated,
+        Err(error) => {
+            eprintln!("Desktop update failed; launching installed bundle: {error}");
+            verified
+        }
+    }
+}
+
 async fn ensure_verified_bundle_with<R: DesktopCommandRunner>(
     cache_root: &Path,
     cache_dir: &Path,
@@ -307,39 +422,40 @@ async fn ensure_verified_bundle_with<R: DesktopCommandRunner>(
     allow_source_build: bool,
     runner: &mut R,
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
-    match verify_bundle(cache_dir) {
-        Ok(bundle) => Ok(bundle),
-        Err(_first_error) => {
-            if let Some(bundle_dir) = bundle_dir {
-                if cache_dir.exists() {
-                    remove_cache_entry(cache_root, cache_dir)?;
-                }
-                copy_dir_all(bundle_dir, cache_dir)?;
-                match verify_bundle(cache_dir) {
-                    Ok(bundle) => Ok(bundle),
-                    Err(source) => {
-                        remove_cache_entry(cache_root, cache_dir)?;
-                        Err(source)
-                    }
-                }
-            } else {
-                match install_release_bundle(cache_root, cache_dir, release_index_url).await {
-                    Ok(bundle) => Ok(bundle),
-                    Err(error)
-                        if allow_source_build && release_error_allows_source_fallback(&error) =>
-                    {
-                        build_source_fallback(cache_root, cache_dir, runner).await
-                    }
-                    Err(error) if release_error_allows_source_fallback(&error) => {
-                        Err(DesktopLauncherError::DryRunSourceBuildRequired {
-                            version: desktop_version().to_string(),
-                            platform: current_platform().to_string(),
-                            arch: current_arch().to_string(),
-                        })
-                    }
-                    Err(error) => Err(error),
-                }
+    let cached = if bundle_dir.is_none() {
+        latest_verified_cached_bundle(cache_root).or_else(|| verify_bundle(cache_dir).ok())
+    } else {
+        verify_bundle(cache_dir).ok()
+    };
+    if let Some(bundle) = cached {
+        return Ok(bundle);
+    }
+    if let Some(bundle_dir) = bundle_dir {
+        if cache_dir.exists() {
+            remove_cache_entry(cache_root, cache_dir)?;
+        }
+        copy_dir_all(bundle_dir, cache_dir)?;
+        match verify_bundle(cache_dir) {
+            Ok(bundle) => Ok(bundle),
+            Err(source) => {
+                remove_cache_entry(cache_root, cache_dir)?;
+                Err(source)
             }
+        }
+    } else {
+        match install_release_bundle(cache_root, cache_dir, release_index_url).await {
+            Ok(bundle) => Ok(bundle),
+            Err(error) if allow_source_build && release_error_allows_source_fallback(&error) => {
+                build_source_fallback(cache_root, cache_dir, runner).await
+            }
+            Err(error) if release_error_allows_source_fallback(&error) => {
+                Err(DesktopLauncherError::DryRunSourceBuildRequired {
+                    version: desktop_version().to_string(),
+                    platform: current_platform().to_string(),
+                    arch: current_arch().to_string(),
+                })
+            }
+            Err(error) => Err(error),
         }
     }
 }
@@ -355,14 +471,115 @@ fn release_error_allows_source_fallback(error: &DesktopLauncherError) -> bool {
     )
 }
 
+async fn latest_update_candidate(
+    release_index_url: &str,
+    installed_version: &str,
+) -> Result<Option<DesktopReleaseAsset>, DesktopLauncherError> {
+    let index = download_release_index_task(release_index_url).await?;
+    Ok(newest_compatible_release_asset(&index, release_index_url, installed_version)?.cloned())
+}
+
+async fn download_release_index_task(
+    release_index_url: &str,
+) -> Result<DesktopReleaseIndex, DesktopLauncherError> {
+    let release_index_url = release_index_url.to_string();
+    tokio::task::spawn_blocking(move || download_release_index(&release_index_url))
+        .await
+        .map_err(|source| DesktopLauncherError::ReleaseInstallTask { source })?
+}
+
+fn newest_compatible_release_asset<'a>(
+    index: &'a DesktopReleaseIndex,
+    _release_index_url: &str,
+    installed_version: &str,
+) -> Result<Option<&'a DesktopReleaseAsset>, DesktopLauncherError> {
+    let Some(installed_version) = SemanticVersion::parse(installed_version) else {
+        return Ok(None);
+    };
+    let asset = index
+        .assets
+        .iter()
+        .filter(|asset| asset.platform == current_platform() && asset.arch == current_arch())
+        .filter_map(|asset| Some((SemanticVersion::parse(&asset.version)?, asset)))
+        .filter(|(version, _)| *version > installed_version)
+        .max_by_key(|(version, _)| *version)
+        .map(|(_, asset)| asset);
+    if let Some(asset) = asset {
+        validate_release_asset(asset)?;
+    }
+    Ok(asset)
+}
+
+fn prompt_update_decision<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    interactive: bool,
+    installed_version: &str,
+    update_version: &str,
+) -> io::Result<bool>
+where
+    R: BufRead,
+    W: Write,
+{
+    if !interactive {
+        return Ok(true);
+    }
+    writeln!(
+        writer,
+        "OpenSymphony desktop {update_version} is available; installed version is {installed_version}."
+    )?;
+    loop {
+        write!(writer, "Update before launch? [Y/n] ")?;
+        writer.flush()?;
+        let mut response = String::new();
+        if reader.read_line(&mut response)? == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "update prompt closed before a response",
+            ));
+        }
+        match response.trim().to_ascii_lowercase().as_str() {
+            "" | "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => writeln!(writer, "Please answer with `yes` or `no`.")?,
+        }
+    }
+}
+
+fn latest_verified_cached_bundle(cache_root: &Path) -> Option<VerifiedBundle> {
+    fs::read_dir(cache_root)
+        .ok()?
+        .filter_map(|entry| {
+            let cache_dir = entry.ok()?.path();
+            reject_symlink(cache_root).ok()?;
+            reject_symlink(&cache_dir).ok()?;
+            let manifest = read_manifest(&cache_dir.join(MANIFEST_FILE)).ok()?;
+            validate_cache_dir_for_version(cache_root, &cache_dir, &manifest.version).ok()?;
+            let version = SemanticVersion::parse(&manifest.version)?;
+            let verified = verify_bundle_for_version(&cache_dir, Some(&manifest.version)).ok()?;
+            Some((version, verified))
+        })
+        .max_by_key(|(version, _)| *version)
+        .map(|(_, verified)| verified)
+}
+
 fn verify_bundle(cache_dir: &Path) -> Result<VerifiedBundle, DesktopLauncherError> {
+    verify_bundle_for_version(cache_dir, Some(desktop_version()))
+}
+
+fn verify_bundle_for_version(
+    cache_dir: &Path,
+    expected_version: Option<&str>,
+) -> Result<VerifiedBundle, DesktopLauncherError> {
     let manifest_path = cache_dir.join(MANIFEST_FILE);
     let manifest = read_manifest(&manifest_path)?;
 
-    if manifest.version != desktop_version() {
+    if let Some(expected) = expected_version
+        && manifest.version != expected
+    {
         return Err(DesktopLauncherError::WrongVersion {
             path: manifest_path,
-            expected: desktop_version().to_string(),
+            expected: expected.to_string(),
             actual: manifest.version,
         });
     }
@@ -392,6 +609,7 @@ fn verify_bundle(cache_dir: &Path) -> Result<VerifiedBundle, DesktopLauncherErro
     }
 
     Ok(VerifiedBundle {
+        bundle_dir: cache_dir.to_path_buf(),
         executable,
         manifest,
     })
@@ -459,6 +677,28 @@ fn install_release_bundle_blocking(
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
     let index = download_release_index(release_index_url)?;
     let asset = compatible_release_asset(&index, release_index_url)?;
+    install_release_asset_blocking(cache_root, cache_dir, asset)
+}
+
+async fn install_release_asset(
+    cache_root: &Path,
+    asset: DesktopReleaseAsset,
+) -> Result<VerifiedBundle, DesktopLauncherError> {
+    let cache_root = cache_root.to_path_buf();
+    let cache_dir = cache_root.join(&asset.version);
+    tokio::task::spawn_blocking(move || {
+        install_release_asset_blocking(&cache_root, &cache_dir, &asset)
+    })
+    .await
+    .map_err(|source| DesktopLauncherError::ReleaseInstallTask { source })?
+}
+
+fn install_release_asset_blocking(
+    cache_root: &Path,
+    cache_dir: &Path,
+    asset: &DesktopReleaseAsset,
+) -> Result<VerifiedBundle, DesktopLauncherError> {
+    validate_cache_dir_for_version(cache_root, cache_dir, &asset.version)?;
     fs::create_dir_all(cache_root).map_err(|source| DesktopLauncherError::Repair {
         path: cache_root.to_path_buf(),
         source,
@@ -478,8 +718,9 @@ fn install_release_bundle_blocking(
         verify_archive_checksum(&archive_path, asset)?;
         extract_release_archive(&archive_path, &stage_dir)?;
         let verified = verify_bundle_matches_asset(&stage_dir, asset)?;
-        promote_verified_bundle(cache_root, cache_dir, &stage_dir)?;
-        verify_bundle(cache_dir).map(|promoted| VerifiedBundle {
+        promote_verified_bundle(cache_root, cache_dir, &stage_dir, &asset.version)?;
+        verify_bundle_for_version(cache_dir, Some(&asset.version)).map(|promoted| VerifiedBundle {
+            bundle_dir: promoted.bundle_dir,
             executable: promoted.executable,
             manifest: verified.manifest,
         })
@@ -536,38 +777,43 @@ fn compatible_release_asset<'a>(
             arch: current_arch().to_string(),
         })
         .and_then(|asset| {
-            let display_asset_url = release_url_display_url(&asset.url);
-            if asset.checksum.algorithm != "sha256" {
-                return Err(DesktopLauncherError::UnsupportedReleaseChecksum {
-                    url: display_asset_url,
-                    algorithm: asset.checksum.algorithm.clone(),
-                });
-            }
-            if !asset.launch_target.args.is_empty() {
-                return Err(DesktopLauncherError::UnsupportedLaunchArgs {
-                    url: display_asset_url,
-                });
-            }
-            if asset.launch_target.executable.is_absolute()
-                || asset
-                    .launch_target
-                    .executable
-                    .components()
-                    .any(|component| {
-                        matches!(
-                            component,
-                            std::path::Component::ParentDir
-                                | std::path::Component::RootDir
-                                | std::path::Component::Prefix(_)
-                        )
-                    })
-            {
-                return Err(DesktopLauncherError::UnsafeExecutablePath {
-                    path: asset.launch_target.executable.clone(),
-                });
-            }
+            validate_release_asset(asset)?;
             Ok(asset)
         })
+}
+
+fn validate_release_asset(asset: &DesktopReleaseAsset) -> Result<(), DesktopLauncherError> {
+    let display_asset_url = release_url_display_url(&asset.url);
+    if asset.checksum.algorithm != "sha256" {
+        return Err(DesktopLauncherError::UnsupportedReleaseChecksum {
+            url: display_asset_url,
+            algorithm: asset.checksum.algorithm.clone(),
+        });
+    }
+    if !asset.launch_target.args.is_empty() {
+        return Err(DesktopLauncherError::UnsupportedLaunchArgs {
+            url: display_asset_url,
+        });
+    }
+    if asset.launch_target.executable.is_absolute()
+        || asset
+            .launch_target
+            .executable
+            .components()
+            .any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            })
+    {
+        return Err(DesktopLauncherError::UnsafeExecutablePath {
+            path: asset.launch_target.executable.clone(),
+        });
+    }
+    Ok(())
 }
 
 fn download_file(url: &str, destination: &Path) -> Result<(), DesktopLauncherError> {
@@ -690,7 +936,7 @@ fn verify_bundle_matches_asset(
     stage_dir: &Path,
     asset: &DesktopReleaseAsset,
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
-    let verified = verify_bundle(stage_dir)?;
+    let verified = verify_bundle_for_version(stage_dir, Some(&asset.version))?;
     if verified.manifest.executable != asset.launch_target.executable {
         return Err(DesktopLauncherError::LaunchTargetMismatch {
             expected: asset.launch_target.executable.clone(),
@@ -704,10 +950,11 @@ fn promote_verified_bundle(
     cache_root: &Path,
     cache_dir: &Path,
     stage_dir: &Path,
+    version: &str,
 ) -> Result<(), DesktopLauncherError> {
-    validate_cache_dir(cache_root, cache_dir)?;
+    validate_cache_dir_for_version(cache_root, cache_dir, version)?;
     if cache_dir.exists() {
-        remove_cache_entry(cache_root, cache_dir)?;
+        remove_cache_entry_for_version(cache_root, cache_dir, version)?;
     }
     fs::rename(stage_dir, cache_dir).map_err(|source| DesktopLauncherError::Repair {
         path: cache_dir.to_path_buf(),
@@ -1352,7 +1599,15 @@ fn copy_dir_all(from: &Path, to: &Path) -> Result<(), DesktopLauncherError> {
 }
 
 fn remove_cache_entry(cache_root: &Path, cache_dir: &Path) -> Result<(), DesktopLauncherError> {
-    validate_cache_dir(cache_root, cache_dir)?;
+    remove_cache_entry_for_version(cache_root, cache_dir, desktop_version())
+}
+
+fn remove_cache_entry_for_version(
+    cache_root: &Path,
+    cache_dir: &Path,
+    version: &str,
+) -> Result<(), DesktopLauncherError> {
+    validate_cache_dir_for_version(cache_root, cache_dir, version)?;
     let metadata =
         fs::symlink_metadata(cache_dir).map_err(|source| DesktopLauncherError::Repair {
             path: cache_dir.to_path_buf(),
@@ -1464,13 +1719,21 @@ fn normalize_cache_root(path: PathBuf) -> Result<PathBuf, DesktopLauncherError> 
 }
 
 fn validate_cache_dir(cache_root: &Path, cache_dir: &Path) -> Result<(), DesktopLauncherError> {
+    validate_cache_dir_for_version(cache_root, cache_dir, desktop_version())
+}
+
+fn validate_cache_dir_for_version(
+    cache_root: &Path,
+    cache_dir: &Path,
+    version: &str,
+) -> Result<(), DesktopLauncherError> {
     reject_parent_components(cache_root)?;
     reject_parent_components(cache_dir)?;
     reject_symlink(cache_root)?;
     reject_symlink(cache_dir)?;
     if cache_root.parent().is_none()
         || !cache_dir.starts_with(cache_root)
-        || cache_dir.file_name().and_then(|name| name.to_str()) != Some(desktop_version())
+        || cache_dir.file_name().and_then(|name| name.to_str()) != Some(version)
     {
         return Err(DesktopLauncherError::DangerousCacheRoot {
             path: cache_root.to_path_buf(),
@@ -1931,6 +2194,55 @@ mod tests {
     }
 
     #[test]
+    fn semver_selection_treats_numeric_segments_as_numbers() {
+        let index = DesktopReleaseIndex {
+            schema_version: 1,
+            assets: vec![
+                desktop_release_asset("2.9.9", "http://example.com/2.9.9.tar.gz", "0"),
+                desktop_release_asset("2.10.0", "http://example.com/2.10.0.tar.gz", "0"),
+            ],
+        };
+
+        let asset =
+            newest_compatible_release_asset(&index, "http://example.com/index.json", "2.8.0")
+                .expect("candidate lookup should succeed")
+                .expect("newer asset should exist");
+
+        assert_eq!(asset.version, "2.10.0");
+    }
+
+    #[test]
+    fn update_prompt_defaults_enter_to_yes() {
+        let mut output = Vec::new();
+        let accepted = prompt_update_decision(&mut &b"\n"[..], &mut output, true, "2.7.0", "2.7.1")
+            .expect("prompt should succeed");
+        let rendered = String::from_utf8(output).expect("prompt output utf8");
+
+        assert!(accepted);
+        assert!(rendered.contains("Update before launch? [Y/n]"));
+    }
+
+    #[test]
+    fn update_prompt_accepts_explicit_no() {
+        let mut output = Vec::new();
+        let accepted =
+            prompt_update_decision(&mut &b"n\n"[..], &mut output, true, "2.7.0", "2.7.1")
+                .expect("prompt should succeed");
+
+        assert!(!accepted);
+    }
+
+    #[test]
+    fn noninteractive_update_prompt_defaults_to_yes_without_reading() {
+        let mut output = Vec::new();
+        let accepted = prompt_update_decision(&mut &b""[..], &mut output, false, "2.7.0", "2.7.1")
+            .expect("noninteractive default should succeed");
+
+        assert!(accepted);
+        assert!(output.is_empty());
+    }
+
+    #[test]
     fn release_asset_download_error_redacts_reqwest_url() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind unused port");
         let addr = listener.local_addr().expect("local address");
@@ -2140,6 +2452,105 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn current_cached_bundle_checks_index_without_asset_download() {
+        let archive = desktop_release_archive(b"fake desktop");
+        let archive_sha = sha256_bytes(&archive);
+        let server = FakeReleaseServer::start(|base_url| {
+            vec![(
+                "/index.json",
+                release_index_body(base_url, archive_sha.as_str()).into_bytes(),
+            )]
+        });
+        let install_root = TempDir::new().expect("install root");
+        let cache_dir = install_root.path().join(desktop_version());
+        write_installed_bundle(&cache_dir, b"fake desktop");
+        let verified = verify_bundle(&cache_dir).expect("cache should verify");
+
+        let launched = maybe_update_verified_bundle(
+            install_root.path(),
+            verified,
+            &server.url("/index.json"),
+            false,
+        )
+        .await;
+
+        assert_eq!(launched.manifest.version, desktop_version());
+        assert_eq!(server.requests(), vec!["/index.json".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn failed_update_launches_existing_verified_bundle() {
+        let archive = desktop_release_archive_for_version("2.7.1", b"updated desktop");
+        let server = FakeReleaseServer::start(|base_url| {
+            vec![
+                (
+                    "/index.json",
+                    release_index_body_for_version(
+                        base_url,
+                        "2.7.1",
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                    .into_bytes(),
+                ),
+                ("/bundle.tar.gz", archive),
+            ]
+        });
+        let install_root = TempDir::new().expect("install root");
+        let cache_dir = install_root.path().join(desktop_version());
+        write_installed_bundle(&cache_dir, b"fake desktop");
+        let verified = verify_bundle(&cache_dir).expect("cache should verify");
+
+        let launched = maybe_update_verified_bundle(
+            install_root.path(),
+            verified,
+            &server.url("/index.json"),
+            false,
+        )
+        .await;
+
+        assert_eq!(launched.manifest.version, desktop_version());
+        assert!(cache_dir.join(MANIFEST_FILE).is_file());
+        assert!(!install_root.path().join("2.7.1").exists());
+    }
+
+    #[tokio::test]
+    async fn newer_release_promotes_and_launches_updated_bundle() {
+        let archive = desktop_release_archive_for_version("2.7.1", b"updated desktop");
+        let archive_sha = sha256_bytes(&archive);
+        let server = FakeReleaseServer::start(|base_url| {
+            vec![
+                (
+                    "/index.json",
+                    release_index_body_for_version(base_url, "2.7.1", archive_sha.as_str())
+                        .into_bytes(),
+                ),
+                ("/bundle.tar.gz", archive),
+            ]
+        });
+        let install_root = TempDir::new().expect("install root");
+        let cache_dir = install_root.path().join(desktop_version());
+        write_installed_bundle(&cache_dir, b"fake desktop");
+        let verified = verify_bundle(&cache_dir).expect("cache should verify");
+
+        let launched = maybe_update_verified_bundle(
+            install_root.path(),
+            verified,
+            &server.url("/index.json"),
+            false,
+        )
+        .await;
+
+        let updated_dir = install_root.path().join("2.7.1");
+        assert_eq!(launched.manifest.version, "2.7.1");
+        assert_eq!(launched.bundle_dir, updated_dir);
+        assert!(updated_dir.join(MANIFEST_FILE).is_file());
+        assert_eq!(
+            server.requests(),
+            vec!["/index.json".to_string(), "/bundle.tar.gz".to_string()]
+        );
+    }
+
     #[test]
     fn platform_selection_uses_current_target() {
         assert_eq!(current_platform(), env::consts::OS);
@@ -2341,6 +2752,7 @@ mod tests {
             cache_root: None,
             release_index_url: Some(server.url("/index.json")),
             dry_run: true,
+            no_update: false,
         })
         .await
         .expect_err("dry run should report missing source-build target without building");
@@ -2942,8 +3354,12 @@ mod tests {
     }
 
     fn desktop_release_archive(executable_contents: &[u8]) -> Vec<u8> {
+        desktop_release_archive_for_version(desktop_version(), executable_contents)
+    }
+
+    fn desktop_release_archive_for_version(version: &str, executable_contents: &[u8]) -> Vec<u8> {
         let manifest = DesktopBundleManifest {
-            version: desktop_version().to_string(),
+            version: version.to_string(),
             platform: current_platform().to_string(),
             arch: current_arch().to_string(),
             executable: PathBuf::from("OpenSymphony"),
@@ -2969,10 +3385,14 @@ mod tests {
     }
 
     fn release_index_body(base_url: &str, archive_sha: &str) -> String {
+        release_index_body_for_version(base_url, desktop_version(), archive_sha)
+    }
+
+    fn release_index_body_for_version(base_url: &str, version: &str, archive_sha: &str) -> String {
         serde_json::json!({
             "schema_version": 1,
             "assets": [{
-                "version": desktop_version(),
+                "version": version,
                 "platform": current_platform(),
                 "arch": current_arch(),
                 "url": format!("{base_url}/bundle.tar.gz"),
@@ -2987,6 +3407,23 @@ mod tests {
             }]
         })
         .to_string()
+    }
+
+    fn desktop_release_asset(version: &str, url: &str, checksum: &str) -> DesktopReleaseAsset {
+        DesktopReleaseAsset {
+            version: version.to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            url: url.to_string(),
+            checksum: DesktopReleaseChecksum {
+                algorithm: "sha256".to_string(),
+                value: checksum.to_string(),
+            },
+            launch_target: DesktopLaunchTarget {
+                executable: PathBuf::from("OpenSymphony"),
+                args: Vec::new(),
+            },
+        }
     }
 
     fn sha256_bytes(bytes: &[u8]) -> String {

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -638,8 +638,7 @@ fn selected_release_index_url(override_url: Option<String>) -> String {
 
 fn default_release_index_url() -> String {
     format!(
-        "https://github.com/kumanday/OpenSymphony/releases/download/v{}/{}",
-        desktop_version(),
+        "https://github.com/kumanday/OpenSymphony/releases/latest/download/{}",
         RELEASE_INDEX_FILE
     )
 }
@@ -2175,6 +2174,14 @@ mod tests {
             release_url_display_url("https://user:secret@example.com/index.json?token=secret#frag");
 
         assert_eq!(display, "https://example.com/index.json");
+    }
+
+    #[test]
+    fn default_release_index_uses_stable_latest_url() {
+        assert_eq!(
+            default_release_index_url(),
+            "https://github.com/kumanday/OpenSymphony/releases/latest/download/opensymphony-desktop-release-index.json"
+        );
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -363,20 +363,21 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
         return Ok(verified.executable);
     }
 
-    let release_index_url = selected_release_index_url(args.release_index_url);
+    let (install_release_index_url, update_release_index_url) =
+        selected_release_index_urls(args.release_index_url);
 
     let verified = ensure_verified_bundle(
         &cache_root,
         &cache_dir,
         bundle_dir,
-        release_index_url.as_str(),
+        install_release_index_url.as_str(),
         true,
     )
     .await?;
     let verified = maybe_update_verified_bundle(
         &cache_root,
         verified,
-        release_index_url.as_str(),
+        update_release_index_url.as_str(),
         skip_update,
     )
     .await;
@@ -698,11 +699,25 @@ fn parse_release_index(contents: &str) -> Result<DesktopReleaseIndex, serde_json
     serde_json::from_str(contents)
 }
 
-fn selected_release_index_url(override_url: Option<String>) -> String {
-    override_url.unwrap_or_else(default_release_index_url)
+fn selected_release_index_urls(override_url: Option<String>) -> (String, String) {
+    match override_url {
+        Some(url) => (url.clone(), url),
+        None => (
+            default_install_release_index_url(),
+            default_update_release_index_url(),
+        ),
+    }
 }
 
-fn default_release_index_url() -> String {
+fn default_install_release_index_url() -> String {
+    format!(
+        "https://github.com/kumanday/OpenSymphony/releases/download/v{}/{}",
+        desktop_version(),
+        RELEASE_INDEX_FILE
+    )
+}
+
+fn default_update_release_index_url() -> String {
     format!(
         "https://github.com/kumanday/OpenSymphony/releases/latest/download/{}",
         RELEASE_INDEX_FILE
@@ -2243,10 +2258,25 @@ mod tests {
     }
 
     #[test]
-    fn default_release_index_uses_stable_latest_url() {
+    fn default_release_index_urls_keep_installs_versioned_and_updates_latest() {
         assert_eq!(
-            default_release_index_url(),
+            default_install_release_index_url(),
+            "https://github.com/kumanday/OpenSymphony/releases/download/v2.7.0/opensymphony-desktop-release-index.json"
+        );
+        assert_eq!(
+            default_update_release_index_url(),
             "https://github.com/kumanday/OpenSymphony/releases/latest/download/opensymphony-desktop-release-index.json"
+        );
+    }
+
+    #[test]
+    fn release_index_override_applies_to_install_and_update() {
+        assert_eq!(
+            selected_release_index_urls(Some("http://example.com/index.json".to_string())),
+            (
+                "http://example.com/index.json".to_string(),
+                "http://example.com/index.json".to_string()
+            )
         );
     }
 

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -353,7 +353,8 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
     validate_cache_dir(&cache_root, &cache_dir)?;
     let bundle_dir = args.bundle_dir.as_deref();
     let no_update = args.no_update;
-    let skip_update = no_update || bundle_dir.is_some();
+    let cached_before_launch = bundle_dir.is_none()
+        && latest_current_or_newer_verified_cached_bundle(&cache_root).is_some();
     if args.dry_run {
         let verified = dry_run_verified_bundle(&cache_root, &cache_dir, bundle_dir)?;
         println!(
@@ -378,7 +379,7 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
         &cache_root,
         verified,
         update_release_index_url.as_str(),
-        skip_update,
+        !should_check_for_desktop_update(no_update, bundle_dir, cached_before_launch),
     )
     .await;
     Command::new(&verified.executable)
@@ -397,7 +398,7 @@ fn dry_run_verified_bundle(
     bundle_dir: Option<&Path>,
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
     if bundle_dir.is_none()
-        && let Some(bundle) = latest_verified_cached_bundle(cache_root)
+        && let Some(bundle) = latest_current_or_newer_verified_cached_bundle(cache_root)
     {
         return Ok(bundle);
     }
@@ -457,12 +458,12 @@ async fn maybe_update_verified_bundle(
     let Some(asset) = candidate else {
         return verified;
     };
-    let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+    let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
     if interactive {
         let stdin = io::stdin();
-        let stdout = io::stdout();
+        let stderr = io::stderr();
         let mut reader = stdin.lock();
-        let mut writer = stdout.lock();
+        let mut writer = stderr.lock();
         match prompt_update_decision(
             &mut reader,
             &mut writer,
@@ -496,7 +497,8 @@ async fn ensure_verified_bundle_with<R: DesktopCommandRunner>(
     runner: &mut R,
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
     let cached = if bundle_dir.is_none() {
-        latest_verified_cached_bundle(cache_root).or_else(|| verify_bundle(cache_dir).ok())
+        latest_current_or_newer_verified_cached_bundle(cache_root)
+            .or_else(|| verify_bundle(cache_dir).ok())
     } else {
         verify_bundle(cache_dir).ok()
     };
@@ -531,6 +533,14 @@ async fn ensure_verified_bundle_with<R: DesktopCommandRunner>(
             Err(error) => Err(error),
         }
     }
+}
+
+fn should_check_for_desktop_update(
+    no_update: bool,
+    bundle_dir: Option<&Path>,
+    cached_before_launch: bool,
+) -> bool {
+    !no_update && bundle_dir.is_none() && cached_before_launch
 }
 
 fn release_error_allows_source_fallback(error: &DesktopLauncherError) -> bool {
@@ -613,7 +623,17 @@ where
     }
 }
 
-fn latest_verified_cached_bundle(cache_root: &Path) -> Option<VerifiedBundle> {
+fn latest_current_or_newer_verified_cached_bundle(cache_root: &Path) -> Option<VerifiedBundle> {
+    latest_verified_cached_bundle_with_minimum(
+        cache_root,
+        SemanticVersion::parse(desktop_version()),
+    )
+}
+
+fn latest_verified_cached_bundle_with_minimum(
+    cache_root: &Path,
+    minimum_version: Option<SemanticVersion>,
+) -> Option<VerifiedBundle> {
     fs::read_dir(cache_root)
         .ok()?
         .filter_map(|entry| {
@@ -623,6 +643,12 @@ fn latest_verified_cached_bundle(cache_root: &Path) -> Option<VerifiedBundle> {
             let manifest = read_manifest(&cache_dir.join(MANIFEST_FILE)).ok()?;
             validate_cache_dir_for_version(cache_root, &cache_dir, &manifest.version).ok()?;
             let version = SemanticVersion::parse(&manifest.version)?;
+            if minimum_version
+                .as_ref()
+                .is_some_and(|minimum_version| &version < minimum_version)
+            {
+                return None;
+            }
             let verified = verify_bundle_for_version(&cache_dir, Some(&manifest.version)).ok()?;
             Some((version, verified))
         })
@@ -2590,6 +2616,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn older_cached_bundle_does_not_satisfy_current_cache_miss() {
+        let archive = desktop_release_archive(b"current desktop");
+        let archive_sha = sha256_bytes(&archive);
+        let server = FakeReleaseServer::start(|base_url| {
+            vec![
+                (
+                    "/index.json",
+                    release_index_body(base_url, archive_sha.as_str()).into_bytes(),
+                ),
+                ("/bundle.tar.gz", archive),
+            ]
+        });
+        let install_root = TempDir::new().expect("install root");
+        let cache_dir = install_root.path().join(desktop_version());
+        write_installed_bundle_for_version(
+            &install_root.path().join("2.6.0"),
+            "2.6.0",
+            b"old desktop",
+        );
+
+        let verified = ensure_verified_bundle(
+            install_root.path(),
+            &cache_dir,
+            None,
+            &server.url("/index.json"),
+            false,
+        )
+        .await
+        .expect("current bundle should install instead of launching stale cache");
+
+        assert_eq!(verified.manifest.version, desktop_version());
+        assert_eq!(verified.bundle_dir, cache_dir);
+        assert_eq!(
+            server.requests(),
+            vec!["/index.json".to_string(), "/bundle.tar.gz".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn current_cached_bundle_checks_index_without_asset_download() {
         let archive = desktop_release_archive(b"fake desktop");
         let archive_sha = sha256_bytes(&archive);
@@ -2638,6 +2703,42 @@ mod tests {
 
         assert_eq!(verified.manifest.version, "2.7.1");
         assert_eq!(verified.bundle_dir, install_root.path().join("2.7.1"));
+    }
+
+    #[test]
+    fn dry_run_ignores_older_cached_bundle_when_current_missing() {
+        let install_root = TempDir::new().expect("install root");
+        write_installed_bundle_for_version(
+            &install_root.path().join("2.6.0"),
+            "2.6.0",
+            b"old desktop",
+        );
+
+        let error = dry_run_verified_bundle(
+            install_root.path(),
+            &install_root.path().join(desktop_version()),
+            None,
+        )
+        .expect_err("older cache should not satisfy current dry-run launch");
+
+        assert!(matches!(
+            error,
+            DesktopLauncherError::DryRunSourceBuildRequired { .. }
+        ));
+    }
+
+    #[test]
+    fn update_policy_only_checks_after_existing_cached_launch() {
+        let override_bundle = Path::new("/tmp/desktop-bundle");
+
+        assert!(should_check_for_desktop_update(false, None, true));
+        assert!(!should_check_for_desktop_update(true, None, true));
+        assert!(!should_check_for_desktop_update(
+            false,
+            Some(override_bundle),
+            true
+        ));
+        assert!(!should_check_for_desktop_update(false, None, false));
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -117,17 +117,28 @@ struct VerifiedBundle {
     manifest: DesktopBundleManifest,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct SemanticVersion {
     major: u64,
     minor: u64,
     patch: u64,
+    pre_release: Option<Vec<PreReleaseIdentifier>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PreReleaseIdentifier {
+    Numeric(u64),
+    Text(String),
 }
 
 impl SemanticVersion {
     fn parse(value: &str) -> Option<Self> {
-        let core = value.split_once('+').map_or(value, |(core, _)| core);
-        let core = core.split_once('-').map_or(core, |(core, _)| core);
+        let without_build = value.split_once('+').map_or(value, |(core, _)| core);
+        let (core, pre_release) = without_build
+            .split_once('-')
+            .map_or((without_build, None), |(core, pre_release)| {
+                (core, Some(pre_release))
+            });
         let mut parts = core.split('.');
         let major = parse_version_part(parts.next()?)?;
         let minor = parse_version_part(parts.next()?)?;
@@ -135,17 +146,25 @@ impl SemanticVersion {
         if parts.next().is_some() {
             return None;
         }
+        let pre_release = match pre_release {
+            Some(value) => Some(parse_pre_release(value)?),
+            None => None,
+        }
+        .filter(|identifiers| !identifiers.is_empty());
         Some(Self {
             major,
             minor,
             patch,
+            pre_release,
         })
     }
 }
 
 impl Ord for SemanticVersion {
     fn cmp(&self, other: &Self) -> Ordering {
-        (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch))
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            .then_with(|| compare_pre_release(&self.pre_release, &other.pre_release))
     }
 }
 
@@ -160,6 +179,53 @@ fn parse_version_part(part: &str) -> Option<u64> {
         return None;
     }
     part.parse().ok()
+}
+
+fn parse_pre_release(value: &str) -> Option<Vec<PreReleaseIdentifier>> {
+    value
+        .split('.')
+        .map(|identifier| {
+            if identifier.is_empty() {
+                return None;
+            }
+            if identifier.bytes().all(|byte| byte.is_ascii_digit()) {
+                Some(PreReleaseIdentifier::Numeric(identifier.parse().ok()?))
+            } else {
+                Some(PreReleaseIdentifier::Text(identifier.to_string()))
+            }
+        })
+        .collect()
+}
+
+fn compare_pre_release(
+    left: &Option<Vec<PreReleaseIdentifier>>,
+    right: &Option<Vec<PreReleaseIdentifier>>,
+) -> Ordering {
+    match (left, right) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(left), Some(right)) => left
+            .iter()
+            .zip(right.iter())
+            .map(|(left, right)| compare_pre_release_identifier(left, right))
+            .find(|ordering| *ordering != Ordering::Equal)
+            .unwrap_or_else(|| left.len().cmp(&right.len())),
+    }
+}
+
+fn compare_pre_release_identifier(
+    left: &PreReleaseIdentifier,
+    right: &PreReleaseIdentifier,
+) -> Ordering {
+    match (left, right) {
+        (PreReleaseIdentifier::Numeric(left), PreReleaseIdentifier::Numeric(right)) => {
+            left.cmp(right)
+        }
+        (PreReleaseIdentifier::Numeric(_), PreReleaseIdentifier::Text(_)) => Ordering::Less,
+        (PreReleaseIdentifier::Text(_), PreReleaseIdentifier::Numeric(_)) => Ordering::Greater,
+        (PreReleaseIdentifier::Text(left), PreReleaseIdentifier::Text(right)) => left.cmp(right),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,7 +355,7 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
     let no_update = args.no_update;
     let skip_update = no_update || bundle_dir.is_some();
     if args.dry_run {
-        let verified = dry_run_verified_bundle(&cache_dir, bundle_dir)?;
+        let verified = dry_run_verified_bundle(&cache_root, &cache_dir, bundle_dir)?;
         println!(
             "Dry run: would launch OpenSymphony desktop at {}",
             verified.executable.display()
@@ -325,9 +391,15 @@ async fn run_app(args: AppArgs) -> Result<PathBuf, DesktopLauncherError> {
 }
 
 fn dry_run_verified_bundle(
+    cache_root: &Path,
     cache_dir: &Path,
     bundle_dir: Option<&Path>,
 ) -> Result<VerifiedBundle, DesktopLauncherError> {
+    if bundle_dir.is_none()
+        && let Some(bundle) = latest_verified_cached_bundle(cache_root)
+    {
+        return Ok(bundle);
+    }
     if let Ok(bundle) = verify_bundle(cache_dir) {
         return Ok(bundle);
     }
@@ -476,7 +548,7 @@ async fn latest_update_candidate(
     installed_version: &str,
 ) -> Result<Option<DesktopReleaseAsset>, DesktopLauncherError> {
     let index = download_release_index_task(release_index_url).await?;
-    Ok(newest_compatible_release_asset(&index, release_index_url, installed_version)?.cloned())
+    Ok(newest_compatible_release_asset(&index, installed_version).cloned())
 }
 
 async fn download_release_index_task(
@@ -490,24 +562,18 @@ async fn download_release_index_task(
 
 fn newest_compatible_release_asset<'a>(
     index: &'a DesktopReleaseIndex,
-    _release_index_url: &str,
     installed_version: &str,
-) -> Result<Option<&'a DesktopReleaseAsset>, DesktopLauncherError> {
-    let Some(installed_version) = SemanticVersion::parse(installed_version) else {
-        return Ok(None);
-    };
-    let asset = index
+) -> Option<&'a DesktopReleaseAsset> {
+    let installed_version = SemanticVersion::parse(installed_version)?;
+    index
         .assets
         .iter()
         .filter(|asset| asset.platform == current_platform() && asset.arch == current_arch())
+        .filter(|asset| validate_release_asset(asset).is_ok())
         .filter_map(|asset| Some((SemanticVersion::parse(&asset.version)?, asset)))
         .filter(|(version, _)| *version > installed_version)
-        .max_by_key(|(version, _)| *version)
-        .map(|(_, asset)| asset);
-    if let Some(asset) = asset {
-        validate_release_asset(asset)?;
-    }
-    Ok(asset)
+        .max_by(|(left, _), (right, _)| left.cmp(right))
+        .map(|(_, asset)| asset)
 }
 
 fn prompt_update_decision<R, W>(
@@ -559,7 +625,7 @@ fn latest_verified_cached_bundle(cache_root: &Path) -> Option<VerifiedBundle> {
             let verified = verify_bundle_for_version(&cache_dir, Some(&manifest.version)).ok()?;
             Some((version, verified))
         })
-        .max_by_key(|(version, _)| *version)
+        .max_by(|(left, _), (right, _)| left.cmp(right))
         .map(|(_, verified)| verified)
 }
 
@@ -2211,11 +2277,45 @@ mod tests {
         };
 
         let asset =
-            newest_compatible_release_asset(&index, "http://example.com/index.json", "2.8.0")
-                .expect("candidate lookup should succeed")
-                .expect("newer asset should exist");
+            newest_compatible_release_asset(&index, "2.8.0").expect("newer asset should exist");
 
         assert_eq!(asset.version, "2.10.0");
+    }
+
+    #[test]
+    fn semver_selection_treats_stable_as_newer_than_prerelease() {
+        let index = DesktopReleaseIndex {
+            schema_version: 1,
+            assets: vec![desktop_release_asset(
+                "2.8.0",
+                "http://example.com/2.8.0.tar.gz",
+                "0",
+            )],
+        };
+
+        let asset = newest_compatible_release_asset(&index, "2.8.0-beta.1")
+            .expect("stable release should be newer than prerelease");
+
+        assert_eq!(asset.version, "2.8.0");
+    }
+
+    #[test]
+    fn update_selection_skips_unsupported_highest_asset() {
+        let mut unsupported =
+            desktop_release_asset("2.9.0", "http://example.com/2.9.0.tar.gz", "0");
+        unsupported.launch_target.args = vec!["--future".to_string()];
+        let index = DesktopReleaseIndex {
+            schema_version: 1,
+            assets: vec![
+                desktop_release_asset("2.8.0", "http://example.com/2.8.0.tar.gz", "0"),
+                unsupported,
+            ],
+        };
+
+        let asset = newest_compatible_release_asset(&index, "2.7.0")
+            .expect("compatible update should exist");
+
+        assert_eq!(asset.version, "2.8.0");
     }
 
     #[test]
@@ -2484,6 +2584,30 @@ mod tests {
 
         assert_eq!(launched.manifest.version, desktop_version());
         assert_eq!(server.requests(), vec!["/index.json".to_string()]);
+    }
+
+    #[test]
+    fn dry_run_uses_latest_verified_cached_bundle() {
+        let install_root = TempDir::new().expect("install root");
+        write_installed_bundle(
+            &install_root.path().join(desktop_version()),
+            b"current desktop",
+        );
+        write_installed_bundle_for_version(
+            &install_root.path().join("2.7.1"),
+            "2.7.1",
+            b"updated desktop",
+        );
+
+        let verified = dry_run_verified_bundle(
+            install_root.path(),
+            &install_root.path().join(desktop_version()),
+            None,
+        )
+        .expect("dry-run should use latest cached bundle");
+
+        assert_eq!(verified.manifest.version, "2.7.1");
+        assert_eq!(verified.bundle_dir, install_root.path().join("2.7.1"));
     }
 
     #[tokio::test]
@@ -3343,11 +3467,19 @@ mod tests {
     }
 
     fn write_installed_bundle(cache_dir: &Path, executable_contents: &[u8]) {
+        write_installed_bundle_for_version(cache_dir, desktop_version(), executable_contents);
+    }
+
+    fn write_installed_bundle_for_version(
+        cache_dir: &Path,
+        version: &str,
+        executable_contents: &[u8],
+    ) {
         fs::create_dir_all(cache_dir).expect("create cache dir");
         let executable = cache_dir.join("OpenSymphony");
         fs::write(&executable, executable_contents).expect("write fake executable");
         let manifest = DesktopBundleManifest {
-            version: desktop_version().to_string(),
+            version: version.to_string(),
             platform: current_platform().to_string(),
             arch: current_arch().to_string(),
             executable: PathBuf::from("OpenSymphony"),

--- a/crates/opensymphony-cli/tests/help.rs
+++ b/crates/opensymphony-cli/tests/help.rs
@@ -235,6 +235,7 @@ fn app_help_explains_install_path() {
         "--install-path <DIR>",
         "Install root for versioned desktop bundles",
         "--bundle-dir <BUNDLE_DIR>",
+        "--no-update",
         "--dry-run",
     ] {
         assert!(

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -74,6 +74,8 @@ with `--bundle-dir <path>` or `OPENSYMPHONY_DESKTOP_BUNDLE_DIR`. If no bundle
 verifies, the launcher can build the matching source archive after checking
 Rust/Cargo, Node/npm, and platform desktop/Tauri prerequisites. `--dry-run`
 stays read-only and reports when source build fallback would be required. For
+an installed cache, launch checks for newer compatible release metadata first;
+pass `--no-update` to skip that check during local smoke work. For
 active desktop development, run the Tauri app from this checkout.
 
 On Windows, the source fallback does not require `cl.exe` to be present on

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -44,10 +44,12 @@ materialize an early local bundle from `--bundle-dir <path>` or
 `OPENSYMPHONY_DESKTOP_BUNDLE_DIR` without adding Tauri or npm dependencies to
 the normal Cargo install path. `--install-path <dir>` selects a custom install
 root with versioned bundles beneath it. When no verified bundle is cached, the
-launcher downloads the schema version 1 release index from the latest GitHub
-release, verifies the compatible archive, promotes it into the versioned cache,
-and launches from there. Set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to use a
-private mirror or fake release server.
+launcher downloads the schema version 1 release index from the versioned GitHub
+release for the running CLI, verifies the compatible archive, promotes it into
+the versioned cache, and launches from there. Existing cached bundles check the
+latest GitHub release index for newer compatible updates before launch. Set
+`OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to use a private mirror or fake release
+server.
 
 For development from a clone, rebuild the desktop frontend when `apps/desktop`
 or shared frontend packages change:

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -44,7 +44,7 @@ materialize an early local bundle from `--bundle-dir <path>` or
 `OPENSYMPHONY_DESKTOP_BUNDLE_DIR` without adding Tauri or npm dependencies to
 the normal Cargo install path. `--install-path <dir>` selects a custom install
 root with versioned bundles beneath it. When no verified bundle is cached, the
-launcher downloads the schema version 1 release index from the matching GitHub
+launcher downloads the schema version 1 release index from the latest GitHub
 release, verifies the compatible archive, promotes it into the versioned cache,
 and launches from there. Set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to use a
 private mirror or fake release server.

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -73,8 +73,11 @@ binary. The archive contains:
 The release index is the metadata asset consumed by the CLI download path. It
 uses schema version `1`, lists compatible assets by version/platform/arch, and
 records the archive URL, archive SHA-256, and launch target. By default,
-`opensymphony app` reads it from the latest GitHub release; set
-`OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` for a mirror or fake release server.
+cache-miss installs read the versioned GitHub release for the running CLI
+version, while update checks read the latest GitHub release index so existing
+desktop installs can discover newer compatible bundles. Set
+`OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` for a mirror or fake release server;
+the override applies to both install and update checks.
 When an existing release index is present in the output directory, the package
 command preserves other assets and unknown top-level metadata, then replaces
 only the matching version/platform/arch entry. Upload the archive asset first,
@@ -89,8 +92,8 @@ The release index selects assets by OpenSymphony version, platform,
 architecture, URL, SHA-256 checksum metadata, and launch target. The install
 root defaults to `~/.opensymphony/desktop`, while `--install-path <dir>` and
 `OPENSYMPHONY_DESKTOP_INSTALL_PATH` choose a custom root with versioned bundles
-beneath it. Update prompts default to yes only for interactive TTY execution;
-non-TTY runs do not prompt and must not infer consent.
+beneath it. Interactive update prompts default to yes; non-TTY runs do not
+prompt and update by default unless `--no-update` is supplied.
 
 Do not make downloaded prebuilt DuckDB the default `cargo install` path until a
 managed installer or equivalent runtime-library strategy owns native library

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -73,7 +73,7 @@ binary. The archive contains:
 The release index is the metadata asset consumed by the CLI download path. It
 uses schema version `1`, lists compatible assets by version/platform/arch, and
 records the archive URL, archive SHA-256, and launch target. By default,
-`opensymphony app` reads it from the matching GitHub release; set
+`opensymphony app` reads it from the latest GitHub release; set
 `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` for a mirror or fake release server.
 When an existing release index is present in the output directory, the package
 command preserves other assets and unknown top-level metadata, then replaces

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,7 +39,7 @@ The desktop launcher is intentionally lazy. `opensymphony app` and its visible
 alias `opensymphony desktop` verify and launch a cached desktop bundle from
 `~/.opensymphony/desktop/<version>/` without making the normal Cargo install
 compile Tauri, npm, or platform desktop dependencies. On a cache miss, it reads
-`opensymphony-desktop-release-index.json` from the matching GitHub release,
+`opensymphony-desktop-release-index.json` from the latest GitHub release,
 downloads the compatible archive, verifies the archive and installed manifest,
 then promotes the bundle into the versioned cache. Set
 `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to test a fake release server or use a

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,11 +39,13 @@ The desktop launcher is intentionally lazy. `opensymphony app` and its visible
 alias `opensymphony desktop` verify and launch a cached desktop bundle from
 `~/.opensymphony/desktop/<version>/` without making the normal Cargo install
 compile Tauri, npm, or platform desktop dependencies. On a cache miss, it reads
-`opensymphony-desktop-release-index.json` from the latest GitHub release,
-downloads the compatible archive, verifies the archive and installed manifest,
-then promotes the bundle into the versioned cache. Set
-`OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to test a fake release server or use a
-private mirror. For early local testing, pass `--bundle-dir <path>` or set
+`opensymphony-desktop-release-index.json` from the versioned GitHub release for
+the running CLI, downloads the compatible archive, verifies the archive and
+installed manifest, then promotes the bundle into the versioned cache. Existing
+cached bundles check the latest release index for newer compatible updates
+before launch. Set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to test a fake
+release server or use a private mirror. For early local testing, pass
+`--bundle-dir <path>` or set
 `OPENSYMPHONY_DESKTOP_BUNDLE_DIR` to a bundle directory containing
 `opensymphony-desktop-manifest.json`. The manifest records the OpenSymphony
 version, platform, architecture, relative executable path, and executable

--- a/docs/specs/desktop-app-installer-auto-update-spec.md
+++ b/docs/specs/desktop-app-installer-auto-update-spec.md
@@ -103,9 +103,10 @@ When the installed version is older than a matching release-index asset:
   yes when the operator presses Enter.
 - TTY execution accepts an explicit no and launches the cached installed bundle
   when it still verifies.
-- Non-TTY execution does not prompt. It may update only when a future
-  non-interactive flag or config explicitly opts in; otherwise it launches the
-  cached verified bundle or follows the fallback order below.
+- Non-TTY execution does not prompt and updates by default when a newer
+  compatible release is available.
+- `--no-update` skips the update check and launches the cached installed bundle
+  when it still verifies.
 
 The launcher must never treat a failed prompt read as consent.
 

--- a/docs/specs/desktop-app-installer-auto-update-spec.md
+++ b/docs/specs/desktop-app-installer-auto-update-spec.md
@@ -117,9 +117,10 @@ The launcher must never treat a failed prompt read as consent.
 1. Use the cached installed bundle for the requested OpenSymphony version when
    the installed manifest verifies.
 2. Use a matching prebuilt download from the release index when update policy
-   permits it. The default index URL is the latest GitHub release asset named
-   `opensymphony-desktop-release-index.json`; test and mirror flows can set
-   `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL`.
+   permits it. Cache-miss installs default to the versioned GitHub release for
+   the running CLI. Update checks default to the latest GitHub release asset
+   named `opensymphony-desktop-release-index.json`; test and mirror flows can
+   set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` for both paths.
 3. Use source-build fallback when prerequisites pass.
 4. Fail with a clear repair message.
 

--- a/docs/specs/desktop-app-installer-auto-update-spec.md
+++ b/docs/specs/desktop-app-installer-auto-update-spec.md
@@ -117,7 +117,7 @@ The launcher must never treat a failed prompt read as consent.
 1. Use the cached installed bundle for the requested OpenSymphony version when
    the installed manifest verifies.
 2. Use a matching prebuilt download from the release index when update policy
-   permits it. The default index URL is the matching GitHub release asset named
+   permits it. The default index URL is the latest GitHub release asset named
    `opensymphony-desktop-release-index.json`; test and mirror flows can set
    `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL`.
 3. Use source-build fallback when prerequisites pass.


### PR DESCRIPTION
## Summary

Adds the COE-529 desktop app bundle auto-update flow before launch.

## Changes

- Check desktop release metadata before launching an existing verified cached bundle.
- Compare semantic versions for compatible platform/arch assets and install the newest compatible bundle when accepted/defaulted.
- Prompt interactive runs with `Update before launch? [Y/n]`, treat Enter and non-interactive execution as yes, and add `--no-update` as an explicit opt-out.
- Fall back to the previously verified bundle when update checks or installs fail, while reusing the existing staged promotion path.
- Update launcher help and docs for the update policy.

## Evidence

### Test output

```
cargo test-system-duckdb desktop_launcher -- --nocapture
# 59 passed; 0 failed

cargo test-system-duckdb --test help
# 12 passed; 0 failed

cargo fmt --check
# passed

git diff --check
# passed

cargo clippy-system-duckdb
# passed
```

### Verification

Reproduced the previous behavior with `cargo test-system-duckdb existing_verified_bundle_skips_release_download -- --nocapture`, then added coverage for default-yes prompt handling, explicit no, non-interactive default update, current-cache/no asset download, failed update fallback, semver candidate ordering, and successful update promotion.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other:

## Breaking changes

None.

## Related issues

- COE-529: https://linear.app/trilogy-ai-coe/issue/COE-529/desktop-auto-update-flow

## Additional notes

`WORKFLOW.md` in this workspace still names `main`, but this orchestration session explicitly targets `develop`; this PR is opened against `develop`.
