### PR TITLE
docs(installer): document desktop installer validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,13 @@ Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 different install root; the launcher still creates the versioned bundle beneath
 that root. On a cache miss, the launcher downloads the release index from the
 versioned GitHub release matching the running CLI and installs the compatible
-asset; set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to point at a private or
-test index. When a cached bundle is already installed, the launcher checks the
-latest release index before launch, prompts `Update before launch? [Y/n]` in an
-interactive terminal when a newer compatible bundle is available, and updates
-by default in non-interactive runs. Pass `--no-update` to launch the cached
-bundle without checking first.
+asset, so an empty desktop cache produces a real install attempt instead of a
+missing-manifest dead end. Set `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to
+point at a private or test index. When a cached bundle is already installed,
+the launcher checks the latest release index before launch, prompts
+`Update before launch? [Y/n]` in an interactive terminal when a newer
+compatible bundle is available, and updates by default in non-interactive runs.
+Pass `--no-update` to launch the cached bundle without checking first.
 The release-index and update prompt contract is defined in
 [Desktop App Installer And Auto-Update Spec](docs/specs/desktop-app-installer-auto-update-spec.md).
 

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -2498,6 +2498,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fake_release_smoke_covers_install_update_custom_path_and_cache_repair() {
+        let install_root = TempDir::new().expect("custom install root");
+        let cache_dir = install_root.path().join(desktop_version());
+        let first_server = fake_release_server_for_version(desktop_version(), b"first desktop");
+
+        let installed = ensure_verified_bundle(
+            install_root.path(),
+            &cache_dir,
+            None,
+            &first_server.url("/index.json"),
+            false,
+        )
+        .await
+        .expect("empty custom cache should install from fake release");
+
+        assert_eq!(installed.bundle_dir, cache_dir);
+        assert_eq!(
+            fs::read(&installed.executable).expect("read installed executable"),
+            b"first desktop"
+        );
+        assert_eq!(
+            first_server.requests(),
+            vec!["/index.json".to_string(), "/bundle.tar.gz".to_string()]
+        );
+
+        let update_server = fake_release_server_for_version("2.7.1", b"updated desktop");
+        let updated = maybe_update_verified_bundle(
+            install_root.path(),
+            installed,
+            &update_server.url("/index.json"),
+            false,
+        )
+        .await;
+        let update_dir = install_root.path().join("2.7.1");
+
+        assert_eq!(updated.manifest.version, "2.7.1");
+        assert_eq!(updated.bundle_dir, update_dir);
+        assert_eq!(
+            fs::read(&updated.executable).expect("read updated executable"),
+            b"updated desktop"
+        );
+        assert_eq!(
+            update_server.requests(),
+            vec!["/index.json".to_string(), "/bundle.tar.gz".to_string()]
+        );
+
+        let corrupt_root = TempDir::new().expect("corrupt cache root");
+        let corrupt_dir = corrupt_root.path().join(desktop_version());
+        fs::write(&corrupt_dir, b"corrupt cache entry").expect("write corrupt cache file");
+        let repair_server = fake_release_server_for_version(desktop_version(), b"repaired desktop");
+
+        let repaired = ensure_verified_bundle(
+            corrupt_root.path(),
+            &corrupt_dir,
+            None,
+            &repair_server.url("/index.json"),
+            false,
+        )
+        .await
+        .expect("fake release should repair corrupt cache entry");
+
+        assert_eq!(repaired.bundle_dir, corrupt_dir);
+        assert!(corrupt_dir.join(MANIFEST_FILE).is_file());
+        assert_eq!(
+            fs::read(repaired.executable).expect("read repaired executable"),
+            b"repaired desktop"
+        );
+    }
+
+    #[tokio::test]
     async fn remote_promotion_repairs_file_cache_entry() {
         let archive = desktop_release_archive(b"fake desktop");
         let archive_sha = sha256_bytes(&archive);
@@ -3677,6 +3747,24 @@ mod tests {
             }]
         })
         .to_string()
+    }
+
+    fn fake_release_server_for_version(
+        version: &str,
+        executable_contents: &[u8],
+    ) -> FakeReleaseServer {
+        let archive = desktop_release_archive_for_version(version, executable_contents);
+        let archive_sha = sha256_bytes(&archive);
+        FakeReleaseServer::start(|base_url| {
+            vec![
+                (
+                    "/index.json",
+                    release_index_body_for_version(base_url, version, archive_sha.as_str())
+                        .into_bytes(),
+                ),
+                ("/bundle.tar.gz", archive),
+            ]
+        })
     }
 
     fn desktop_release_asset(version: &str, url: &str, checksum: &str) -> DesktopReleaseAsset {

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -458,7 +458,7 @@ async fn maybe_update_verified_bundle(
     let Some(asset) = candidate else {
         return verified;
     };
-    let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+    let interactive = !cfg!(test) && io::stdin().is_terminal() && io::stderr().is_terminal();
     if interactive {
         let stdin = io::stdin();
         let stderr = io::stderr();

--- a/crates/opensymphony-cli/src/desktop_launcher.rs
+++ b/crates/opensymphony-cli/src/desktop_launcher.rs
@@ -2523,7 +2523,8 @@ mod tests {
             vec!["/index.json".to_string(), "/bundle.tar.gz".to_string()]
         );
 
-        let update_server = fake_release_server_for_version("2.7.1", b"updated desktop");
+        let update_version = next_patch_version(desktop_version());
+        let update_server = fake_release_server_for_version(&update_version, b"updated desktop");
         let updated = maybe_update_verified_bundle(
             install_root.path(),
             installed,
@@ -2531,9 +2532,9 @@ mod tests {
             false,
         )
         .await;
-        let update_dir = install_root.path().join("2.7.1");
+        let update_dir = install_root.path().join(&update_version);
 
-        assert_eq!(updated.manifest.version, "2.7.1");
+        assert_eq!(updated.manifest.version, update_version);
         assert_eq!(updated.bundle_dir, update_dir);
         assert_eq!(
             fs::read(&updated.executable).expect("read updated executable"),
@@ -3765,6 +3766,13 @@ mod tests {
                 ("/bundle.tar.gz", archive),
             ]
         })
+    }
+
+    fn next_patch_version(version: &str) -> String {
+        let parts: Vec<_> = version.split('.').collect();
+        assert_eq!(parts.len(), 3, "test version should be major.minor.patch");
+        let patch = parts[2].parse::<u64>().expect("patch version");
+        format!("{}.{}.{}", parts[0], parts[1], patch + 1)
     }
 
     fn desktop_release_asset(version: &str, url: &str, checksum: &str) -> DesktopReleaseAsset {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,13 +70,17 @@ The `opensymphony app` command, with visible alias `opensymphony desktop`, is
 implemented by COE-488 / OSYM-811 as a lazy cached launcher for released/local
 desktop bundles. It verifies the cache under
 `~/.opensymphony/desktop/<version>/`; early local bundles can be materialized
-with `--bundle-dir <path>` or `OPENSYMPHONY_DESKTOP_BUNDLE_DIR`. If no bundle
-verifies, the launcher can build the matching source archive after checking
-Rust/Cargo, Node/npm, and platform desktop/Tauri prerequisites. `--dry-run`
-stays read-only and reports when source build fallback would be required. For
-an installed cache, launch checks for newer compatible release metadata first;
-pass `--no-update` to skip that check during local smoke work. For
-active desktop development, run the Tauri app from this checkout.
+with `--bundle-dir <path>` or `OPENSYMPHONY_DESKTOP_BUNDLE_DIR`. Use
+`--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to replace the
+default install root with another directory that still contains
+`<version>/` bundle children. If no bundle verifies, the launcher can download
+a compatible prebuilt archive from release metadata or build the matching
+source archive after checking Rust/Cargo, Node/npm, and platform desktop/Tauri
+prerequisites. `--dry-run` stays read-only and reports when source build
+fallback would be required. For an installed cache, launch checks for newer
+compatible release metadata first; the update prompt defaults to yes. Pass
+`--no-update` to skip that check during local smoke work. For active desktop
+development, run the Tauri app from this checkout.
 
 On Windows, the source fallback does not require `cl.exe` to be present on
 `PATH`; a normal PowerShell can use installed Microsoft C++ Build Tools through

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -50,6 +50,11 @@ the versioned cache, and launches from there. Existing cached bundles check the
 latest GitHub release index for newer compatible updates before launch. Set
 `OPENSYMPHONY_DESKTOP_RELEASE_INDEX_URL` to use a private mirror or fake release
 server.
+If the release index has no compatible prebuilt asset, or the index/archive
+download is unavailable, the launcher falls back to a matching source build
+after prerequisite checks. Interactive updates prompt with
+`Update before launch? [Y/n]`; Enter means yes, and non-interactive launches
+update by default unless `--no-update` is supplied.
 
 For development from a clone, rebuild the desktop frontend when `apps/desktop`
 or shared frontend packages change:

--- a/docs/installer-and-distribution.md
+++ b/docs/installer-and-distribution.md
@@ -1,7 +1,7 @@
 # Installer and Distribution Strategy
 
-This document defines a future installer and update shape for OpenSymphony. It
-is a planning spec, not the current installation path.
+This document tracks the current Cargo install plus lazy desktop launcher path
+and the future managed installer/update shape.
 
 ## Audience and outcome
 
@@ -39,8 +39,9 @@ installation commands when available, prints exact manual commands otherwise,
 builds into staging, writes the installed manifest, and promotes only after the
 same verification path succeeds. `--dry-run` does not install prerequisites,
 download sources, or build; it only verifies an existing cached/local bundle or
-reports that a normal run would need source build fallback. Signed/downloaded
-desktop bundle distribution is still future installer work.
+reports that a normal run would need source build fallback. A production-signed
+native installer and hosted desktop update channels remain future installer
+work; the current prebuilt path is the release index plus verified tarball.
 
 Maintainers can produce the current early desktop release assets from a source
 checkout with the desktop workspace script:
@@ -85,6 +86,17 @@ then upload or replace `opensymphony-desktop-release-index.json` last. The
 packaging script follows the same rule locally: it stages all output, publishes
 the archive, and only then publishes the index, so a failed packaging run does
 not leave new metadata claiming an unavailable archive.
+
+Release checklist for desktop bundle metadata:
+
+- Confirm package, Tauri crate, and Tauri config versions match the root Cargo
+  version before publishing metadata.
+- Upload the `opensymphony-desktop-v<VERSION>-<PLATFORM>-<ARCH>.tar.gz`
+  archive first.
+- Upload or replace `opensymphony-desktop-release-index.json` last, after the
+  archive URL is reachable.
+- Preserve existing release-index entries for other platforms and architectures
+  unless intentionally replacing them.
 
 The desktop bundle contract is intentionally small and lives in
 [Desktop App Installer And Auto-Update Spec](specs/desktop-app-installer-auto-update-spec.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -52,6 +52,12 @@ version, platform, architecture, relative executable path, and executable
 SHA-256. Local bundle materialization copies regular files and directories;
 symlinked bundle entries should be packaged by the downloaded archive path
 instead of this local smoke path.
+When no compatible prebuilt asset is available or a release download fails, a
+normal run attempts the source-build fallback after checking Rust/Cargo,
+Node/npm, source archive extraction, and platform desktop/Tauri prerequisites.
+Interactive update prompts use `Update before launch? [Y/n]`; pressing Enter
+accepts the update, and non-interactive runs update by default unless
+`--no-update` is supplied.
 
 Maintainers can build the current release bundle assets from a checkout:
 
@@ -74,8 +80,8 @@ would change the desktop dependency graph.
 Use `--install-path <dir>` or `OPENSYMPHONY_DESKTOP_INSTALL_PATH` to choose a
 custom install root. That root contains versioned bundles such as
 `<dir>/<version>/`; it is not the bundle directory itself. `--dry-run` remains
-read-only and never starts source-build prerequisite installation. Download metadata,
-auto-update prompting, fallback order, and path-safety rules are defined in
+read-only and never starts source-build prerequisite installation. Download
+metadata, auto-update prompting, fallback order, and path-safety rules are defined in
 [Desktop App Installer And Auto-Update Spec](specs/desktop-app-installer-auto-update-spec.md).
 
 Important `init` behavior:


### PR DESCRIPTION
## Summary

Finish COE-530 installer docs and validation by documenting the real lazy desktop installer behavior and adding a fake-release smoke test for the complete install/update path.

## Changes

- Added a fake-release desktop launcher smoke test covering first install, update, custom install root, and corrupt cache repair.
- Clarified README, operations, desktop, and development docs for empty-cache installs, `--install-path`, default-yes update prompts, prebuilt downloads, and source-build fallback.
- Updated installer/distribution guidance with the current prebuilt release-index path and desktop bundle metadata release checklist.

## Evidence

### Test output

```
cargo test-system-duckdb fake_release_smoke_covers_install_update_custom_path_and_cache_repair -- --nocapture
result: ok. 1 passed; 0 failed

cargo test-system-duckdb desktop_launcher -- --nocapture
result: ok. 68 passed; 0 failed

cargo fmt --check
result: passed

git diff --check
result: passed
```

### Verification

Verified the fake release path installs from an empty custom root, promotes a newer fake release, and repairs a corrupt versioned cache entry. Documentation now states the default install root, custom install root semantics, update default behavior, prebuilt download path, source-build fallback, and remaining production-signed installer limitation.

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [ ] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [x] Other: Tests

## Breaking changes

None.

## Related issues

COE-530

## Additional notes

Full `cargo test` and clippy were not run; validation used the ticket-required fake-release smoke test, focused `desktop_launcher` tests, formatting, and diff checks.
