### PR TITLE
perf(desktop): fix task/diff click latency and live-refresh selection clobbering

### DIFF
--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2236,7 +2236,9 @@ fn parse_git_numstat_z(output: &str) -> HashMap<String, (u32, u32)> {
         if record.is_empty() {
             continue;
         }
-        let mut columns = record.split('\t');
+        // Three-field split: the path column is the remainder, so file names
+        // containing tabs stay intact.
+        let mut columns = record.splitn(3, '\t');
         let lines_added = parse_numstat_count(columns.next());
         let lines_removed = parse_numstat_count(columns.next());
         match columns.next() {
@@ -4687,16 +4689,19 @@ exit 2
     #[test]
     fn parse_git_numstat_z_handles_regular_rename_and_binary_entries() {
         // Regular entry, rename entry (empty path column + two NUL paths),
-        // and a binary entry reporting `-` counts.
+        // a binary entry reporting `-` counts, and a path containing a tab
+        // (legal in git; only the first two columns are numstat fields).
         let output = "3\t1\tsrc/main.rs\0\
                       5\t2\t\0src/old_name.rs\0src/new_name.rs\0\
-                      -\t-\tassets/logo.png\0";
+                      -\t-\tassets/logo.png\0\
+                      4\t0\tweird\tname.txt\0";
         let counts = parse_git_numstat_z(output);
 
         assert_eq!(counts.get("src/main.rs"), Some(&(3, 1)));
         assert_eq!(counts.get("src/new_name.rs"), Some(&(5, 2)));
         assert_eq!(counts.get("assets/logo.png"), Some(&(0, 0)));
-        assert_eq!(counts.len(), 3);
+        assert_eq!(counts.get("weird\tname.txt"), Some(&(4, 0)));
+        assert_eq!(counts.len(), 4);
     }
 
     #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -116,6 +116,8 @@ const GATEWAY_WS_INIT_TIMEOUT: Duration = Duration::from_secs(10);
 const CODEX_READINESS_CACHE_TTL: Duration = Duration::from_secs(30);
 const CODEX_READINESS_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const CODEX_CLI_COMMAND: &str = "codex";
+const PR_URL_CACHE_TTL: Duration = Duration::from_secs(60);
+const PR_URL_COMMAND: &str = "gh";
 
 #[async_trait]
 pub trait LinearTaskGraphClient: Send + Sync + 'static {
@@ -266,6 +268,8 @@ pub struct GatewayState {
     pub linear_task_graph: Option<Arc<dyn LinearTaskGraphClient>>,
     pub memory_config: Option<MemoryConfig>,
     pub codex_readiness_cache: Arc<CodexReadinessCache>,
+    pub workspace_scans: WorkspaceScans,
+    pub pr_urls: PrUrls,
 }
 
 impl Clone for GatewayState {
@@ -281,7 +285,146 @@ impl Clone for GatewayState {
             linear_task_graph: self.linear_task_graph.clone(),
             memory_config: self.memory_config.clone(),
             codex_readiness_cache: self.codex_readiness_cache.clone(),
+            workspace_scans: self.workspace_scans.clone(),
+            pr_urls: self.pr_urls.clone(),
         }
+    }
+}
+
+/// Coalesces concurrent workspace git scans so simultaneous
+/// `run_files`/`run_diffs`/`run_validation` requests for the same workspace
+/// share a single subprocess sweep instead of each spawning their own.
+///
+/// This is deliberately a coalescer rather than a TTL cache: results are
+/// never served after the computation that produced them finishes, so
+/// callers always observe the current working-tree state.
+#[derive(Clone, Default)]
+pub struct WorkspaceScans {
+    state: Arc<tokio::sync::Mutex<HashMap<PathBuf, WorkspaceScanReceiver>>>,
+}
+
+type WorkspaceScanReceiver = tokio::sync::watch::Receiver<Option<WorkspaceScanOutcome>>;
+
+/// Result of one workspace git sweep: the comparison base (when resolvable)
+/// and the changed-file listing derived from it.
+#[derive(Clone)]
+pub(crate) struct WorkspaceScanOutcome {
+    comparison_base: Option<WorkspaceComparisonBase>,
+    files: Result<Arc<Vec<WorkspaceRunFileChange>>, String>,
+}
+
+impl WorkspaceScans {
+    pub(crate) async fn scan(&self, workspace_path: PathBuf) -> WorkspaceScanOutcome {
+        let mut receiver = {
+            let mut state = self.state.lock().await;
+            if let Some(receiver) = state.get(&workspace_path) {
+                receiver.clone()
+            } else {
+                let (sender, receiver) = tokio::sync::watch::channel(None);
+                state.insert(workspace_path.clone(), receiver.clone());
+                let entries = self.state.clone();
+                let path = workspace_path.clone();
+                tokio::spawn(async move {
+                    let scan_path = path.clone();
+                    let outcome =
+                        tokio::task::spawn_blocking(move || compute_workspace_scan(&scan_path))
+                            .await
+                            .unwrap_or_else(|error| WorkspaceScanOutcome {
+                                comparison_base: None,
+                                files: Err(format!("workspace scan task failed: {error}")),
+                            });
+                    let _ = sender.send(Some(outcome));
+                    entries.lock().await.remove(&path);
+                });
+                receiver
+            }
+        };
+
+        if let Some(outcome) = receiver.borrow().clone() {
+            return outcome;
+        }
+        if receiver.changed().await.is_ok()
+            && let Some(outcome) = receiver.borrow().clone()
+        {
+            return outcome;
+        }
+        WorkspaceScanOutcome {
+            comparison_base: None,
+            files: Err("workspace scan ended before reporting a result".to_owned()),
+        }
+    }
+}
+
+fn compute_workspace_scan(workspace_path: &StdPath) -> WorkspaceScanOutcome {
+    match workspace_comparison_base(workspace_path) {
+        Ok(base) => {
+            let files =
+                build_workspace_run_file_changes_with_base(workspace_path, &base).map(Arc::new);
+            WorkspaceScanOutcome {
+                comparison_base: Some(base),
+                files,
+            }
+        }
+        Err(error) => WorkspaceScanOutcome {
+            comparison_base: None,
+            files: Err(error),
+        },
+    }
+}
+
+/// Cache of `gh pr view` lookups keyed by workspace path.
+///
+/// Resolving a PR URL shells out to `gh`, which performs a network round
+/// trip to the forge. That must never sit on the `run_detail` hot path (the
+/// dashboard polls run detail for every task-graph node), so lookups are
+/// resolved in the background: a request that misses the cache returns
+/// `None` immediately and a later poll picks up the resolved URL.
+#[derive(Clone, Default)]
+pub struct PrUrls {
+    state: Arc<Mutex<HashMap<PathBuf, PrUrlCacheEntry>>>,
+}
+
+struct PrUrlCacheEntry {
+    resolved_at: Option<Instant>,
+    url: Option<String>,
+    in_flight: bool,
+}
+
+impl PrUrls {
+    fn lookup(&self, workspace_path: PathBuf, program: impl Into<String>) -> Option<String> {
+        let program = program.into();
+        let mut state = self.state.lock().expect("pr url cache mutex poisoned");
+        let entry = state
+            .entry(workspace_path.clone())
+            .or_insert(PrUrlCacheEntry {
+                resolved_at: None,
+                url: None,
+                in_flight: false,
+            });
+        let fresh = entry
+            .resolved_at
+            .is_some_and(|resolved_at| resolved_at.elapsed() < PR_URL_CACHE_TTL);
+        if fresh || entry.in_flight {
+            return entry.url.clone();
+        }
+        entry.in_flight = true;
+        let stale_url = entry.url.clone();
+        drop(state);
+
+        let cache = self.state.clone();
+        tokio::task::spawn_blocking(move || {
+            let url = workspace_pr_url_from_command(&workspace_path, &program);
+            let mut state = cache.lock().expect("pr url cache mutex poisoned");
+            state.insert(
+                workspace_path,
+                PrUrlCacheEntry {
+                    resolved_at: Some(Instant::now()),
+                    url,
+                    in_flight: false,
+                },
+            );
+        });
+        stale_url
     }
 }
 
@@ -305,6 +448,18 @@ struct CachedCodexReadiness {
 impl axum::extract::FromRef<GatewayState> for SnapshotStore {
     fn from_ref(state: &GatewayState) -> Self {
         state.store.clone()
+    }
+}
+
+impl axum::extract::FromRef<GatewayState> for WorkspaceScans {
+    fn from_ref(state: &GatewayState) -> Self {
+        state.workspace_scans.clone()
+    }
+}
+
+impl axum::extract::FromRef<GatewayState> for PrUrls {
+    fn from_ref(state: &GatewayState) -> Self {
+        state.pr_urls.clone()
     }
 }
 
@@ -460,6 +615,8 @@ impl GatewayServer {
             linear_task_graph: self.linear_task_graph.clone(),
             memory_config: self.memory_config.clone(),
             codex_readiness_cache: Arc::new(CodexReadinessCache::default()),
+            workspace_scans: WorkspaceScans::default(),
+            pr_urls: PrUrls::default(),
         };
 
         // Abort any previous terminal ingest task associated with this server
@@ -1850,16 +2007,10 @@ fn workspace_path_for_issue(
     candidate.starts_with(&root).then_some(candidate)
 }
 
-fn issue_file_changes(
+fn snapshot_fallback_file_changes(
     envelope: &SnapshotEnvelope,
     issue: &ControlPlaneIssueSnapshot,
 ) -> Vec<WorkspaceRunFileChange> {
-    if let Some(workspace_path) = workspace_path_for_issue(envelope, issue)
-        && let Ok(files) = build_workspace_run_file_changes(&workspace_path)
-    {
-        return files;
-    }
-
     let workspace_root = &envelope.snapshot.daemon.workspace_root;
     issue
         .modified_files
@@ -1880,14 +2031,6 @@ fn issue_file_changes(
         .collect()
 }
 
-fn workspace_pr_url(
-    envelope: &SnapshotEnvelope,
-    issue: &ControlPlaneIssueSnapshot,
-) -> Option<String> {
-    let workspace_path = workspace_path_for_issue(envelope, issue)?;
-    workspace_pr_url_from_command(&workspace_path, "gh")
-}
-
 fn workspace_pr_url_from_command(workspace_path: &StdPath, program: &str) -> Option<String> {
     command_single_line(
         workspace_path,
@@ -1898,20 +2041,59 @@ fn workspace_pr_url_from_command(workspace_path: &StdPath, program: &str) -> Opt
     .filter(|url| !url.is_empty())
 }
 
-async fn issue_file_changes_async(
-    envelope: SnapshotEnvelope,
-    issue: ControlPlaneIssueSnapshot,
-) -> Result<Vec<WorkspaceRunFileChange>, String> {
-    tokio::task::spawn_blocking(move || issue_file_changes(&envelope, &issue))
-        .await
-        .map_err(|error| format!("workspace file change task failed: {error}"))
+/// Changed-file listing for one issue plus the comparison base the scan
+/// resolved, so callers producing diffs can reuse it instead of re-probing.
+struct IssueFileChangeSet {
+    comparison_base: Option<WorkspaceComparisonBase>,
+    files: Arc<Vec<WorkspaceRunFileChange>>,
 }
 
+/// Resolve the changed files for an issue: the git sweep runs on the
+/// blocking pool and concurrent requests for the same workspace share one
+/// sweep. Falls back to the snapshot's `modified_files` when the workspace
+/// cannot be scanned.
+async fn issue_file_changes_coalesced(
+    scans: &WorkspaceScans,
+    envelope: &SnapshotEnvelope,
+    issue: &ControlPlaneIssueSnapshot,
+) -> IssueFileChangeSet {
+    if let Some(workspace_path) = workspace_path_for_issue(envelope, issue) {
+        let outcome = scans.scan(workspace_path).await;
+        match outcome.files {
+            Ok(files) => {
+                return IssueFileChangeSet {
+                    comparison_base: outcome.comparison_base,
+                    files,
+                };
+            }
+            Err(error) => {
+                tracing::debug!(
+                    %error,
+                    run_id = %issue.identifier,
+                    "workspace scan unavailable; falling back to snapshot file changes"
+                );
+            }
+        }
+    }
+    IssueFileChangeSet {
+        comparison_base: None,
+        files: Arc::new(snapshot_fallback_file_changes(envelope, issue)),
+    }
+}
+
+#[cfg(test)]
 fn build_workspace_run_file_changes(
     workspace_path: &StdPath,
 ) -> Result<Vec<WorkspaceRunFileChange>, String> {
     let comparison_base = workspace_comparison_base(workspace_path)?;
-    let mut files = tracked_workspace_file_changes(workspace_path, &comparison_base)?;
+    build_workspace_run_file_changes_with_base(workspace_path, &comparison_base)
+}
+
+fn build_workspace_run_file_changes_with_base(
+    workspace_path: &StdPath,
+    comparison_base: &WorkspaceComparisonBase,
+) -> Result<Vec<WorkspaceRunFileChange>, String> {
+    let mut files = tracked_workspace_file_changes(workspace_path, comparison_base)?;
     files.extend(untracked_workspace_file_changes(workspace_path)?);
     files.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(files)
@@ -1961,6 +2143,22 @@ fn tracked_workspace_file_changes(
             "--".to_owned(),
         ],
     )?;
+    // One batched numstat sweep for the whole tree. Running numstat per file
+    // spawns a git subprocess per changed path, which dominates request
+    // latency once a workspace accumulates more than a handful of edits.
+    let numstat_output = command_output_args(
+        workspace_path,
+        "git",
+        [
+            "diff".to_owned(),
+            "--numstat".to_owned(),
+            "-z".to_owned(),
+            "--find-renames".to_owned(),
+            comparison_base.merge_base.clone(),
+            "--".to_owned(),
+        ],
+    )?;
+    let line_counts = parse_git_numstat_z(&numstat_output);
     let mut fields = output
         .split('\0')
         .filter(|field| !field.is_empty())
@@ -1975,12 +2173,8 @@ fn tracked_workspace_file_changes(
             let query_path = fields
                 .next()
                 .ok_or_else(|| "missing current path for rename entry".to_owned())?;
-            let (lines_added, lines_removed) = git_numstat_for_change(
-                workspace_path,
-                comparison_base,
-                query_path,
-                Some(previous_path),
-            )?;
+            let (lines_added, lines_removed) =
+                line_counts.get(query_path).copied().unwrap_or((0, 0));
             files.push(WorkspaceRunFileChange {
                 path: query_path.to_owned(),
                 query_path: query_path.to_owned(),
@@ -1996,7 +2190,7 @@ fn tracked_workspace_file_changes(
                 .next()
                 .ok_or_else(|| "missing path for git diff entry".to_owned())?;
             let (lines_added, lines_removed) =
-                git_numstat_for_change(workspace_path, comparison_base, query_path, None)?;
+                line_counts.get(query_path).copied().unwrap_or((0, 0));
             files.push(WorkspaceRunFileChange {
                 path: query_path.to_owned(),
                 query_path: query_path.to_owned(),
@@ -2011,6 +2205,43 @@ fn tracked_workspace_file_changes(
     }
 
     Ok(files)
+}
+
+/// Parse `git diff --numstat -z` output into a map from current path to
+/// `(lines_added, lines_removed)`.
+///
+/// Entry formats with `-z`:
+/// - regular: `added\tremoved\tpath NUL`
+/// - rename/copy: `added\tremoved\t NUL source NUL dest NUL` (empty path
+///   field, followed by the two NUL-terminated paths)
+///
+/// Binary files report `-` for both counts and are recorded as `(0, 0)`.
+fn parse_git_numstat_z(output: &str) -> HashMap<String, (u32, u32)> {
+    let mut counts = HashMap::new();
+    let mut fields = output.split('\0').peekable();
+    while let Some(record) = fields.next() {
+        if record.is_empty() {
+            continue;
+        }
+        let mut columns = record.split('\t');
+        let lines_added = parse_numstat_count(columns.next());
+        let lines_removed = parse_numstat_count(columns.next());
+        match columns.next() {
+            Some(path) if !path.is_empty() => {
+                counts.insert(path.to_owned(), (lines_added, lines_removed));
+            }
+            Some(_) => {
+                // Rename/copy: the record's path column is empty and the
+                // source/destination paths follow as separate NUL fields.
+                let _source = fields.next();
+                if let Some(dest) = fields.next().filter(|dest| !dest.is_empty()) {
+                    counts.insert(dest.to_owned(), (lines_added, lines_removed));
+                }
+            }
+            None => {}
+        }
+    }
+    counts
 }
 
 fn untracked_workspace_file_changes(
@@ -2037,35 +2268,6 @@ fn untracked_workspace_file_changes(
     }
 
     Ok(files)
-}
-
-fn git_numstat_for_change(
-    workspace_path: &StdPath,
-    comparison_base: &WorkspaceComparisonBase,
-    query_path: &str,
-    previous_path: Option<&str>,
-) -> Result<(u32, u32), String> {
-    let mut args = vec![
-        "diff".to_owned(),
-        "--numstat".to_owned(),
-        "--find-renames".to_owned(),
-        comparison_base.merge_base.clone(),
-        "--".to_owned(),
-    ];
-    if let Some(previous_path) = previous_path {
-        args.push(previous_path.to_owned());
-    }
-    args.push(query_path.to_owned());
-
-    let output = command_output_args(workspace_path, "git", args)?;
-    let Some(line) = output.lines().find(|line| !line.trim().is_empty()) else {
-        return Ok((0, 0));
-    };
-    let mut fields = line.split('\t');
-    Ok((
-        parse_numstat_count(fields.next()),
-        parse_numstat_count(fields.next()),
-    ))
 }
 
 fn parse_numstat_count(field: Option<&str>) -> u32 {
@@ -2817,6 +3019,7 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
 
 async fn get_run_detail(
     State(store): State<SnapshotStore>,
+    State(pr_urls): State<PrUrls>,
     AxumPath(run_id): AxumPath<String>,
 ) -> impl IntoResponse {
     let envelope = store.current().await;
@@ -2901,10 +3104,13 @@ async fn get_run_detail(
             _ => None,
         }
     };
-    let pr_url = issue
-        .pr_url
-        .clone()
-        .or_else(|| workspace_pr_url(&envelope, issue));
+    // `gh pr view` performs a network round trip, so it never runs inline:
+    // the cache answers immediately (possibly with `None` on first sight of a
+    // workspace) and resolves in the background for the next poll.
+    let pr_url = issue.pr_url.clone().or_else(|| {
+        workspace_path_for_issue(&envelope, issue)
+            .and_then(|workspace_path| pr_urls.lookup(workspace_path, PR_URL_COMMAND))
+    });
 
     (
         StatusCode::OK,
@@ -3056,34 +3262,23 @@ async fn get_run_events(
 
 async fn get_run_files(
     State(store): State<SnapshotStore>,
+    State(scans): State<WorkspaceScans>,
     AxumPath(run_id): AxumPath<String>,
 ) -> impl IntoResponse {
     let envelope = store.current().await;
     let files: Vec<ChangedFileEntry> = match find_issue_snapshot(&envelope, &run_id) {
-        Some(issue) => match issue_file_changes_async(envelope.clone(), issue.clone()).await {
-            Ok(files) => files
-                .iter()
-                .map(|fc| ChangedFileEntry {
-                    path: fc.path.clone(),
-                    change_kind: map_file_change_kind(fc.change_kind),
-                    lines_added: fc.lines_added,
-                    lines_removed: fc.lines_removed,
-                    size_bytes: None,
-                })
-                .collect(),
-            Err(error) => {
-                tracing::warn!(%error, run_id = %issue.identifier, "failed to load run files");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(RunFilesPage {
-                        schema_version: SchemaVersion::v1(),
-                        run_id,
-                        next_cursor: None,
-                        files: Vec::new(),
-                    }),
-                );
-            }
-        },
+        Some(issue) => issue_file_changes_coalesced(&scans, &envelope, issue)
+            .await
+            .files
+            .iter()
+            .map(|fc| ChangedFileEntry {
+                path: fc.path.clone(),
+                change_kind: map_file_change_kind(fc.change_kind),
+                lines_added: fc.lines_added,
+                lines_removed: fc.lines_removed,
+                size_bytes: None,
+            })
+            .collect(),
         None => {
             return (
                 StatusCode::NOT_FOUND,
@@ -3110,6 +3305,7 @@ async fn get_run_files(
 
 async fn get_run_diffs(
     State(store): State<SnapshotStore>,
+    State(scans): State<WorkspaceScans>,
     AxumPath(run_id): AxumPath<String>,
     Query(query): Query<RunDiffQuery>,
 ) -> impl IntoResponse {
@@ -3132,36 +3328,21 @@ async fn get_run_diffs(
         }
     };
     let workspace_path = workspace_path_for_issue(&envelope, issue);
-    let all_files = match issue_file_changes_async(envelope.clone(), issue.clone()).await {
-        Ok(files) => files,
-        Err(error) => {
-            tracing::warn!(%error, run_id = %issue.identifier, "failed to load run diffs");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(FileDiffPage {
-                    schema_version: SchemaVersion::v1(),
-                    run_id,
-                    file_path: String::new(),
-                    next_cursor: None,
-                    hunks: Vec::new(),
-                    total_lines_added: 0,
-                    total_lines_removed: 0,
-                }),
-            );
-        }
-    };
+    let change_set = issue_file_changes_coalesced(&scans, &envelope, issue).await;
     let requested_path = query.file_path.as_deref().map(normalize_query_file_path);
     let files: Vec<WorkspaceRunFileChange> = match &requested_path {
-        Some(path) => all_files
-            .into_iter()
+        Some(path) => change_set
+            .files
+            .iter()
             .filter(|fc| fc.path == *path || fc.query_path == *path)
+            .cloned()
             .collect(),
-        None => all_files,
+        None => change_set.files.as_ref().clone(),
     };
 
-    let comparison_base = workspace_path
-        .as_ref()
-        .and_then(|path| workspace_comparison_base(path).ok());
+    // Reuse the base resolved by the coalesced scan instead of re-probing
+    // git references on every diff request.
+    let comparison_base = change_set.comparison_base;
     let mut hunks: Vec<DiffHunk> = Vec::new();
     for fc in &files {
         if let Some(path) = &workspace_path
@@ -3316,6 +3497,7 @@ fn build_synthetic_hunks(fc: &WorkspaceRunFileChange) -> Vec<DiffHunk> {
 
 async fn get_run_validation(
     State(store): State<SnapshotStore>,
+    State(scans): State<WorkspaceScans>,
     AxumPath(run_id): AxumPath<String>,
 ) -> impl IntoResponse {
     let envelope = store.current().await;
@@ -3336,23 +3518,10 @@ async fn get_run_validation(
         }
     };
 
-    let has_file_changes = match issue_file_changes_async(envelope.clone(), issue.clone()).await {
-        Ok(files) => !files.is_empty(),
-        Err(error) => {
-            tracing::warn!(%error, run_id = %issue.identifier, "failed to load validation files");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(RunValidationSummary {
-                    schema_version: SchemaVersion::v1(),
-                    run_id,
-                    generated_at: Utc::now(),
-                    overall_status: ValidationStatus::Error,
-                    commands: Vec::new(),
-                    evidence: Vec::new(),
-                }),
-            );
-        }
-    };
+    let has_file_changes = !issue_file_changes_coalesced(&scans, &envelope, &issue)
+        .await
+        .files
+        .is_empty();
     let overall_status = validation_status_for_issue(&issue, has_file_changes);
 
     (
@@ -4427,6 +4596,105 @@ exit 2
                 .as_deref(),
             Some("https://github.com/kumanday/OpenSymphony/pull/461")
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pr_url_cache_resolves_in_background_without_blocking_lookup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("COE-461");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let fake_gh = temp.path().join("gh");
+        std::fs::write(
+            &fake_gh,
+            "#!/bin/sh\nprintf '%s\\n' 'https://github.com/kumanday/OpenSymphony/pull/461'\n",
+        )
+        .expect("write fake gh");
+        let mut perms = std::fs::metadata(&fake_gh)
+            .expect("fake gh metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).expect("chmod fake gh");
+        let fake_gh = fake_gh.to_str().expect("utf-8 path").to_owned();
+
+        let cache = PrUrls::default();
+        // First lookup misses: it must return immediately (no URL yet) and
+        // kick off the background resolution.
+        assert_eq!(cache.lookup(workspace.clone(), fake_gh.clone()), None);
+
+        let resolved = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(url) = cache.lookup(workspace.clone(), fake_gh.clone()) {
+                    return url;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("background pr url resolution");
+        assert_eq!(
+            resolved,
+            "https://github.com/kumanday/OpenSymphony/pull/461"
+        );
+    }
+
+    #[test]
+    fn parse_git_numstat_z_handles_regular_rename_and_binary_entries() {
+        // Regular entry, rename entry (empty path column + two NUL paths),
+        // and a binary entry reporting `-` counts.
+        let output = "3\t1\tsrc/main.rs\0\
+                      5\t2\t\0src/old_name.rs\0src/new_name.rs\0\
+                      -\t-\tassets/logo.png\0";
+        let counts = parse_git_numstat_z(output);
+
+        assert_eq!(counts.get("src/main.rs"), Some(&(3, 1)));
+        assert_eq!(counts.get("src/new_name.rs"), Some(&(5, 2)));
+        assert_eq!(counts.get("assets/logo.png"), Some(&(0, 0)));
+        assert_eq!(counts.len(), 3);
+    }
+
+    #[test]
+    fn workspace_run_file_changes_report_batched_counts_for_renames() {
+        let temp = tempfile::tempdir().expect("temp workspace");
+        let workspace = temp.path();
+        std::fs::create_dir_all(workspace.join("src")).expect("create src");
+        let body: String = (0..40).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(workspace.join("src/original.rs"), &body).expect("write original");
+
+        run_git(workspace, &["init"]);
+        run_git(workspace, &["checkout", "-B", "main"]);
+        run_git(workspace, &["add", "src/original.rs"]);
+        run_git(
+            workspace,
+            &[
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "initial",
+                "--no-gpg-sign",
+            ],
+        );
+
+        std::fs::rename(
+            workspace.join("src/original.rs"),
+            workspace.join("src/renamed.rs"),
+        )
+        .expect("rename file");
+        std::fs::write(workspace.join("src/renamed.rs"), format!("{body}tail\n"))
+            .expect("modify renamed file");
+        run_git(workspace, &["add", "-A"]);
+
+        let changes = build_workspace_run_file_changes(workspace).expect("build workspace changes");
+        let renamed = changes
+            .iter()
+            .find(|change| change.path == "src/renamed.rs")
+            .expect("renamed change");
+        assert_eq!(renamed.previous_path.as_deref(), Some("src/original.rs"));
+        assert_eq!(renamed.lines_added, 1);
+        assert_eq!(renamed.lines_removed, 0);
     }
 
     #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -117,6 +117,7 @@ const CODEX_READINESS_CACHE_TTL: Duration = Duration::from_secs(30);
 const CODEX_READINESS_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const CODEX_CLI_COMMAND: &str = "codex";
 const PR_URL_CACHE_TTL: Duration = Duration::from_secs(60);
+const PR_URL_MISS_TTL: Duration = Duration::from_secs(5);
 const PR_URL_COMMAND: &str = "gh";
 
 #[async_trait]
@@ -390,6 +391,21 @@ struct PrUrlCacheEntry {
     in_flight: bool,
 }
 
+/// Misses expire much sooner than hits: a run usually gains its PR shortly
+/// after starting, and caching `None` for the full TTL would keep showing
+/// "Not found" long after the PR exists. A short miss TTL means the next
+/// dashboard poll retries while resolved URLs stay cached for the full TTL.
+fn pr_url_entry_fresh(entry: &PrUrlCacheEntry) -> bool {
+    let ttl = if entry.url.is_some() {
+        PR_URL_CACHE_TTL
+    } else {
+        PR_URL_MISS_TTL
+    };
+    entry
+        .resolved_at
+        .is_some_and(|resolved_at| resolved_at.elapsed() < ttl)
+}
+
 impl PrUrls {
     fn lookup(&self, workspace_path: PathBuf, program: impl Into<String>) -> Option<String> {
         let program = program.into();
@@ -401,10 +417,7 @@ impl PrUrls {
                 url: None,
                 in_flight: false,
             });
-        let fresh = entry
-            .resolved_at
-            .is_some_and(|resolved_at| resolved_at.elapsed() < PR_URL_CACHE_TTL);
-        if fresh || entry.in_flight {
+        if pr_url_entry_fresh(entry) || entry.in_flight {
             return entry.url.clone();
         }
         entry.in_flight = true;
@@ -4638,6 +4651,37 @@ exit 2
             resolved,
             "https://github.com/kumanday/OpenSymphony/pull/461"
         );
+    }
+
+    #[test]
+    fn pr_url_misses_expire_sooner_than_hits() {
+        let hit = PrUrlCacheEntry {
+            resolved_at: Instant::now().checked_sub(Duration::from_secs(30)),
+            url: Some("https://github.com/kumanday/OpenSymphony/pull/461".to_owned()),
+            in_flight: false,
+        };
+        let miss = PrUrlCacheEntry {
+            resolved_at: Instant::now().checked_sub(Duration::from_secs(30)),
+            url: None,
+            in_flight: false,
+        };
+        let recent_miss = PrUrlCacheEntry {
+            resolved_at: Some(Instant::now()),
+            url: None,
+            in_flight: false,
+        };
+        let unresolved = PrUrlCacheEntry {
+            resolved_at: None,
+            url: None,
+            in_flight: false,
+        };
+
+        // A 30s-old hit is still inside the 60s hit TTL; a 30s-old miss is
+        // well past the 5s miss TTL and must be retried.
+        assert!(pr_url_entry_fresh(&hit));
+        assert!(!pr_url_entry_fresh(&miss));
+        assert!(pr_url_entry_fresh(&recent_miss));
+        assert!(!pr_url_entry_fresh(&unresolved));
     }
 
     #[test]

--- a/packages/ui-core/__tests__/dom-morph.test.ts
+++ b/packages/ui-core/__tests__/dom-morph.test.ts
@@ -134,6 +134,32 @@ describe("morphChildren", () => {
     expect(root.children[1].nodeName).toBe("EM");
   });
 
+  it("does not migrate approval row state when an earlier approval disappears", () => {
+    const root = mount(`
+      <div>
+        <div data-approval-id="app-1"><input class="explain" value=""></div>
+        <div data-approval-id="app-2"><input class="explain" value=""></div>
+      </div>
+    `);
+    const secondRow = root.querySelector("[data-approval-id='app-2']")!;
+    const firstInput = root.querySelector<HTMLInputElement>("[data-approval-id='app-1'] input")!;
+    firstInput.focus();
+    firstInput.value = "typed for app-1";
+
+    // The first approval resolves away; app-2 must not inherit app-1's DOM
+    // (or the operator's typed explanation).
+    morphChildren(root, `
+      <div>
+        <div data-approval-id="app-2"><input class="explain" value=""></div>
+      </div>
+    `);
+
+    const remaining = root.querySelector("[data-approval-id='app-2']")!;
+    expect(remaining).toBe(secondRow);
+    expect(remaining.querySelector("input")!.value).toBe("");
+    expect(root.querySelector("[data-approval-id='app-1']")).toBeNull();
+  });
+
   it("replaces nodes whose keys differ instead of reusing them", () => {
     const root = mount(`<div data-node-id="alpha">alpha</div>`);
     const alpha = root.querySelector("div")!;

--- a/packages/ui-core/__tests__/dom-morph.test.ts
+++ b/packages/ui-core/__tests__/dom-morph.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment jsdom
+ *
+ * DOM morphing unit tests: re-renders must mutate only what changed so node
+ * identity (focus, listeners, canvas bitmaps) survives.
+ */
+
+import { morphChildren } from "../src/dom-morph.js";
+
+function mount(html: string): HTMLElement {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  root.innerHTML = html;
+  return root;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("morphChildren", () => {
+  it("updates text and attributes in place without replacing the element", () => {
+    const root = mount(`<p class="a" data-x="1">before</p>`);
+    const paragraph = root.querySelector("p")!;
+
+    morphChildren(root, `<p class="b">after</p>`);
+
+    expect(root.querySelector("p")).toBe(paragraph);
+    expect(paragraph.textContent).toBe("after");
+    expect(paragraph.className).toBe("b");
+    expect(paragraph.hasAttribute("data-x")).toBe(false);
+  });
+
+  it("keeps identity of keyed nodes when the list reorders", () => {
+    const root = mount(`
+      <ul>
+        <li data-key="a">A</li>
+        <li data-key="b">B</li>
+        <li data-key="c">C</li>
+      </ul>
+    `);
+    const itemC = root.querySelector("[data-key='c']")!;
+
+    morphChildren(root, `
+      <ul>
+        <li data-key="c">C2</li>
+        <li data-key="a">A</li>
+      </ul>
+    `);
+
+    const items = Array.from(root.querySelectorAll("li"));
+    expect(items.map((item) => item.dataset.key)).toEqual(["c", "a"]);
+    expect(root.querySelector("[data-key='c']")).toBe(itemC);
+    expect(itemC.textContent).toBe("C2");
+  });
+
+  it("preserves attached event listeners on surviving nodes", () => {
+    const root = mount(`<button data-key="go">Go</button>`);
+    const button = root.querySelector("button")!;
+    let clicks = 0;
+    button.addEventListener("click", () => {
+      clicks += 1;
+    });
+
+    morphChildren(root, `<button data-key="go">Go!</button>`);
+    (root.querySelector("button") as HTMLButtonElement).click();
+
+    expect(clicks).toBe(1);
+  });
+
+  it("keeps the focused input's value and focus across a morph", () => {
+    const root = mount(`<input data-key="search" value="old">`);
+    const input = root.querySelector("input")!;
+    input.focus();
+    input.value = "user typed this";
+
+    morphChildren(root, `<input data-key="search" value="rendered">`);
+
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe("user typed this");
+  });
+
+  it("syncs value on unfocused inputs to the new render", () => {
+    const root = mount(`<input data-key="search" value="old">`);
+    const input = root.querySelector("input")!;
+    input.value = "stale user edit";
+
+    morphChildren(root, `<input data-key="search" value="rendered">`);
+
+    expect(input.value).toBe("rendered");
+  });
+
+  it("syncs textarea content and select values", () => {
+    const root = mount(`
+      <textarea>old text</textarea>
+      <select><option value="a" selected>A</option><option value="b">B</option></select>
+    `);
+    const textarea = root.querySelector("textarea")!;
+    const select = root.querySelector("select")!;
+
+    morphChildren(root, `
+      <textarea>new text</textarea>
+      <select><option value="a">A</option><option value="b" selected>B</option></select>
+    `);
+
+    expect(textarea.value).toBe("new text");
+    expect(textarea.textContent).toBe("new text");
+    expect(select.value).toBe("b");
+  });
+
+  it("preserves canvas identity and imperatively-set attributes", () => {
+    const root = mount(`<div><canvas data-testid="stage"></canvas></div>`);
+    const canvas = root.querySelector("canvas")!;
+    canvas.setAttribute("width", "640");
+    canvas.setAttribute("height", "480");
+    canvas.setAttribute("style", "width: 320px;");
+
+    morphChildren(root, `<div><canvas data-testid="stage" class="lit"></canvas></div>`);
+
+    expect(root.querySelector("canvas")).toBe(canvas);
+    expect(canvas.getAttribute("width")).toBe("640");
+    expect(canvas.getAttribute("height")).toBe("480");
+    expect(canvas.getAttribute("style")).toBe("width: 320px;");
+    expect(canvas.className).toBe("lit");
+  });
+
+  it("adds and removes nodes to match the new markup", () => {
+    const root = mount(`<span>one</span><span>two</span><span>three</span>`);
+
+    morphChildren(root, `<span>one</span><em>replacement</em>`);
+
+    expect(root.children).toHaveLength(2);
+    expect(root.children[0].textContent).toBe("one");
+    expect(root.children[1].nodeName).toBe("EM");
+  });
+
+  it("replaces nodes whose keys differ instead of reusing them", () => {
+    const root = mount(`<div data-node-id="alpha">alpha</div>`);
+    const alpha = root.querySelector("div")!;
+
+    morphChildren(root, `<div data-node-id="beta">beta</div>`);
+
+    const beta = root.querySelector("div")!;
+    expect(beta).not.toBe(alpha);
+    expect(beta.dataset.nodeId).toBe("beta");
+  });
+});

--- a/packages/ui-core/__tests__/live-refresh-behavior.test.ts
+++ b/packages/ui-core/__tests__/live-refresh-behavior.test.ts
@@ -1,0 +1,375 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Live-refresh behavior regression tests.
+ *
+ * The 5s poll used to re-apply a selection captured before its awaits (so a
+ * task the user clicked mid-refresh was reverted), null evidence state while
+ * loading (panels flashed empty), and rebuild the whole DOM via innerHTML
+ * (focus and input state were lost). These tests pin the fixed behavior:
+ * refreshes resolve selection at apply time, abandon their results when the
+ * user navigates mid-flight, and re-render without stealing focus.
+ */
+
+import { renderOpenSymphonyApp } from "../src/app-shell.js";
+import { MockGatewayTransport } from "@opensymphony/api-client";
+import { schemaVersionV1 } from "@opensymphony/gateway-schema";
+import type {
+  ChangedFileEntry,
+  DashboardSnapshot,
+  FileDiffPage,
+  GatewayCapabilities,
+  RunDetail,
+  RunEventPage,
+  TaskGraphSnapshot,
+} from "@opensymphony/gateway-schema";
+
+const capabilities: GatewayCapabilities = {
+  schema_version: schemaVersionV1(),
+  gateway_version: "live-refresh-test",
+  supported_api_versions: ["1.0.0"],
+  transports: [
+    {
+      transport: "loopback_http",
+      modes: ["json"],
+      supported_encodings: ["utf-8"],
+      bidirectional: false,
+    },
+  ],
+  features: [
+    { feature: "task_graph", available: true, requires_auth: false },
+  ],
+  auth_modes: ["none"],
+  max_event_page_size: 1000,
+  max_terminal_frame_batch: 500,
+};
+
+const dashboard: DashboardSnapshot = {
+  schema_version: schemaVersionV1(),
+  generated_at: "2025-09-01T00:00:00Z",
+  sequence: 7,
+  health: "healthy",
+  metrics: {
+    running_issue_count: 1,
+    retry_queue_depth: 0,
+    total_input_tokens: 100,
+    total_output_tokens: 50,
+    total_cache_read_tokens: 10,
+    total_cost_micros: 1,
+  },
+  projects: [
+    {
+      project_id: "proj-alpha",
+      name: "Alpha",
+      milestone_count: 1,
+      issue_count: 2,
+      running_count: 1,
+      completed_count: 0,
+      failed_count: 0,
+    },
+  ],
+  recent_events: [],
+};
+
+const taskGraph: TaskGraphSnapshot = {
+  schema_version: schemaVersionV1(),
+  project_id: "proj-alpha",
+  generated_at: "2025-09-01T00:00:00Z",
+  root_ids: ["node-a"],
+  nodes: [
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "node-a",
+      kind: "issue",
+      identifier: "RUN-A",
+      title: "First task",
+      state: "In Progress",
+      state_category: "in_progress",
+      children: [],
+      blocked_by: [],
+      labels: [],
+    },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "node-b",
+      kind: "issue",
+      identifier: "RUN-B",
+      title: "Second task",
+      state: "Todo",
+      state_category: "todo",
+      children: [],
+      blocked_by: [],
+      labels: [],
+    },
+  ],
+};
+
+function buildRunDetail(runId: string): RunDetail {
+  return {
+    schema_version: schemaVersionV1(),
+    run_id: runId,
+    issue_id: `issue-${runId}`,
+    issue_identifier: runId,
+    worker_id: "worker-alpha",
+    status: "running",
+    claimed_at: "2025-09-01T00:00:00Z",
+    started_at: "2025-09-01T00:00:30Z",
+    turn_count: 1,
+    max_turns: 8,
+    input_tokens: 10,
+    output_tokens: 5,
+    cache_read_tokens: 1,
+    runtime_seconds: 30,
+    workspace_path: `/tmp/opensymphony/projects/${runId}`,
+    safe_actions: {
+      retry: false,
+      cancel: true,
+      rehydrate: true,
+      detach: false,
+    },
+  };
+}
+
+const changedFiles: ChangedFileEntry[] = [
+  { path: "src/config.ts", change_kind: "modified", lines_added: 12, lines_removed: 3 },
+  { path: "src/other.ts", change_kind: "modified", lines_added: 4, lines_removed: 1 },
+];
+
+function buildFileDiff(runId: string, filePath: string): FileDiffPage {
+  return {
+    schema_version: schemaVersionV1(),
+    run_id: runId,
+    file_path: filePath,
+    hunks: [
+      {
+        file_path: filePath,
+        header: "@@ -1 +1 @@",
+        start_line: 1,
+        old_line_count: 1,
+        new_line_count: 1,
+        lines: [{ type: "addition", line: `// ${filePath}` }],
+      },
+    ],
+    total_lines_added: 1,
+    total_lines_removed: 0,
+  };
+}
+
+function buildRunEvents(runId: string): RunEventPage {
+  return {
+    schema_version: schemaVersionV1(),
+    run_id: runId,
+    events: [
+      {
+        sequence: 1,
+        event_id: `${runId}-evt-1`,
+        happened_at: "2025-09-01T00:00:05Z",
+        kind: "ActionEvent",
+        summary: `action for ${runId}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Transport whose task-graph reads can be gated so a live refresh can be
+ * frozen mid-flight while the test simulates user navigation.
+ */
+class GatedTransport extends MockGatewayTransport {
+  taskGraphReads = 0;
+  private gateFromRead = Number.POSITIVE_INFINITY;
+  private gateResolvers: Array<() => void> = [];
+
+  /** Gate task-graph reads starting with the given 1-based read number. */
+  gateTaskGraphFromRead(read: number): void {
+    this.gateFromRead = read;
+  }
+
+  releaseGatedReads(): void {
+    const resolvers = this.gateResolvers.splice(0);
+    resolvers.forEach((resolve) => resolve());
+  }
+
+  override async taskGraph(projectId: string): Promise<TaskGraphSnapshot> {
+    this.taskGraphReads += 1;
+    if (this.taskGraphReads >= this.gateFromRead) {
+      await new Promise<void>((resolve) => {
+        this.gateResolvers.push(resolve);
+      });
+    }
+    return super.taskGraph(projectId);
+  }
+}
+
+function buildGatedTransport(): GatedTransport {
+  return new GatedTransport({
+    baseUri: "http://127.0.0.1:2468",
+    health: capabilities,
+    snapshot: dashboard,
+    taskGraph,
+    runDetails: [buildRunDetail("RUN-A"), buildRunDetail("RUN-B")],
+    runFiles: [
+      { runId: "RUN-A", files: changedFiles },
+      { runId: "RUN-B", files: changedFiles },
+    ],
+    runDiffs: [
+      { runId: "RUN-A", filePath: "src/config.ts", diff: buildFileDiff("RUN-A", "src/config.ts") },
+      { runId: "RUN-A", filePath: "src/other.ts", diff: buildFileDiff("RUN-A", "src/other.ts") },
+      { runId: "RUN-B", filePath: "src/config.ts", diff: buildFileDiff("RUN-B", "src/config.ts") },
+      { runId: "RUN-B", filePath: "src/other.ts", diff: buildFileDiff("RUN-B", "src/other.ts") },
+    ],
+    runEvents: [buildRunEvents("RUN-A"), buildRunEvents("RUN-B")],
+  });
+}
+
+interface LiveRefreshDriver {
+  requestLiveRefresh(): Promise<void>;
+}
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushUntil(
+  predicate: () => boolean,
+  maxIterations = 40,
+): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    if (predicate()) return;
+    await flushAsync();
+  }
+  throw new Error(
+    `flushUntil timed out after ${maxIterations} iterations waiting for predicate`,
+  );
+}
+
+async function mountApp(transport: MockGatewayTransport): Promise<{
+  root: HTMLElement;
+  handle: Awaited<ReturnType<typeof renderOpenSymphonyApp>>;
+}> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const handle = renderOpenSymphonyApp({
+    root,
+    mode: "desktop",
+    title: "Live Refresh Test",
+    transport,
+  });
+  await flushUntil(() => root.querySelector(".os-run-head strong")?.textContent === "RUN-A");
+  await flushUntil(() => root.querySelector("[data-testid='changed-file-item']") !== null);
+  return { root, handle };
+}
+
+function selectedNode(root: HTMLElement): string | null {
+  return root.querySelector<HTMLElement>("[data-node-id].os-node-selected, [data-node-id][aria-selected='true'], [data-node-id][data-selected='true'], [data-node-id].is-selected")?.dataset.nodeId
+    ?? root.querySelector(".os-run-head strong")?.textContent
+    ?? null;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("live refresh vs. user navigation", () => {
+  it("does not revert a task the user opened while a refresh was in flight", async () => {
+    const transport = buildGatedTransport();
+    const { root, handle } = await mountApp(transport);
+    const driver = handle as unknown as LiveRefreshDriver;
+
+    // Freeze the next task-graph read: the refresh will hang there while the
+    // user clicks a different task.
+    transport.gateTaskGraphFromRead(transport.taskGraphReads + 1);
+    const refresh = driver.requestLiveRefresh();
+    await flushUntil(() => transport.taskGraphReads >= 2);
+
+    const nodeB = root.querySelector<HTMLElement>("[data-node-id='node-b']");
+    expect(nodeB).not.toBeNull();
+    nodeB!.click();
+    await flushUntil(() => root.querySelector(".os-run-head strong")?.textContent === "RUN-B");
+
+    transport.releaseGatedReads();
+    await refresh;
+    await flushAsync();
+
+    // The stale refresh must not restore RUN-A.
+    expect(root.querySelector(".os-run-head strong")?.textContent).toBe("RUN-B");
+    expect(selectedNode(root)).toContain("node-b");
+
+    await handle.destroy();
+  });
+
+  it("preserves the selected diff file and evidence view across a refresh", async () => {
+    const transport = buildGatedTransport();
+    const { root, handle } = await mountApp(transport);
+    const driver = handle as unknown as LiveRefreshDriver;
+
+    // Select the non-default diff file.
+    const otherFile = root.querySelector<HTMLElement>("[data-testid='changed-file-item'][data-path='src/other.ts']");
+    expect(otherFile).not.toBeNull();
+    otherFile!.click();
+    await flushUntil(() =>
+      root.querySelector("[data-testid='file-diff']")?.getAttribute("data-file-path") === "src/other.ts",
+    );
+
+    await driver.requestLiveRefresh();
+    await flushAsync();
+
+    const selectedFile = root.querySelector<HTMLElement>("[data-testid='changed-file-item'].os-selected");
+    expect(selectedFile?.dataset.path).toBe("src/other.ts");
+    expect(root.querySelector("[data-testid='file-diff']")?.getAttribute("data-file-path")).toBe("src/other.ts");
+
+    // Same for the Activity evidence view.
+    root.querySelector<HTMLElement>("[data-evidence-view='activity']")!.click();
+    await flushUntil(() =>
+      root.querySelector("[data-evidence-view='activity']")?.classList.contains("is-selected") ?? false,
+    );
+    await driver.requestLiveRefresh();
+    await flushAsync();
+    expect(root.querySelector("[data-evidence-view='activity']")?.classList.contains("is-selected")).toBe(true);
+
+    await handle.destroy();
+  });
+
+  it("keeps evidence panels populated during a refresh instead of flashing empty", async () => {
+    const transport = buildGatedTransport();
+    const { root, handle } = await mountApp(transport);
+    const driver = handle as unknown as LiveRefreshDriver;
+
+    // Freeze the refresh mid-flight and force a re-render: previously the
+    // refresh nulled runFiles/runDiff up front, so any render in that window
+    // showed empty panels.
+    transport.gateTaskGraphFromRead(transport.taskGraphReads + 1);
+    const refresh = driver.requestLiveRefresh();
+    await flushUntil(() => transport.taskGraphReads >= 2);
+
+    expect(root.querySelectorAll("[data-testid='changed-file-item']").length).toBeGreaterThan(0);
+    expect(root.querySelector("[data-testid='file-diff']")).not.toBeNull();
+
+    transport.releaseGatedReads();
+    await refresh;
+    expect(root.querySelectorAll("[data-testid='changed-file-item']").length).toBeGreaterThan(0);
+    expect(root.querySelector("[data-testid='file-diff']")).not.toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("keeps focus and typed text in the task filter across a refresh", async () => {
+    const transport = buildGatedTransport();
+    const { root, handle } = await mountApp(transport);
+    const driver = handle as unknown as LiveRefreshDriver;
+
+    const search = root.querySelector<HTMLInputElement>("[data-tg-filter='search']");
+    expect(search).not.toBeNull();
+    search!.focus();
+    search!.value = "half-typed query";
+
+    await driver.requestLiveRefresh();
+    await flushAsync();
+
+    const searchAfter = root.querySelector<HTMLInputElement>("[data-tg-filter='search']");
+    expect(document.activeElement).toBe(searchAfter);
+    expect(searchAfter?.value).toBe("half-typed query");
+
+    await handle.destroy();
+  });
+});

--- a/packages/ui-core/__tests__/live-refresh-behavior.test.ts
+++ b/packages/ui-core/__tests__/live-refresh-behavior.test.ts
@@ -177,12 +177,19 @@ function buildRunEvents(runId: string): RunEventPage {
  */
 class GatedTransport extends MockGatewayTransport {
   taskGraphReads = 0;
+  runDetailGateHits = 0;
   private gateFromRead = Number.POSITIVE_INFINITY;
+  private gatedRunDetailId: string | null = null;
   private gateResolvers: Array<() => void> = [];
 
   /** Gate task-graph reads starting with the given 1-based read number. */
   gateTaskGraphFromRead(read: number): void {
     this.gateFromRead = read;
+  }
+
+  /** Gate run-detail reads for one specific run id. */
+  gateRunDetailFor(runId: string | null): void {
+    this.gatedRunDetailId = runId;
   }
 
   releaseGatedReads(): void {
@@ -198,6 +205,16 @@ class GatedTransport extends MockGatewayTransport {
       });
     }
     return super.taskGraph(projectId);
+  }
+
+  override async runDetail(runId: string): Promise<RunDetail> {
+    if (runId === this.gatedRunDetailId) {
+      this.runDetailGateHits += 1;
+      await new Promise<void>((resolve) => {
+        this.gateResolvers.push(resolve);
+      });
+    }
+    return super.runDetail(runId);
   }
 }
 
@@ -349,6 +366,32 @@ describe("live refresh vs. user navigation", () => {
     await refresh;
     expect(root.querySelectorAll("[data-testid='changed-file-item']").length).toBeGreaterThan(0);
     expect(root.querySelector("[data-testid='file-diff']")).not.toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("does not cancel an in-flight task open when a stale diff file is clicked", async () => {
+    const transport = buildGatedTransport();
+    const { root, handle } = await mountApp(transport);
+
+    // Freeze RUN-B's detail read so opening node-b hangs mid-flight.
+    transport.gateRunDetailFor("RUN-B");
+    root.querySelector<HTMLElement>("[data-node-id='node-b']")!.click();
+    await flushUntil(() => transport.runDetailGateHits >= 1);
+
+    // While RUN-B is loading, RUN-A's changed files are still on screen;
+    // clicking one used to bump the shared epoch and abort the open.
+    const staleFile = root.querySelector<HTMLElement>("[data-testid='changed-file-item'][data-path='src/other.ts']");
+    expect(staleFile).not.toBeNull();
+    staleFile!.click();
+    await flushAsync();
+
+    transport.gateRunDetailFor(null);
+    transport.releaseGatedReads();
+    await flushUntil(() => root.querySelector(".os-run-head strong")?.textContent === "RUN-B");
+
+    // The opened run applied; its diff selection reset to the new run's data.
+    expect(root.querySelector(".os-run-head strong")?.textContent).toBe("RUN-B");
 
     await handle.destroy();
   });

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -112,12 +112,12 @@ import {
   type PlanningEditState,
 } from "./planning-workspace-ui.js";
 import {
-  disposeKnowledgeGraphCanvas,
   disposeKnowledgeGraphRenderer,
   type KnowledgeGraphViewState,
   mountKnowledgeGraphRenderer,
   renderKnowledgeGraphSurface,
 } from "./knowledge-graph-renderer.js";
+import { morphChildren } from "./dom-morph.js";
 
 export interface GatewayReader {
   readonly baseUri: string;
@@ -247,6 +247,17 @@ interface AuditTrailEntry {
   details?: string;
 }
 
+/** Evidence for one run, fetched concurrently and applied atomically. */
+interface RunDetailBundle {
+  runFiles: ChangedFileEntry[];
+  selectedDiffPath: string | null;
+  runDiff: FileDiffPage | null;
+  runEvents: RunEvent[];
+  runValidation: RunValidationSummary | null;
+  runApprovals: ApprovalRequest[];
+  warnings: string[];
+}
+
 type EvidenceView = "diff" | "activity";
 type GraphPaneView = "task" | "knowledge" | "code";
 type WorkspacePaneResizeHandle = "lower-columns";
@@ -296,6 +307,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private graphLayoutRun = 0;
   private knowledgeGraphView: KnowledgeGraphViewState = { scale: 1, dx: 0, dy: 0 };
   private knowledgeGraphLayoutSize: { width: number; height: number } | null = null;
+  /**
+   * Monotonic counter bumped by every user-initiated navigation (task click,
+   * project switch, diff-file click, full refresh). Background work snapshots
+   * the epoch when it starts and discards its results if the user navigated
+   * while it was in flight, so a slow poll can never revert a selection.
+   */
+  private interactionEpoch = 0;
+  /** Tracks bindEvents sites already attached per element (see listen()). */
+  private boundListeners = new WeakMap<Element, Set<string>>();
 
   constructor(options: OpenSymphonyAppOptions) {
     this.options = options;
@@ -358,61 +378,87 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.loadPlanningWorkspace("opensymphony-local");
   }
 
-  private async loadRunDetails(runId: string, preserveSelection = false): Promise<void> {
-    const previousDiffPath = preserveSelection ? this.state.selectedDiffPath : null;
-    const previousEvidenceView = preserveSelection ? this.state.evidenceView : "diff";
-    this.state.runFiles = null;
-    this.state.runDiff = null;
-    this.state.runEvents = null;
-    this.state.expandedActivityEvents = new Set();
-    this.state.collapsedActivityEvents = new Set();
-    this.state.runValidation = null;
-    this.state.runApprovals = null;
-    this.state.selectedDiffPath = null;
-    try {
-      this.state.runFiles = typeof this.transport.runFiles === "function"
-        ? await this.transport.runFiles(runId)
-        : [];
-    } catch (error) {
-      this.state.runFiles = [];
-      this.state.connectionMessage = `Changed files unavailable: ${errorMessage(error)}`;
-    }
-    this.state.selectedDiffPath = previousDiffPath && this.state.runFiles.some((file) => file.path === previousDiffPath)
-      ? previousDiffPath
-      : this.state.runFiles[0]?.path ?? null;
-    this.state.evidenceView = previousEvidenceView;
-    try {
-      this.state.runDiff = this.state.selectedDiffPath
-        && typeof this.transport.runDiffs === "function"
-        ? await this.transport.runDiffs(runId, this.state.selectedDiffPath)
-        : null;
-    } catch (error) {
-      this.state.runDiff = null;
-      this.state.connectionMessage = `Diff unavailable: ${errorMessage(error)}`;
-    }
-    try {
-      this.state.runEvents = typeof this.transport.runEvents === "function"
-        ? (await this.transport.runEvents(runId)).events
-        : [];
-    } catch (error) {
-      this.state.runEvents = [];
-      this.state.connectionMessage = `Conversation activity unavailable: ${errorMessage(error)}`;
-    }
-    try {
-      this.state.runValidation = typeof this.transport.runValidation === "function"
-        ? await this.transport.runValidation(runId)
-        : null;
-    } catch (error) {
-      this.state.runValidation = null;
-      this.state.connectionMessage = `Validation summary unavailable: ${errorMessage(error)}`;
-    }
-    try {
-      this.state.runApprovals = typeof this.transport.runApprovals === "function"
-        ? await this.transport.runApprovals(runId)
-        : [];
-    } catch (error) {
-      this.state.runApprovals = [];
-      this.state.connectionMessage = `Approvals unavailable: ${errorMessage(error)}`;
+  /**
+   * Fetch all evidence for a run concurrently, without touching state. The
+   * caller applies the returned bundle atomically (applyRunDetailBundle), so
+   * the UI never renders a half-cleared panel while requests are in flight.
+   */
+  private async fetchRunDetailBundle(
+    runId: string,
+    preferredDiffPath: string | null,
+  ): Promise<RunDetailBundle> {
+    const warnings: string[] = [];
+    const filesAndDiff = (async () => {
+      let runFiles: ChangedFileEntry[] = [];
+      try {
+        runFiles = typeof this.transport.runFiles === "function"
+          ? await this.transport.runFiles(runId)
+          : [];
+      } catch (error) {
+        warnings.push(`Changed files unavailable: ${errorMessage(error)}`);
+      }
+      const selectedDiffPath = preferredDiffPath && runFiles.some((file) => file.path === preferredDiffPath)
+        ? preferredDiffPath
+        : runFiles[0]?.path ?? null;
+      let runDiff: FileDiffPage | null = null;
+      if (selectedDiffPath && typeof this.transport.runDiffs === "function") {
+        try {
+          runDiff = await this.transport.runDiffs(runId, selectedDiffPath);
+        } catch (error) {
+          warnings.push(`Diff unavailable: ${errorMessage(error)}`);
+        }
+      }
+      return { runFiles, selectedDiffPath, runDiff };
+    })();
+    const events = (async () => {
+      try {
+        return typeof this.transport.runEvents === "function"
+          ? (await this.transport.runEvents(runId)).events
+          : [];
+      } catch (error) {
+        warnings.push(`Conversation activity unavailable: ${errorMessage(error)}`);
+        return [];
+      }
+    })();
+    const validation = (async () => {
+      try {
+        return typeof this.transport.runValidation === "function"
+          ? await this.transport.runValidation(runId)
+          : null;
+      } catch (error) {
+        warnings.push(`Validation summary unavailable: ${errorMessage(error)}`);
+        return null;
+      }
+    })();
+    const approvals = (async () => {
+      try {
+        return typeof this.transport.runApprovals === "function"
+          ? await this.transport.runApprovals(runId)
+          : [];
+      } catch (error) {
+        warnings.push(`Approvals unavailable: ${errorMessage(error)}`);
+        return [];
+      }
+    })();
+
+    const [
+      { runFiles, selectedDiffPath, runDiff },
+      runEvents,
+      runValidation,
+      runApprovals,
+    ] = await Promise.all([filesAndDiff, events, validation, approvals]);
+    return { runFiles, selectedDiffPath, runDiff, runEvents, runValidation, runApprovals, warnings };
+  }
+
+  private applyRunDetailBundle(bundle: RunDetailBundle): void {
+    this.state.runFiles = bundle.runFiles;
+    this.state.selectedDiffPath = bundle.selectedDiffPath;
+    this.state.runDiff = bundle.runDiff;
+    this.state.runEvents = bundle.runEvents;
+    this.state.runValidation = bundle.runValidation;
+    this.state.runApprovals = bundle.runApprovals;
+    if (bundle.warnings.length > 0) {
+      this.state.connectionMessage = bundle.warnings[bundle.warnings.length - 1];
     }
   }
 
@@ -420,6 +466,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     if (this.destroyed) {
       return;
     }
+    this.interactionEpoch += 1;
     this.state.loading = true;
     this.render();
 
@@ -654,10 +701,18 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runValidation = null;
     this.state.runApprovals = null;
     this.state.selectedDiffPath = null;
-    await this.loadRunOverlays(taskGraph);
-    if (initialNode) {
-      await this.openRun(initialNode);
-    }
+    await Promise.all([
+      this.fetchRunOverlays(taskGraph).then((overlays) => {
+        // A concurrently opened run may already have stored a fresher detail.
+        for (const [runId, run] of this.state.runOverlays) {
+          if (!overlays.has(runId)) {
+            overlays.set(runId, run);
+          }
+        }
+        this.state.runOverlays = overlays;
+      }),
+      initialNode ? this.openRun(initialNode) : Promise.resolve(),
+    ]);
   }
 
   private async loadKnowledgeGraph(bundleId?: string): Promise<void> {
@@ -879,55 +934,87 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private async refreshLiveGatewayData(): Promise<void> {
+    // Snapshot the epoch: if the user navigates (task click, project switch,
+    // diff selection) while this refresh is in flight, its results are stale
+    // by definition and must be dropped rather than applied over the user's
+    // choice. The next poll tick picks up the fresh selection.
+    const epoch = this.interactionEpoch;
+    const abandoned = () => this.destroyed || epoch !== this.interactionEpoch;
+
     const snapshot = await this.transport.snapshot();
-    this.state.snapshot = snapshot;
+    if (abandoned()) return;
+
     const previousProjectId = this.state.selectedProjectId;
     const projectStillPresent = snapshot.projects.some((project) => project.project_id === previousProjectId);
-    this.state.selectedProjectId = projectStillPresent
+    const nextProjectId = projectStillPresent
       ? previousProjectId
       : snapshot.projects[0]?.project_id ?? "default";
 
-    if (!this.state.selectedProjectId) {
+    if (!nextProjectId) {
+      this.state.snapshot = snapshot;
+      this.state.selectedProjectId = nextProjectId;
       this.render();
       return;
     }
 
-    const previousNodeId = this.state.selectedNodeId;
-    const previousRunId = this.state.runDetail?.run_id ?? null;
-    const taskGraph = await this.transport.taskGraph(this.state.selectedProjectId);
-    this.state.taskGraph = taskGraph;
-    const selectedNode = taskGraph.nodes.find((node) => node.node_id === previousNodeId)
-      ?? taskGraph.nodes.find((node) => node.run_id === previousRunId)
+    const taskGraph = await this.transport.taskGraph(nextProjectId);
+    if (abandoned()) return;
+
+    // Resolve the preserved selection against the *current* state, not
+    // values captured before the awaits above.
+    const currentNodeId = this.state.selectedNodeId;
+    const currentRunId = this.state.runDetail?.run_id ?? null;
+    const selectedNode = taskGraph.nodes.find((node) => node.node_id === currentNodeId)
+      ?? taskGraph.nodes.find((node) => node.run_id === currentRunId)
       ?? initialSelectedTaskNode(taskGraph.nodes, taskGraph.root_ids);
+
+    const [overlays, selectedRun] = await Promise.all([
+      this.fetchRunOverlays(taskGraph),
+      selectedNode ? this.fetchSelectedRunRefresh(selectedNode) : Promise.resolve(null),
+    ]);
+    if (abandoned()) return;
+
+    // Apply everything atomically: the previous data stays on screen until
+    // the replacement is fully loaded, so panels never flash empty.
+    this.state.snapshot = snapshot;
+    this.state.selectedProjectId = nextProjectId;
+    this.state.taskGraph = taskGraph;
+    this.state.runOverlays = overlays;
     this.state.selectedNodeId = selectedNode?.node_id ?? null;
-    await this.loadRunOverlays(taskGraph);
-    if (selectedNode) {
-      await this.refreshSelectedRun(selectedNode);
+    if (selectedRun) {
+      this.state.runDetail = selectedRun.runDetail;
+      this.state.runOverlays.set(selectedRun.runDetail.run_id, selectedRun.runDetail);
+      this.applyRunDetailBundle(selectedRun.bundle);
     }
     if (this.state.graphPaneView === "knowledge") {
       await this.loadKnowledgeGraph();
+      if (abandoned()) return;
     }
     this.render();
   }
 
-  private async refreshSelectedRun(node: TaskGraphNode): Promise<void> {
+  private async fetchSelectedRunRefresh(
+    node: TaskGraphNode,
+  ): Promise<{ runDetail: RunDetail; bundle: RunDetailBundle } | null> {
     const runId = runIdForNode(node);
     try {
-      this.state.runDetail = await this.transport.runDetail(runId);
-      this.state.runOverlays.set(runId, this.state.runDetail);
-      await this.loadRunDetails(runId, true);
+      const [runDetail, bundle] = await Promise.all([
+        this.transport.runDetail(runId),
+        this.fetchRunDetailBundle(runId, this.state.selectedDiffPath),
+      ]);
+      return { runDetail, bundle };
     } catch (error) {
       this.state.connectionMessage = `Run ${runId} unavailable: ${errorMessage(error)}`;
+      return null;
     }
   }
 
-  private async loadRunOverlays(taskGraph: TaskGraphSnapshot): Promise<void> {
+  private async fetchRunOverlays(taskGraph: TaskGraphSnapshot): Promise<Map<string, RunDetail>> {
     const runIds = new Set(taskGraph.nodes.map((node) => node.run_id).filter((id): id is string => Boolean(id)));
-    if (runIds.size === 0) {
-      this.state.runOverlays = new Map();
-      return;
-    }
     const overlays = new Map<string, RunDetail>();
+    if (runIds.size === 0) {
+      return overlays;
+    }
     await Promise.all(
       Array.from(runIds).map(async (runId) => {
         try {
@@ -938,18 +1025,35 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         }
       }),
     );
-    this.state.runOverlays = overlays;
+    return overlays;
   }
 
   private async openRun(node: TaskGraphNode): Promise<void> {
     const runId = runIdForNode(node);
+    const epoch = ++this.interactionEpoch;
     this.state.selectedNodeId = node.node_id;
     this.state.loading = true;
     this.render();
     try {
-      this.state.runDetail = await this.transport.runDetail(runId);
-      this.state.runOverlays.set(runId, this.state.runDetail);
+      // The run detail and every evidence pane load concurrently: the click
+      // latency is one round trip, not six queued ones.
+      const [runDetail, bundle] = await Promise.all([
+        this.transport.runDetail(runId),
+        this.fetchRunDetailBundle(runId, null),
+      ]);
+      if (this.destroyed || epoch !== this.interactionEpoch) {
+        return;
+      }
+      this.state.runDetail = runDetail;
+      this.state.runOverlays.set(runId, runDetail);
+      this.state.evidenceView = "diff";
+      this.state.expandedActivityEvents = new Set();
+      this.state.collapsedActivityEvents = new Set();
+      this.applyRunDetailBundle(bundle);
     } catch (error) {
+      if (this.destroyed || epoch !== this.interactionEpoch) {
+        return;
+      }
       this.state.runDetail = null;
       this.state.runFiles = null;
       this.state.runDiff = null;
@@ -959,26 +1063,33 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.collapsedActivityEvents = new Set();
       this.state.runValidation = null;
       this.state.runApprovals = null;
+      this.state.selectedDiffPath = null;
       this.state.connectionMessage = `Run ${runId} unavailable: ${errorMessage(error)}`;
-      this.state.loading = false;
-      this.render();
-      return;
     }
-    await this.loadRunDetails(runId);
     this.state.loading = false;
     this.render();
   }
 
   private async selectDiffFile(path: string): Promise<void> {
+    const epoch = ++this.interactionEpoch;
     this.state.selectedDiffPath = path;
     this.state.evidenceView = "diff";
+    this.render();
     const runId = this.state.runDetail?.run_id;
     if (runId && typeof this.transport.runDiffs === "function") {
+      let runDiff: FileDiffPage | null = null;
+      let warning: string | null = null;
       try {
-        this.state.runDiff = await this.transport.runDiffs!(runId, path);
+        runDiff = await this.transport.runDiffs!(runId, path);
       } catch (error) {
-        this.state.runDiff = null;
-        this.state.connectionMessage = `Diff unavailable: ${errorMessage(error)}`;
+        warning = `Diff unavailable: ${errorMessage(error)}`;
+      }
+      if (this.destroyed || epoch !== this.interactionEpoch) {
+        return;
+      }
+      this.state.runDiff = runDiff;
+      if (warning) {
+        this.state.connectionMessage = warning;
       }
     } else if (runId) {
       this.state.runDiff = null;
@@ -1261,6 +1372,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private async selectProject(projectId: string): Promise<void> {
+    this.interactionEpoch += 1;
     this.state.selectedProjectId = projectId;
     this.state.loading = true;
     this.render();
@@ -1604,13 +1716,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     }
     const scrollPositions = captureShellScrollPositions(this.options.root);
     const title = this.options.title ?? "OpenSymphony";
-    const preservedKnowledgeCanvas = this.state.graphPaneView === "knowledge"
-      ? this.options.root.querySelector<HTMLCanvasElement>("[data-testid='knowledge-graph-canvas']")
-      : null;
-    if (!preservedKnowledgeCanvas) {
+    if (this.state.graphPaneView !== "knowledge") {
       disposeKnowledgeGraphRenderer(this.options.root);
     }
-    this.options.root.innerHTML = `
+    // Morph the new markup into the live DOM instead of rebuilding it with
+    // innerHTML: only changed nodes mutate, so focus, input state, scroll
+    // offsets, the knowledge-graph canvas bitmap, and attached listeners all
+    // survive background refreshes.
+    morphChildren(this.options.root, `
       <style>${appShellStyles()}</style>
       <main class="os-app" data-opensymphony-app-shell="mounted" data-mode="${this.options.mode}" data-auth-state="${this.state.authState}">
         <header class="os-topbar">
@@ -1629,15 +1742,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         </section>
         ${this.renderGlobalModals()}
       </main>
-    `;
-    if (preservedKnowledgeCanvas) {
-      const nextCanvas = this.options.root.querySelector<HTMLCanvasElement>("[data-testid='knowledge-graph-canvas']");
-      if (nextCanvas) {
-        nextCanvas.replaceWith(preservedKnowledgeCanvas);
-      } else {
-        disposeKnowledgeGraphCanvas(preservedKnowledgeCanvas);
-      }
-    }
+    `);
     this.bindEvents();
     restoreShellScrollPositions(this.options.root, scrollPositions);
   }
@@ -2374,43 +2479,74 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     );
   }
 
+  /**
+   * Attach a listener exactly once per (element, site, event type).
+   *
+   * render() morphs the DOM in place, so elements — and their listeners —
+   * survive re-renders. bindEvents() still runs after every render to cover
+   * newly created elements; this guard keeps it from stacking duplicate
+   * listeners on the survivors. The site string identifies the bindEvents
+   * call site so distinct handlers for the same element/event coexist.
+   */
+  private listen(
+    element: Element | null | undefined,
+    site: string,
+    type: string,
+    handler: (event: Event) => void,
+  ): void {
+    if (!element) {
+      return;
+    }
+    let sites = this.boundListeners.get(element);
+    if (!sites) {
+      sites = new Set();
+      this.boundListeners.set(element, sites);
+    }
+    const key = `${site}:${type}`;
+    if (sites.has(key)) {
+      return;
+    }
+    sites.add(key);
+    element.addEventListener(type, handler);
+  }
+
   private bindEvents(): void {
-    this.options.root.querySelector("[data-save-profile]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-save-profile]"), "save-profile", "click", () => {
       void this.saveProfile();
     });
-    this.options.root.querySelector("[data-new-profile]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-new-profile]"), "new-profile", "click", () => {
       void this.createProfileDraft();
     });
-    this.options.root.querySelector("[data-remove-profile]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-remove-profile]"), "remove-profile", "click", () => {
       void this.removeProfile();
     });
-    this.options.root.querySelector("[data-save-model-profile]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-save-model-profile]"), "save-model-profile", "click", () => {
       void this.saveModelProfile();
     });
-    this.options.root.querySelector("[data-new-model-profile]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-new-model-profile]"), "new-model-profile", "click", () => {
       void this.createModelProfileDraft();
     });
-    this.options.root.querySelector("[data-remove-model-profile]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-remove-model-profile]"), "remove-model-profile", "click", () => {
       void this.removeModelProfile();
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-toggle-settings]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "toggle-settings", "click", () => {
         const panel = button.dataset.toggleSettings;
         if (panel === "connection" || panel === "model") {
           this.toggleSettingsPanel(panel);
         }
       });
     });
-    this.options.root.querySelector("[data-open-event-log]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-open-event-log]"), "open-event-log", "click", () => {
       this.state.eventLogModalOpen = true;
       this.render();
     });
-    this.options.root.querySelector("[data-close-event-log]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-close-event-log]"), "close-event-log", "click", () => {
       this.state.eventLogModalOpen = false;
       this.render();
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-auth-action]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "auth-action", "click", () => {
         const action = button.dataset.authAction;
         if (action === "sign-in") {
           // Hosted auth provider integration is a follow-on task; the
@@ -2422,20 +2558,20 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         }
       });
     });
-    this.options.root.querySelector("[data-profile-select]")?.addEventListener("change", (event) => {
+    this.listen(this.options.root.querySelector("[data-profile-select]"), "profile-select", "change", (event) => {
       const target = event.target as HTMLSelectElement;
       void this.selectProfile(target.value);
     });
-    this.options.root.querySelector("[data-model-profile-select]")?.addEventListener("change", (event) => {
+    this.listen(this.options.root.querySelector("[data-model-profile-select]"), "model-profile-select", "change", (event) => {
       const target = event.target as HTMLSelectElement;
       void this.selectModelProfile(target.value);
     });
-    this.options.root.querySelector("[data-model-mode]")?.addEventListener("change", (event) => {
+    this.listen(this.options.root.querySelector("[data-model-mode]"), "model-mode", "change", (event) => {
       const target = event.target as HTMLSelectElement;
       this.changeModelProfileMode(modelModeFromValue(target.value));
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-project-id]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "project-id", "click", () => {
         const projectId = button.dataset.projectId;
         if (projectId) {
           void this.selectProject(projectId);
@@ -2443,7 +2579,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-node-id]").forEach((button) => {
-      button.addEventListener("click", (event) => {
+      this.listen(button, "node-id", "click", (event) => {
         // Avoid selecting when clicking inline editor controls or action buttons.
         const target = event.target as HTMLElement;
         if (target.closest(".os-node-actions, .os-inline-input, .os-node-badges")) {
@@ -2463,7 +2599,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-project-group-toggle]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "project-group-toggle", "click", () => {
         const projectKey = button.dataset.projectGroupToggle;
         if (!projectKey) return;
         if (this.state.collapsedProjectGroups.has(projectKey)) {
@@ -2475,7 +2611,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-open-run]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "open-run", "click", () => {
         const node = this.state.taskGraph?.nodes.find(
           (candidate) => candidate.node_id === button.dataset.openRun,
         );
@@ -2485,7 +2621,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-testid='changed-file-item']").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "changed-file-item", "click", () => {
         const path = button.dataset.path;
         if (path) {
           void this.selectDiffFile(path);
@@ -2493,7 +2629,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-evidence-view]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "evidence-view", "click", () => {
         const view = button.dataset.evidenceView;
         if (view === "diff" || view === "activity") {
           this.selectEvidenceView(view);
@@ -2501,7 +2637,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-graph-view]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "graph-view", "click", () => {
         const view = button.dataset.graphView;
         if (view === "task" || view === "knowledge" || view === "code") {
           this.selectGraphPaneView(view);
@@ -2510,15 +2646,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     });
     this.bindKnowledgeGraph();
     this.options.root.querySelectorAll<HTMLElement>("[data-pane-resizer]").forEach((handle) => {
-      handle.addEventListener("pointerdown", (event) => {
+      this.listen(handle, "pane-resizer", "pointerdown", (event) => {
         this.startPaneResize(handle.dataset.paneResizer, event as PointerEvent);
       });
-      handle.addEventListener("keydown", (event) => {
+      this.listen(handle, "pane-resizer", "keydown", (event) => {
         this.onPaneResizeKey(handle.dataset.paneResizer, event as KeyboardEvent);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-activity-toggle]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "activity-toggle", "click", () => {
         const eventKey = button.dataset.activityToggle;
         if (eventKey) {
           this.toggleActivityEvent(eventKey);
@@ -2526,7 +2662,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-testid='run-action-button']").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "run-action-button", "click", () => {
         const action = button.dataset.action as RunAction | undefined;
         if (action) {
           void this.dispatchRunAction(action);
@@ -2534,7 +2670,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-testid='approve-button']").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "approve-button", "click", () => {
         const approvalId = button.dataset.approvalId;
         if (!approvalId) return;
         const container = button.closest("[data-testid='approval-item']");
@@ -2543,7 +2679,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-testid='deny-button']").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "deny-button", "click", () => {
         const approvalId = button.dataset.approvalId;
         if (!approvalId) return;
         const container = button.closest("[data-testid='approval-item']");
@@ -2555,22 +2691,22 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
     // Task graph filters
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-filter]").forEach((control) => {
-      control.addEventListener("change", () => this.onFilterChange());
-      control.addEventListener("input", () => this.onFilterChange());
+      this.listen(control, "tg-filter", "change", () => this.onFilterChange());
+      this.listen(control, "tg-filter", "input", () => this.onFilterChange());
     });
-    this.options.root.querySelector("[data-tg-filter-reset]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-filter-reset]"), "tg-filter-reset", "click", () => {
       this.state.taskGraphFilter = { ...defaultTaskGraphFilter };
       this.render();
     });
 
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-create]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-create", "click", () => {
         const kind = button.dataset.tgCreate as TaskGraphNodeKind;
         this.openCreateDialog(kind, null);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-create-child]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-create-child", "click", () => {
         const parentId = button.dataset.tgCreateChild;
         if (!parentId) return;
         const parent = this.state.taskGraph?.nodes.find((node) => node.node_id === parentId);
@@ -2579,61 +2715,61 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         this.openCreateDialog(childKind, parentId);
       });
     });
-    this.options.root.querySelector("[data-tg-create-save]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-create-save]"), "tg-create-save", "click", () => {
       void this.saveCreateDialog();
     });
-    this.options.root.querySelector("[data-tg-create-cancel]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-create-cancel]"), "tg-create-cancel", "click", () => {
       this.state.createDialog = { ...emptyEditorDialog };
       this.render();
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-edit]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-edit", "click", () => {
         const nodeId = button.dataset.tgEdit;
         if (nodeId) this.startInlineEdit(nodeId);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-inline-save]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-inline-save", "click", () => {
         const nodeId = button.dataset.tgInlineSave;
         if (nodeId) void this.saveInlineEdit(nodeId);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-inline-cancel]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-inline-cancel", "click", () => {
         this.state.inlineEdit = { ...emptyInlineEdit };
         this.render();
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-deps]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-deps", "click", () => {
         const nodeId = button.dataset.tgDeps;
         if (nodeId) this.openDependencyEditor(nodeId);
       });
     });
-    this.options.root.querySelector("[data-tg-deps-save]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-deps-save]"), "tg-deps-save", "click", () => {
       void this.saveDependencyEdit();
     });
-    this.options.root.querySelector("[data-tg-deps-cancel]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-deps-cancel]"), "tg-deps-cancel", "click", () => {
       this.state.dependencyEdit = { ...emptyDependencyEdit };
       this.render();
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-comment]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "tg-comment", "click", () => {
         const nodeId = button.dataset.tgComment;
         if (nodeId) this.openCommentEditor(nodeId);
       });
     });
-    this.options.root.querySelector("[data-tg-comment-save]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-comment-save]"), "tg-comment-save", "click", () => {
       void this.saveCommentEdit();
     });
-    this.options.root.querySelector("[data-tg-comment-cancel]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-tg-comment-cancel]"), "tg-comment-cancel", "click", () => {
       this.state.commentEdit = { ...emptyCommentEdit };
       this.render();
     });
 
     // Planning workspace view navigation
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-view]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-view", "click", () => {
         const view = button.dataset.planView as AppState["activeView"];
         if (view) {
           this.state.activeView = view;
@@ -2644,7 +2780,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
     // Planning workspace tabs
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-tab]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-tab", "click", () => {
         const tab = button.dataset.planTab;
         if (!tab) return;
         this.state.planningWorkspace = { ...this.state.planningWorkspace, activeTab: tab as typeof this.state.planningWorkspace.activeTab };
@@ -2653,43 +2789,43 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     });
 
     // Planning conversation
-    this.options.root.querySelector("[data-plan-send-message]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-plan-send-message]"), "plan-send-message", "click", () => {
       this.sendPlanMessage();
     });
-    this.options.root.querySelector("[data-plan-composer]")?.addEventListener("keydown", (event) => {
+    this.listen(this.options.root.querySelector("[data-plan-composer]"), "plan-composer", "keydown", (event) => {
       if ((event as KeyboardEvent).key === "Enter" && !(event as KeyboardEvent).shiftKey) {
         (event as KeyboardEvent).preventDefault();
         this.sendPlanMessage();
       }
     });
-    this.options.root.querySelector("[data-plan-composer]")?.addEventListener("input", () => {
+    this.listen(this.options.root.querySelector("[data-plan-composer]"), "plan-composer", "input", () => {
       this.state.planningWorkspace.composerDraft = this.options.root.querySelector<HTMLTextAreaElement>("[data-plan-composer]")?.value ?? "";
     });
 
     // Planning artifact editor
-    this.options.root.querySelector("[data-plan-artifact-select]")?.addEventListener("change", () => {
+    this.listen(this.options.root.querySelector("[data-plan-artifact-select]"), "plan-artifact-select", "change", () => {
       const artifactId = this.options.root.querySelector<HTMLSelectElement>("[data-plan-artifact-select]")?.value ?? null;
       this.state.planningWorkspace = selectArtifact(this.state.planningWorkspace, artifactId);
       this.renderPreservingFocus();
     });
-    this.options.root.querySelector("[data-plan-revision-select]")?.addEventListener("change", () => {
+    this.listen(this.options.root.querySelector("[data-plan-revision-select]"), "plan-revision-select", "change", () => {
       const revisionId = this.options.root.querySelector<HTMLSelectElement>("[data-plan-revision-select]")?.value ?? null;
       this.state.planningWorkspace = selectRevision(this.state.planningWorkspace, revisionId);
       this.renderPreservingFocus();
     });
-    this.options.root.querySelector("[data-plan-save-artifact]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-plan-save-artifact]"), "plan-save-artifact", "click", () => {
       this.savePlanArtifact();
     });
-    this.options.root.querySelector("[data-plan-add-artifact]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-plan-add-artifact]"), "plan-add-artifact", "click", () => {
       this.addPlanArtifact();
     });
-    this.options.root.querySelector("[data-plan-artifact-content]")?.addEventListener("input", () => {
+    this.listen(this.options.root.querySelector("[data-plan-artifact-content]"), "plan-artifact-content", "input", () => {
       // Content is not persisted continuously; only saved on explicit save.
     });
 
     // Planning hierarchy editor
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-node-select]").forEach((row) => {
-      row.addEventListener("click", (event) => {
+      this.listen(row, "plan-node-select", "click", (event) => {
         if ((event.target as HTMLElement).closest(".os-node-actions, .os-plan-toggle, .os-plan-node-body input")) return;
         const nodeId = row.dataset.planNodeSelect;
         if (nodeId) {
@@ -2699,7 +2835,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-node-toggle]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-node-toggle", "click", () => {
         const nodeId = button.dataset.planNodeToggle;
         if (nodeId) {
           this.state.planningWorkspace = toggleNodeExpanded(this.state.planningWorkspace, nodeId);
@@ -2708,13 +2844,13 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-add-node]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-add-node", "click", () => {
         const kind = button.dataset.planAddNode as "milestone" | "issue" | "sub_issue";
         this.addPlanNode(kind, null);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-add-child]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-add-child", "click", () => {
         const parentId = button.dataset.planAddChild;
         if (!parentId) return;
         const parent = this.state.planningWorkspace.nodes.find((n) => n.node_id === parentId);
@@ -2724,7 +2860,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-node-edit]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-node-edit", "click", () => {
         const nodeId = button.dataset.planNodeEdit;
         if (!nodeId) return;
         const node = this.state.planningWorkspace.nodes.find((n) => n.node_id === nodeId);
@@ -2734,19 +2870,19 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-node-save]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-node-save", "click", () => {
         const nodeId = button.dataset.planNodeSave;
         if (nodeId) this.savePlanNodeEdit(nodeId);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-node-cancel]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-node-cancel", "click", () => {
         this.state.planningEdit = { ...emptyPlanningEditState };
         this.render();
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-remove-node]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-remove-node", "click", () => {
         const nodeId = button.dataset.planRemoveNode;
         if (nodeId) {
           this.state.planningWorkspace = removePlanningNode(this.state.planningWorkspace, nodeId);
@@ -2755,7 +2891,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-graph-node]").forEach((node) => {
-      node.addEventListener("click", () => {
+      this.listen(node, "plan-graph-node", "click", () => {
         const nodeId = node.dataset.planGraphNode;
         if (nodeId) {
           this.state.planningWorkspace = { ...this.state.planningWorkspace, selectedNodeId: nodeId };
@@ -2765,24 +2901,24 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     });
 
     // Planning dependency editor
-    this.options.root.querySelector("[data-plan-deps-node-select]")?.addEventListener("change", () => {
+    this.listen(this.options.root.querySelector("[data-plan-deps-node-select]"), "plan-deps-node-select", "change", () => {
       const nodeId = this.options.root.querySelector<HTMLSelectElement>("[data-plan-deps-node-select]")?.value ?? null;
       this.state.planningWorkspace = { ...this.state.planningWorkspace, selectedNodeId: nodeId };
       this.renderPreservingFocus();
     });
-    this.options.root.querySelector("[data-plan-deps-save]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-plan-deps-save]"), "plan-deps-save", "click", () => {
       this.savePlanDependencies();
     });
 
     // Planning acceptance criteria / verification editor
-    this.options.root.querySelector("[data-plan-criteria-add]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-plan-criteria-add]"), "plan-criteria-add", "click", () => {
       const text = this.options.root.querySelector<HTMLInputElement>("[data-plan-criteria-new]")?.value ?? "";
       if (!text.trim()) return;
       this.state.planningWorkspace = addCriterion(this.state.planningWorkspace, text);
       this.render();
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-criteria-toggle]").forEach((checkbox) => {
-      checkbox.addEventListener("change", () => {
+      this.listen(checkbox, "plan-criteria-toggle", "change", () => {
         const id = checkbox.dataset.planCriteriaToggle;
         if (id) {
           this.state.planningWorkspace = toggleCriterion(this.state.planningWorkspace, id);
@@ -2791,7 +2927,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-criteria-text]").forEach((input) => {
-      input.addEventListener("input", () => {
+      this.listen(input, "plan-criteria-text", "input", () => {
         const id = input.dataset.planCriteriaText;
         const value = (input as HTMLInputElement).value;
         if (id) {
@@ -2801,7 +2937,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-criteria-remove]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-criteria-remove", "click", () => {
         const id = button.dataset.planCriteriaRemove;
         if (id) {
           this.state.planningWorkspace = removeCriterion(this.state.planningWorkspace, id);
@@ -2809,14 +2945,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         }
       });
     });
-    this.options.root.querySelector("[data-plan-verification-add]")?.addEventListener("click", () => {
+    this.listen(this.options.root.querySelector("[data-plan-verification-add]"), "plan-verification-add", "click", () => {
       const text = this.options.root.querySelector<HTMLInputElement>("[data-plan-verification-new]")?.value ?? "";
       if (!text.trim()) return;
       this.state.planningWorkspace = addVerification(this.state.planningWorkspace, text);
       this.render();
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-verification-toggle]").forEach((checkbox) => {
-      checkbox.addEventListener("change", () => {
+      this.listen(checkbox, "plan-verification-toggle", "change", () => {
         const id = checkbox.dataset.planVerificationToggle;
         if (id) {
           this.state.planningWorkspace = toggleVerification(this.state.planningWorkspace, id);
@@ -2825,7 +2961,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-verification-text]").forEach((input) => {
-      input.addEventListener("input", () => {
+      this.listen(input, "plan-verification-text", "input", () => {
         const id = input.dataset.planVerificationText;
         const value = (input as HTMLInputElement).value;
         if (id) {
@@ -2835,7 +2971,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-verification-remove]").forEach((button) => {
-      button.addEventListener("click", () => {
+      this.listen(button, "plan-verification-remove", "click", () => {
         const id = button.dataset.planVerificationRemove;
         if (id) {
           this.state.planningWorkspace = removeVerification(this.state.planningWorkspace, id);
@@ -2846,20 +2982,20 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
     // Planning validation links
     this.options.root.querySelectorAll<HTMLElement>("[data-plan-validation-link]").forEach((link) => {
-      link.addEventListener("click", () => {
+      this.listen(link, "plan-validation-link", "click", () => {
         this.followPlanValidationLink(link);
       });
     });
 
     // Planning diff revision selectors
-    this.options.root.querySelector("[data-plan-diff-left]")?.addEventListener("change", () => {
+    this.listen(this.options.root.querySelector("[data-plan-diff-left]"), "plan-diff-left", "change", () => {
       this.state.planningWorkspace = {
         ...this.state.planningWorkspace,
         diffLeftRevisionId: this.options.root.querySelector<HTMLSelectElement>("[data-plan-diff-left]")?.value ?? null,
       };
       this.renderPreservingFocus();
     });
-    this.options.root.querySelector("[data-plan-diff-right]")?.addEventListener("change", () => {
+    this.listen(this.options.root.querySelector("[data-plan-diff-right]"), "plan-diff-right", "change", () => {
       this.state.planningWorkspace = {
         ...this.state.planningWorkspace,
         diffRightRevisionId: this.options.root.querySelector<HTMLSelectElement>("[data-plan-diff-right]")?.value ?? null,

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -314,6 +314,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    * while it was in flight, so a slow poll can never revert a selection.
    */
   private interactionEpoch = 0;
+  /**
+   * Guards in-flight openRun loads. Deliberately separate from
+   * interactionEpoch: selecting a diff file bumps the epoch (to invalidate
+   * background refreshes) but must not cancel a task open that is still
+   * loading — only a newer open, project switch, or full refresh does.
+   */
+  private runOpenSeq = 0;
+  /** Guards in-flight selectDiffFile loads (superseded by newer diff clicks or opens). */
+  private diffSelectSeq = 0;
   /** Tracks bindEvents sites already attached per element (see listen()). */
   private boundListeners = new WeakMap<Element, Set<string>>();
 
@@ -467,6 +476,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       return;
     }
     this.interactionEpoch += 1;
+    this.runOpenSeq += 1;
+    this.diffSelectSeq += 1;
     this.state.loading = true;
     this.render();
 
@@ -1030,7 +1041,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   private async openRun(node: TaskGraphNode): Promise<void> {
     const runId = runIdForNode(node);
-    const epoch = ++this.interactionEpoch;
+    this.interactionEpoch += 1;
+    this.diffSelectSeq += 1;
+    const openSeq = ++this.runOpenSeq;
     this.state.selectedNodeId = node.node_id;
     this.state.loading = true;
     this.render();
@@ -1041,7 +1054,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         this.transport.runDetail(runId),
         this.fetchRunDetailBundle(runId, null),
       ]);
-      if (this.destroyed || epoch !== this.interactionEpoch) {
+      if (this.destroyed || openSeq !== this.runOpenSeq) {
         return;
       }
       this.state.runDetail = runDetail;
@@ -1051,7 +1064,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.collapsedActivityEvents = new Set();
       this.applyRunDetailBundle(bundle);
     } catch (error) {
-      if (this.destroyed || epoch !== this.interactionEpoch) {
+      if (this.destroyed || openSeq !== this.runOpenSeq) {
         return;
       }
       this.state.runDetail = null;
@@ -1071,7 +1084,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private async selectDiffFile(path: string): Promise<void> {
-    const epoch = ++this.interactionEpoch;
+    // Invalidates background refreshes and older diff fetches, but not an
+    // in-flight openRun: clicking a (possibly stale) file must never cancel
+    // a task the user just opened.
+    this.interactionEpoch += 1;
+    const seq = ++this.diffSelectSeq;
     this.state.selectedDiffPath = path;
     this.state.evidenceView = "diff";
     this.render();
@@ -1084,7 +1101,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       } catch (error) {
         warning = `Diff unavailable: ${errorMessage(error)}`;
       }
-      if (this.destroyed || epoch !== this.interactionEpoch) {
+      // Drop the result if a newer diff click or task open superseded this
+      // fetch, or if the shown run changed while it was in flight.
+      if (this.destroyed || seq !== this.diffSelectSeq || this.state.runDetail?.run_id !== runId) {
         return;
       }
       this.state.runDiff = runDiff;
@@ -1373,6 +1392,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   private async selectProject(projectId: string): Promise<void> {
     this.interactionEpoch += 1;
+    this.runOpenSeq += 1;
+    this.diffSelectSeq += 1;
     this.state.selectedProjectId = projectId;
     this.state.loading = true;
     this.render();
@@ -1716,7 +1737,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     }
     const scrollPositions = captureShellScrollPositions(this.options.root);
     const title = this.options.title ?? "OpenSymphony";
-    if (this.state.graphPaneView !== "knowledge") {
+    // Dispose whenever the upcoming render will not include the Knowledge
+    // Graph surface — not only on pane switches: the planning view and auth
+    // placeholders also drop the canvas, and morphing it away without
+    // disposal would leak the WebGL context and scheduled draws.
+    const rendersKnowledgeGraph = this.state.graphPaneView === "knowledge"
+      && this.state.activeView === "dashboard"
+      && this.state.authState === "open";
+    if (!rendersKnowledgeGraph) {
       disposeKnowledgeGraphRenderer(this.options.root);
     }
     // Morph the new markup into the live DOM instead of rebuilding it with
@@ -1733,7 +1761,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           </div>
           <div class="os-view-tabs">
             <button type="button" class="os-view-tab ${this.state.activeView === "dashboard" ? "os-view-tab-active" : ""}" data-plan-view="dashboard">Dashboard</button>
-            <button type="button" class="os-view-tab ${this.state.activeView === "planning" ? "os-view-tab-active" : ""}" data-plan-view="planning">Planning</button>
+            <button type="button" class="os-view-tab os-view-tab-preview ${this.state.activeView === "planning" ? "os-view-tab-active" : ""}" data-plan-view="planning" title="Planning is under construction">Planning<span class="os-tab-badge">WIP</span></button>
           </div>
           ${this.renderTopbarStatusStrip()}
         </header>
@@ -1753,6 +1781,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     }
     if (this.state.activeView === "planning") {
       return `
+        <div class="os-preview-banner" role="status" data-testid="planning-preview-banner">
+          <strong>Under construction</strong>
+          <span>This planning workspace shows fixture data for preview purposes — it is not wired to a live planning session yet.</span>
+        </div>
         ${renderPlanningWorkspace(this.state.planningWorkspace, this.state.planningEdit)}
       `;
     }
@@ -1818,7 +1850,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         <div class="os-strip-metrics">${metrics}</div>
         <div class="os-strip-connection">
           <span>${escapeHtml(activeProfile?.label ?? "Connection")}</span>
-          <button type="button" class="os-icon-button" data-toggle-settings="connection" aria-expanded="${this.state.profilePanelExpanded ? "true" : "false"}" aria-label="Connection settings" title="Connection settings">Connection</button>
+          <button type="button" class="os-icon-button os-glyph-button" data-toggle-settings="connection" aria-expanded="${this.state.profilePanelExpanded ? "true" : "false"}" aria-label="Connection settings" title="Connection settings">${connectionIconSvg()}</button>
         </div>
         <div class="os-event-mini" data-testid="event-log-mini">
           <ol>${events || `<li>No recent events</li>`}</ol>
@@ -1828,7 +1860,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           <span>${escapeHtml(activeModel?.model || activeModel?.label || "Model")}</span>
           ${persistenceMeta}
           ${modelProfileError}
-          <button type="button" class="os-icon-button os-model-gear" data-toggle-settings="model" aria-expanded="${this.state.modelPanelExpanded ? "true" : "false"}" aria-label="Model Configuration settings" title="Model Configuration settings">&#9881;</button>
+          <button type="button" class="os-icon-button os-glyph-button os-model-gear" data-toggle-settings="model" aria-expanded="${this.state.modelPanelExpanded ? "true" : "false"}" aria-label="Model Configuration settings" title="Model Configuration settings">${gearIconSvg()}</button>
         </div>
       </div>
     `;
@@ -4478,6 +4510,16 @@ function stageSizeChanged(
   return Math.abs(previous.width - next.width) > 32 || Math.abs(previous.height - next.height) > 32;
 }
 
+/** Feather-style "link" glyph used for the connection settings toggle. */
+function connectionIconSvg(): string {
+  return `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>`;
+}
+
+/** Feather-style "settings" gear glyph used for the model settings toggle. */
+function gearIconSvg(): string {
+  return `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>`;
+}
+
 function appShellStyles(): string {
   return `
     :root { color-scheme: light dark; }
@@ -4487,13 +4529,14 @@ function appShellStyles(): string {
     .os-topbar { display: grid; grid-template-columns: minmax(180px, 0.9fr) auto minmax(420px, 2fr); align-items: center; gap: 18px; padding: 14px 18px; background: #ffffff; border-bottom: 1px solid #d8dee4; }
     .os-topbar h1 { margin: 0; font-size: 18px; line-height: 1.2; letter-spacing: 0; }
     .os-topbar p { margin: 5px 0 0; color: #5d6b78; font-size: 13px; }
-    .os-status-strip { min-width: 0; display: grid; grid-template-columns: auto auto minmax(120px, 0.8fr) minmax(170px, 1.1fr) minmax(150px, 1fr); gap: 8px; align-items: center; }
+    .os-status-strip { min-width: 0; display: grid; grid-template-columns: auto auto minmax(110px, 0.8fr) minmax(150px, 1.1fr) minmax(130px, 1fr); gap: 8px; align-items: center; }
     .os-status { display: inline-flex; align-items: center; gap: 8px; border: 1px solid #cad3dd; border-radius: 6px; padding: 7px 10px; background: #f8fafc; font-size: 13px; white-space: nowrap; }
     .os-status span { width: 9px; height: 9px; border-radius: 50%; background: #6b7280; }
     .os-status-connected span { background: #1f9d55; }
     .os-status-failed span { background: #c2410c; }
     .os-strip-metrics, .os-strip-connection, .os-strip-model, .os-event-mini { min-width: 0; min-height: 34px; display: flex; align-items: center; gap: 7px; border: 1px solid #d8dee4; border-radius: 6px; padding: 5px 7px; background: #fbfcfd; font-size: 12px; color: #536170; }
-    .os-strip-metrics { flex-wrap: wrap; }
+    .os-strip-metrics { flex-wrap: nowrap; }
+    .os-strip-metrics span { white-space: nowrap; }
     .os-strip-metrics strong { color: #17202a; }
     .os-strip-connection > span, .os-strip-model > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .os-event-mini ol { min-width: 0; display: grid; gap: 2px; margin: 0; padding: 0; list-style: none; }
@@ -4501,7 +4544,9 @@ function appShellStyles(): string {
     .os-event-mini time { color: #667788; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; margin-right: 4px; }
     .os-event-mini span { color: #39708f; margin-right: 4px; }
     .os-icon-button { flex: 0 0 auto; min-height: 28px; padding: 4px 8px; font-size: 12px; }
-    .os-model-gear { width: 30px; padding: 0; font-size: 15px; }
+    .os-glyph-button { width: 32px; min-height: 32px; margin-left: auto; padding: 0; display: inline-flex; align-items: center; justify-content: center; color: #536170; }
+    .os-glyph-button svg { display: block; }
+    .os-glyph-button:hover { color: #17202a; }
     .os-strip-alert { margin: 0; max-width: 240px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .os-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; padding: 14px; align-items: start; }
     .os-panel { background: #ffffff; border: 1px solid #d8dee4; border-radius: 8px; padding: 14px; min-width: 0; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05); }
@@ -4777,6 +4822,11 @@ function appShellStyles(): string {
     .os-view-tabs { display: inline-flex; gap: 6px; }
     .os-view-tab { min-height: 32px; padding: 6px 12px; font-size: 13px; border-radius: 6px; background: #f8fafc; border: 1px solid #cad3dd; }
     .os-view-tab-active { background: #e7f1f5; border-color: #39708f; font-weight: 600; }
+    .os-view-tab-preview { color: #8a97a3; }
+    .os-view-tab-preview.os-view-tab-active { color: #536170; }
+    .os-tab-badge { margin-left: 6px; padding: 1px 5px; font-size: 10px; font-weight: 600; letter-spacing: 0.04em; border-radius: 4px; background: #fef3c7; border: 1px solid #f0d48a; color: #92600a; vertical-align: 1px; }
+    .os-preview-banner { grid-column: 1 / -1; display: flex; align-items: baseline; gap: 10px; padding: 10px 14px; border: 1px solid #f0d48a; border-radius: 8px; background: #fef8e7; color: #92600a; font-size: 13px; }
+    .os-preview-banner strong { text-transform: uppercase; font-size: 11px; letter-spacing: 0.06em; white-space: nowrap; }
     .os-planning-panel { grid-column: 1 / -1; display: flex; flex-direction: column; gap: 14px; }
     .os-planning-head { display: flex; align-items: center; justify-content: space-between; gap: 14px; flex-wrap: wrap; }
     .os-planning-head h2 { margin: 0; font-size: 16px; }

--- a/packages/ui-core/src/dom-morph.ts
+++ b/packages/ui-core/src/dom-morph.ts
@@ -1,0 +1,220 @@
+/**
+ * Minimal dependency-free DOM morphing.
+ *
+ * `morphChildren` reconciles a live element's children against a new HTML
+ * string, mutating only what changed instead of rebuilding the subtree via
+ * `innerHTML`. Unchanged nodes keep their identity, so focus, text
+ * selection, scroll offsets, canvas bitmaps, and attached event listeners
+ * survive a re-render.
+ *
+ * Reconciliation rules:
+ * - Nodes match by position when they share node type and tag name.
+ * - Elements carrying an identity attribute (`id`, `data-key`,
+ *   `data-node-id`, or `data-path`) only match a node with the same key and
+ *   are searched for out of position, so keyed list items move instead of
+ *   being rewritten in place.
+ * - Form fields that currently hold focus keep their user-entered value,
+ *   checked state, and selection; everything else syncs to the new render.
+ */
+
+const KEY_ATTRIBUTES = ["id", "data-key", "data-node-id", "data-path"] as const;
+
+export function morphChildren(target: Element, html: string): void {
+  const template = target.ownerDocument.createElement("template");
+  template.innerHTML = html;
+  morphChildNodes(target, template.content);
+}
+
+function morphChildNodes(target: ParentNode & Node, source: ParentNode): void {
+  const sourceChildren = Array.from(source.childNodes);
+
+  for (let index = 0; index < sourceChildren.length; index += 1) {
+    const sourceChild = sourceChildren[index];
+    const existing = target.childNodes[index] ?? null;
+
+    const keyed = findKeyedMatch(target, index, sourceChild);
+    if (keyed && keyed !== existing) {
+      target.insertBefore(keyed, existing);
+    }
+
+    const current = target.childNodes[index] ?? null;
+    if (!current) {
+      target.appendChild(sourceChild);
+      continue;
+    }
+    if (isCompatible(current, sourceChild)) {
+      morphNode(current, sourceChild);
+    } else {
+      target.replaceChild(sourceChild, current);
+    }
+  }
+
+  while (target.childNodes.length > sourceChildren.length) {
+    target.removeChild(target.lastChild!);
+  }
+}
+
+function findKeyedMatch(target: ParentNode, fromIndex: number, sourceChild: Node): Element | null {
+  if (sourceChild.nodeType !== 1) {
+    return null;
+  }
+  const key = nodeKey(sourceChild as Element);
+  if (key === null) {
+    return null;
+  }
+  for (let index = fromIndex; index < target.childNodes.length; index += 1) {
+    const candidate = target.childNodes[index];
+    if (
+      candidate.nodeType === 1
+      && candidate.nodeName === sourceChild.nodeName
+      && nodeKey(candidate as Element) === key
+    ) {
+      return candidate as Element;
+    }
+  }
+  return null;
+}
+
+function nodeKey(element: Element): string | null {
+  for (const attribute of KEY_ATTRIBUTES) {
+    const value = element.getAttribute(attribute);
+    if (value !== null && value !== "") {
+      return `${attribute}=${value}`;
+    }
+  }
+  // Canvas identity matters (a redrawn canvas loses its bitmap), and canvases
+  // in this app are addressed by test id rather than a list key.
+  if (element.nodeName === "CANVAS") {
+    const testId = element.getAttribute("data-testid");
+    if (testId) {
+      return `data-testid=${testId}`;
+    }
+  }
+  return null;
+}
+
+function isCompatible(current: Node, next: Node): boolean {
+  if (current.nodeType !== next.nodeType) {
+    return false;
+  }
+  if (current.nodeType !== 1) {
+    return true;
+  }
+  if (current.nodeName !== next.nodeName) {
+    return false;
+  }
+  return nodeKey(current as Element) === nodeKey(next as Element);
+}
+
+function morphNode(current: Node, next: Node): void {
+  if (current.nodeType === 3 || current.nodeType === 8) {
+    if (current.nodeValue !== next.nodeValue) {
+      current.nodeValue = next.nodeValue;
+    }
+    return;
+  }
+  if (current.nodeType !== 1) {
+    return;
+  }
+  const currentElement = current as Element;
+  const nextElement = next as Element;
+  const focused = currentElement.ownerDocument.activeElement === currentElement;
+
+  if (currentElement.nodeName === "CANVAS") {
+    // Canvases are imperative surfaces: their bitmap, dimensions, and inline
+    // style are managed by the code drawing on them. Only add or update
+    // attributes the new render declares; never remove the rest (removing
+    // width/height would clear the bitmap).
+    for (const attribute of Array.from(nextElement.attributes)) {
+      if (currentElement.getAttribute(attribute.name) !== attribute.value) {
+        currentElement.setAttribute(attribute.name, attribute.value);
+      }
+    }
+    return;
+  }
+
+  // Capture the target form state before morphing children: reconciliation
+  // can move option nodes out of `next`, which would change its `value`.
+  const formState = captureFormState(nextElement);
+  syncAttributes(currentElement, nextElement, focused);
+  if (currentElement.nodeName === "TEXTAREA") {
+    // A textarea's child text is its default value; sync it as plain text and
+    // let applyFormState decide whether the live value follows.
+    if (currentElement.textContent !== nextElement.textContent) {
+      currentElement.textContent = nextElement.textContent;
+    }
+  } else {
+    morphChildNodes(currentElement, nextElement);
+  }
+  applyFormState(currentElement, formState, focused);
+}
+
+function syncAttributes(current: Element, next: Element, focused: boolean): void {
+  for (const attribute of Array.from(current.attributes)) {
+    if (focused && (attribute.name === "value" || attribute.name === "checked")) {
+      continue;
+    }
+    if (!next.hasAttribute(attribute.name)) {
+      current.removeAttribute(attribute.name);
+    }
+  }
+  for (const attribute of Array.from(next.attributes)) {
+    if (focused && (attribute.name === "value" || attribute.name === "checked")) {
+      continue;
+    }
+    if (current.getAttribute(attribute.name) !== attribute.value) {
+      current.setAttribute(attribute.name, attribute.value);
+    }
+  }
+}
+
+interface FormState {
+  value?: string;
+  checked?: boolean;
+  selected?: boolean;
+}
+
+/**
+ * Live form state (`value`, `checked`, `selected`) diverges from the
+ * rendered attributes as soon as the user interacts with a field, so it must
+ * be written back explicitly — unless the field holds focus, in which case
+ * the user's in-progress input wins over the render.
+ */
+function captureFormState(next: Element): FormState {
+  if (next instanceof HTMLInputElement) {
+    return { value: next.value, checked: next.checked };
+  }
+  if (next instanceof HTMLTextAreaElement || next instanceof HTMLSelectElement) {
+    return { value: next.value };
+  }
+  if (next instanceof HTMLOptionElement) {
+    return { selected: next.selected };
+  }
+  return {};
+}
+
+function applyFormState(current: Element, state: FormState, focused: boolean): void {
+  if (focused) {
+    return;
+  }
+  if (current instanceof HTMLInputElement) {
+    if (state.value !== undefined && current.value !== state.value) {
+      current.value = state.value;
+    }
+    if (state.checked !== undefined && current.checked !== state.checked) {
+      current.checked = state.checked;
+    }
+    return;
+  }
+  if (current instanceof HTMLTextAreaElement || current instanceof HTMLSelectElement) {
+    if (state.value !== undefined && current.value !== state.value) {
+      current.value = state.value;
+    }
+    return;
+  }
+  if (current instanceof HTMLOptionElement && state.selected !== undefined) {
+    if (current.selected !== state.selected) {
+      current.selected = state.selected;
+    }
+  }
+}

--- a/packages/ui-core/src/dom-morph.ts
+++ b/packages/ui-core/src/dom-morph.ts
@@ -17,7 +17,7 @@
  *   checked state, and selection; everything else syncs to the new render.
  */
 
-const KEY_ATTRIBUTES = ["id", "data-key", "data-node-id", "data-path"] as const;
+const KEY_ATTRIBUTES = ["id", "data-key", "data-node-id", "data-path", "data-approval-id"] as const;
 
 export function morphChildren(target: Element, html: string): void {
   const template = target.ownerDocument.createElement("template");

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -144,12 +144,15 @@ export function mountKnowledgeGraphRenderer(
       if (nodeId) options.onSelect(nodeId);
     }
   };
+  // Handler properties (not addEventListener) so re-mounting after every
+  // render stays idempotent: the DOM morph preserves these buttons across
+  // renders, and stacked listeners would fire once per past render.
   root.querySelectorAll<HTMLElement>("[data-kg-node-id]").forEach((button) => {
-    button.addEventListener("click", () => {
+    button.onclick = () => {
       const nodeId = button.dataset.kgNodeId;
       if (nodeId) options.onSelect(nodeId);
-    });
-    button.addEventListener("keydown", (event) => {
+    };
+    button.onkeydown = (event) => {
       const direction = graphListNavigationDirection(event.key);
       if (!direction) return;
       const buttons = Array.from(root.querySelectorAll<HTMLElement>(".os-kg-list [data-kg-node-id]"));
@@ -162,11 +165,11 @@ export function mountKnowledgeGraphRenderer(
           ? buttons.length - 1
           : (index + direction + buttons.length) % buttons.length;
       buttons[nextIndex]?.focus();
-    });
-    button.addEventListener("focus", () => {
+    };
+    button.onfocus = () => {
       const nodeId = button.dataset.kgNodeId;
       if (nodeId) options.onFocus(nodeId);
-    });
+    };
   });
 }
 

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -68,7 +68,25 @@ export function mountKnowledgeGraphRenderer(
   options: KnowledgeGraphMountOptions,
 ): void {
   const canvas = root.querySelector<HTMLCanvasElement>("[data-testid='knowledge-graph-canvas']");
-  if (!canvas || !options.snapshot || !options.layout) return;
+  if (!canvas) return;
+  if (!options.snapshot || !options.layout) {
+    // The morphing render preserves the canvas node, so without drawable
+    // data the previous mount's bitmap and handlers would otherwise stay
+    // live and interactive against a stale layout. Always detach the
+    // interaction handlers; drop the bitmap too once the snapshot itself is
+    // gone (bundle switch/reset). During a pure re-layout the snapshot is
+    // still present and keeping the bitmap avoids a blank flash.
+    canvas.onwheel = null;
+    canvas.onpointerdown = null;
+    canvas.onpointermove = null;
+    canvas.onpointerup = null;
+    if (!options.snapshot) {
+      disposeKnowledgeGraphCanvas(canvas);
+      canvas.width = canvas.width || 1;
+      canvas.dataset.nonblank = "false";
+    }
+    return;
+  }
   const stage = canvas.closest<HTMLElement>("[data-kg-stage]");
   const view = {
     scale: options.view.scale,


### PR DESCRIPTION
## Summary

The desktop app felt slow (task clicks ~1s, diff clicks ~2s) and the 5-second live-refresh poll rebuilt the whole app DOM, closing the open task in favor of a previously selected one and dropping focus/input state. This PR removes the latency sources in the gateway, parallelizes the frontend fetch fan-out, and replaces the innerHTML full rebuild with diff-based DOM morphing plus an interaction-epoch guard so background refreshes can never override user navigation.

## Changes

- **Gateway — `gh pr view` off the hot path**: `run_detail` shelled out to `gh pr view` (a network round trip, blocking a tokio worker) whenever the snapshot lacked a `pr_url` — on every task click and for every task-graph node each poll. PR URLs now resolve in a background cache (`PrUrls`, 60s TTL); `run_detail` responds immediately and the link fills in on the next poll.
- **Gateway — batched git numstat**: `tracked_workspace_file_changes` ran one `git diff --numstat` subprocess *per changed file* (N+1). It now runs a single batched `--numstat -z` sweep parsed by `parse_git_numstat_z`.
- **Gateway — coalesced workspace scans**: concurrent `run_files`/`run_diffs`/`run_validation` requests for the same workspace share one git sweep (`WorkspaceScans`, watch-channel singleflight — no TTL, so results are never stale). `run_diffs` reuses the sweep's comparison base instead of re-probing refs a second time.
- **ui-core — parallel run open**: `openRun` fetched detail → files → diff → events → validation → approvals sequentially (6 queued round trips). All now load concurrently and apply atomically (`fetchRunDetailBundle`/`applyRunDetailBundle`).
- **ui-core — interaction epoch**: live refresh used to capture `selectedNodeId` before several awaits and write it back afterwards, reverting any task clicked mid-refresh. Refreshes now resolve selection at apply time and abandon their results entirely if the user navigated while they were in flight. Evidence state is no longer nulled during refresh, so panels stop flashing empty and the selected diff file / evidence tab / activity expansions survive polls.
- **ui-core — DOM morphing**: `render()` morphs new markup into the live DOM (new dependency-free `dom-morph.ts`) instead of `innerHTML` rebuilds. Focus, in-progress input, scroll offsets, canvas bitmaps, and listeners survive re-renders; `bindEvents` is idempotent via a bind-once `listen()` helper so surviving nodes don't accumulate duplicate listeners.

## Evidence

### Test output

```
cargo test --lib opensymphony_gateway   → 50 passed (3 new: batched numstat parse, rename counts, pr-url background cache)
cargo test --test gateway               → 56 passed
npx jest                                → 34 suites, 592 passed (13 new)
cargo fmt --check / cargo clippy        → clean
npx tsc --noEmit -p tsconfig.projects.json → clean
```

### Verification

- New `live-refresh-behavior.test.ts` pins the fixed behavior: a task opened while a refresh is frozen mid-flight stays selected; selected diff file and evidence view survive refreshes; evidence panels stay populated during a refresh; focus + typed filter text survive a refresh. The selection-race test was verified to **fail** against a simulated pre-fix `refreshLiveGatewayData` (stale capture + no epoch guard), so it has teeth.
- New `dom-morph.test.ts` covers node identity across keyed reorders, listener preservation, focused-input protection, textarea/select sync, and canvas attribute preservation.
- Subprocess math per task click: previously 3 full scans × (N files + ~10 git calls) plus a GitHub network call; now ~4 git spawns total and no network.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [ ] Documentation updated (if behavior changed)
- [ ] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Breaking changes

None in the API shape. Two behavior notes for reviewers:
- A run's PR link may show "Not found" for up to one poll cycle (~5s) on first sight of a workspace while the background `gh` lookup resolves.
- `run_files`/`run_diffs` no longer return 500 when a workspace scan fails; they fall back to the snapshot's `modified_files`, matching the existing fallback for unscannable workspaces.

## Related issues

None filed — driven by observed desktop latency/re-render UX.

## Additional notes

The morph keys elements by `id`/`data-key`/`data-node-id`/`data-path` (and `data-testid` for canvases); unkeyed nodes match by tag + position, which is safe because all bindEvents handlers read `dataset` at event time.