### PR TITLE
feat(graph): 3D knowledge-graph command center, differentiated task-graph arrows, shared viz fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,13 @@ Do not silently invent behavior when the upstream spec or chosen integration con
 - The daemon must remain correct without any UI attached.
 - The UI consumes the control-plane snapshot and event stream only.
 - UI code must not reach into orchestrator internals directly.
+- Graph-visualization work (knowledge graph, task graph arrows) iterates
+  against the shared fixtures and desktop `?fixtures` workbench described in
+  `docs/graph-view.md` ("Graph visualization workbench"). Do not recreate
+  ad-hoc demo data; extend `packages/graph/src/viz-fixture.ts` and
+  `packages/api-client/src/graph-viz-demo.ts` instead, and keep the scene
+  math covered by `packages/ui-core/__tests__/knowledge-graph-scene.test.ts`
+  (including the THREE.js projection-parity test).
 
 ### CLI surface
 

--- a/apps/desktop/__tests__/app-shell-render.test.ts
+++ b/apps/desktop/__tests__/app-shell-render.test.ts
@@ -108,6 +108,7 @@ describe("desktop app shell render", () => {
         setTransform: jest.fn(),
         fillRect: jest.fn(),
         beginPath: jest.fn(),
+        closePath: jest.fn(),
         moveTo: jest.fn(),
         lineTo: jest.fn(),
         stroke: jest.fn(),

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -1,13 +1,18 @@
 import {
   HttpGatewayTransport,
+  createGraphVizDemoTransport,
   type ActionCapableTransport,
   type ActionDispatch,
   type ActionReceipt,
   type GatewayTransport,
 } from "@opensymphony/api-client";
 import {
+  createFixtureGraphAdapter,
   createGatewayGraphAdapter,
   createTauriNativeGraphAdapter,
+  graphVizFixtureBundleList,
+  graphVizFixtureCommunityList,
+  graphVizFixtureSnapshot,
   type MemoryBundleList,
   type MemoryCommunityList,
   type MemoryConceptDetail,
@@ -609,8 +614,36 @@ async function createTransportForGateway(gatewayUrl: string): Promise<TauriTrans
   return transport;
 }
 
+/**
+ * Fixture workbench mode: `?fixtures` mounts the app on deterministic demo
+ * data (dense knowledge graph + dependency-heavy task graph) instead of the
+ * local gateway. Used for graph-visualization iteration and screenshots via
+ * the vite dev server; a packaged Tauri build never carries a query string,
+ * so production behavior is unchanged. See docs/graph-view.md.
+ */
+function fixtureWorkbenchRequested(): boolean {
+  try {
+    return new URLSearchParams(globalThis.location?.search ?? "").has("fixtures");
+  } catch {
+    return false;
+  }
+}
+
 const root = document.getElementById("root");
-if (root) {
+if (root && fixtureWorkbenchRequested()) {
+  renderOpenSymphonyApp({
+    root,
+    mode: "desktop",
+    title: "OpenSymphony Desktop (fixtures)",
+    transport: createGraphVizDemoTransport(),
+    graphAdapter: createFixtureGraphAdapter({
+      bundles: graphVizFixtureBundleList,
+      snapshot: graphVizFixtureSnapshot,
+      communities: graphVizFixtureCommunityList,
+    }),
+    modelProfileController: createDesktopModelProfileController(),
+  });
+} else if (root) {
   const transport = createDesktopTransport();
   void transport.attach();
   renderOpenSymphonyApp({

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -35,3 +35,67 @@ last_memory_sync: 2026-07-02T03:46:15.373470+00:00
 - PR-196
 
 <!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## Graph visualization workbench
+
+Graph rendering work needs dense, stable data long before a live daemon has
+any. The workbench provides that as code, so every iteration, screenshot, and
+test sees the same graph:
+
+- `packages/graph/src/viz-fixture.ts` — deterministic knowledge-graph
+  snapshot (~100 nodes, 7 `area:*` communities, concepts that belong to more
+  than one area, mixed node kinds and degrees) built from a seeded PRNG.
+- `packages/api-client/src/graph-viz-demo.ts` — matching task-graph demo
+  (`graphVizDemoTaskGraph`) whose dependency shapes stress the arrow
+  routing: several skip-level dependencies fanning out from one blocker plus
+  overlapping skips from different blockers. `createGraphVizDemoTransport()`
+  wraps it all in a `MockGatewayTransport`.
+
+### Running the workbench
+
+```bash
+npm run dev --workspace @opensymphony/desktop
+# then open http://127.0.0.1:1420/?fixtures
+```
+
+`?fixtures` mounts the desktop shell on the demo transport and fixture graph
+adapter instead of the local gateway (see `apps/desktop/src/index.ts`).
+Packaged Tauri builds never carry a query string, so production behavior is
+unchanged.
+
+### Renderer architecture
+
+The knowledge-graph surface is a 3D command center:
+
+- `packages/ui-core/src/knowledge-graph-scene.ts` — pure scene model: an
+  orbital perspective camera (pan / cursor-anchored dolly / yaw-pitch
+  orbit), a software projector that matches `THREE.PerspectiveCamera`
+  (parity is unit-tested), diffuse per-area hull geometry with spatial
+  outlier trimming (multi-area membership renders as overlapping hulls),
+  zoom-dependent label opacities (area titles when zoomed out, node labels
+  when zoomed in), hover adjacency emphasis, and hit-testing.
+- `packages/ui-core/src/knowledge-graph-renderer.ts` — DOM/WebGL wiring:
+  three.js rasterizes the already-projected screen-space scene (2D canvas
+  fallback draws the identical scene), HTML overlays carry node labels,
+  area titles, and the hover tooltip, and pointer handlers implement node
+  dragging, panning, orbiting, wheel dolly, and double-click framing of a
+  node's neighborhood or an area hull. Camera and drag overrides persist in
+  `KnowledgeGraphViewState` across live refreshes.
+
+Task-graph dependency arrows route skip-level edges through a left gutter
+with one lane and one hue per blocker (rounded corners, colored arrowheads);
+hovering a task spotlights its incident arrows. See
+`renderTaskGraphLink`/`buildTaskGraphLinks` in
+`packages/ui-core/src/app-shell.ts`.
+
+### Tests that gate this area
+
+- `packages/ui-core/__tests__/knowledge-graph-scene.test.ts` — projector ↔
+  THREE parity, camera ops, hulls (incl. multi-area and outlier trimming),
+  label LOD, hover emphasis, hit-tests, fixture density/determinism.
+- `packages/ui-core/__tests__/app-shell.test.ts` — surface markup, LOD label
+  budget through the real mount, arrow routing shape (`os-tg-hue-*`,
+  rounded gutter paths), WebGL smoke via Playwright when available.
+
+When iterating on visuals, extend these fixtures and tests rather than
+creating throwaway data; `AGENTS.md` ("UI separation") points here.

--- a/packages/api-client/__tests__/graph-viz-demo.test.ts
+++ b/packages/api-client/__tests__/graph-viz-demo.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The graph-viz task-graph demo must keep exercising multi-level dependency
+ * routing: deep active chains, blockers fanning to several dependents,
+ * diamonds, and long skips — not a single flat level of arrows.
+ */
+
+import { graphVizDemoTaskGraph, createGraphVizDemoTransport } from "../src/graph-viz-demo.js";
+
+type Node = (typeof graphVizDemoTaskGraph)["nodes"][number];
+
+function activeIssueNodes(): Node[] {
+  return graphVizDemoTaskGraph.nodes.filter(
+    (node) => node.kind === "issue" && node.state !== "Done",
+  );
+}
+
+/** Longest active-blocker chain length ending at each node. */
+function dependencyLevels(): Map<string, number> {
+  const active = activeIssueNodes();
+  const byIdentifier = new Map(active.map((node) => [node.identifier, node]));
+  const levels = new Map<string, number>();
+  const levelOf = (node: Node, trail: Set<string>): number => {
+    const cached = levels.get(node.identifier);
+    if (cached !== undefined) return cached;
+    if (trail.has(node.identifier)) throw new Error(`dependency cycle through ${node.identifier}`);
+    trail.add(node.identifier);
+    const blockers = node.blocked_by
+      .map((ref) => byIdentifier.get(ref))
+      .filter((blocker): blocker is Node => Boolean(blocker));
+    const level = blockers.length === 0
+      ? 0
+      : 1 + Math.max(...blockers.map((blocker) => levelOf(blocker, trail)));
+    trail.delete(node.identifier);
+    levels.set(node.identifier, level);
+    return level;
+  };
+  for (const node of active) levelOf(node, new Set());
+  return levels;
+}
+
+describe("graph viz task-graph demo", () => {
+  it("keeps at least five simultaneous active dependency levels", () => {
+    const levels = dependencyLevels();
+    const maxLevel = Math.max(...levels.values());
+    expect(maxLevel).toBeGreaterThanOrEqual(5);
+    // Every intermediate level is populated, so arrows render at each depth.
+    for (let level = 0; level <= maxLevel; level += 1) {
+      expect([...levels.values()]).toContain(level);
+    }
+  });
+
+  it("has blockers fanning to three dependents and re-blocking diamonds", () => {
+    const active = activeIssueNodes();
+    const dependents = new Map<string, string[]>();
+    for (const node of active) {
+      for (const blocker of node.blocked_by) {
+        dependents.set(blocker, [...(dependents.get(blocker) ?? []), node.identifier]);
+      }
+    }
+    const fanouts = [...dependents.values()].map((list) => list.length);
+    // "A blocks B, C, D" and "C blocks E, F, G": at least two three-way fans.
+    expect(fanouts.filter((count) => count >= 3).length).toBeGreaterThanOrEqual(2);
+    // Diamond: some node is blocked by both a level-0 root and one of that
+    // root's own dependents ("B blocks C and D" while A also blocks them).
+    const diamond = active.some((node) =>
+      node.blocked_by.length >= 2
+      && node.blocked_by.some((blockerRef) =>
+        active.some((candidate) =>
+          candidate.identifier === blockerRef
+          && candidate.blocked_by.some((upper) => node.blocked_by.includes(upper)),
+        ),
+      ));
+    expect(diamond).toBe(true);
+  });
+
+  it("suppresses arrows from completed blockers by keeping one Done source", () => {
+    const done = graphVizDemoTaskGraph.nodes.filter(
+      (node) => node.kind === "issue" && node.state === "Done",
+    );
+    expect(done.length).toBeGreaterThanOrEqual(1);
+    const doneIds = new Set(done.map((node) => node.identifier));
+    const blockedByDone = graphVizDemoTaskGraph.nodes.filter((node) =>
+      node.blocked_by.some((ref) => doneIds.has(ref)),
+    );
+    expect(blockedByDone.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("serves run details for every running fixture issue", async () => {
+    const transport = createGraphVizDemoTransport();
+    const running = graphVizDemoTaskGraph.nodes.filter((node) => node.run_id);
+    expect(running.length).toBeGreaterThanOrEqual(2);
+    for (const node of running) {
+      const detail = await transport.runDetail(node.run_id!);
+      expect(detail.run_id).toBe(node.run_id);
+      expect(detail.status).toBe("running");
+    }
+  });
+});

--- a/packages/api-client/src/graph-viz-demo.ts
+++ b/packages/api-client/src/graph-viz-demo.ts
@@ -36,20 +36,32 @@ interface DemoIssue {
 
 // Row order matters: the renderer lays nodes out top-to-bottom in array
 // order, so the blockedBy spans below encode the arrow shapes under test.
+//
+// The dependency web is deliberately deep and overlapping, following the
+// "A blocks B, C, D; B blocks C, D; C blocks E, F, G" pattern so arrow
+// routing is exercised across several simultaneous levels:
+//
+//   VIZ-100 (Done)   — completed blocker: its arrows must NOT render
+//   VIZ-101 (L0) → VIZ-102, VIZ-103, VIZ-104        (A fans three)
+//   VIZ-102 (L1) → VIZ-103, VIZ-104                 (B re-blocks C and D: diamond)
+//   VIZ-103 (L2) → VIZ-105, VIZ-106, VIZ-107        (C fans E, F, G)
+//   VIZ-104 (L2) → VIZ-108, VIZ-113                 (long skip to the tail)
+//   VIZ-105..108 (L3) → VIZ-109..112 (L4) → VIZ-113 (L5)
 const demoIssues: DemoIssue[] = [
-  { id: "VIZ-101", title: "Scene model and shared projector", state: "Done" },
+  { id: "VIZ-100", title: "Scene model spike", state: "Done" },
+  { id: "VIZ-101", title: "Shared projector foundation", state: "In Progress", blockedBy: ["VIZ-100"], running: true },
   { id: "VIZ-102", title: "Area hull computation", state: "In Progress", blockedBy: ["VIZ-101"], running: true },
-  { id: "VIZ-103", title: "Hover highlight and tooltip", state: "In Progress", blockedBy: ["VIZ-101"], running: true },
-  { id: "VIZ-104", title: "Node dragging interactions", state: "Todo", blockedBy: ["VIZ-103"] },
-  { id: "VIZ-105", title: "Zoom-dependent label fades", state: "Todo", blockedBy: ["VIZ-101", "VIZ-102"] },
-  { id: "VIZ-106", title: "Camera framing animations", state: "Todo", blockedBy: ["VIZ-102"] },
-  { id: "VIZ-107", title: "Task graph lane routing", state: "Human Review", blockedBy: ["VIZ-101"] },
-  { id: "VIZ-108", title: "Arrow palette and markers", state: "Todo", blockedBy: ["VIZ-107"] },
-  { id: "VIZ-109", title: "Dependency hover emphasis", state: "Todo", blockedBy: ["VIZ-103", "VIZ-107"] },
-  { id: "VIZ-110", title: "Fixture workbench docs", state: "Todo", blockedBy: ["VIZ-102"] },
-  { id: "VIZ-111", title: "Playwright visual sweep", state: "Todo", blockedBy: ["VIZ-105", "VIZ-108"] },
-  { id: "VIZ-112", title: "Reduced motion audit", state: "Todo", blockedBy: ["VIZ-103"] },
-  { id: "VIZ-113", title: "Release notes and demo capture", state: "Todo", blockedBy: ["VIZ-111", "VIZ-112", "VIZ-101"] },
+  { id: "VIZ-103", title: "Hover highlight and tooltip", state: "Human Review", blockedBy: ["VIZ-101", "VIZ-102"] },
+  { id: "VIZ-104", title: "Node dragging interactions", state: "Todo", blockedBy: ["VIZ-101", "VIZ-102"] },
+  { id: "VIZ-105", title: "Zoom-dependent label fades", state: "Todo", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-106", title: "Camera framing animations", state: "Todo", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-107", title: "Task graph lane routing", state: "Todo", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-108", title: "Arrow palette and markers", state: "Todo", blockedBy: ["VIZ-104"] },
+  { id: "VIZ-109", title: "Dependency hover emphasis", state: "Todo", blockedBy: ["VIZ-105", "VIZ-106"] },
+  { id: "VIZ-110", title: "Fixture workbench docs", state: "Todo", blockedBy: ["VIZ-106"] },
+  { id: "VIZ-111", title: "Playwright visual sweep", state: "Todo", blockedBy: ["VIZ-107", "VIZ-108"] },
+  { id: "VIZ-112", title: "Reduced motion audit", state: "Todo", blockedBy: ["VIZ-108"] },
+  { id: "VIZ-113", title: "Release notes and demo capture", state: "Todo", blockedBy: ["VIZ-104", "VIZ-109", "VIZ-111"] },
 ];
 
 function demoNode(issue: DemoIssue): TaskGraphNode {

--- a/packages/api-client/src/graph-viz-demo.ts
+++ b/packages/api-client/src/graph-viz-demo.ts
@@ -1,0 +1,235 @@
+import type {
+  ChangedFileEntry,
+  DashboardSnapshot,
+  FileDiffPage,
+  GatewayCapabilities,
+  RunDetail,
+  RunEventPage,
+  TaskGraphNode,
+  TaskGraphSnapshot,
+} from "@opensymphony/gateway-schema";
+import { MockGatewayTransport } from "./mock.js";
+
+/**
+ * Deterministic task-graph demo fixture for graph-visualization work.
+ *
+ * The graph deliberately contains the dependency shapes that stress the
+ * task-graph arrow routing: several skip-level dependencies fanning out from
+ * one blocker, skip-level dependencies from *different* blockers spanning the
+ * same rows (the case that conflated the old L-shaped routes), plus ordinary
+ * next-row edges. Paired with the knowledge-graph fixture in
+ * `@opensymphony/graph` it powers the desktop `?fixtures` workbench; see
+ * docs/graph-view.md ("Graph visualization workbench").
+ */
+
+const schema_version = { major: 1, minor: 0, patch: 0 };
+const generatedAt = "2026-07-04T00:00:00Z";
+const projectId = "viz-workbench";
+
+interface DemoIssue {
+  id: string;
+  title: string;
+  state: "Todo" | "In Progress" | "Human Review" | "Done";
+  blockedBy?: string[];
+  running?: boolean;
+}
+
+// Row order matters: the renderer lays nodes out top-to-bottom in array
+// order, so the blockedBy spans below encode the arrow shapes under test.
+const demoIssues: DemoIssue[] = [
+  { id: "VIZ-101", title: "Scene model and shared projector", state: "Done" },
+  { id: "VIZ-102", title: "Area hull computation", state: "In Progress", blockedBy: ["VIZ-101"], running: true },
+  { id: "VIZ-103", title: "Hover highlight and tooltip", state: "In Progress", blockedBy: ["VIZ-101"], running: true },
+  { id: "VIZ-104", title: "Node dragging interactions", state: "Todo", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-105", title: "Zoom-dependent label fades", state: "Todo", blockedBy: ["VIZ-101", "VIZ-102"] },
+  { id: "VIZ-106", title: "Camera framing animations", state: "Todo", blockedBy: ["VIZ-102"] },
+  { id: "VIZ-107", title: "Task graph lane routing", state: "Human Review", blockedBy: ["VIZ-101"] },
+  { id: "VIZ-108", title: "Arrow palette and markers", state: "Todo", blockedBy: ["VIZ-107"] },
+  { id: "VIZ-109", title: "Dependency hover emphasis", state: "Todo", blockedBy: ["VIZ-103", "VIZ-107"] },
+  { id: "VIZ-110", title: "Fixture workbench docs", state: "Todo", blockedBy: ["VIZ-102"] },
+  { id: "VIZ-111", title: "Playwright visual sweep", state: "Todo", blockedBy: ["VIZ-105", "VIZ-108"] },
+  { id: "VIZ-112", title: "Reduced motion audit", state: "Todo", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-113", title: "Release notes and demo capture", state: "Todo", blockedBy: ["VIZ-111", "VIZ-112", "VIZ-101"] },
+];
+
+function demoNode(issue: DemoIssue): TaskGraphNode {
+  const stateCategory = issue.state === "Done"
+    ? "done"
+    : issue.state === "Todo"
+      ? "todo"
+      : "in_progress";
+  return {
+    schema_version,
+    node_id: issue.id.toLowerCase(),
+    kind: "issue",
+    identifier: issue.id,
+    title: issue.title,
+    state: issue.state,
+    state_category: stateCategory,
+    parent_id: "viz-milestone",
+    children: [],
+    blocked_by: issue.blockedBy ?? [],
+    labels: ["graph-viz"],
+    run_id: issue.running ? issue.id : undefined,
+  };
+}
+
+export const graphVizDemoTaskGraph: TaskGraphSnapshot = {
+  schema_version,
+  project_id: projectId,
+  generated_at: generatedAt,
+  root_ids: ["viz-milestone"],
+  nodes: [
+    {
+      schema_version,
+      node_id: "viz-milestone",
+      kind: "milestone",
+      identifier: "M13",
+      title: "Graph Visualization Command Center",
+      state: "In Progress",
+      state_category: "in_progress",
+      children: demoIssues.map((issue) => issue.id.toLowerCase()),
+      blocked_by: [],
+      labels: ["graph-viz"],
+    },
+    ...demoIssues.map(demoNode),
+  ],
+};
+
+const demoCapabilities: GatewayCapabilities = {
+  schema_version,
+  gateway_version: "graph-viz-demo",
+  supported_api_versions: ["1.0.0"],
+  transports: [
+    { transport: "loopback_http", modes: ["json"], supported_encodings: ["utf-8"], bidirectional: false },
+  ],
+  features: [{ feature: "task_graph", available: true, requires_auth: false }],
+  auth_modes: ["none"],
+  max_event_page_size: 1000,
+  max_terminal_frame_batch: 500,
+};
+
+const demoDashboard: DashboardSnapshot = {
+  schema_version,
+  generated_at: generatedAt,
+  sequence: 1,
+  health: "healthy",
+  metrics: {
+    running_issue_count: demoIssues.filter((issue) => issue.running).length,
+    retry_queue_depth: 0,
+    total_input_tokens: 128_000,
+    total_output_tokens: 24_000,
+    total_cache_read_tokens: 64_000,
+    total_cost_micros: 4_200,
+  },
+  projects: [
+    {
+      project_id: projectId,
+      name: "Graph Viz Workbench",
+      milestone_count: 1,
+      issue_count: demoIssues.length,
+      running_count: demoIssues.filter((issue) => issue.running).length,
+      completed_count: demoIssues.filter((issue) => issue.state === "Done").length,
+      failed_count: 0,
+    },
+  ],
+  recent_events: [
+    {
+      happened_at: generatedAt,
+      kind: "snapshot_published",
+      issue_identifier: "VIZ-102",
+      summary: "graph viz fixture snapshot published",
+    },
+  ],
+};
+
+function demoRunDetail(runId: string): RunDetail {
+  return {
+    schema_version,
+    run_id: runId,
+    issue_id: `issue-${runId}`,
+    issue_identifier: runId,
+    worker_id: "viz-worker",
+    status: "running",
+    claimed_at: generatedAt,
+    started_at: generatedAt,
+    turn_count: 2,
+    max_turns: 8,
+    input_tokens: 12_000,
+    output_tokens: 2_400,
+    cache_read_tokens: 6_000,
+    runtime_seconds: 210,
+    workspace_path: `/tmp/opensymphony/projects/${runId}`,
+    branch_name: `opensymphony/${runId.toLowerCase()}-graph-viz`,
+    safe_actions: { retry: false, cancel: true, rehydrate: true, detach: false },
+  };
+}
+
+const demoChangedFiles: ChangedFileEntry[] = [
+  { path: "packages/ui-core/src/knowledge-graph-renderer.ts", change_kind: "modified", lines_added: 320, lines_removed: 180 },
+  { path: "packages/ui-core/src/knowledge-graph-scene.ts", change_kind: "created", lines_added: 400, lines_removed: 0 },
+  { path: "packages/graph/src/viz-fixture.ts", change_kind: "created", lines_added: 240, lines_removed: 0 },
+];
+
+function demoDiff(runId: string, filePath: string): FileDiffPage {
+  return {
+    schema_version,
+    run_id: runId,
+    file_path: filePath,
+    hunks: [
+      {
+        file_path: filePath,
+        header: "@@ -1,2 +1,4 @@",
+        start_line: 1,
+        old_line_count: 2,
+        new_line_count: 4,
+        lines: [
+          { type: "context", line: "// graph viz workbench" },
+          { type: "addition", line: "export const hulls = buildAreaHulls(layout);" },
+          { type: "addition", line: "export const tooltip = buildTooltipModel(hover);" },
+          { type: "context", line: "" },
+        ],
+      },
+    ],
+    total_lines_added: 2,
+    total_lines_removed: 0,
+  };
+}
+
+function demoEvents(runId: string): RunEventPage {
+  return {
+    schema_version,
+    run_id: runId,
+    events: [
+      {
+        sequence: 1,
+        event_id: `${runId}-evt-1`,
+        happened_at: generatedAt,
+        kind: "ActionEvent",
+        summary: `Working ${runId}: iterating on graph visuals`,
+      },
+    ],
+  };
+}
+
+/**
+ * Full mock gateway wired with the graph-viz demo data. The desktop app
+ * mounts on this transport when started with `?fixtures` (see
+ * apps/desktop/src/index.ts) so graph work can iterate against dense,
+ * stable data without a running daemon.
+ */
+export function createGraphVizDemoTransport(): MockGatewayTransport {
+  const runningIds = demoIssues.filter((issue) => issue.running).map((issue) => issue.id);
+  return new MockGatewayTransport({
+    baseUri: "http://graph-viz.fixtures.local",
+    health: demoCapabilities,
+    snapshot: demoDashboard,
+    taskGraph: graphVizDemoTaskGraph,
+    runDetails: runningIds.map(demoRunDetail),
+    runFiles: runningIds.map((runId) => ({ runId, files: demoChangedFiles })),
+    runDiffs: runningIds.flatMap((runId) =>
+      demoChangedFiles.map((file) => ({ runId, filePath: file.path, diff: demoDiff(runId, file.path) })),
+    ),
+    runEvents: runningIds.map(demoEvents),
+  });
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -42,6 +42,10 @@ export {
 export type { TauriChannel, TauriRuntime } from "./transports.js";
 export { MockGatewayTransport } from "./mock.js";
 export {
+  createGraphVizDemoTransport,
+  graphVizDemoTaskGraph,
+} from "./graph-viz-demo.js";
+export {
   StreamReplayBuffer,
   orderedEvents,
   StreamCorrelator,

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -37,6 +37,11 @@ export {
   fixtureSearchResponse,
   createScaleGraphSnapshot,
 } from "./fixture.js";
+export {
+  graphVizFixtureBundleList,
+  graphVizFixtureCommunityList,
+  graphVizFixtureSnapshot,
+} from "./viz-fixture.js";
 
 export type GraphMode =
   | "atlas"
@@ -252,9 +257,13 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
       {
         const staleCursor = state.staleCursors[action.snapshot.bundle_id];
         const existingSnapshot = state.snapshots[action.snapshot.bundle_id];
+        // Same-partition snapshots must be strictly newer to replace the
+        // current one: polls frequently redeliver the identical sequence,
+        // and treating those as fresh data forced a full re-layout (and
+        // reset hover/zoom) every refresh cycle.
         const isOlderSamePartitionSnapshot = existingSnapshot !== undefined
           && existingSnapshot.cursor.partition === action.snapshot.cursor.partition
-          && action.snapshot.cursor.sequence < existingSnapshot.cursor.sequence;
+          && action.snapshot.cursor.sequence <= existingSnapshot.cursor.sequence;
         const isStaleSnapshot = (staleCursor !== undefined && isCursorBefore(action.snapshot.cursor, staleCursor))
           || isOlderSamePartitionSnapshot;
         if (isStaleSnapshot) {
@@ -707,29 +716,69 @@ function forceLayout(
   height: number,
 ): GraphLayoutNode[] {
   if (nodes.length > 400) return progressiveCommunityLayout(nodes, width, height);
+  if (nodes.length === 0) return [];
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
-  const tickCount = nodes.length > 160 ? 45 : 90;
-  const points = nodes.map((node, index) => ({
-    id: node.id,
-    x: width / 2 + Math.cos(index) * 80,
-    y: height / 2 + Math.sin(index) * 80,
-    vx: 0,
-    vy: 0,
-  }));
+  const tickCount = nodes.length > 160 ? 140 : 220;
+  // Fruchterman–Reingold ideal spacing: nodes should spread over the whole
+  // canvas instead of contracting into a center clump, which made zoomed-out
+  // views an unreadable label pile.
+  const k = 0.6 * Math.sqrt((width * height) / nodes.length);
+  const communityById = new Map(nodes.map((node) => [node.id, node.metrics?.community_id]));
+  // Communities get fixed anchors on an ellipse so clusters occupy distinct
+  // regions; without this, cross-community edges shuffle every community
+  // across the whole canvas and cluster hulls all overlap.
+  const communityIds = [...new Set(
+    nodes.map((node) => node.metrics?.community_id).filter((id): id is string => Boolean(id)),
+  )].sort(compareStrings);
+  const communityAnchors = new Map<string, { x: number; y: number }>(
+    communityIds.map((communityId, index) => {
+      const angle = (index / Math.max(1, communityIds.length)) * Math.PI * 2 - Math.PI / 2;
+      return [communityId, {
+        x: width / 2 + Math.cos(angle) * width * 0.26,
+        y: height / 2 + Math.sin(angle) * height * 0.26,
+      }];
+    }),
+  );
+  // Deterministic golden-angle spiral seed around each node's community
+  // anchor: clusters start separated so the simulated annealing only has to
+  // refine locally instead of untangling an interleaved global spiral.
+  const seedCounters = new Map<string, number>();
+  const points = nodes.map((node) => {
+    const communityId = node.metrics?.community_id ?? "";
+    const anchor = communityAnchors.get(communityId) ?? { x: width / 2, y: height / 2 };
+    const seedIndex = seedCounters.get(communityId) ?? 0;
+    seedCounters.set(communityId, seedIndex + 1);
+    const angle = seedIndex * 2.399963; // golden angle
+    const radius = 8 + Math.sqrt(seedIndex) * k * 0.42;
+    return {
+      id: node.id,
+      x: clamp(anchor.x + Math.cos(angle) * radius, 28, width - 28),
+      y: clamp(anchor.y + Math.sin(angle) * radius, 28, height - 28),
+      vx: 0,
+      vy: 0,
+    };
+  });
   const byId = new Map(points.map((point) => [point.id, point]));
+  let temperature = Math.max(width, height) / 10;
+  const cooling = 0.975;
   for (let tick = 0; tick < tickCount; tick += 1) {
+    const repulsionRange = k * 3;
     for (let i = 0; i < points.length; i += 1) {
       for (let j = i + 1; j < points.length; j += 1) {
         const a = points[i];
         const b = points[j];
         const dx = a.x - b.x || 0.01;
         const dy = a.y - b.y || 0.01;
-        const distance = Math.max(24, Math.hypot(dx, dy));
-        const push = 70 / (distance * distance);
-        a.vx += (dx / distance) * push;
-        a.vy += (dy / distance) * push;
-        b.vx -= (dx / distance) * push;
-        b.vy -= (dy / distance) * push;
+        const distance = Math.max(6, Math.hypot(dx, dy));
+        // Short-range repulsion only: distant pairs contribute nothing, so
+        // the summed outward pressure cannot overpower the community
+        // anchors and pin every node against the canvas walls.
+        if (distance > repulsionRange) continue;
+        const push = (k * k) / distance / distance;
+        a.vx += dx * push;
+        a.vy += dy * push;
+        b.vx -= dx * push;
+        b.vy -= dy * push;
       }
     }
     for (const edge of edges) {
@@ -738,21 +787,34 @@ function forceLayout(
       if (!source || !target) continue;
       const dx = target.x - source.x;
       const dy = target.y - source.y;
-      const distance = Math.max(1, Math.hypot(dx, dy));
-      const pull = (distance - 95) * 0.004;
+      const distance = Math.max(6, Math.hypot(dx, dy));
+      // Same-community edges pull a little harder so clusters condense
+      // around their areas while distinct areas stay apart.
+      const sameCommunity = communityById.get(edge.source_id) !== undefined
+        && communityById.get(edge.source_id) === communityById.get(edge.target_id);
+      const pull = (distance * distance) / k * (sameCommunity ? 0.0016 : 0.0006);
       source.vx += (dx / distance) * pull;
       source.vy += (dy / distance) * pull;
       target.vx -= (dx / distance) * pull;
       target.vy -= (dy / distance) * pull;
     }
     for (const point of points) {
-      point.vx += (width / 2 - point.x) * 0.002;
-      point.vy += (height / 2 - point.y) * 0.002;
-      point.x = clamp(point.x + point.vx, 28, width - 28);
-      point.y = clamp(point.y + point.vy, 28, height - 28);
-      point.vx *= 0.82;
-      point.vy *= 0.82;
+      const anchor = communityAnchors.get(communityById.get(point.id) ?? "");
+      if (anchor) {
+        point.vx += (anchor.x - point.x) * 0.05;
+        point.vy += (anchor.y - point.y) * 0.05;
+      } else {
+        point.vx += (width / 2 - point.x) * 0.0012;
+        point.vy += (height / 2 - point.y) * 0.0012;
+      }
+      const speed = Math.hypot(point.vx, point.vy);
+      const limited = speed > temperature ? temperature / speed : 1;
+      point.x = clamp(point.x + point.vx * limited, 28, width - 28);
+      point.y = clamp(point.y + point.vy * limited, 28, height - 28);
+      point.vx = 0;
+      point.vy = 0;
     }
+    temperature = Math.max(2.5, temperature * cooling);
   }
   return points.map((point) => {
     const node = nodesById.get(point.id)!;

--- a/packages/graph/src/viz-fixture.ts
+++ b/packages/graph/src/viz-fixture.ts
@@ -1,0 +1,411 @@
+import type {
+  MemoryBundleList,
+  MemoryCommunityList,
+  MemoryGraphEdge,
+  MemoryGraphNode,
+  MemoryGraphSnapshot,
+} from "@opensymphony/gateway-schema";
+
+/**
+ * Dense, deterministic knowledge-graph fixture for graph-visualization work.
+ *
+ * The default fixture (`fixtureGraphSnapshot`) is intentionally tiny; it
+ * exercises reducers, not rendering. Visualization work needs the opposite:
+ * enough nodes that labels collide when zoomed out, several area clusters,
+ * concepts that belong to more than one area (overlapping hulls), long and
+ * short titles, and a spread of node kinds/degrees. This module builds that
+ * graph from a seeded PRNG so every run — tests, the `?fixtures` desktop
+ * workbench, screenshots in docs — sees the same graph.
+ *
+ * See docs/graph-view.md ("Graph visualization workbench") before reaching
+ * for ad-hoc data in graph-viz iterations.
+ */
+
+const schema_version = { major: 1, minor: 0, patch: 0 };
+const generated_at = "2026-07-04T00:00:00Z";
+const bundleId = "viz-workbench";
+
+interface VizArea {
+  slug: string;
+  label: string;
+  topics: string[];
+}
+
+const vizAreas: VizArea[] = [
+  {
+    slug: "code-intelligence",
+    label: "Code Intelligence",
+    topics: [
+      "Tree-sitter Provider Skeleton",
+      "Query Packs For Supported Agent Languages",
+      "Read-Only AST MCP And CLI Tools",
+      "Memory Context AST Provider Integration",
+      "Code Intelligence Persistence And Ingest",
+      "Cache Code-Intel Parsers And Compiled Query Packs",
+      "Graph Extraction Metrics And Ingest Benchmarks",
+      "Deduplicate Query-Pack Assets Across Harnesses",
+      "Symbol Search Ranking",
+      "Incremental Reparse Scheduling",
+      "Language Injection Handling",
+      "AST Evidence Citations",
+    ],
+  },
+  {
+    slug: "memory-graph",
+    label: "Memory Graph",
+    topics: [
+      "Memory Graph DTOs And Gateway Reads",
+      "OKF Bundle Schema And Legacy Migration",
+      "Concept Inspector Search And Filters",
+      "Catalog Reindex And Query Compatibility From OKF",
+      "Memory Bundle Visibility Policies",
+      "Community Detection Aggregation",
+      "Concept Freshness And Warning Counters",
+      "Graph Snapshot Cursor Semantics",
+      "Bundle Import Export Round-Trips",
+      "Stale Snapshot Reconciliation",
+      "Frontmatter Quarantine Rules",
+      "Memory Admin Token Gating",
+    ],
+  },
+  {
+    slug: "desktop-shell",
+    label: "Desktop Shell",
+    topics: [
+      "Desktop Project Grouping And Filters",
+      "Desktop Run Detail Action Wiring",
+      "Lazy Desktop Launcher Commands",
+      "Desktop Task Graph Dependency Lanes",
+      "Hosted Auth Placeholders",
+      "Model Configuration Settings Surface",
+      "Workspace Pane Resize Persistence",
+      "Live Refresh Interaction Epochs",
+      "DOM Morph Render Pipeline",
+      "Status Strip Density Pass",
+      "Planning Workspace Preview Banner",
+      "Desktop Installer Validation",
+    ],
+  },
+  {
+    slug: "gateway",
+    label: "Gateway",
+    topics: [
+      "Gateway DTO Boundary Checklist",
+      "Run Diff Endpoint Batching",
+      "Workspace Scan Coalescing",
+      "PR URL Background Resolution",
+      "Event Journal Cursor Replay",
+      "Terminal Log Store Ingest",
+      "Capabilities Matrix Truth",
+      "Dashboard Snapshot Projection",
+      "Approval Decision Dispatch",
+      "Loopback Transport Contract",
+    ],
+  },
+  {
+    slug: "orchestrator",
+    label: "Orchestrator",
+    topics: [
+      "Scheduler-Side Codex Stdio Interrupt Channel",
+      "Retry Queue Depth Accounting",
+      "Issue Session Runner Lifecycle",
+      "Hierarchy Selection Guardrails",
+      "Tracker Polling Cadence",
+      "Cancellation Acknowledgement Path",
+      "Workspace Key Sanitization",
+      "Dependency-Aware Dispatch Ordering",
+      "Blocked Issue Signaling",
+      "Run Outcome Reconciliation",
+    ],
+  },
+  {
+    slug: "harness-runtime",
+    label: "Harness Runtime",
+    topics: [
+      "OpenHands Agent-Server Integration",
+      "Codex App Server Turn Interrupts",
+      "ChatGPT OAuth For Codex Harness",
+      "App-Server Turn Interrupt Fallbacks",
+      "WebSocket Readiness Barrier",
+      "Conversation Reuse Per Issue",
+      "Subscription Credential Bootstrap",
+      "Harness Capability Discovery",
+      "Linear Polling And Rate-Limit Backoff",
+      "Turn Token Usage Accounting",
+    ],
+  },
+  {
+    slug: "testing",
+    label: "Testing And Operations",
+    topics: [
+      "Fake Server Contract Suite",
+      "Live Pinned Server Checks",
+      "Graph Scale Visual Regression Fixtures",
+      "Terminal Renderer Benchmarks",
+      "Client Resilience Scenarios",
+      "Doctor Diagnostics Coverage",
+      "Deployment Mode Smoke Runs",
+      "Accessibility Audit Sweeps",
+    ],
+  },
+];
+
+const vizTags = [
+  "frontend",
+  "rust",
+  "performance",
+  "streaming",
+  "security",
+  "protocol",
+  "ux",
+  "observability",
+] as const;
+
+/** Deterministic PRNG (mulberry32) so the fixture never shifts between runs. */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface VizConcept {
+  id: string;
+  label: string;
+  areas: string[];
+  tags: string[];
+}
+
+function buildVizConcepts(): VizConcept[] {
+  const random = mulberry32(0x0587_0a11);
+  const concepts: VizConcept[] = [];
+  vizAreas.forEach((area, areaIndex) => {
+    area.topics.forEach((topic, topicIndex) => {
+      const areas = [area.slug];
+      // Roughly a quarter of concepts also belong to a neighboring area so
+      // hull rendering must cope with overlapping membership.
+      if (random() < 0.28) {
+        const other = vizAreas[(areaIndex + 1 + Math.floor(random() * (vizAreas.length - 1))) % vizAreas.length];
+        if (other.slug !== area.slug) areas.push(other.slug);
+      }
+      const tags = [vizTags[(areaIndex + topicIndex) % vizTags.length]];
+      if (random() < 0.35) {
+        tags.push(vizTags[(areaIndex * 3 + topicIndex * 5 + 2) % vizTags.length]);
+      }
+      concepts.push({
+        id: `concept:${area.slug}-${String(topicIndex + 1).padStart(2, "0")}`,
+        label: topic,
+        areas,
+        tags: [...new Set(tags)],
+      });
+    });
+  });
+  return concepts;
+}
+
+function conceptNode(concept: VizConcept, index: number): MemoryGraphNode {
+  return {
+    id: concept.id,
+    kind: "concept",
+    label: concept.label,
+    bundle_id: bundleId,
+    concept_id: concept.id.replace("concept:", "concepts/"),
+    concept_type: "concept",
+    path_display: `${concept.id.replace("concept:", "concepts/")}.md`,
+    tags: concept.tags,
+    timestamp: generated_at,
+    visibility: index % 7 === 3 ? "public" : "private",
+    freshness: index % 23 === 11 ? "stale" : "current",
+    warning_count: index % 29 === 17 ? 1 : 0,
+    frontmatter_summary: {
+      areas: concept.areas,
+      project: "OpenSymphony-bootstrap",
+      repository: "OpenSymphony",
+    },
+    unknown_frontmatter: {},
+    body_preview: `${concept.label} — fixture concept for graph visualization work.`,
+    metrics: { indegree: 0, outdegree: 0, community_id: `area:${concept.areas[0]}` },
+  };
+}
+
+function buildSnapshot(): MemoryGraphSnapshot {
+  const random = mulberry32(0x870);
+  const concepts = buildVizConcepts();
+  const conceptNodes = concepts.map(conceptNode);
+  const byArea = new Map<string, VizConcept[]>();
+  for (const concept of concepts) {
+    for (const area of concept.areas) {
+      const members = byArea.get(area) ?? [];
+      members.push(concept);
+      byArea.set(area, members);
+    }
+  }
+
+  const bundleNode: MemoryGraphNode = {
+    id: `bundle:${bundleId}`,
+    kind: "bundle",
+    label: "Graph Viz Workbench",
+    bundle_id: bundleId,
+    tags: [],
+    visibility: "private",
+    freshness: "current",
+    warning_count: 0,
+    frontmatter_summary: {},
+    unknown_frontmatter: {},
+    metrics: { indegree: 0, outdegree: vizAreas.length },
+  };
+
+  const tagNodes: MemoryGraphNode[] = vizTags.map((tag) => ({
+    id: `tag:${tag}`,
+    kind: "tag",
+    label: tag,
+    bundle_id: bundleId,
+    tags: [tag],
+    visibility: "private",
+    freshness: "current",
+    warning_count: 0,
+    frontmatter_summary: {},
+    unknown_frontmatter: {},
+    metrics: { indegree: 0, outdegree: 0 },
+  }));
+
+  const sourceNodes: MemoryGraphNode[] = vizAreas.slice(0, 5).map((area, index) => ({
+    id: `source:osym-${900 + index}`,
+    kind: "source_ref",
+    label: `OSYM-${900 + index}`,
+    bundle_id: bundleId,
+    tags: [],
+    visibility: "private",
+    freshness: "current",
+    warning_count: 0,
+    frontmatter_summary: { source_kind: "task", areas: [area.slug] },
+    unknown_frontmatter: {},
+    metrics: { indegree: 0, outdegree: 0 },
+  }));
+
+  const edges: MemoryGraphEdge[] = [];
+  const pushEdge = (kind: MemoryGraphEdge["kind"], sourceId: string, targetId: string) => {
+    edges.push({
+      id: `edge:${kind}:${sourceId}:${targetId}`,
+      kind,
+      source_id: sourceId,
+      target_id: targetId,
+      unresolved: false,
+      metadata: {},
+    });
+  };
+
+  // The bundle anchors one root concept per area (a full contains-fan would
+  // collapse the force layout into a hub-and-spoke hairball).
+  for (const area of vizAreas) {
+    const root = byArea.get(area.slug)?.[0];
+    if (root) pushEdge("contains", bundleNode.id, root.id);
+  }
+
+  // Intra-area web: chain plus a few shortcuts so clusters read as clusters.
+  for (const area of vizAreas) {
+    const members = (byArea.get(area.slug) ?? []).filter((concept) => concept.areas[0] === area.slug);
+    for (let index = 1; index < members.length; index += 1) {
+      pushEdge("markdown_link", members[index - 1].id, members[index].id);
+    }
+    for (let index = 0; index < members.length; index += 1) {
+      if (random() < 0.4 && members.length > 3) {
+        const target = members[Math.floor(random() * members.length)];
+        if (target.id !== members[index].id) {
+          pushEdge("markdown_link", members[index].id, target.id);
+        }
+      }
+    }
+  }
+
+  // Sparse cross-area references: enough to pull hulls near one another
+  // without merging the clusters.
+  for (let index = 0; index < concepts.length; index += 1) {
+    if (random() < 0.12) {
+      const target = concepts[Math.floor(random() * concepts.length)];
+      if (target.areas[0] !== concepts[index].areas[0]) {
+        pushEdge("cites", concepts[index].id, target.id);
+      }
+    }
+  }
+
+  for (const concept of concepts) {
+    if (random() < 0.3) {
+      pushEdge("tagged_with", concept.id, `tag:${concept.tags[0]}`);
+    }
+  }
+  sourceNodes.forEach((source, index) => {
+    const area = vizAreas[index];
+    const anchor = byArea.get(area.slug)?.[1];
+    if (anchor) pushEdge("source_supported_by", anchor.id, source.id);
+  });
+
+  const dedupedEdges = [...new Map(edges.map((edge) => [edge.id, edge])).values()];
+  const nodes = [bundleNode, ...conceptNodes, ...tagNodes, ...sourceNodes];
+  const degreeById = new Map<string, { indegree: number; outdegree: number }>();
+  for (const edge of dedupedEdges) {
+    const source = degreeById.get(edge.source_id) ?? { indegree: 0, outdegree: 0 };
+    source.outdegree += 1;
+    degreeById.set(edge.source_id, source);
+    const target = degreeById.get(edge.target_id) ?? { indegree: 0, outdegree: 0 };
+    target.indegree += 1;
+    degreeById.set(edge.target_id, target);
+  }
+  for (const node of nodes) {
+    const degrees = degreeById.get(node.id);
+    if (degrees) {
+      node.metrics = { ...node.metrics, ...degrees };
+    }
+  }
+
+  const communities = vizAreas.map((area) => ({
+    id: `area:${area.slug}`,
+    label: area.label,
+    node_ids: (byArea.get(area.slug) ?? []).map((concept) => concept.id).sort(),
+    concept_count: (byArea.get(area.slug) ?? []).length,
+  }));
+
+  return {
+    schema_version,
+    bundle_id: bundleId,
+    cursor: { sequence: 1, partition: `memory-graph:${bundleId}` },
+    generated_at,
+    filters_applied: [],
+    communities,
+    nodes,
+    edges: dedupedEdges,
+    metrics: {
+      orphan_count: 0,
+      broken_link_count: 0,
+      stale_concept_count: nodes.filter((node) => node.freshness === "stale").length,
+      warning_count: nodes.reduce((sum, node) => sum + node.warning_count, 0),
+    },
+  };
+}
+
+export const graphVizFixtureSnapshot: MemoryGraphSnapshot = buildSnapshot();
+
+export const graphVizFixtureBundleList: MemoryBundleList = {
+  schema_version,
+  bundles: [
+    {
+      id: bundleId,
+      title: "Graph Viz Workbench",
+      okf_version: "0.1",
+      visibility: "private",
+      concept_count: graphVizFixtureSnapshot.nodes.filter((node) => node.kind === "concept").length,
+      updated_at: generated_at,
+    },
+  ],
+};
+
+export const graphVizFixtureCommunityList: MemoryCommunityList = {
+  schema_version,
+  bundle_id: bundleId,
+  communities: graphVizFixtureSnapshot.communities,
+  generated_at,
+};

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@opensymphony/graph";
 import { schemaVersionV1 } from "@opensymphony/gateway-schema";
 import {
+  createKnowledgeGraphViewState,
   disposeKnowledgeGraphRenderer,
   mountKnowledgeGraphRenderer,
   renderKnowledgeGraphSurface,
@@ -812,6 +813,7 @@ describe("OpenSymphonyApp mount", () => {
         setTransform: jest.fn(),
         fillRect: jest.fn(),
         beginPath: jest.fn(),
+        closePath: jest.fn(),
         moveTo: jest.fn(),
         lineTo: jest.fn(),
         stroke: jest.fn(),
@@ -832,7 +834,7 @@ describe("OpenSymphonyApp mount", () => {
       expect(root.querySelector("[data-graph-view='knowledge']")?.classList.contains("is-selected")).toBe(true);
       expect(root.querySelector(".os-graph-hero-panel [data-testid='knowledge-graph-canvas']")).not.toBeNull();
       expect(root.querySelector(".os-graph-hero-panel [data-testid='knowledge-graph-canvas']")?.getAttribute("data-nonblank")).toBe("true");
-      expect(fillStyles).toContain("#e7ebef");
+      expect(fillStyles).toContain("#eef1f4");
       expect(getContext.mock.calls.some(([contextId]) => String(contextId).startsWith("webgl"))).toBe(true);
       expect(root.querySelector("[data-testid='knowledge-graph-metrics']")?.textContent).toContain(`${fixtureGraphSnapshot.nodes.length} nodes`);
       const fallbackButtons = Array.from(root.querySelectorAll<HTMLButtonElement>(".os-kg-list [data-kg-node-id]"));
@@ -886,6 +888,7 @@ describe("OpenSymphonyApp mount", () => {
         setTransform: jest.fn(),
         fillRect: jest.fn(),
         beginPath: jest.fn(),
+        closePath: jest.fn(),
         moveTo: jest.fn(),
         lineTo: jest.fn(),
         stroke: jest.fn(),
@@ -1026,6 +1029,7 @@ describe("OpenSymphonyApp mount", () => {
         setTransform: jest.fn(),
         fillRect: jest.fn(),
         beginPath: jest.fn(),
+        closePath: jest.fn(),
         moveTo: jest.fn(),
         lineTo: jest.fn(),
         stroke: jest.fn(),
@@ -1042,7 +1046,7 @@ describe("OpenSymphonyApp mount", () => {
         snapshot: fixtureGraphSnapshot,
         layout,
         selectedNodeIds: [],
-        view: { scale: 1, dx: 0, dy: 0 },
+        view: createKnowledgeGraphViewState(),
         onSelect: jest.fn(),
         onFocus: jest.fn(),
       });
@@ -1083,9 +1087,23 @@ describe("OpenSymphonyApp mount", () => {
       },
     });
     document.body.appendChild(root);
-    const labels = root.querySelectorAll(".os-kg-label");
-    expect(labels.length).toBeLessThanOrEqual(80);
-    expect(root.querySelector(".os-kg-label[data-kg-node-id='bundle:scale-5000']")?.textContent).toContain("Scale fixture");
+    // Labels are created imperatively by the renderer with zoom-based LOD;
+    // the server-rendered surface starts with an empty overlay layer, and
+    // selected nodes always earn a label regardless of zoom.
+    expect(root.querySelectorAll(".os-kg-label").length).toBe(0);
+    mountKnowledgeGraphRenderer(root, {
+      snapshot,
+      layout,
+      selectedNodeIds: [selectedNodeId],
+      view: createKnowledgeGraphViewState(),
+      onSelect: jest.fn(),
+      onFocus: jest.fn(),
+    });
+    expect(root.querySelectorAll(".os-kg-label").length).toBeLessThanOrEqual(80);
+    expect(
+      root.querySelector(`.os-kg-label[data-kg-node-id='${selectedNodeId}']`)?.classList.contains("is-selected"),
+    ).toBe(true);
+    disposeKnowledgeGraphRenderer(root);
     expect(root.querySelector("[data-testid='knowledge-graph-inspector'] dl")?.textContent).toContain("concept");
     expect(root.querySelector("[data-testid='knowledge-graph-inspector'] dl div")).toBeNull();
     expect(root.querySelector(".os-kg-list [data-kg-node-id='concept:scale-1']")?.getAttribute("aria-current")).toBe("true");
@@ -1120,7 +1138,7 @@ describe("OpenSymphonyApp mount", () => {
         snapshot,
         layout,
         selectedNodeIds: [selectedNodeId],
-        view: { scale: 1, dx: 0, dy: 0 },
+        view: createKnowledgeGraphViewState(),
         onSelect: jest.fn(),
         onFocus: jest.fn(),
       });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -729,7 +729,10 @@ describe("OpenSymphonyApp mount", () => {
     expect(root.querySelector(".os-project-group-header")).toBeNull();
     expect(root.querySelector("[data-testid='task-graph-link']")).not.toBeNull();
     expect(root.querySelector(".os-task-graph-link-skip")).not.toBeNull();
-    expect(root.querySelector(".os-task-graph-link-skip")?.getAttribute("d")).toMatch(/ H \d+ V \d+ H /);
+    // Skip arrows route through the left gutter with rounded corners and a
+    // per-source hue/lane instead of sharp L-shapes.
+    expect(root.querySelector(".os-task-graph-link-skip")?.getAttribute("d")).toMatch(/ H \S+ Q .+ V .+ Q .+ H /);
+    expect(root.querySelector(".os-task-graph-link-skip")?.getAttribute("class")).toMatch(/os-tg-hue-\d/);
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-lane")).toBe("1");
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-indent")).toBe("34px");
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-height")).toBe("78px");

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -944,6 +944,40 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("offers a home path back to the full Knowledge Graph after narrowing", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+      graphAdapter: createFixtureGraphAdapter(),
+    });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-node-id='desktop-alpha']") !== null);
+      (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") !== null);
+      expect(root.querySelector("[data-testid='knowledge-graph-reset']")).toBeNull();
+
+      // Keyboard focus narrows to the neighborhood; the home button appears.
+      (root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") as HTMLButtonElement).focus();
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-reset']") !== null);
+
+      (root.querySelector("[data-testid='knowledge-graph-reset']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-reset']") === null);
+      expect(root.querySelector(".os-kg-list li.is-selected")).toBeNull();
+
+      // Escape offers the same escape hatch.
+      (root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-reset']") !== null);
+      root.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-reset']") === null);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("refreshes the Knowledge Graph on memory_graph_updated events", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -733,6 +733,13 @@ describe("OpenSymphonyApp mount", () => {
     // per-source hue/lane instead of sharp L-shapes.
     expect(root.querySelector(".os-task-graph-link-skip")?.getAttribute("d")).toMatch(/ H \S+ Q .+ V .+ Q .+ H /);
     expect(root.querySelector(".os-task-graph-link-skip")?.getAttribute("class")).toMatch(/os-tg-hue-\d/);
+    // The hue marker is applied via CSS, not an inline `marker-end` that the
+    // base `.os-task-graph-link` rule would override to the default arrow.
+    expect(root.querySelector(".os-task-graph-link-skip")?.hasAttribute("marker-end")).toBe(false);
+    const shellStyleText = Array.from(root.querySelectorAll("style"))
+      .map((style) => style.textContent ?? "")
+      .join("\n");
+    expect(shellStyleText).toMatch(/\.os-tg-hue-0 \{[^}]*marker-end: url\(#os-task-arrow-0\)/);
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-lane")).toBe("1");
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-indent")).toBe("34px");
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-height")).toBe("78px");

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -944,6 +944,58 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("gives every skip-level blocker its own routing lane, beyond the hue palette", async () => {
+    const sourceCount = 7;
+    const nodeFor = (index: number, overrides: Partial<TaskGraphNode>): TaskGraphNode => ({
+      schema_version: schemaVersionV1(),
+      node_id: `lane-node-${index}`,
+      kind: "issue",
+      identifier: `LANE-${index}`,
+      title: `Lane test ${index}`,
+      state: "In Progress",
+      state_category: "in_progress",
+      children: [],
+      blocked_by: [],
+      labels: [],
+      ...overrides,
+    });
+    const sources = Array.from({ length: sourceCount }, (_, index) => nodeFor(index, {}));
+    // Targets sit far below their blockers so every link is a skip (span > 1).
+    const targets = Array.from({ length: sourceCount }, (_, index) => nodeFor(100 + index, {
+      state: "Todo",
+      state_category: "todo",
+      blocked_by: [`LANE-${index}`],
+    }));
+    const laneGraph: TaskGraphSnapshot = {
+      schema_version: schemaVersionV1(),
+      project_id: "proj-alpha",
+      generated_at: "2025-09-01T00:00:00Z",
+      root_ids: [sources[0].node_id],
+      nodes: [...sources, ...targets],
+    };
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ taskGraph: laneGraph }),
+    });
+
+    try {
+      await flushUntil(() => root.querySelectorAll(".os-task-graph-link-skip").length >= sourceCount);
+      const skips = Array.from(root.querySelectorAll(".os-task-graph-link-skip"));
+      const routeXs = new Set(skips.map((path) => path.getAttribute("d")?.match(/Q (\S+) /)?.[1]));
+      // Seven blockers → seven distinct gutter rails, even though the hue
+      // palette (5 entries) cycles.
+      expect(routeXs.size).toBe(sourceCount);
+      const stage = root.querySelector<HTMLElement>("[data-testid='task-graph-visualization']");
+      const gutter = Number.parseInt(stage?.style.getPropertyValue("--os-tg-gutter") ?? "0", 10);
+      expect(gutter).toBeGreaterThanOrEqual(30 + sourceCount * 11);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("offers a home path back to the full Knowledge Graph after narrowing", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/__tests__/knowledge-graph-scene.test.ts
+++ b/packages/ui-core/__tests__/knowledge-graph-scene.test.ts
@@ -201,6 +201,26 @@ describe("area hulls", () => {
     expect(hulls[0].memberNodeIds).toContain("remote");
   });
 
+  it("encloses both members of a two-node area", () => {
+    const members = [
+      { nodeId: "near", x: 0, y: 0, z: 0, radius: 9, label: "near", kind: "concept", degree: 1 },
+      { nodeId: "far", x: 300, y: 40, z: 0, radius: 9, label: "far", kind: "concept", degree: 1 },
+    ];
+    const hulls = buildAreaHulls(
+      members,
+      [{ id: "area:pair", label: "Pair", node_ids: ["near", "far"] }],
+    );
+    expect(hulls).toHaveLength(1);
+    const xs = hulls[0].outline.map((point) => point.x);
+    const ys = hulls[0].outline.map((point) => point.y);
+    // The stadium outline must wrap both endpoints (plus padding), not just
+    // a fixed-radius circle around the first member.
+    expect(Math.min(...xs)).toBeLessThan(0);
+    expect(Math.max(...xs)).toBeGreaterThan(300);
+    expect(Math.min(...ys)).toBeLessThan(0);
+    expect(Math.max(...ys)).toBeGreaterThan(40);
+  });
+
   it("feeds one node into every area hull it belongs to", () => {
     const shared = { nodeId: "shared", x: 0, y: 0, z: 0, radius: 9, label: "s", kind: "concept", degree: 1 };
     const hulls = buildAreaHulls(

--- a/packages/ui-core/__tests__/knowledge-graph-scene.test.ts
+++ b/packages/ui-core/__tests__/knowledge-graph-scene.test.ts
@@ -122,6 +122,25 @@ describe("camera operations", () => {
     }
   });
 
+  it("frames points so they fit the viewport under an orbited camera", () => {
+    const points = [
+      { x: -420, y: -180, z: -120 },
+      { x: 430, y: 210, z: 140 },
+      { x: 60, y: -240, z: 40 },
+    ];
+    const framed = frameWorldPoints(points, viewport, { yaw: 0.7, pitch: 0.45 }, 1.1);
+    expect(framed.yaw).toBeCloseTo(0.7, 5);
+    expect(framed.pitch).toBeCloseTo(0.45, 5);
+    for (const point of points) {
+      const projected = projectWorldPoint(framed, viewport, point);
+      expect(projected.visible).toBe(true);
+      expect(projected.x).toBeGreaterThanOrEqual(0);
+      expect(projected.x).toBeLessThanOrEqual(viewport.width);
+      expect(projected.y).toBeGreaterThanOrEqual(0);
+      expect(projected.y).toBeLessThanOrEqual(viewport.height);
+    }
+  });
+
   it("unprojects a node's screen position back onto its drag plane", () => {
     const camera = testCamera();
     const world = { x: 150, y: -80, z: 40 };
@@ -286,12 +305,18 @@ describe("scene assembly on the viz fixture", () => {
     expect(hitTestScene(scene, -50, -50)).toBeNull();
   });
 
-  it("applies drag overrides to world positions", () => {
+  it("applies drag overrides to world positions, including dropped z", () => {
     const nodeId = layout.nodes[0].nodeId;
-    const overrides = new Map([[nodeId, { x: 77, y: 88 }]]);
+    const overrides = new Map([[nodeId, { x: 77, y: 88, z: 55 }]]);
     const moved = worldNodesFor(layout, overrides).find((node) => node.nodeId === nodeId)!;
     expect(moved.x).toBeCloseTo(77 - layout.width / 2, 5);
     expect(moved.y).toBeCloseTo(layout.height / 2 - 88, 5);
+    // Drops on an orbited camera-facing plane land off the community depth
+    // band; the stored z wins so the node stays under the cursor.
+    expect(moved.z).toBe(55);
+    const withoutZ = worldNodesFor(layout, new Map([[nodeId, { x: 77, y: 88 }]]))
+      .find((node) => node.nodeId === nodeId)!;
+    expect(withoutZ.z).not.toBe(55);
   });
 });
 

--- a/packages/ui-core/__tests__/knowledge-graph-scene.test.ts
+++ b/packages/ui-core/__tests__/knowledge-graph-scene.test.ts
@@ -1,0 +1,290 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Scene-model tests for the knowledge-graph command center: the software
+ * projector must match THREE's perspective camera, hulls must hug their
+ * clusters (including multi-area membership), and label visibility must
+ * follow the zoom level.
+ */
+
+import * as THREE from "three";
+import {
+  advanceCameraToward,
+  buildAreaHulls,
+  buildGraphScene,
+  cameraBasis,
+  convexHull,
+  defaultCameraForLayout,
+  dollyCamera,
+  frameWorldPoints,
+  graphCameraFovDegrees,
+  hitTestScene,
+  orbitCamera,
+  panCamera,
+  projectWorldPoint,
+  unprojectToPlaneThroughPoint,
+  worldNodesFor,
+  type GraphCameraState,
+} from "../src/knowledge-graph-scene.js";
+import { computeGraphLayout, graphVizFixtureSnapshot } from "@opensymphony/graph";
+
+const viewport = { width: 1200, height: 700 };
+
+function testCamera(overrides: Partial<GraphCameraState> = {}): GraphCameraState {
+  return {
+    targetX: 0,
+    targetY: 0,
+    targetZ: 0,
+    distance: 900,
+    yaw: 0.35,
+    pitch: 0.2,
+    ...overrides,
+  };
+}
+
+describe("software projector parity with three.js", () => {
+  it("matches THREE.PerspectiveCamera projection for sample points", () => {
+    const camera = testCamera();
+    const basis = cameraBasis(camera);
+    const three = new THREE.PerspectiveCamera(
+      graphCameraFovDegrees,
+      viewport.width / viewport.height,
+      6,
+      12_000,
+    );
+    three.position.set(basis.position.x, basis.position.y, basis.position.z);
+    three.up.set(0, 1, 0);
+    three.lookAt(camera.targetX, camera.targetY, camera.targetZ);
+    three.updateMatrixWorld();
+
+    const samples = [
+      { x: 0, y: 0, z: 0 },
+      { x: 320, y: -140, z: 60 },
+      { x: -510, y: 220, z: -90 },
+      { x: 44, y: 380, z: 130 },
+    ];
+    for (const sample of samples) {
+      const mine = projectWorldPoint(camera, viewport, sample);
+      const vector = new THREE.Vector3(sample.x, sample.y, sample.z).project(three);
+      const expectedX = ((vector.x + 1) / 2) * viewport.width;
+      const expectedY = ((1 - vector.y) / 2) * viewport.height;
+      expect(mine.visible).toBe(true);
+      expect(Math.abs(mine.x - expectedX)).toBeLessThan(0.75);
+      expect(Math.abs(mine.y - expectedY)).toBeLessThan(0.75);
+    }
+  });
+
+  it("marks points behind the camera as not visible", () => {
+    const camera = testCamera({ yaw: 0, pitch: 0 });
+    const behind = projectWorldPoint(camera, viewport, { x: 0, y: 0, z: 5_000 });
+    expect(behind.visible).toBe(false);
+  });
+});
+
+describe("camera operations", () => {
+  it("pans the target in the view plane", () => {
+    const camera = testCamera({ yaw: 0, pitch: 0 });
+    const panned = panCamera(camera, viewport, 120, -40);
+    expect(panned.targetX).not.toBe(camera.targetX);
+    expect(panned.targetY).not.toBe(camera.targetY);
+    expect(panned.distance).toBe(camera.distance);
+  });
+
+  it("dollies toward the cursor anchor when zooming in", () => {
+    const camera = testCamera({ yaw: 0, pitch: 0 });
+    const zoomed = dollyCamera(camera, 0.5, { viewport, screenX: viewport.width * 0.85, screenY: viewport.height * 0.25 });
+    expect(zoomed.distance).toBeCloseTo(camera.distance * 0.5, 5);
+    // The target moves toward the anchored point (right of and above center).
+    expect(zoomed.targetX).toBeGreaterThan(camera.targetX);
+    expect(zoomed.targetY).toBeGreaterThan(camera.targetY);
+  });
+
+  it("clamps orbit pitch", () => {
+    const camera = testCamera();
+    const orbited = orbitCamera(camera, 0.4, 10);
+    expect(orbited.yaw).toBeCloseTo(camera.yaw + 0.4, 5);
+    expect(orbited.pitch).toBeLessThanOrEqual(1.15);
+  });
+
+  it("frames points so they fit the viewport", () => {
+    const points = [
+      { x: -400, y: -200, z: 0 },
+      { x: 400, y: 200, z: 0 },
+    ];
+    const framed = frameWorldPoints(points, viewport, { yaw: 0, pitch: 0 }, 1.1);
+    for (const point of points) {
+      const projected = projectWorldPoint(framed, viewport, point);
+      expect(projected.visible).toBe(true);
+      expect(projected.x).toBeGreaterThanOrEqual(0);
+      expect(projected.x).toBeLessThanOrEqual(viewport.width);
+      expect(projected.y).toBeGreaterThanOrEqual(0);
+      expect(projected.y).toBeLessThanOrEqual(viewport.height);
+    }
+  });
+
+  it("unprojects a node's screen position back onto its drag plane", () => {
+    const camera = testCamera();
+    const world = { x: 150, y: -80, z: 40 };
+    const projected = projectWorldPoint(camera, viewport, world);
+    const roundTripped = unprojectToPlaneThroughPoint(camera, viewport, projected.x, projected.y, world);
+    expect(roundTripped).not.toBeNull();
+    expect(Math.abs(roundTripped!.x - world.x)).toBeLessThan(0.5);
+    expect(Math.abs(roundTripped!.y - world.y)).toBeLessThan(0.5);
+    expect(Math.abs(roundTripped!.z - world.z)).toBeLessThan(0.5);
+  });
+
+  it("eases toward a goal and settles", () => {
+    let camera = testCamera({ distance: 900 });
+    const goal = testCamera({ distance: 300, targetX: 200 });
+    let done = false;
+    for (let step = 0; step < 200 && !done; step += 1) {
+      const advanced = advanceCameraToward(camera, goal, 1 / 60);
+      camera = advanced.camera;
+      done = advanced.done;
+    }
+    expect(done).toBe(true);
+    expect(camera).toEqual(goal);
+  });
+
+  it("snaps immediately under reduced motion", () => {
+    const goal = testCamera({ distance: 250 });
+    const advanced = advanceCameraToward(testCamera(), goal, 1 / 60, true);
+    expect(advanced.done).toBe(true);
+    expect(advanced.camera).toEqual(goal);
+  });
+});
+
+describe("area hulls", () => {
+  it("computes convex hulls containing all inputs", () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+      { x: 5, y: 5 },
+    ];
+    const hull = convexHull(points);
+    expect(hull).toHaveLength(4);
+    expect(hull).not.toContainEqual({ x: 5, y: 5 });
+  });
+
+  it("hugs the resident cluster and ignores remote multi-area members", () => {
+    const cluster = Array.from({ length: 8 }, (_, index) => ({
+      nodeId: `core-${index}`,
+      x: (index % 3) * 40,
+      y: Math.floor(index / 3) * 40,
+      z: 0,
+      radius: 9,
+      label: `core ${index}`,
+      kind: "concept",
+      degree: 2,
+    }));
+    const remote = {
+      nodeId: "remote",
+      x: 4_000,
+      y: 4_000,
+      z: 0,
+      radius: 9,
+      label: "remote multi-area member",
+      kind: "concept",
+      degree: 1,
+    };
+    const hulls = buildAreaHulls(
+      [...cluster, remote],
+      [{ id: "area:x", label: "X", node_ids: [...cluster.map((node) => node.nodeId), "remote"] }],
+    );
+    expect(hulls).toHaveLength(1);
+    const xs = hulls[0].outline.map((point) => point.x);
+    // The outline stays near the cluster; the remote member cannot stretch
+    // the hull across the canvas.
+    expect(Math.max(...xs)).toBeLessThan(1_000);
+    expect(hulls[0].memberNodeIds).toContain("remote");
+  });
+
+  it("feeds one node into every area hull it belongs to", () => {
+    const shared = { nodeId: "shared", x: 0, y: 0, z: 0, radius: 9, label: "s", kind: "concept", degree: 1 };
+    const hulls = buildAreaHulls(
+      [shared],
+      [
+        { id: "area:a", label: "A", node_ids: ["shared"] },
+        { id: "area:b", label: "B", node_ids: ["shared"] },
+      ],
+    );
+    expect(hulls).toHaveLength(2);
+    expect(hulls[0].memberNodeIds).toEqual(["shared"]);
+    expect(hulls[1].memberNodeIds).toEqual(["shared"]);
+  });
+});
+
+describe("scene assembly on the viz fixture", () => {
+  const layout = computeGraphLayout(graphVizFixtureSnapshot, { kind: "force", width: 1400, height: 900 });
+
+  function buildScene(overrides: Partial<Parameters<typeof buildGraphScene>[0]> = {}) {
+    return buildGraphScene({
+      layout,
+      communities: graphVizFixtureSnapshot.communities,
+      camera: defaultCameraForLayout(layout, viewport),
+      viewport,
+      overrides: new Map(),
+      selectedNodeIds: [],
+      hoveredNodeId: null,
+      ...overrides,
+    });
+  }
+
+  it("shows area labels and hides node labels at the framed overview", () => {
+    const scene = buildScene();
+    expect(scene.hulls.length).toBe(graphVizFixtureSnapshot.communities.length);
+    expect(scene.hulls.every((hull) => hull.labelAlpha > 0.5)).toBe(true);
+    expect(scene.nodes.every((node) => node.labelAlpha < 0.05)).toBe(true);
+  });
+
+  it("fades node labels in and area labels out when zoomed in", () => {
+    const overview = defaultCameraForLayout(layout, viewport);
+    const scene = buildScene({ camera: { ...overview, distance: overview.distance / 3 } });
+    expect(scene.nodes.some((node) => node.labelAlpha > 0.5)).toBe(true);
+    expect(scene.hulls.every((hull) => hull.labelAlpha < 0.05)).toBe(true);
+  });
+
+  it("dims non-neighbors and emphasizes connected edges on hover", () => {
+    const edge = layout.edges[0];
+    const scene = buildScene({ hoveredNodeId: edge.sourceId });
+    const hovered = scene.nodes.find((node) => node.nodeId === edge.sourceId);
+    const neighbor = scene.nodes.find((node) => node.nodeId === edge.targetId);
+    expect(hovered?.emphasis).toBe("hovered");
+    expect(neighbor?.emphasis).toBe("neighbor");
+    expect(scene.nodes.some((node) => node.emphasis === "dimmed")).toBe(true);
+    const emphasized = scene.edges.filter((candidate) => candidate.emphasized);
+    expect(emphasized.length).toBeGreaterThan(0);
+    expect(scene.edges.filter((candidate) => !candidate.emphasized).every((candidate) => candidate.alpha < 0.1)).toBe(true);
+  });
+
+  it("hit-tests the node under a screen point", () => {
+    const scene = buildScene();
+    const probe = scene.nodes[Math.floor(scene.nodes.length / 2)];
+    expect(hitTestScene(scene, probe.x, probe.y)).toBe(probe.nodeId);
+    expect(hitTestScene(scene, -50, -50)).toBeNull();
+  });
+
+  it("applies drag overrides to world positions", () => {
+    const nodeId = layout.nodes[0].nodeId;
+    const overrides = new Map([[nodeId, { x: 77, y: 88 }]]);
+    const moved = worldNodesFor(layout, overrides).find((node) => node.nodeId === nodeId)!;
+    expect(moved.x).toBeCloseTo(77 - layout.width / 2, 5);
+    expect(moved.y).toBeCloseTo(layout.height / 2 - 88, 5);
+  });
+});
+
+describe("graph viz fixture", () => {
+  it("is deterministic and dense enough to exercise the visualization", () => {
+    expect(graphVizFixtureSnapshot.nodes.length).toBeGreaterThan(80);
+    expect(graphVizFixtureSnapshot.edges.length).toBeGreaterThan(100);
+    expect(graphVizFixtureSnapshot.communities.length).toBe(7);
+    const multiArea = graphVizFixtureSnapshot.communities.flatMap((community) => community.node_ids)
+      .reduce((counts, nodeId) => counts.set(nodeId, (counts.get(nodeId) ?? 0) + 1), new Map<string, number>());
+    const inTwoAreas = [...multiArea.values()].filter((count) => count > 1).length;
+    expect(inTwoAreas).toBeGreaterThan(5);
+    // Determinism: rebuilding module state elsewhere must not shift ids.
+    expect(graphVizFixtureSnapshot.nodes[0].id).toBe("bundle:viz-workbench");
+  });
+});

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -112,6 +112,7 @@ import {
   type PlanningEditState,
 } from "./planning-workspace-ui.js";
 import {
+  createKnowledgeGraphViewState,
   disposeKnowledgeGraphRenderer,
   type KnowledgeGraphViewState,
   mountKnowledgeGraphRenderer,
@@ -305,7 +306,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private graphLayoutAdapter: GraphLayoutAdapter = createGraphLayoutAdapter(() => null);
   private pendingGraphLayoutAdapter: GraphLayoutAdapter | null = null;
   private graphLayoutRun = 0;
-  private knowledgeGraphView: KnowledgeGraphViewState = { scale: 1, dx: 0, dy: 0 };
+  private knowledgeGraphView: KnowledgeGraphViewState = createKnowledgeGraphViewState();
   private knowledgeGraphLayoutSize: { width: number; height: number } | null = null;
   /**
    * Monotonic counter bumped by every user-initiated navigation (task click,
@@ -786,7 +787,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const previousGraph = this.state.knowledgeGraph;
     this.state.knowledgeGraph = graphReducer(previousGraph, { type: "SNAPSHOT_LOADED", snapshot });
     const acceptedSnapshot = this.state.knowledgeGraph !== previousGraph;
-    if (acceptedSnapshot || !this.state.knowledgeGraph.staleBundleIds.includes(bundleId)) {
+    // Only invalidate the layout when the reducer actually accepted a newer
+    // snapshot. Re-layouting on every identical poll churned the whole
+    // graph surface every five seconds (and reset in-progress hover/zoom).
+    if (acceptedSnapshot) {
       this.state.knowledgeGraphLayout = null;
       this.knowledgeGraphLayoutSize = null;
       this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
@@ -1207,11 +1211,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const run = ++this.graphLayoutRun;
     this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "loading" });
     const { width, height } = size;
+    // The layout runs on a canvas larger than the stage: the 3D camera fits
+    // whatever extent the layout produces, and the extra room lets the force
+    // layout separate clusters instead of packing them into the viewport.
+    const layoutScale = Math.min(2, Math.max(1.4, Math.sqrt((visibleGraphSnapshot(this.state.knowledgeGraph)?.nodes.length ?? 60) / 40)));
     void this.graphLayoutAdapter.layout(snapshot, {
       kind: graphLayoutKindForMode(this.state.knowledgeGraph.mode),
       focusedNodeId: this.state.knowledgeGraph.focusedNodeId,
-      width,
-      height,
+      width: Math.round(Math.max(1280, width * layoutScale)),
+      height: Math.round(Math.max(900, height * layoutScale)),
     }).then((layout) => {
       if (this.destroyed || run !== this.graphLayoutRun) return;
       this.state.knowledgeGraphLayout = layout;
@@ -4611,11 +4619,20 @@ function appShellStyles(): string {
     .os-knowledge-toolbar span { color: #667788; font-size: 12px; }
     .os-kg-status { flex: 0 0 auto; border: 1px solid #cbd5df; border-radius: 999px; padding: 3px 8px; color: #23566f; background: #e7f1f5; font-size: 11px; }
     .os-kg-status-failed { color: #991b1b; background: #fee2e2; border-color: #fecaca; }
-    .os-knowledge-stage { position: relative; height: clamp(260px, 38vh, 460px); min-width: 0; overflow: hidden; border: 1px solid #d8dee4; border-radius: 6px; background: #e7ebef; }
-    .os-knowledge-canvas { display: block; width: 100%; height: 100%; touch-action: none; outline: none; }
+    .os-knowledge-stage { position: relative; height: clamp(320px, 52vh, 680px); min-width: 0; overflow: hidden; border: 1px solid #d8dee4; border-radius: 6px; background: #eef1f4; }
+    .os-knowledge-canvas { display: block; width: 100%; height: 100%; touch-action: none; outline: none; cursor: grab; }
+    .os-knowledge-canvas[data-kg-pointer="pan"], .os-knowledge-canvas[data-kg-pointer="orbit"] { cursor: grabbing; }
+    .os-knowledge-canvas[data-kg-pointer="drag-node"] { cursor: move; }
     .os-knowledge-labels { position: absolute; inset: 0; pointer-events: none; }
-    .os-kg-label { position: absolute; transform: translate(-50%, calc(-100% - 10px)); max-width: min(180px, 42%); min-height: 24px; padding: 3px 7px; border-color: rgba(57, 112, 143, 0.28); border-radius: 999px; background: rgba(255, 255, 255, 0.92); color: #17202a; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; pointer-events: auto; box-shadow: 0 3px 10px rgba(15, 23, 42, 0.08); }
+    .os-kg-label { position: absolute; transform: translate(-50%, 0); max-width: min(200px, 46%); min-height: 22px; padding: 2px 7px; border: 1px solid rgba(57, 112, 143, 0.24); border-radius: 999px; background: rgba(255, 255, 255, 0.92); color: #17202a; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; pointer-events: auto; box-shadow: 0 3px 10px rgba(15, 23, 42, 0.08); transition: opacity 0.16s ease; }
     .os-kg-label.is-selected { border-color: #c2410c; color: #9a3412; background: #fff7ed; }
+    .os-kg-label.is-hovered { border-color: #c2410c; color: #9a3412; }
+    .os-kg-area-label { position: absolute; transform: translate(-50%, -50%); font-size: 17px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; opacity: 0.8; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.75); transition: opacity 0.18s ease; pointer-events: none; white-space: nowrap; }
+    .os-kg-tooltip { position: absolute; transform: translate(-50%, -100%); display: grid; gap: 2px; max-width: 260px; padding: 8px 10px; border: 1px solid #cbd5df; border-radius: 8px; background: rgba(255, 255, 255, 0.97); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.16); pointer-events: none; z-index: 3; }
+    .os-kg-tooltip strong { font-size: 12px; line-height: 1.25; white-space: normal; }
+    .os-kg-tooltip span { color: #536170; font-size: 11px; }
+    .os-kg-tooltip em { color: #23566f; font-size: 11px; font-style: normal; }
+    .os-kg-controls-hint { position: absolute; right: 8px; bottom: 6px; color: #8a97a3; font-size: 10.5px; letter-spacing: 0.02em; pointer-events: none; user-select: none; }
     .os-kg-list { display: grid; gap: 5px; list-style: none; margin: 0; padding: 0; max-height: 160px; overflow: auto; }
     .os-kg-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; border: 1px solid #d8dee4; border-radius: 6px; padding: 6px 8px; background: #ffffff; }
     .os-kg-list li.is-selected { border-color: #c2410c; background: #fff7ed; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -645,6 +645,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.knowledgeGraphLayoutSize = null;
     this.knowledgeGraphLoadInFlight = null;
     this.knowledgeGraphLoadQueuedBundleId = undefined;
+    // A different bundle/gateway is different content: drop the camera and
+    // any node drag overrides along with the graph state.
+    this.knowledgeGraphView = createKnowledgeGraphViewState();
   }
 
   /**
@@ -772,8 +775,16 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.render();
       return;
     }
-    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "loading" });
-    this.render();
+    // Only surface the loading state before anything is on screen. A
+    // background refresh over an already-rendered graph stays silent: if the
+    // incoming snapshot is identical (the common poll case) nothing resets
+    // the status, and a dangling "loading" would block resize relayouts and
+    // pin the status pill on "Stabilizing" forever.
+    const hasRenderedGraph = Boolean(visibleGraphSnapshot(this.state.knowledgeGraph) && this.state.knowledgeGraphLayout);
+    if (!hasRenderedGraph) {
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "loading" });
+      this.render();
+    }
     try {
       if (!this.state.knowledgeGraph.bundles) {
         const bundles = await this.graphAdapter.listBundles();
@@ -4104,15 +4115,19 @@ const taskGraphRowGap = 8;
 /**
  * Skip-level dependency arrows route through a dedicated left gutter, one
  * lane and one hue per blocker, so several long-range dependencies stay
- * readable instead of conflating into a single L-shaped rail.
+ * readable instead of conflating into a single L-shaped rail. The gutter
+ * widens with the number of distinct blockers so lanes are never reused
+ * (hues cycle, lanes do not).
  */
-const taskGraphRouteGutterWidth = 62;
+const taskGraphMinRouteGutterWidth = 62;
 const taskGraphSkipLaneGap = 11;
-const taskGraphSkipLaneCount = 5;
 const taskGraphLinkHues = ["#39708f", "#7c3aed", "#0f766e", "#b0762f", "#a05577"] as const;
+
+function taskGraphRouteGutterWidth(links: readonly TaskGraphLink[]): number {
+  const laneCount = links.reduce((max, link) => Math.max(max, link.routeLane + 1), 0);
+  return Math.max(taskGraphMinRouteGutterWidth, 30 + laneCount * taskGraphSkipLaneGap);
+}
 const taskGraphLaneWidth = 34;
-// Node rows sit right of the routing gutter (see .os-node-graph-list padding).
-const taskGraphRailX = 21 + taskGraphRouteGutterWidth;
 
 function buildDependencySignals(
   allNodes: TaskGraphNode[],
@@ -4243,8 +4258,9 @@ function renderTaskGraphVisualization(
   const links = buildTaskGraphLinks(models);
   const graphHeight = models.length * taskGraphRowHeight + Math.max(0, models.length - 1) * taskGraphRowGap;
   const maxLane = models.reduce((max, model) => Math.max(max, model.lane), 0);
-  const graphWidth = Math.max(620, 360 + maxLane * taskGraphLaneWidth) + taskGraphRouteGutterWidth;
-  const svgLinks = links.map((link) => renderTaskGraphLink(link)).join("");
+  const gutterWidth = taskGraphRouteGutterWidth(links);
+  const graphWidth = Math.max(620, 360 + maxLane * taskGraphLaneWidth) + gutterWidth;
+  const svgLinks = links.map((link) => renderTaskGraphLink(link, gutterWidth)).join("");
   const renderedNodes = models.map((model) => renderReadOnlyTaskGraphNode(
     model,
     selectedNodeId,
@@ -4252,7 +4268,7 @@ function renderTaskGraphVisualization(
   )).join("");
 
   return `
-    <div class="os-task-graph-stage" data-testid="task-graph-visualization" style="--os-graph-height: ${graphHeight}px; --os-graph-width: ${graphWidth}px;">
+    <div class="os-task-graph-stage" data-testid="task-graph-visualization" style="--os-graph-height: ${graphHeight}px; --os-graph-width: ${graphWidth}px; --os-tg-gutter: ${gutterWidth}px;">
       <svg class="os-task-graph-links" data-testid="task-graph-links" viewBox="0 0 ${graphWidth} ${graphHeight}" preserveAspectRatio="none" aria-hidden="true">
         <defs>
           <marker id="os-task-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
@@ -4397,7 +4413,9 @@ function buildTaskGraphLinks(models: TaskGraphRenderModel[]): TaskGraphLink[] {
       .sort((a, b) => a.from.index - b.from.index)
       .map((link) => link.from.node.node_id),
   )];
-  const laneBySource = new Map(skipSources.map((sourceId, index) => [sourceId, index % taskGraphSkipLaneCount]));
+  // Lanes are never reused: every distinct blocker gets its own rail and
+  // the gutter widens to fit (taskGraphRouteGutterWidth). Hues cycle.
+  const laneBySource = new Map(skipSources.map((sourceId, index) => [sourceId, index]));
   return links.map((link) => {
     const lane = link.span > 1 ? laneBySource.get(link.from.node.node_id) ?? 0 : 0;
     return { ...link, routeLane: lane, hue: lane % taskGraphLinkHues.length };
@@ -4406,14 +4424,17 @@ function buildTaskGraphLinks(models: TaskGraphRenderModel[]): TaskGraphLink[] {
 
 function renderTaskGraphLink(
   link: TaskGraphLink,
+  gutterWidth: number,
 ): string {
-  const x1 = taskGraphRailX + link.from.lane * taskGraphLaneWidth;
-  const x2 = taskGraphRailX + link.to.lane * taskGraphLaneWidth;
+  // Node rows sit right of the routing gutter (see .os-node-graph-list padding).
+  const railX = 21 + gutterWidth;
+  const x1 = railX + link.from.lane * taskGraphLaneWidth;
+  const x2 = railX + link.to.lane * taskGraphLaneWidth;
   const y1 = link.from.index * (taskGraphRowHeight + taskGraphRowGap) + taskGraphRowHeight / 2;
   const y2 = link.to.index * (taskGraphRowHeight + taskGraphRowGap) + taskGraphRowHeight / 2;
   const linkAttrs = `data-testid="task-graph-link" data-link-from="${escapeAttr(link.from.node.node_id)}" data-link-to="${escapeAttr(link.to.node.node_id)}"`;
   if (link.span > 1) {
-    const routeX = Math.max(4, taskGraphRailX - 16 - link.routeLane * taskGraphSkipLaneGap);
+    const routeX = Math.max(4, railX - 16 - link.routeLane * taskGraphSkipLaneGap);
     const turn = Math.min(14, Math.abs(y2 - y1) / 2, Math.max(4, x1 - routeX));
     const direction = y2 > y1 ? 1 : -1;
     const d = [
@@ -4709,7 +4730,7 @@ function appShellStyles(): string {
     .os-task-graph-links.os-links-hover .os-task-graph-link.is-active { opacity: 1; stroke-width: 2.5; }
     .os-task-graph-links marker path:not([fill]) { fill: #39708f; }
     /* Reserve the skip-arrow routing gutter (taskGraphRouteGutterWidth). */
-    .os-node-graph-list { position: relative; z-index: 1; min-width: var(--os-graph-width); gap: 8px; padding-left: 62px; }
+    .os-node-graph-list { position: relative; z-index: 1; min-width: var(--os-graph-width); gap: 8px; padding-left: var(--os-tg-gutter, 62px); }
     .os-knowledge-graph { display: grid; gap: 10px; min-width: 0; }
     .os-knowledge-toolbar { display: flex; justify-content: space-between; gap: 10px; align-items: center; min-width: 0; }
     .os-knowledge-toolbar div { display: grid; gap: 2px; min-width: 0; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -2550,6 +2550,24 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     element.addEventListener(type, handler);
   }
 
+  private setTaskGraphLinkEmphasis(nodeButton: HTMLElement, active: boolean): void {
+    const nodeId = nodeButton.dataset.nodeId;
+    const svg = nodeButton.closest(".os-task-graph-stage")?.querySelector<SVGElement>(".os-task-graph-links");
+    if (!nodeId || !svg) {
+      return;
+    }
+    svg.classList.toggle("os-links-hover", active);
+    svg.querySelectorAll(".os-task-graph-link.is-active").forEach((path) => {
+      path.classList.remove("is-active");
+    });
+    if (active) {
+      const escaped = cssEscape(nodeId);
+      svg.querySelectorAll(`[data-link-from="${escaped}"], [data-link-to="${escaped}"]`).forEach((path) => {
+        path.classList.add("is-active");
+      });
+    }
+  }
+
   private bindEvents(): void {
     this.listen(this.options.root.querySelector("[data-save-profile]"), "save-profile", "click", () => {
       void this.saveProfile();
@@ -2636,6 +2654,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
             this.render();
           }
         }
+      });
+      // Hovering a task spotlights its dependency arrows: pure class
+      // toggling on the already-rendered SVG, no re-render involved.
+      this.listen(button, "node-id-hover", "pointerenter", () => {
+        this.setTaskGraphLinkEmphasis(button, true);
+      });
+      this.listen(button, "node-id-hover", "pointerleave", () => {
+        this.setTaskGraphLinkEmphasis(button, false);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-project-group-toggle]").forEach((button) => {
@@ -4037,12 +4063,23 @@ interface TaskGraphLink {
   to: TaskGraphRenderModel;
   routeLane: number;
   span: number;
+  hue: number;
 }
 
 const taskGraphRowHeight = 78;
 const taskGraphRowGap = 8;
+/**
+ * Skip-level dependency arrows route through a dedicated left gutter, one
+ * lane and one hue per blocker, so several long-range dependencies stay
+ * readable instead of conflating into a single L-shaped rail.
+ */
+const taskGraphRouteGutterWidth = 62;
+const taskGraphSkipLaneGap = 11;
+const taskGraphSkipLaneCount = 5;
+const taskGraphLinkHues = ["#39708f", "#7c3aed", "#0f766e", "#b0762f", "#a05577"] as const;
 const taskGraphLaneWidth = 34;
-const taskGraphRailX = 21;
+// Node rows sit right of the routing gutter (see .os-node-graph-list padding).
+const taskGraphRailX = 21 + taskGraphRouteGutterWidth;
 
 function buildDependencySignals(
   allNodes: TaskGraphNode[],
@@ -4173,7 +4210,7 @@ function renderTaskGraphVisualization(
   const links = buildTaskGraphLinks(models);
   const graphHeight = models.length * taskGraphRowHeight + Math.max(0, models.length - 1) * taskGraphRowGap;
   const maxLane = models.reduce((max, model) => Math.max(max, model.lane), 0);
-  const graphWidth = Math.max(620, 360 + maxLane * taskGraphLaneWidth);
+  const graphWidth = Math.max(620, 360 + maxLane * taskGraphLaneWidth) + taskGraphRouteGutterWidth;
   const svgLinks = links.map((link) => renderTaskGraphLink(link)).join("");
   const renderedNodes = models.map((model) => renderReadOnlyTaskGraphNode(
     model,
@@ -4188,6 +4225,10 @@ function renderTaskGraphVisualization(
           <marker id="os-task-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
             <path d="M 0 0 L 8 4 L 0 8 z"></path>
           </marker>
+          ${taskGraphLinkHues.map((hue, index) => `
+          <marker id="os-task-arrow-${index}" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="${escapeAttr(hue)}"></path>
+          </marker>`).join("")}
         </defs>
         ${svgLinks}
       </svg>
@@ -4306,22 +4347,28 @@ function buildTaskGraphRenderModels(
 
 function buildTaskGraphLinks(models: TaskGraphRenderModel[]): TaskGraphLink[] {
   const byId = new Map(models.map((model) => [model.node.node_id, model]));
-  const links: TaskGraphLink[] = [];
+  const links: Array<Omit<TaskGraphLink, "routeLane" | "hue">> = [];
   for (const model of models) {
     for (const upstream of model.signal.upstreamVisible) {
       const from = byId.get(upstream.node_id);
       if (from) {
-        const span = Math.abs(model.index - from.index);
-        links.push({
-          from,
-          to: model,
-          span,
-          routeLane: Math.max(0, Math.min(3, span - 2)),
-        });
+        links.push({ from, to: model, span: Math.abs(model.index - from.index) });
       }
     }
   }
-  return links;
+  // Every skip-level source gets its own gutter lane and hue (in row order),
+  // shared by all of that blocker's arrows: same-source fans stay visually
+  // grouped while different blockers never share a rail.
+  const skipSources = [...new Set(
+    links.filter((link) => link.span > 1)
+      .sort((a, b) => a.from.index - b.from.index)
+      .map((link) => link.from.node.node_id),
+  )];
+  const laneBySource = new Map(skipSources.map((sourceId, index) => [sourceId, index % taskGraphSkipLaneCount]));
+  return links.map((link) => {
+    const lane = link.span > 1 ? laneBySource.get(link.from.node.node_id) ?? 0 : 0;
+    return { ...link, routeLane: lane, hue: lane % taskGraphLinkHues.length };
+  });
 }
 
 function renderTaskGraphLink(
@@ -4331,14 +4378,24 @@ function renderTaskGraphLink(
   const x2 = taskGraphRailX + link.to.lane * taskGraphLaneWidth;
   const y1 = link.from.index * (taskGraphRowHeight + taskGraphRowGap) + taskGraphRowHeight / 2;
   const y2 = link.to.index * (taskGraphRowHeight + taskGraphRowGap) + taskGraphRowHeight / 2;
+  const linkAttrs = `data-testid="task-graph-link" data-link-from="${escapeAttr(link.from.node.node_id)}" data-link-to="${escapeAttr(link.to.node.node_id)}"`;
   if (link.span > 1) {
-    const routeX = Math.max(4, taskGraphRailX - 9 - link.routeLane * 7);
-    const d = `M ${x1} ${y1} H ${routeX} V ${y2} H ${x2}`;
-    return `<path class="os-task-graph-link os-task-graph-link-skip" data-testid="task-graph-link" d="${escapeAttr(d)}"></path>`;
+    const routeX = Math.max(4, taskGraphRailX - 16 - link.routeLane * taskGraphSkipLaneGap);
+    const turn = Math.min(14, Math.abs(y2 - y1) / 2, Math.max(4, x1 - routeX));
+    const direction = y2 > y1 ? 1 : -1;
+    const d = [
+      `M ${x1} ${y1}`,
+      `H ${routeX + turn}`,
+      `Q ${routeX} ${y1} ${routeX} ${y1 + turn * direction}`,
+      `V ${y2 - turn * direction}`,
+      `Q ${routeX} ${y2} ${routeX + turn} ${y2}`,
+      `H ${x2}`,
+    ].join(" ");
+    return `<path class="os-task-graph-link os-task-graph-link-skip os-tg-hue-${link.hue}" ${linkAttrs} marker-end="url(#os-task-arrow-${link.hue})" d="${escapeAttr(d)}"></path>`;
   }
   const bend = Math.max(34, Math.abs(y2 - y1) * 0.24);
   const d = `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${Math.max(x2 - bend, x1 + 18)} ${y2}, ${x2} ${y2}`;
-  return `<path class="os-task-graph-link" data-testid="task-graph-link" d="${escapeAttr(d)}"></path>`;
+  return `<path class="os-task-graph-link" ${linkAttrs} d="${escapeAttr(d)}"></path>`;
 }
 
 function dependencySuffix(
@@ -4608,10 +4665,18 @@ function appShellStyles(): string {
     .os-list-item, .os-node { width: 100%; text-align: left; display: grid; gap: 3px; padding: 10px; background: #ffffff; }
     .os-task-graph-stage { position: relative; min-width: min(100%, var(--os-graph-width)); overflow-x: auto; padding: 2px 0; }
     .os-task-graph-links { position: absolute; z-index: 3; inset: 2px auto auto 0; width: var(--os-graph-width); height: var(--os-graph-height); pointer-events: none; overflow: visible; }
-    .os-task-graph-link { fill: none; stroke: #39708f; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; opacity: 0.9; marker-end: url(#os-task-arrow); }
-    .os-task-graph-link-skip { opacity: 0.78; }
-    .os-task-graph-links marker path { fill: #39708f; }
-    .os-node-graph-list { position: relative; z-index: 1; min-width: var(--os-graph-width); gap: 8px; }
+    .os-task-graph-link { fill: none; stroke: #39708f; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; opacity: 0.9; marker-end: url(#os-task-arrow); transition: opacity 0.14s ease, stroke-width 0.14s ease; }
+    .os-task-graph-link-skip { opacity: 0.72; }
+    .os-task-graph-link.os-tg-hue-0 { stroke: #39708f; }
+    .os-task-graph-link.os-tg-hue-1 { stroke: #7c3aed; }
+    .os-task-graph-link.os-tg-hue-2 { stroke: #0f766e; }
+    .os-task-graph-link.os-tg-hue-3 { stroke: #b0762f; }
+    .os-task-graph-link.os-tg-hue-4 { stroke: #a05577; }
+    .os-task-graph-links.os-links-hover .os-task-graph-link { opacity: 0.1; }
+    .os-task-graph-links.os-links-hover .os-task-graph-link.is-active { opacity: 1; stroke-width: 2.5; }
+    .os-task-graph-links marker path:not([fill]) { fill: #39708f; }
+    /* Reserve the skip-arrow routing gutter (taskGraphRouteGutterWidth). */
+    .os-node-graph-list { position: relative; z-index: 1; min-width: var(--os-graph-width); gap: 8px; padding-left: 62px; }
     .os-knowledge-graph { display: grid; gap: 10px; min-width: 0; }
     .os-knowledge-toolbar { display: flex; justify-content: space-between; gap: 10px; align-items: center; min-width: 0; }
     .os-knowledge-toolbar div { display: grid; gap: 2px; min-width: 0; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -28,6 +28,7 @@ import {
   createInitialGraphState,
   graphLayoutKindForMode,
   graphReducer,
+  currentGraphSnapshot,
   visibleGraphSnapshot,
   type GraphDataAdapter,
   type GraphLayoutAdapter,
@@ -775,13 +776,13 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.render();
       return;
     }
-    // Only surface the loading state before anything is on screen. A
-    // background refresh over an already-rendered graph stays silent: if the
-    // incoming snapshot is identical (the common poll case) nothing resets
-    // the status, and a dangling "loading" would block resize relayouts and
-    // pin the status pill on "Stabilizing" forever.
-    const hasRenderedGraph = Boolean(visibleGraphSnapshot(this.state.knowledgeGraph) && this.state.knowledgeGraphLayout);
-    if (!hasRenderedGraph) {
+    // Only surface the loading state while the very first snapshot is being
+    // fetched. Once a snapshot exists the status belongs to the layout
+    // pipeline: marking background refreshes as "loading" left the status
+    // dangling whenever the poll redelivered an identical snapshot (nothing
+    // resets it), pinning the pill on "Stabilizing" and blocking both resize
+    // relayouts and retries of failed layouts.
+    if (!currentGraphSnapshot(this.state.knowledgeGraph)) {
       this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "loading" });
       this.render();
     }
@@ -818,6 +819,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     if (acceptedSnapshot) {
       this.state.knowledgeGraphLayout = null;
       this.knowledgeGraphLayoutSize = null;
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
+    } else if (!this.state.knowledgeGraphLayout && this.state.knowledgeGraph.layoutStatus === "failed") {
+      // Identical poll while nothing is on screen after a failed layout:
+      // return to idle so the next bind pass schedules a retry instead of
+      // staying failed until a newer snapshot happens to arrive.
       this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
     }
     this.render();

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -4451,7 +4451,10 @@ function renderTaskGraphLink(
       `Q ${routeX} ${y2} ${routeX + turn} ${y2}`,
       `H ${x2}`,
     ].join(" ");
-    return `<path class="os-task-graph-link os-task-graph-link-skip os-tg-hue-${link.hue}" ${linkAttrs} marker-end="url(#os-task-arrow-${link.hue})" d="${escapeAttr(d)}"></path>`;
+    // The hue-specific marker is applied via CSS (see .os-tg-hue-* rules):
+    // a `marker-end` presentation attribute here would lose to the base
+    // `.os-task-graph-link` CSS rule, leaving every skip arrowhead default.
+    return `<path class="os-task-graph-link os-task-graph-link-skip os-tg-hue-${link.hue}" ${linkAttrs} d="${escapeAttr(d)}"></path>`;
   }
   const bend = Math.max(34, Math.abs(y2 - y1) * 0.24);
   const d = `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${Math.max(x2 - bend, x1 + 18)} ${y2}, ${x2} ${y2}`;
@@ -4727,11 +4730,11 @@ function appShellStyles(): string {
     .os-task-graph-links { position: absolute; z-index: 3; inset: 2px auto auto 0; width: var(--os-graph-width); height: var(--os-graph-height); pointer-events: none; overflow: visible; }
     .os-task-graph-link { fill: none; stroke: #39708f; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; opacity: 0.9; marker-end: url(#os-task-arrow); transition: opacity 0.14s ease, stroke-width 0.14s ease; }
     .os-task-graph-link-skip { opacity: 0.72; }
-    .os-task-graph-link.os-tg-hue-0 { stroke: #39708f; }
-    .os-task-graph-link.os-tg-hue-1 { stroke: #7c3aed; }
-    .os-task-graph-link.os-tg-hue-2 { stroke: #0f766e; }
-    .os-task-graph-link.os-tg-hue-3 { stroke: #b0762f; }
-    .os-task-graph-link.os-tg-hue-4 { stroke: #a05577; }
+    .os-task-graph-link.os-tg-hue-0 { stroke: #39708f; marker-end: url(#os-task-arrow-0); }
+    .os-task-graph-link.os-tg-hue-1 { stroke: #7c3aed; marker-end: url(#os-task-arrow-1); }
+    .os-task-graph-link.os-tg-hue-2 { stroke: #0f766e; marker-end: url(#os-task-arrow-2); }
+    .os-task-graph-link.os-tg-hue-3 { stroke: #b0762f; marker-end: url(#os-task-arrow-3); }
+    .os-task-graph-link.os-tg-hue-4 { stroke: #a05577; marker-end: url(#os-task-arrow-4); }
     .os-task-graph-links.os-links-hover .os-task-graph-link { opacity: 0.1; }
     .os-task-graph-links.os-links-hover .os-task-graph-link.is-active { opacity: 1; stroke-width: 2.5; }
     .os-task-graph-links marker path:not([fill]) { fill: #39708f; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -386,7 +386,20 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       planningEdit: { ...emptyPlanningEditState },
     };
     this.loadPlanningWorkspace("opensymphony-local");
+    // Document-level so Escape works even when focus sits on the body (the
+    // graph canvas itself is not focusable). Removed in destroy().
+    this.options.root.ownerDocument.addEventListener("keydown", this.onDocumentKeydown);
   }
+
+  private onDocumentKeydown = (event: KeyboardEvent): void => {
+    if (this.destroyed || event.key !== "Escape" || this.state.graphPaneView !== "knowledge") {
+      return;
+    }
+    const graph = this.state.knowledgeGraph;
+    if (graph.mode !== "atlas" || graph.focusedNodeId || graph.selectedNodeIds.length > 0) {
+      this.resetKnowledgeGraphView();
+    }
+  };
 
   /**
    * Fetch all evidence for a run concurrently, without touching state. The
@@ -491,6 +504,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   async destroy(): Promise<void> {
     this.destroyed = true;
+    this.options.root.ownerDocument.removeEventListener("keydown", this.onDocumentKeydown);
     this.stopLiveRefreshTimer();
     this.stopEventSubscription();
     this.graphLayoutAdapter.dispose();
@@ -2550,6 +2564,22 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     element.addEventListener(type, handler);
   }
 
+  /**
+   * Return the Knowledge Graph to its home view: atlas mode, no focus, no
+   * selection, camera reframed to the full layout. Bound to the
+   * "Show full graph" toolbar button and Escape.
+   */
+  private resetKnowledgeGraphView(): void {
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "NODE_FOCUSED", nodeId: null });
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: "atlas" });
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [] });
+    this.state.knowledgeGraphLayout = null;
+    this.knowledgeGraphLayoutSize = null;
+    this.knowledgeGraphView.camera = null;
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
+    this.render();
+  }
+
   private setTaskGraphLinkEmphasis(nodeButton: HTMLElement, active: boolean): void {
     const nodeId = nodeButton.dataset.nodeId;
     const svg = nodeButton.closest(".os-task-graph-stage")?.querySelector<SVGElement>(".os-task-graph-links");
@@ -2709,6 +2739,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           this.selectGraphPaneView(view);
         }
       });
+    });
+    this.listen(this.options.root.querySelector("[data-kg-reset]"), "kg-reset", "click", () => {
+      this.resetKnowledgeGraphView();
     });
     this.bindKnowledgeGraph();
     this.options.root.querySelectorAll<HTMLElement>("[data-pane-resizer]").forEach((handle) => {
@@ -4682,6 +4715,7 @@ function appShellStyles(): string {
     .os-knowledge-toolbar div { display: grid; gap: 2px; min-width: 0; }
     .os-knowledge-toolbar strong { font-size: 13px; }
     .os-knowledge-toolbar span { color: #667788; font-size: 12px; }
+    .os-kg-reset { flex: 0 0 auto; border-color: #39708f; color: #23566f; background: #e7f1f5; font-weight: 600; }
     .os-kg-status { flex: 0 0 auto; border: 1px solid #cbd5df; border-radius: 999px; padding: 3px 8px; color: #23566f; background: #e7f1f5; font-size: 11px; }
     .os-kg-status-failed { color: #991b1b; background: #fee2e2; border-color: #fecaca; }
     .os-knowledge-stage { position: relative; height: clamp(320px, 52vh, 680px); min-width: 0; overflow: hidden; border: 1px solid #d8dee4; border-radius: 6px; background: #eef1f4; }

--- a/packages/ui-core/src/dom-morph.ts
+++ b/packages/ui-core/src/dom-morph.ts
@@ -133,6 +133,13 @@ function morphNode(current: Node, next: Node): void {
     return;
   }
 
+  if (currentElement.hasAttribute("data-morph-ignore-children")) {
+    // Imperative islands (e.g. the knowledge-graph overlay layer) own their
+    // children outside the render cycle; only their attributes sync.
+    syncAttributes(currentElement, nextElement, focused);
+    return;
+  }
+
   // Capture the target form state before morphing children: reconciliation
   // can move option nodes out of `next`, which would change its `value`.
   const formState = captureFormState(nextElement);

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -53,6 +53,15 @@ export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): str
   const summary = snapshot
     ? `${snapshot.nodes.length} nodes / ${snapshot.edges.length} edges / ${metrics?.stale_concept_count ?? 0} stale / ${metrics?.warning_count ?? 0} warnings`
     : "No graph snapshot";
+  // Home affordance: once the operator narrows the view (neighborhood focus,
+  // a selection, or a non-atlas mode) there must always be a one-click path
+  // back to the full graph.
+  const narrowed = state.mode !== "atlas"
+    || state.focusedNodeId !== null
+    || state.selectedNodeIds.length > 0;
+  const resetButton = narrowed
+    ? `<button type="button" class="os-icon-button os-kg-reset" data-kg-reset data-testid="knowledge-graph-reset" title="Show the full graph (Esc)">Show full graph</button>`
+    : "";
   return `
     <div class="os-knowledge-graph" data-testid="knowledge-graph-renderer" data-layout-status="${escapeAttr(status)}">
       <div class="os-knowledge-toolbar">
@@ -60,6 +69,7 @@ export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): str
           <strong>Knowledge Graph</strong>
           <span data-testid="knowledge-graph-metrics">${escapeHtml(summary)}</span>
         </div>
+        ${resetButton}
         ${renderStatus(surface.state)}
       </div>
       <div class="os-knowledge-stage" data-kg-stage>
@@ -394,7 +404,10 @@ function bindNodeButton(root: HTMLElement, button: HTMLElement, options: Knowled
   };
   button.onfocus = () => {
     const nodeId = button.dataset.kgNodeId;
-    if (nodeId) options.onFocus(nodeId);
+    // Focus-driven neighborhood preview is a keyboard affordance; a mouse
+    // click also focuses the button, and jumping into neighborhood mode on
+    // every click stranded users away from the full graph.
+    if (nodeId && matchesFocusVisible(button)) options.onFocus(nodeId);
   };
 }
 
@@ -966,6 +979,16 @@ function now(): number {
 
 function shortLabel(label: string): string {
   return label.length > 34 ? `${label.slice(0, 31)}...` : label;
+}
+
+function matchesFocusVisible(element: Element): boolean {
+  try {
+    return element.matches(":focus-visible");
+  } catch {
+    // Environments without :focus-visible (older jsdom) keep the previous
+    // behavior of treating any focus as intentional.
+    return true;
+  }
 }
 
 function cssEscape(value: string): string {

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -5,16 +5,31 @@ import type {
 } from "@opensymphony/graph";
 import * as THREE from "three";
 import { escapeAttr, escapeHtml } from "./html.js";
+import {
+  advanceCameraToward,
+  buildGraphScene,
+  defaultCameraForLayout,
+  dollyCamera,
+  frameWorldPoints,
+  hitTestHull,
+  hitTestScene,
+  nodeEmphasisColor,
+  orbitCamera,
+  panCamera,
+  unprojectToPlaneThroughPoint,
+  worldNodesFor,
+  worldToLayout,
+  type GraphCameraState,
+  type GraphScene,
+  type KnowledgeGraphViewState,
+  type SceneViewport,
+} from "./knowledge-graph-scene.js";
 
-type ScheduledDraw = {
-  handle: ReturnType<typeof setTimeout> | number;
-  kind: "animation-frame" | "timeout";
-};
+export { createKnowledgeGraphViewState } from "./knowledge-graph-scene.js";
+export type { KnowledgeGraphViewState } from "./knowledge-graph-scene.js";
 
-const scheduledCanvasDraws = new WeakMap<HTMLCanvasElement, ScheduledDraw>();
-const maxVisibleGraphLabels = 80;
-const graphSurfaceColor = "#e7ebef";
-const graphSurfaceColorInt = 0xe7ebef;
+const graphSurfaceColor = "#eef1f4";
+const graphSurfaceColorInt = 0xeef1f4;
 
 export interface KnowledgeGraphSurface {
   snapshot: MemoryGraphSnapshot | null;
@@ -31,14 +46,8 @@ export interface KnowledgeGraphMountOptions {
   onFocus(nodeId: string): void;
 }
 
-export interface KnowledgeGraphViewState {
-  scale: number;
-  dx: number;
-  dy: number;
-}
-
 export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): string {
-  const { snapshot, layout, state } = surface;
+  const { snapshot, state } = surface;
   const status = state.layoutStatus;
   const metrics = snapshot?.metrics;
   const summary = snapshot
@@ -51,17 +60,44 @@ export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): str
           <strong>Knowledge Graph</strong>
           <span data-testid="knowledge-graph-metrics">${escapeHtml(summary)}</span>
         </div>
-        ${renderStatus(state)}
+        ${renderStatus(surface.state)}
       </div>
       <div class="os-knowledge-stage" data-kg-stage>
         <canvas class="os-knowledge-canvas" data-testid="knowledge-graph-canvas" aria-label="Knowledge Graph canvas"></canvas>
-        <div class="os-knowledge-labels" data-kg-labels>${renderLabels(layout, state.selectedNodeIds)}</div>
+        <div class="os-knowledge-labels" data-kg-labels data-morph-ignore-children></div>
+        <span class="os-kg-controls-hint" aria-hidden="true">drag pan &middot; &#8997;-drag orbit &middot; scroll zoom &middot; double-click frame</span>
       </div>
-      ${renderSelectedInspector(snapshot, state.selectedNodeIds)}
-      ${renderFallbackList(snapshot, state.selectedNodeIds)}
+      ${renderSelectedInspector(snapshot, surface.state.selectedNodeIds)}
+      ${renderFallbackList(snapshot, surface.state.selectedNodeIds)}
     </div>
   `;
 }
+
+// ─── Renderer state ─────────────────────────────────────────────────────────
+
+interface RendererState {
+  options: KnowledgeGraphMountOptions;
+  camera: GraphCameraState;
+  goal: GraphCameraState;
+  hoveredNodeId: string | null;
+  pointer: {
+    mode: "idle" | "pan" | "orbit" | "drag-node";
+    nodeId: string | null;
+    lastX: number;
+    lastY: number;
+    moved: boolean;
+  };
+  rafHandle: number | ReturnType<typeof setTimeout> | null;
+  rafKind: "animation-frame" | "timeout";
+  lastFrameAt: number;
+  animating: boolean;
+  reducedMotion: boolean;
+  canvasSize: { width: number; height: number; cssWidth: number; cssHeight: number };
+  lastScene: GraphScene | null;
+  layoutIdentity: string | null;
+}
+
+const rendererStates = new WeakMap<HTMLCanvasElement, RendererState>();
 
 export function mountKnowledgeGraphRenderer(
   root: HTMLElement,
@@ -76,119 +112,60 @@ export function mountKnowledgeGraphRenderer(
     // interaction handlers; drop the bitmap too once the snapshot itself is
     // gone (bundle switch/reset). During a pure re-layout the snapshot is
     // still present and keeping the bitmap avoids a blank flash.
-    canvas.onwheel = null;
-    canvas.onpointerdown = null;
-    canvas.onpointermove = null;
-    canvas.onpointerup = null;
+    detachCanvasHandlers(canvas);
     if (!options.snapshot) {
       disposeKnowledgeGraphCanvas(canvas);
       canvas.width = canvas.width || 1;
       canvas.dataset.nonblank = "false";
+      clearOverlayContainer(root);
     }
     return;
   }
+
   const stage = canvas.closest<HTMLElement>("[data-kg-stage]");
-  const view = {
-    scale: options.view.scale,
-    dx: options.view.dx,
-    dy: options.view.dy,
-    dragging: false,
-    moved: false,
-    px: 0,
-    py: 0,
-  };
-  let canvasSize = { width: 0, height: 0, cssWidth: 0, cssHeight: 0 };
-  let scheduledDraw: ReturnType<typeof setTimeout> | number | null = null;
-  const reducedMotion = prefersReducedMotion();
-  const draw = () => {
-    const viewport = canvasViewport(stage);
-    canvasSize = resizeCanvasIfNeeded(canvas, viewport, canvasSize);
-    if (!drawThree(canvas, viewport, options.layout!, options.selectedNodeIds, view)) {
-      drawCanvas2d(canvas, viewport, options.layout!, options.selectedNodeIds, view);
+  const viewport = canvasViewport(stage);
+  const layoutIdentity = `${options.layout.kind}:${options.layout.width}:${options.layout.height}:${options.layout.generatedAt}`;
+  let state = rendererStates.get(canvas);
+  if (!state) {
+    const camera = options.view.camera ?? defaultCameraForLayout(options.layout, viewport);
+    state = {
+      options,
+      camera,
+      goal: camera,
+      hoveredNodeId: null,
+      pointer: { mode: "idle", nodeId: null, lastX: 0, lastY: 0, moved: false },
+      rafHandle: null,
+      rafKind: "animation-frame",
+      lastFrameAt: 0,
+      animating: false,
+      reducedMotion: prefersReducedMotion(),
+      canvasSize: { width: 0, height: 0, cssWidth: 0, cssHeight: 0 },
+      lastScene: null,
+      layoutIdentity,
+    };
+    rendererStates.set(canvas, state);
+  } else {
+    state.options = options;
+    if (options.view.camera) {
+      state.camera = options.view.camera;
+      if (!state.animating) state.goal = options.view.camera;
     }
-    syncLabels(root, options.layout!, view, viewport);
-    canvas.dataset.nonblank = options.layout!.nodes.length > 0 ? "true" : "false";
-    canvas.dataset.reducedMotion = reducedMotion ? "true" : "false";
-  };
-  const requestDraw = () => {
-    if (scheduledDraw !== null) return;
-    const run = () => {
-      scheduledDraw = null;
-      scheduledCanvasDraws.delete(canvas);
-      if (canvas.isConnected) draw();
-    };
-    if (reducedMotion) {
-      scheduledDraw = setTimeout(run, 120);
-      scheduledCanvasDraws.set(canvas, { handle: scheduledDraw, kind: "timeout" });
-    } else if (typeof requestAnimationFrame === "function") {
-      scheduledDraw = requestAnimationFrame(run);
-      scheduledCanvasDraws.set(canvas, { handle: scheduledDraw, kind: "animation-frame" });
-    } else {
-      scheduledDraw = setTimeout(run, 16);
-      scheduledCanvasDraws.set(canvas, { handle: scheduledDraw, kind: "timeout" });
+    if (state.layoutIdentity !== layoutIdentity) {
+      state.layoutIdentity = layoutIdentity;
+      state.hoveredNodeId = null;
+      // A structurally different layout (mode switch, resize relayout) gets
+      // reframed; small refreshes keep the operator's camera.
+      if (!options.view.camera) {
+        state.camera = defaultCameraForLayout(options.layout, viewport);
+        state.goal = state.camera;
+      }
     }
-  };
-  draw();
-  canvas.onwheel = (event) => {
-    event.preventDefault();
-    view.scale = clamp(view.scale * (event.deltaY < 0 ? 1.08 : 0.92), 0.45, 3);
-    syncViewState(options.view, view);
-    requestDraw();
-  };
-  canvas.onpointerdown = (event) => {
-    canvas.setPointerCapture(event.pointerId);
-    view.dragging = true;
-    view.moved = false;
-    view.px = event.clientX;
-    view.py = event.clientY;
-  };
-  canvas.onpointermove = (event) => {
-    if (!view.dragging) return;
-    const dx = event.clientX - view.px;
-    const dy = event.clientY - view.py;
-    if (Math.abs(dx) + Math.abs(dy) > 2) view.moved = true;
-    view.dx += dx;
-    view.dy += dy;
-    view.px = event.clientX;
-    view.py = event.clientY;
-    syncViewState(options.view, view);
-    requestDraw();
-  };
-  canvas.onpointerup = (event) => {
-    view.dragging = false;
-    canvas.releasePointerCapture(event.pointerId);
-    if (!view.moved) {
-      const nodeId = nearestNode(options.layout!, event.offsetX, event.offsetY, canvasViewport(stage), view);
-      if (nodeId) options.onSelect(nodeId);
-    }
-  };
-  // Handler properties (not addEventListener) so re-mounting after every
-  // render stays idempotent: the DOM morph preserves these buttons across
-  // renders, and stacked listeners would fire once per past render.
-  root.querySelectorAll<HTMLElement>("[data-kg-node-id]").forEach((button) => {
-    button.onclick = () => {
-      const nodeId = button.dataset.kgNodeId;
-      if (nodeId) options.onSelect(nodeId);
-    };
-    button.onkeydown = (event) => {
-      const direction = graphListNavigationDirection(event.key);
-      if (!direction) return;
-      const buttons = Array.from(root.querySelectorAll<HTMLElement>(".os-kg-list [data-kg-node-id]"));
-      const index = buttons.indexOf(button);
-      if (index < 0) return;
-      event.preventDefault();
-      const nextIndex = direction === "first"
-        ? 0
-        : direction === "last"
-          ? buttons.length - 1
-          : (index + direction + buttons.length) % buttons.length;
-      buttons[nextIndex]?.focus();
-    };
-    button.onfocus = () => {
-      const nodeId = button.dataset.kgNodeId;
-      if (nodeId) options.onFocus(nodeId);
-    };
-  });
+  }
+  options.view.camera = state.camera;
+
+  attachCanvasHandlers(canvas, root, stage, state);
+  drawFrame(canvas, root, stage, state);
+  bindListNavigation(root, options);
 }
 
 export function disposeKnowledgeGraphRenderer(root: ParentNode): void {
@@ -198,26 +175,664 @@ export function disposeKnowledgeGraphRenderer(root: ParentNode): void {
 }
 
 export function disposeKnowledgeGraphCanvas(canvas: HTMLCanvasElement): void {
-  const scheduledDraw = scheduledCanvasDraws.get(canvas);
-  if (scheduledDraw) {
-    if (scheduledDraw.kind === "animation-frame" && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(scheduledDraw.handle as number);
+  const state = rendererStates.get(canvas);
+  if (state?.rafHandle !== null && state?.rafHandle !== undefined) {
+    if (state.rafKind === "animation-frame" && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(state.rafHandle as number);
     } else {
-      clearTimeout(scheduledDraw.handle as ReturnType<typeof setTimeout>);
+      clearTimeout(state.rafHandle as ReturnType<typeof setTimeout>);
     }
-    scheduledCanvasDraws.delete(canvas);
+    state.rafHandle = null;
   }
+  rendererStates.delete(canvas);
   resetThreeCanvasState(canvas);
 }
 
-function syncViewState(
-  target: KnowledgeGraphViewState,
-  view: KnowledgeGraphViewState,
-): void {
-  target.scale = view.scale;
-  target.dx = view.dx;
-  target.dy = view.dy;
+// ─── Interaction ────────────────────────────────────────────────────────────
+
+function canvasPointFromEvent(
+  canvas: HTMLCanvasElement,
+  event: MouseEvent,
+): { x: number; y: number } {
+  // offsetX/offsetY are relative to the event *target*, which may be an
+  // overlay label the pointer is passing over (events bubble to the canvas
+  // handlers) — always resolve against the canvas box instead.
+  const rect = canvas.getBoundingClientRect();
+  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
 }
+
+function detachCanvasHandlers(canvas: HTMLCanvasElement): void {
+  canvas.onwheel = null;
+  canvas.onpointerdown = null;
+  canvas.onpointermove = null;
+  canvas.onpointerup = null;
+  canvas.onpointerleave = null;
+  canvas.ondblclick = null;
+  canvas.oncontextmenu = null;
+}
+
+function attachCanvasHandlers(
+  canvas: HTMLCanvasElement,
+  root: HTMLElement,
+  stage: HTMLElement | null,
+  state: RendererState,
+): void {
+  canvas.oncontextmenu = (event) => {
+    event.preventDefault();
+  };
+  canvas.onwheel = (event) => {
+    event.preventDefault();
+    const viewport = canvasViewport(stage);
+    const factor = event.deltaY < 0 ? 0.88 : 1.14;
+    const point = canvasPointFromEvent(canvas, event);
+    state.goal = dollyCamera(state.goal, factor, {
+      viewport,
+      screenX: point.x,
+      screenY: point.y,
+    });
+    startAnimation(canvas, root, stage, state);
+  };
+  canvas.onpointerdown = (event) => {
+    try {
+      canvas.setPointerCapture(event.pointerId);
+    } catch {
+      // Pointer capture is an enhancement (keeps drags alive outside the
+      // canvas); synthetic pointers in tests have no capturable id.
+    }
+    const viewport = canvasViewport(stage);
+    const scene = state.lastScene ?? rebuildScene(state, viewport);
+    const point = canvasPointFromEvent(canvas, event);
+    const nodeId = event.button === 0 && !event.altKey && !event.metaKey
+      ? hitTestScene(scene, point.x, point.y)
+      : null;
+    state.pointer = {
+      mode: nodeId
+        ? "drag-node"
+        : event.button === 2 || event.altKey || event.metaKey
+          ? "orbit"
+          : "pan",
+      nodeId,
+      lastX: event.clientX,
+      lastY: event.clientY,
+      moved: false,
+    };
+    canvas.dataset.kgPointer = state.pointer.mode;
+  };
+  canvas.onpointermove = (event) => {
+    const viewport = canvasViewport(stage);
+    if (state.pointer.mode === "idle") {
+      const scene = state.lastScene ?? rebuildScene(state, viewport);
+      const point = canvasPointFromEvent(canvas, event);
+      const nodeId = hitTestScene(scene, point.x, point.y);
+      if (nodeId !== state.hoveredNodeId) {
+        state.hoveredNodeId = nodeId;
+        drawFrame(canvas, root, stage, state);
+      }
+      canvas.style.cursor = nodeId ? "pointer" : "grab";
+      return;
+    }
+    const deltaX = event.clientX - state.pointer.lastX;
+    const deltaY = event.clientY - state.pointer.lastY;
+    if (Math.abs(deltaX) + Math.abs(deltaY) > 2) state.pointer.moved = true;
+    state.pointer.lastX = event.clientX;
+    state.pointer.lastY = event.clientY;
+    if (state.pointer.mode === "pan") {
+      state.camera = panCamera(state.camera, viewport, deltaX, deltaY);
+      state.goal = state.camera;
+    } else if (state.pointer.mode === "orbit") {
+      state.camera = orbitCamera(state.camera, deltaX * 0.005, deltaY * 0.004);
+      state.goal = state.camera;
+    } else if (state.pointer.mode === "drag-node" && state.pointer.nodeId && state.options.layout) {
+      const worldNode = worldNodesFor(state.options.layout, state.options.view.overrides)
+        .find((node) => node.nodeId === state.pointer.nodeId);
+      if (worldNode) {
+        const dragPoint = canvasPointFromEvent(canvas, event);
+        const dropped = unprojectToPlaneThroughPoint(
+          state.camera,
+          viewport,
+          dragPoint.x,
+          dragPoint.y,
+          worldNode,
+        );
+        if (dropped) {
+          state.options.view.overrides.set(
+            state.pointer.nodeId,
+            worldToLayout(state.options.layout, dropped),
+          );
+        }
+      }
+    }
+    state.options.view.camera = state.camera;
+    drawFrame(canvas, root, stage, state);
+  };
+  canvas.onpointerup = (event) => {
+    try {
+      canvas.releasePointerCapture(event.pointerId);
+    } catch {
+      // Matching guard for synthetic pointers; see onpointerdown.
+    }
+    const { mode, nodeId, moved } = state.pointer;
+    state.pointer = { mode: "idle", nodeId: null, lastX: 0, lastY: 0, moved: false };
+    delete canvas.dataset.kgPointer;
+    canvas.style.cursor = "grab";
+    if (!moved && mode === "drag-node" && nodeId) {
+      state.options.onSelect(nodeId);
+    }
+  };
+  canvas.onpointerleave = () => {
+    if (state.hoveredNodeId !== null && state.pointer.mode === "idle") {
+      state.hoveredNodeId = null;
+      drawFrame(canvas, root, stage, state);
+    }
+  };
+  canvas.ondblclick = (event) => {
+    event.preventDefault();
+    const viewport = canvasViewport(stage);
+    const scene = state.lastScene ?? rebuildScene(state, viewport);
+    const layout = state.options.layout;
+    if (!layout) return;
+    const worldNodes = worldNodesFor(layout, state.options.view.overrides);
+    const point = canvasPointFromEvent(canvas, event);
+    const nodeId = hitTestScene(scene, point.x, point.y);
+    if (nodeId) {
+      // Frame the node and its direct neighborhood.
+      const neighborhood = new Set([nodeId]);
+      for (const edge of layout.edges) {
+        if (edge.sourceId === nodeId) neighborhood.add(edge.targetId);
+        if (edge.targetId === nodeId) neighborhood.add(edge.sourceId);
+      }
+      const points = worldNodes.filter((node) => neighborhood.has(node.nodeId));
+      state.goal = frameWorldPoints(points, viewport, state.camera, 1.35);
+      startAnimation(canvas, root, stage, state);
+      state.options.onSelect(nodeId);
+      return;
+    }
+    const hull = hitTestHull(scene, point.x, point.y);
+    if (hull) {
+      const members = new Set(
+        state.options.snapshot?.communities.find((community) => community.id === hull.areaId)?.node_ids ?? [],
+      );
+      const points = worldNodes.filter((node) => members.has(node.nodeId));
+      if (points.length > 0) {
+        state.goal = frameWorldPoints(points, viewport, state.camera, 1.25);
+        startAnimation(canvas, root, stage, state);
+        return;
+      }
+    }
+    state.goal = defaultCameraForLayout(layout, viewport);
+    startAnimation(canvas, root, stage, state);
+  };
+}
+
+function bindListNavigation(root: HTMLElement, options: KnowledgeGraphMountOptions): void {
+  // Handler properties (not addEventListener) so re-mounting after every
+  // render stays idempotent: the DOM morph preserves these buttons across
+  // renders, and stacked listeners would fire once per past render.
+  root.querySelectorAll<HTMLElement>("[data-kg-node-id]").forEach((button) => {
+    bindNodeButton(root, button, options);
+  });
+}
+
+function bindNodeButton(root: HTMLElement, button: HTMLElement, options: KnowledgeGraphMountOptions): void {
+  button.onclick = () => {
+    const nodeId = button.dataset.kgNodeId;
+    if (nodeId) options.onSelect(nodeId);
+  };
+  button.onkeydown = (event) => {
+    const direction = graphListNavigationDirection(event.key);
+    if (!direction) return;
+    const buttons = Array.from(root.querySelectorAll<HTMLElement>(".os-kg-list [data-kg-node-id]"));
+    const index = buttons.indexOf(button);
+    if (index < 0) return;
+    event.preventDefault();
+    const nextIndex = direction === "first"
+      ? 0
+      : direction === "last"
+        ? buttons.length - 1
+        : (index + direction + buttons.length) % buttons.length;
+    buttons[nextIndex]?.focus();
+  };
+  button.onfocus = () => {
+    const nodeId = button.dataset.kgNodeId;
+    if (nodeId) options.onFocus(nodeId);
+  };
+}
+
+// ─── Frame pipeline ─────────────────────────────────────────────────────────
+
+function startAnimation(
+  canvas: HTMLCanvasElement,
+  root: HTMLElement,
+  stage: HTMLElement | null,
+  state: RendererState,
+): void {
+  if (state.reducedMotion) {
+    state.camera = state.goal;
+    state.options.view.camera = state.camera;
+    drawFrame(canvas, root, stage, state);
+    return;
+  }
+  state.animating = true;
+  if (state.rafHandle !== null) return;
+  state.lastFrameAt = now();
+  const step = () => {
+    state.rafHandle = null;
+    if (!canvas.isConnected) return;
+    const at = now();
+    const deltaSeconds = Math.min(0.1, (at - state.lastFrameAt) / 1000);
+    state.lastFrameAt = at;
+    const advanced = advanceCameraToward(state.camera, state.goal, deltaSeconds);
+    state.camera = advanced.camera;
+    state.options.view.camera = state.camera;
+    drawFrame(canvas, root, stage, state);
+    if (!advanced.done) {
+      schedule();
+    } else {
+      state.animating = false;
+    }
+  };
+  const schedule = () => {
+    if (typeof requestAnimationFrame === "function") {
+      state.rafKind = "animation-frame";
+      state.rafHandle = requestAnimationFrame(step);
+    } else {
+      state.rafKind = "timeout";
+      state.rafHandle = setTimeout(step, 16);
+    }
+  };
+  schedule();
+}
+
+function rebuildScene(state: RendererState, viewport: SceneViewport): GraphScene {
+  const scene = buildGraphScene({
+    layout: state.options.layout!,
+    communities: state.options.snapshot?.communities ?? [],
+    camera: state.camera,
+    viewport,
+    overrides: state.options.view.overrides,
+    selectedNodeIds: state.options.selectedNodeIds,
+    hoveredNodeId: state.hoveredNodeId,
+  });
+  state.lastScene = scene;
+  return scene;
+}
+
+function drawFrame(
+  canvas: HTMLCanvasElement,
+  root: HTMLElement,
+  stage: HTMLElement | null,
+  state: RendererState,
+): void {
+  const viewport = canvasViewport(stage);
+  state.canvasSize = resizeCanvasIfNeeded(canvas, viewport, state.canvasSize);
+  const scene = rebuildScene(state, viewport);
+  if (!drawThree(canvas, viewport, scene)) {
+    drawCanvas2d(canvas, scene);
+  }
+  syncOverlay(root, state, scene);
+  canvas.dataset.nonblank = scene.nodes.length > 0 ? "true" : "false";
+  canvas.dataset.reducedMotion = state.reducedMotion ? "true" : "false";
+  // Debug/E2E handle: the last drawn scene, camera, and viewport.
+  (canvas as HTMLCanvasElement & { __kgDebug?: unknown }).__kgDebug = {
+    camera: state.camera,
+    viewport,
+    nodes: scene.nodes.length,
+    scene,
+  };
+}
+
+// ─── HTML overlay: labels, area titles, tooltip ─────────────────────────────
+
+function overlayContainer(root: HTMLElement): HTMLElement | null {
+  return root.querySelector<HTMLElement>("[data-kg-labels]");
+}
+
+function clearOverlayContainer(root: ParentNode): void {
+  const container = (root as HTMLElement).querySelector?.<HTMLElement>("[data-kg-labels]");
+  container?.replaceChildren();
+}
+
+function syncOverlay(
+  root: HTMLElement,
+  state: RendererState,
+  scene: GraphScene,
+): void {
+  const container = overlayContainer(root);
+  if (!container) return;
+  const document = container.ownerDocument;
+  const seen = new Set<Element>();
+
+  // Area titles surface when zoomed out, replacing the node-label noise.
+  for (const hull of scene.hulls) {
+    if (hull.labelAlpha <= 0.02) continue;
+    let label = container.querySelector<HTMLElement>(`[data-kg-area-label="${cssEscape(hull.areaId)}"]`);
+    if (!label) {
+      label = document.createElement("div");
+      label.className = "os-kg-area-label";
+      label.dataset.kgAreaLabel = hull.areaId;
+      container.appendChild(label);
+    }
+    if (label.textContent !== hull.label) label.textContent = hull.label;
+    label.style.left = `${hull.labelX.toFixed(1)}px`;
+    label.style.top = `${hull.labelY.toFixed(1)}px`;
+    label.style.opacity = hull.labelAlpha.toFixed(2);
+    label.style.color = hull.color;
+    seen.add(label);
+  }
+
+  for (const node of scene.nodes) {
+    if (node.labelAlpha <= 0.05) continue;
+    let label = container.querySelector<HTMLElement>(`.os-kg-label[data-kg-node-id="${cssEscape(node.nodeId)}"]`);
+    if (!label) {
+      label = document.createElement("button");
+      (label as HTMLButtonElement).type = "button";
+      label.className = "os-kg-label";
+      label.dataset.kgNodeId = node.nodeId;
+      container.appendChild(label);
+      bindNodeButton(root, label, state.options);
+    }
+    const text = shortLabel(node.labelText);
+    if (label.textContent !== text) label.textContent = text;
+    label.style.left = `${node.x.toFixed(1)}px`;
+    label.style.top = `${(node.y + node.screenRadius + 3).toFixed(1)}px`;
+    label.style.opacity = node.labelAlpha.toFixed(2);
+    label.classList.toggle("is-selected", node.emphasis === "selected");
+    label.classList.toggle("is-hovered", node.emphasis === "hovered");
+    seen.add(label);
+  }
+
+  const tooltip = syncTooltip(container, state, scene);
+  if (tooltip) seen.add(tooltip);
+
+  for (const child of Array.from(container.children)) {
+    if (!seen.has(child) && child !== document.activeElement) {
+      child.remove();
+    }
+  }
+}
+
+function syncTooltip(
+  container: HTMLElement,
+  state: RendererState,
+  scene: GraphScene,
+): HTMLElement | null {
+  const hovered = scene.hoveredNodeId
+    ? scene.nodes.find((node) => node.nodeId === scene.hoveredNodeId)
+    : null;
+  let tooltip = container.querySelector<HTMLElement>("[data-kg-tooltip]");
+  if (!hovered) {
+    tooltip?.remove();
+    return null;
+  }
+  const document = container.ownerDocument;
+  if (!tooltip) {
+    tooltip = document.createElement("div");
+    tooltip.className = "os-kg-tooltip";
+    tooltip.dataset.kgTooltip = "true";
+    tooltip.setAttribute("role", "status");
+    container.appendChild(tooltip);
+  }
+  const snapshotNode = state.options.snapshot?.nodes.find((node) => node.id === hovered.nodeId);
+  const areas = state.options.snapshot?.communities
+    .filter((community) => community.node_ids.includes(hovered.nodeId))
+    .map((community) => community.label)
+    ?? [];
+  const degree = (snapshotNode?.metrics?.indegree ?? 0) + (snapshotNode?.metrics?.outdegree ?? 0);
+  tooltip.innerHTML = `
+    <strong>${escapeHtml(hovered.labelText)}</strong>
+    <span>${escapeHtml(snapshotNode?.kind ?? "node")}${degree ? ` &middot; ${degree} links` : ""}</span>
+    ${areas.length > 0 ? `<em>${escapeHtml(areas.join(" · "))}</em>` : ""}
+  `;
+  positionTooltip(tooltip, hovered.x, hovered.y - hovered.screenRadius - 10);
+  return tooltip;
+}
+
+function positionTooltip(tooltip: HTMLElement, x: number, y: number): void {
+  tooltip.style.left = `${x.toFixed(1)}px`;
+  tooltip.style.top = `${Math.max(8, y).toFixed(1)}px`;
+}
+
+// ─── WebGL backend ──────────────────────────────────────────────────────────
+
+interface ThreeCanvasState {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  graph: THREE.Group;
+  viewportKey: string | null;
+  contentKey: string | null;
+}
+
+const threeCanvasState = new WeakMap<HTMLCanvasElement, ThreeCanvasState>();
+
+function resetThreeCanvasState(canvas: HTMLCanvasElement): void {
+  const state = threeCanvasState.get(canvas);
+  if (!state) return;
+  try {
+    disposeObject3D(state.graph);
+    state.renderer.dispose();
+    state.renderer.forceContextLoss();
+  } catch {
+    // Fall back to 2D drawing; the next WebGL attempt starts from a fresh state.
+  }
+  threeCanvasState.delete(canvas);
+}
+
+/**
+ * GPU rasterization of the already-projected scene. The scene is authored in
+ * screen space by the shared projector, so the WebGL path draws with a
+ * simple orthographic screen-space camera and can never disagree with the
+ * hit-testing, labels, or the 2D fallback.
+ */
+function drawThree(
+  canvas: HTMLCanvasElement,
+  viewport: { width: number; height: number; ratio: number },
+  scene: GraphScene,
+): boolean {
+  try {
+    const three = threeStateFor(canvas);
+    const viewportKey = `${viewport.width}:${viewport.height}:${viewport.ratio}`;
+    if (three.viewportKey !== viewportKey) {
+      three.renderer.setPixelRatio(viewport.ratio);
+      three.renderer.setSize(viewport.width, viewport.height, false);
+      three.camera.left = 0;
+      three.camera.right = viewport.width;
+      three.camera.top = 0;
+      three.camera.bottom = viewport.height;
+      three.camera.updateProjectionMatrix();
+      three.viewportKey = viewportKey;
+    }
+    syncThreeScene(three, scene);
+    three.renderer.setClearColor(graphSurfaceColorInt, 1);
+    three.renderer.clear(true, true, true);
+    three.renderer.render(three.scene, three.camera);
+    return true;
+  } catch {
+    resetThreeCanvasState(canvas);
+    return false;
+  }
+}
+
+function threeStateFor(canvas: HTMLCanvasElement): ThreeCanvasState {
+  const existing = threeCanvasState.get(canvas);
+  if (existing) return existing;
+  const contextAttributes = { alpha: false, antialias: true, preserveDrawingBuffer: true };
+  const context = (canvas.getContext("webgl2", contextAttributes) as WebGL2RenderingContext | null)
+    ?? (canvas.getContext("webgl", contextAttributes) as WebGLRenderingContext | null);
+  if (!context) throw new Error("WebGL is unavailable");
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    context,
+    alpha: false,
+    antialias: true,
+    preserveDrawingBuffer: true,
+  });
+  const scene = new THREE.Scene();
+  const graph = new THREE.Group();
+  scene.add(graph);
+  // Screen-space orthographic camera: with top=0 and bottom=height the
+  // default -Z view maps our y-down screen coordinates directly; no up-flip
+  // or lookAt (those would mirror x out of the clip volume).
+  const camera = new THREE.OrthographicCamera(0, 1, 0, 1, -1000, 1000);
+  camera.position.set(0, 0, 500);
+  const state: ThreeCanvasState = { renderer, scene, camera, graph, viewportKey: null, contentKey: null };
+  threeCanvasState.set(canvas, state);
+  return state;
+}
+
+function syncThreeScene(three: ThreeCanvasState, scene: GraphScene): void {
+  disposeObject3D(three.graph);
+  three.graph.clear();
+
+  let order = 0;
+  for (const hull of scene.hulls) {
+    if (hull.outline.length < 3) continue;
+    const shape = new THREE.Shape(hull.outline.map((point) => new THREE.Vector2(point.x, point.y)));
+    const mesh = new THREE.Mesh(
+      new THREE.ShapeGeometry(shape),
+      new THREE.MeshBasicMaterial({
+        color: new THREE.Color(hull.color),
+        transparent: true,
+        opacity: hull.alpha,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+      }),
+    );
+    mesh.renderOrder = order++;
+    three.graph.add(mesh);
+  }
+
+  const edgeGroups = new Map<string, { positions: number[]; color: string; alpha: number }>();
+  for (const edge of scene.edges) {
+    const alphaBucket = Math.round(edge.alpha * 20) / 20;
+    const color = edge.emphasized ? nodeEmphasisColor : "#7d94a8";
+    const key = `${color}:${alphaBucket}`;
+    const group = edgeGroups.get(key) ?? { positions: [], color, alpha: alphaBucket };
+    group.positions.push(edge.x1, edge.y1, 0, edge.x2, edge.y2, 0);
+    edgeGroups.set(key, group);
+  }
+  for (const group of edgeGroups.values()) {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.Float32BufferAttribute(group.positions, 3));
+    const lines = new THREE.LineSegments(
+      geometry,
+      new THREE.LineBasicMaterial({
+        color: new THREE.Color(group.color),
+        transparent: true,
+        opacity: group.alpha,
+        depthWrite: false,
+      }),
+    );
+    lines.renderOrder = order++;
+    three.graph.add(lines);
+  }
+
+  const nodeGroups = new Map<string, { nodes: Array<{ x: number; y: number; r: number }>; color: string; alpha: number }>();
+  for (const node of scene.nodes) {
+    const color = node.emphasis === "hovered" || node.emphasis === "selected" ? nodeEmphasisColor : node.color;
+    const alphaBucket = Math.round(node.alpha * 10) / 10;
+    const key = `${color}:${alphaBucket}`;
+    const radius = node.emphasis === "hovered" || node.emphasis === "selected"
+      ? node.screenRadius * 1.3
+      : node.screenRadius;
+    const group = nodeGroups.get(key) ?? { nodes: [], color, alpha: alphaBucket };
+    group.nodes.push({ x: node.x, y: node.y, r: radius });
+    nodeGroups.set(key, group);
+  }
+  for (const group of nodeGroups.values()) {
+    const geometry = new THREE.CircleGeometry(1, 22);
+    const material = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(group.color),
+      transparent: group.alpha < 1,
+      opacity: group.alpha,
+      depthWrite: false,
+    });
+    const mesh = new THREE.InstancedMesh(geometry, material, group.nodes.length);
+    const matrix = new THREE.Matrix4();
+    group.nodes.forEach((node, index) => {
+      matrix.compose(
+        new THREE.Vector3(node.x, node.y, 0),
+        new THREE.Quaternion(),
+        new THREE.Vector3(node.r, node.r, 1),
+      );
+      mesh.setMatrixAt(index, matrix);
+    });
+    mesh.instanceMatrix.needsUpdate = true;
+    mesh.renderOrder = order++;
+    three.graph.add(mesh);
+  }
+}
+
+function disposeObject3D(object: THREE.Object3D): void {
+  object.traverse((child) => {
+    if (child === object) return;
+    disposeRenderable(child);
+  });
+}
+
+function disposeRenderable(object: THREE.Object3D): void {
+  const renderable = object as THREE.Object3D & {
+    geometry?: { dispose(): void };
+    material?: THREE.Material | THREE.Material[];
+  };
+  renderable.geometry?.dispose();
+  const materials = renderable.material
+    ? Array.isArray(renderable.material) ? renderable.material : [renderable.material]
+    : [];
+  for (const material of materials) material.dispose();
+}
+
+// ─── 2D fallback ────────────────────────────────────────────────────────────
+
+function drawCanvas2d(canvas: HTMLCanvasElement, scene: GraphScene): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const ratio = canvas.width / Number.parseFloat(canvas.style.width || String(canvas.width));
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  ctx.fillStyle = graphSurfaceColor;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  for (const hull of scene.hulls) {
+    if (hull.outline.length < 3) continue;
+    ctx.beginPath();
+    ctx.moveTo(hull.outline[0].x, hull.outline[0].y);
+    for (const point of hull.outline.slice(1)) ctx.lineTo(point.x, point.y);
+    ctx.closePath();
+    ctx.globalAlpha = hull.alpha;
+    ctx.fillStyle = hull.color;
+    ctx.fill();
+    ctx.globalAlpha = Math.min(1, hull.alpha * 2);
+    ctx.lineWidth = 10;
+    ctx.strokeStyle = hull.color;
+    ctx.stroke();
+  }
+
+  ctx.lineWidth = 1;
+  for (const edge of scene.edges) {
+    ctx.globalAlpha = edge.alpha;
+    ctx.strokeStyle = edge.emphasized ? nodeEmphasisColor : "#7d94a8";
+    ctx.lineWidth = edge.emphasized ? 1.6 : 1;
+    ctx.beginPath();
+    ctx.moveTo(edge.x1, edge.y1);
+    ctx.lineTo(edge.x2, edge.y2);
+    ctx.stroke();
+  }
+
+  for (const node of scene.nodes) {
+    const emphasized = node.emphasis === "hovered" || node.emphasis === "selected";
+    ctx.globalAlpha = node.alpha;
+    ctx.beginPath();
+    ctx.fillStyle = emphasized ? nodeEmphasisColor : node.color;
+    ctx.arc(node.x, node.y, emphasized ? node.screenRadius * 1.3 : node.screenRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.lineWidth = emphasized ? 2.4 : 1.4;
+    ctx.strokeStyle = "#ffffff";
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+}
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────
 
 function resizeCanvasIfNeeded(
   canvas: HTMLCanvasElement,
@@ -257,48 +872,6 @@ function renderStatus(state: GraphState): string {
   }
   if (status === "ready") return `<span class="os-kg-status" data-testid="knowledge-graph-status">Ready</span>`;
   return `<span class="os-kg-status" data-testid="knowledge-graph-status">Idle</span>`;
-}
-
-function renderLabels(layout: GraphLayoutResult | null, selectedNodeIds: readonly string[]): string {
-  if (!layout) return "";
-  const selected = new Set(selectedNodeIds);
-  const visible = labelNodes(layout.nodes, selected);
-  return visible
-    .map((node) => {
-      const left = (node.x / layout.width) * 100;
-      const top = (node.y / layout.height) * 100;
-      const picked = selected.has(node.nodeId) ? " is-selected" : "";
-      return `<button type="button" class="os-kg-label${picked}" style="left:${left.toFixed(2)}%;top:${top.toFixed(2)}%;visibility:hidden" data-kg-node-id="${escapeAttr(node.nodeId)}">${escapeHtml(shortLabel(node.label))}</button>`;
-    })
-    .join("");
-}
-
-function labelNodes(
-  nodes: readonly GraphLayoutResult["nodes"][number][],
-  selected: ReadonlySet<string>,
-): GraphLayoutResult["nodes"][number][] {
-  if (nodes.length <= maxVisibleGraphLabels) return [...nodes];
-  const selectedNodes = nodes.filter((node) => selected.has(node.nodeId));
-  const bundleNodes = nodes.filter((node) => node.kind === "bundle");
-  const priorityNodes = uniqueLayoutNodes([...bundleNodes, ...selectedNodes]).slice(0, maxVisibleGraphLabels);
-  const priorityIds = new Set(priorityNodes.map((node) => node.nodeId));
-  return [
-    ...priorityNodes,
-    ...nodes
-      .filter((node) => !priorityIds.has(node.nodeId) && (node.kind === "community" || node.kind === "concept"))
-      .slice(0, Math.max(0, maxVisibleGraphLabels - priorityNodes.length)),
-  ];
-}
-
-function uniqueLayoutNodes(
-  nodes: readonly GraphLayoutResult["nodes"][number][],
-): GraphLayoutResult["nodes"][number][] {
-  const seen = new Set<string>();
-  return nodes.filter((node) => {
-    if (seen.has(node.nodeId)) return false;
-    seen.add(node.nodeId);
-    return true;
-  });
 }
 
 function renderSelectedInspector(snapshot: MemoryGraphSnapshot | null, selectedNodeIds: readonly string[]): string {
@@ -366,257 +939,6 @@ function graphListNavigationDirection(key: string): -1 | 1 | "first" | "last" | 
   }
 }
 
-interface ThreeCanvasState {
-  renderer: THREE.WebGLRenderer;
-  scene: THREE.Scene;
-  camera: THREE.OrthographicCamera;
-  graph: THREE.Group;
-  viewportKey: string | null;
-  layoutKey: string | null;
-  selectionKey: string | null;
-}
-
-const threeCanvasState = new WeakMap<HTMLCanvasElement, ThreeCanvasState>();
-
-function resetThreeCanvasState(canvas: HTMLCanvasElement): void {
-  const state = threeCanvasState.get(canvas);
-  if (!state) return;
-  try {
-    disposeObject3D(state.graph);
-    state.renderer.dispose();
-    state.renderer.forceContextLoss();
-  } catch {
-    // Fall back to 2D drawing; the next WebGL attempt starts from a fresh state.
-  }
-  threeCanvasState.delete(canvas);
-}
-
-function drawThree(
-  canvas: HTMLCanvasElement,
-  viewport: { width: number; height: number; ratio: number },
-  layout: GraphLayoutResult,
-  selectedNodeIds: readonly string[],
-  view: { scale: number; dx: number; dy: number },
-): boolean {
-  try {
-    const state = threeStateFor(canvas);
-    const viewportKey = `${viewport.width}:${viewport.height}:${viewport.ratio}`;
-    if (state.viewportKey !== viewportKey) {
-      state.renderer.setPixelRatio(viewport.ratio);
-      state.renderer.setSize(viewport.width, viewport.height, false);
-      state.camera.left = -viewport.width / 2;
-      state.camera.right = viewport.width / 2;
-      state.camera.top = viewport.height / 2;
-      state.camera.bottom = -viewport.height / 2;
-      state.camera.updateProjectionMatrix();
-      state.viewportKey = viewportKey;
-    }
-    state.renderer.setClearColor(graphSurfaceColorInt, 1);
-    state.renderer.clear(true, true, true);
-    syncGraphObjects(state, layout, selectedNodeIds);
-    state.graph.scale.set(view.scale, view.scale, 1);
-    state.graph.position.set(view.dx, -view.dy, 0);
-    state.renderer.render(state.scene, state.camera);
-    return true;
-  } catch {
-    resetThreeCanvasState(canvas);
-    return false;
-  }
-}
-
-function threeStateFor(canvas: HTMLCanvasElement): ThreeCanvasState {
-  const existing = threeCanvasState.get(canvas);
-  if (existing) return existing;
-  const contextAttributes = { alpha: false, antialias: true, preserveDrawingBuffer: true };
-  const context = (canvas.getContext("webgl2", contextAttributes) as WebGL2RenderingContext | null)
-    ?? (canvas.getContext("webgl", contextAttributes) as WebGLRenderingContext | null);
-  if (!context) throw new Error("WebGL is unavailable");
-  const renderer = new THREE.WebGLRenderer({
-    canvas,
-    context,
-    alpha: false,
-    antialias: true,
-    preserveDrawingBuffer: true,
-  });
-  const scene = new THREE.Scene();
-  const graph = new THREE.Group();
-  scene.add(graph);
-  const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 1, 2000);
-  camera.position.set(0, 0, 800);
-  const state = { renderer, scene, camera, graph, viewportKey: null, layoutKey: null, selectionKey: null };
-  threeCanvasState.set(canvas, state);
-  return state;
-}
-
-function syncGraphObjects(
-  state: ThreeCanvasState,
-  layout: GraphLayoutResult,
-  selectedNodeIds: readonly string[],
-): void {
-  const layoutKey = graphLayoutKey(layout);
-  const selectionKey = [...selectedNodeIds].sort().join("\u0000");
-  if (state.layoutKey === layoutKey && state.selectionKey === selectionKey) return;
-  disposeObject3D(state.graph);
-  state.graph.clear();
-  state.graph.add(edgeSegments(layout));
-  state.graph.add(nodeInstances(layout, selectedNodeIds));
-  state.layoutKey = layoutKey;
-  state.selectionKey = selectionKey;
-}
-
-function disposeObject3D(object: THREE.Object3D): void {
-  object.traverse((child) => {
-    if (child === object) return;
-    disposeRenderable(child);
-  });
-}
-
-function disposeRenderable(object: THREE.Object3D): void {
-  const renderable = object as THREE.Object3D & {
-    geometry?: { dispose(): void };
-    material?: THREE.Material | THREE.Material[];
-  };
-  renderable.geometry?.dispose();
-  const materials = renderable.material
-    ? Array.isArray(renderable.material) ? renderable.material : [renderable.material]
-    : [];
-  for (const material of materials) material.dispose();
-}
-
-function graphLayoutKey(layout: GraphLayoutResult): string {
-  const nodes = layout.nodes
-    .map((node) => `${node.nodeId}:${node.x.toFixed(2)}:${node.y.toFixed(2)}:${node.z.toFixed(2)}:${node.radius}`)
-    .join("|");
-  const edges = layout.edges
-    .map((edge) => `${edge.edgeId}:${edge.sourceId}:${edge.targetId}`)
-    .join("|");
-  return `${layout.kind}:${layout.width}:${layout.height}:${nodes}:${edges}`;
-}
-
-function edgeSegments(layout: GraphLayoutResult): THREE.LineSegments {
-  const byId = new Map(layout.nodes.map((node) => [node.nodeId, node]));
-  const positions: number[] = [];
-  for (const edge of layout.edges) {
-    const source = byId.get(edge.sourceId);
-    const target = byId.get(edge.targetId);
-    if (!source || !target) continue;
-    positions.push(...projectPoint(source.x, source.y, 0, layout, { scale: 1, dx: 0, dy: 0 }));
-    positions.push(...projectPoint(target.x, target.y, 0, layout, { scale: 1, dx: 0, dy: 0 }));
-  }
-  const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
-  return new THREE.LineSegments(geometry, new THREE.LineBasicMaterial({ color: 0x8aa4b8, transparent: true, opacity: 0.62 }));
-}
-
-function nodeInstances(
-  layout: GraphLayoutResult,
-  selectedNodeIds: readonly string[],
-): THREE.Group {
-  const selected = new Set(selectedNodeIds);
-  const grouped = new Map<string, GraphLayoutResult["nodes"]>();
-  for (const node of layout.nodes) {
-    const color = selected.has(node.nodeId) ? "#c2410c" : colorForKind(node.kind);
-    const nodes = grouped.get(color);
-    if (nodes) {
-      nodes.push(node);
-    } else {
-      grouped.set(color, [node]);
-    }
-  }
-  const group = new THREE.Group();
-  for (const [color, nodes] of grouped) {
-    const geometry = new THREE.CircleGeometry(1, 24);
-    const material = new THREE.MeshBasicMaterial({ color });
-    const mesh = new THREE.InstancedMesh(geometry, material, nodes.length);
-    const matrix = new THREE.Matrix4();
-    nodes.forEach((node, index) => {
-      const [x, y, z] = projectPoint(node.x, node.y, node.z, layout, { scale: 1, dx: 0, dy: 0 });
-      const scale = selected.has(node.nodeId) ? node.radius + 12 : node.radius;
-      matrix.compose(new THREE.Vector3(x, y, z), new THREE.Quaternion(), new THREE.Vector3(scale, scale, 1));
-      mesh.setMatrixAt(index, matrix);
-    });
-    mesh.instanceMatrix.needsUpdate = true;
-    group.add(mesh);
-  }
-  return group;
-}
-
-function drawCanvas2d(
-  canvas: HTMLCanvasElement,
-  viewport: { width: number; height: number },
-  layout: GraphLayoutResult,
-  selectedNodeIds: readonly string[],
-  view: { scale: number; dx: number; dy: number },
-): void {
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return;
-  const ratio = canvas.width / Number.parseFloat(canvas.style.width || String(canvas.width));
-  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
-  ctx.fillStyle = graphSurfaceColor;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  const selected = new Set(selectedNodeIds);
-  const byId = new Map(layout.nodes.map((node) => [node.nodeId, node]));
-  ctx.strokeStyle = "#8aa4b8";
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.72;
-  for (const edge of layout.edges) {
-    const source = byId.get(edge.sourceId);
-    const target = byId.get(edge.targetId);
-    if (!source || !target) continue;
-    const a = canvasPoint(source.x, source.y, layout, view, viewport);
-    const b = canvasPoint(target.x, target.y, layout, view, viewport);
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  }
-  ctx.globalAlpha = 1;
-  for (const node of layout.nodes) {
-    const p = canvasPoint(node.x, node.y, layout, view, viewport);
-    ctx.beginPath();
-    ctx.fillStyle = selected.has(node.nodeId) ? "#c2410c" : colorForKind(node.kind);
-    ctx.arc(p.x, p.y, (selected.has(node.nodeId) ? node.radius + 12 : node.radius) * view.scale, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.strokeStyle = "#ffffff";
-    ctx.lineWidth = 2;
-    ctx.stroke();
-  }
-}
-
-function nearestNode(
-  layout: GraphLayoutResult,
-  x: number,
-  y: number,
-  viewport: { width: number; height: number },
-  view: { scale: number; dx: number; dy: number },
-): string | null {
-  let best: { id: string; distance: number } | null = null;
-  for (const node of layout.nodes) {
-    const p = canvasPoint(node.x, node.y, layout, view, viewport);
-    const distance = Math.hypot(p.x - x, p.y - y);
-    const hitRadius = Math.max(8, (node.radius + 9) * view.scale);
-    if (distance <= hitRadius && (!best || distance < best.distance)) best = { id: node.nodeId, distance };
-  }
-  return best?.id ?? null;
-}
-
-function syncLabels(
-  root: HTMLElement,
-  layout: GraphLayoutResult,
-  view: { scale: number; dx: number; dy: number },
-  viewport: { width: number; height: number },
-): void {
-  root.querySelectorAll<HTMLElement>(".os-kg-label[data-kg-node-id]").forEach((label) => {
-    const nodeId = label.dataset.kgNodeId;
-    const node = layout.nodes.find((candidate) => candidate.nodeId === nodeId);
-    if (!node) return;
-    const point = canvasPoint(node.x, node.y, layout, view, viewport);
-    label.style.left = `${point.x}px`;
-    label.style.top = `${point.y}px`;
-    label.style.visibility = "visible";
-  });
-}
-
 function canvasViewport(stage: HTMLElement | null): { width: number; height: number; ratio: number } {
   const rect = stage?.getBoundingClientRect();
   const width = Math.max(320, Math.floor(rect?.width || 640));
@@ -624,54 +946,17 @@ function canvasViewport(stage: HTMLElement | null): { width: number; height: num
   return { width, height, ratio: globalThis.devicePixelRatio || 1 };
 }
 
-function projectPoint(
-  x: number,
-  y: number,
-  z: number,
-  layout: GraphLayoutResult,
-  view: { scale: number; dx: number; dy: number },
-): [number, number, number] {
-  return [
-    (x - layout.width / 2) * view.scale + view.dx,
-    (layout.height / 2 - y) * view.scale - view.dy,
-    z,
-  ];
-}
-
-function canvasPoint(
-  x: number,
-  y: number,
-  layout: GraphLayoutResult,
-  view: { scale: number; dx: number; dy: number },
-  viewport = { width: Number.NaN, height: Number.NaN },
-): { x: number; y: number } {
-  const width = Number.isNaN(viewport.width) ? Math.max(320, layout.width) : viewport.width;
-  const height = Number.isNaN(viewport.height) ? Math.max(260, layout.height) : viewport.height;
-  return {
-    x: width / 2 + (x - layout.width / 2) * view.scale + view.dx,
-    y: height / 2 + (y - layout.height / 2) * view.scale + view.dy,
-  };
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
 
 function shortLabel(label: string): string {
   return label.length > 34 ? `${label.slice(0, 31)}...` : label;
 }
 
-function colorForKind(kind: string): string {
-  switch (kind) {
-    case "concept":
-      return "#1f6f8b";
-    case "bundle":
-      return "#334155";
-    case "tag":
-      return "#7c3aed";
-    case "source_ref":
-      return "#0f766e";
-    default:
-      return "#64748b";
+function cssEscape(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
   }
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
+  return value.replace(/["\\\]]/g, "\\$&");
 }

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -163,19 +163,32 @@ export function mountKnowledgeGraphRenderer(
     if (state.layoutIdentity !== layoutIdentity) {
       state.layoutIdentity = layoutIdentity;
       state.hoveredNodeId = null;
-      // A structurally different layout (mode switch, resize relayout) gets
-      // reframed; small refreshes keep the operator's camera.
-      if (!options.view.camera) {
-        state.camera = defaultCameraForLayout(options.layout, viewport);
-        state.goal = state.camera;
-      }
+      // A new layout means the content genuinely changed (identical
+      // snapshots no longer trigger relayouts): mode switches, bundle
+      // switches, and resize relayouts all reposition nodes, so glide the
+      // camera toward framing the new layout instead of keeping a view
+      // that may point entirely off-frame.
+      state.goal = defaultCameraForLayout(options.layout, viewport);
     }
   }
   options.view.camera = state.camera;
 
   attachCanvasHandlers(canvas, root, stage, state);
-  drawFrame(canvas, root, stage, state);
+  if (cameraDiffers(state.camera, state.goal)) {
+    startAnimation(canvas, root, stage, state);
+  } else {
+    drawFrame(canvas, root, stage, state);
+  }
   bindListNavigation(root, options);
+}
+
+function cameraDiffers(a: GraphCameraState, b: GraphCameraState): boolean {
+  return a.targetX !== b.targetX
+    || a.targetY !== b.targetY
+    || a.targetZ !== b.targetZ
+    || a.distance !== b.distance
+    || a.yaw !== b.yaw
+    || a.pitch !== b.pitch;
 }
 
 export function disposeKnowledgeGraphRenderer(root: ParentNode): void {
@@ -624,7 +637,7 @@ function positionTooltip(tooltip: HTMLElement, x: number, y: number): void {
 interface ThreeCanvasState {
   renderer: THREE.WebGLRenderer;
   scene: THREE.Scene;
-  camera: THREE.PerspectiveCamera;
+  camera: THREE.OrthographicCamera;
   graph: THREE.Group;
   viewportKey: string | null;
   contentKey: string | null;

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -119,15 +119,17 @@ export function mountKnowledgeGraphRenderer(
     // The morphing render preserves the canvas node, so without drawable
     // data the previous mount's bitmap and handlers would otherwise stay
     // live and interactive against a stale layout. Always detach the
-    // interaction handlers; drop the bitmap too once the snapshot itself is
-    // gone (bundle switch/reset). During a pure re-layout the snapshot is
-    // still present and keeping the bitmap avoids a blank flash.
+    // interaction handlers and clear the label/tooltip overlays (they are
+    // positioned against the old layout and remain clickable otherwise);
+    // drop the bitmap too once the snapshot itself is gone (bundle
+    // switch/reset). During a pure re-layout the snapshot is still present
+    // and keeping the bitmap avoids a blank flash.
     detachCanvasHandlers(canvas);
+    clearOverlayContainer(root);
     if (!options.snapshot) {
       disposeKnowledgeGraphCanvas(canvas);
       canvas.width = canvas.width || 1;
       canvas.dataset.nonblank = "false";
-      clearOverlayContainer(root);
     }
     return;
   }
@@ -318,10 +320,10 @@ function attachCanvasHandlers(
           worldNode,
         );
         if (dropped) {
-          state.options.view.overrides.set(
-            state.pointer.nodeId,
-            worldToLayout(state.options.layout, dropped),
-          );
+          state.options.view.overrides.set(state.pointer.nodeId, {
+            ...worldToLayout(state.options.layout, dropped),
+            z: dropped.z,
+          });
         }
       }
     }

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -503,6 +503,9 @@ function syncOverlay(
   const seen = new Set<Element>();
 
   // Area titles surface when zoomed out, replacing the node-label noise.
+  // A light declutter pass nudges titles apart when neighboring clusters
+  // overlap so two areas never render on top of each other.
+  const placedAreaLabels: Array<{ x: number; y: number; halfWidth: number }> = [];
   for (const hull of scene.hulls) {
     if (hull.labelAlpha <= 0.02) continue;
     let label = container.querySelector<HTMLElement>(`[data-kg-area-label="${cssEscape(hull.areaId)}"]`);
@@ -513,8 +516,19 @@ function syncOverlay(
       container.appendChild(label);
     }
     if (label.textContent !== hull.label) label.textContent = hull.label;
+    const halfWidth = hull.label.length * 5.4;
+    let labelY = hull.labelY;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const collision = placedAreaLabels.find((placed) =>
+        Math.abs(placed.y - labelY) < 24
+        && Math.abs(placed.x - hull.labelX) < placed.halfWidth + halfWidth,
+      );
+      if (!collision) break;
+      labelY += 26;
+    }
+    placedAreaLabels.push({ x: hull.labelX, y: labelY, halfWidth });
     label.style.left = `${hull.labelX.toFixed(1)}px`;
-    label.style.top = `${hull.labelY.toFixed(1)}px`;
+    label.style.top = `${labelY.toFixed(1)}px`;
     label.style.opacity = hull.labelAlpha.toFixed(2);
     label.style.color = hull.color;
     seen.add(label);

--- a/packages/ui-core/src/knowledge-graph-scene.ts
+++ b/packages/ui-core/src/knowledge-graph-scene.ts
@@ -32,8 +32,13 @@ export interface GraphCameraState {
 
 export interface KnowledgeGraphViewState {
   camera: GraphCameraState | null;
-  /** Node drag overrides in layout coordinates, keyed by node id. */
-  overrides: Map<string, { x: number; y: number }>;
+  /**
+   * Node drag overrides keyed by node id: x/y in layout coordinates, plus
+   * the world-space z of the drop point. Dragging happens on a camera-facing
+   * plane, so under an orbited camera the dropped point's z differs from the
+   * node's community depth — persisting it keeps the node under the cursor.
+   */
+  overrides: Map<string, { x: number; y: number; z?: number }>;
 }
 
 export function createKnowledgeGraphViewState(): KnowledgeGraphViewState {
@@ -245,31 +250,45 @@ export function frameWorldPoints(
   previous?: Pick<GraphCameraState, "yaw" | "pitch">,
   paddingFactor = 1.2,
 ): GraphCameraState {
+  const yaw = previous?.yaw ?? 0;
+  const pitch = previous?.pitch ?? 0;
   if (points.length === 0) {
-    return { targetX: 0, targetY: 0, targetZ: 0, distance: 900, yaw: previous?.yaw ?? 0, pitch: previous?.pitch ?? 0 };
+    return { targetX: 0, targetY: 0, targetZ: 0, distance: 900, yaw, pitch };
   }
-  let minX = Number.POSITIVE_INFINITY;
-  let maxX = Number.NEGATIVE_INFINITY;
-  let minY = Number.POSITIVE_INFINITY;
-  let maxY = Number.NEGATIVE_INFINITY;
-  let minZ = Number.POSITIVE_INFINITY;
-  let maxZ = Number.NEGATIVE_INFINITY;
+  // Extents are measured in the *active* camera basis (right/up/forward for
+  // the preserved yaw/pitch), not along world axes: framing after an orbit
+  // must still fit every requested point on screen.
+  const basis = cameraBasis({ targetX: 0, targetY: 0, targetZ: 0, distance: 1, yaw, pitch });
+  let minRight = Number.POSITIVE_INFINITY;
+  let maxRight = Number.NEGATIVE_INFINITY;
+  let minUp = Number.POSITIVE_INFINITY;
+  let maxUp = Number.NEGATIVE_INFINITY;
+  let minForward = Number.POSITIVE_INFINITY;
+  let maxForward = Number.NEGATIVE_INFINITY;
   for (const point of points) {
-    minX = Math.min(minX, point.x);
-    maxX = Math.max(maxX, point.x);
-    minY = Math.min(minY, point.y);
-    maxY = Math.max(maxY, point.y);
-    minZ = Math.min(minZ, point.z);
-    maxZ = Math.max(maxZ, point.z);
+    const alongRight = dot(point, basis.right);
+    const alongUp = dot(point, basis.up);
+    const alongForward = dot(point, basis.forward);
+    minRight = Math.min(minRight, alongRight);
+    maxRight = Math.max(maxRight, alongRight);
+    minUp = Math.min(minUp, alongUp);
+    maxUp = Math.max(maxUp, alongUp);
+    minForward = Math.min(minForward, alongForward);
+    maxForward = Math.max(maxForward, alongForward);
   }
+  const centerRight = (minRight + maxRight) / 2;
+  const centerUp = (minUp + maxUp) / 2;
+  const centerForward = (minForward + maxForward) / 2;
+  // The basis is orthonormal, so the view-space center maps back to world
+  // space as a linear combination of the basis directions.
   const center: WorldPoint = {
-    x: (minX + maxX) / 2,
-    y: (minY + maxY) / 2,
-    z: (minZ + maxZ) / 2,
+    x: basis.right.x * centerRight + basis.up.x * centerUp + basis.forward.x * centerForward,
+    y: basis.right.y * centerRight + basis.up.y * centerUp + basis.forward.y * centerForward,
+    z: basis.right.z * centerRight + basis.up.z * centerUp + basis.forward.z * centerForward,
   };
-  const halfWidth = Math.max(40, (maxX - minX) / 2);
-  const halfHeight = Math.max(40, (maxY - minY) / 2);
-  const halfDepth = (maxZ - minZ) / 2;
+  const halfWidth = Math.max(40, (maxRight - minRight) / 2);
+  const halfHeight = Math.max(40, (maxUp - minUp) / 2);
+  const halfDepth = (maxForward - minForward) / 2;
   // Box fit: distance where both the vertical and horizontal extents fill
   // the frustum, pushed back by the content's depth so nothing near-clips.
   const f = Math.tan((graphCameraFovDegrees * Math.PI) / 360);
@@ -281,8 +300,8 @@ export function frameWorldPoints(
     targetY: center.y,
     targetZ: center.z,
     distance: clamp((Math.max(fitHeight, fitWidth) + halfDepth) * paddingFactor, minCameraDistance, maxCameraDistance),
-    yaw: previous?.yaw ?? 0,
-    pitch: previous?.pitch ?? 0,
+    yaw,
+    pitch,
   };
 }
 
@@ -324,7 +343,7 @@ export interface WorldNode extends WorldPoint {
 /** Map a layout node into centered, y-up world space with community depth. */
 export function worldNodesFor(
   layout: GraphLayoutResult,
-  overrides: ReadonlyMap<string, { x: number; y: number }>,
+  overrides: ReadonlyMap<string, { x: number; y: number; z?: number }>,
 ): WorldNode[] {
   const degrees = new Map<string, number>();
   for (const edge of layout.edges) {
@@ -339,7 +358,7 @@ export function worldNodesFor(
       nodeId: node.nodeId,
       x: layoutX - layout.width / 2,
       y: layout.height / 2 - layoutY,
-      z: communityDepth(node.communityId, node.nodeId),
+      z: override?.z ?? communityDepth(node.communityId, node.nodeId),
       radius: node.radius,
       label: node.label,
       kind: node.kind,
@@ -595,7 +614,7 @@ export interface SceneBuildInput {
   communities: readonly CommunityLike[];
   camera: GraphCameraState;
   viewport: SceneViewport;
-  overrides: ReadonlyMap<string, { x: number; y: number }>;
+  overrides: ReadonlyMap<string, { x: number; y: number; z?: number }>;
   selectedNodeIds: readonly string[];
   hoveredNodeId: string | null;
   maxLabels?: number;

--- a/packages/ui-core/src/knowledge-graph-scene.ts
+++ b/packages/ui-core/src/knowledge-graph-scene.ts
@@ -1,0 +1,856 @@
+import type {
+  GraphLayoutResult,
+  MemoryGraphSnapshot,
+} from "@opensymphony/graph";
+
+/**
+ * Pure scene model for the knowledge-graph command center.
+ *
+ * Everything the renderer draws — node positions, hover emphasis, diffuse
+ * area hulls, zoom-dependent label opacities — is computed here from an
+ * orbital perspective camera, with no DOM or WebGL dependencies. The WebGL
+ * backend mirrors this projection with a real THREE.PerspectiveCamera; a
+ * parity unit test keeps the two in lockstep so hit-testing, HTML labels,
+ * and the 2D fallback always agree with what the GPU rasterizes.
+ *
+ * Conventions: layout space is the 2D box produced by `@opensymphony/graph`
+ * (x right, y down). World space re-centers it at the origin with y up and
+ * spreads nodes in z by community so orbiting reveals genuine depth.
+ */
+
+export interface GraphCameraState {
+  targetX: number;
+  targetY: number;
+  targetZ: number;
+  /** Dolly distance from the target, world units. */
+  distance: number;
+  /** Orbit around the world Y axis, radians. */
+  yaw: number;
+  /** Orbit toward the world Y pole, radians, clamped. */
+  pitch: number;
+}
+
+export interface KnowledgeGraphViewState {
+  camera: GraphCameraState | null;
+  /** Node drag overrides in layout coordinates, keyed by node id. */
+  overrides: Map<string, { x: number; y: number }>;
+}
+
+export function createKnowledgeGraphViewState(): KnowledgeGraphViewState {
+  return { camera: null, overrides: new Map() };
+}
+
+export const graphCameraFovDegrees = 55;
+export const graphCameraNear = 6;
+export const graphCameraFar = 12_000;
+const minCameraDistance = 90;
+const maxCameraDistance = 7_000;
+const maxCameraPitch = 1.15;
+
+export interface SceneViewport {
+  width: number;
+  height: number;
+}
+
+export interface WorldPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface ProjectedPoint {
+  x: number;
+  y: number;
+  /** Distance along the camera forward axis; ≤ 0 means behind the camera. */
+  depth: number;
+  /** Screen pixels per world unit at this depth. */
+  pixelsPerWorldUnit: number;
+  visible: boolean;
+}
+
+// ─── Camera math ────────────────────────────────────────────────────────────
+
+export interface CameraBasis {
+  position: WorldPoint;
+  right: WorldPoint;
+  up: WorldPoint;
+  forward: WorldPoint;
+}
+
+export function cameraBasis(camera: GraphCameraState): CameraBasis {
+  const cosPitch = Math.cos(camera.pitch);
+  const offset: WorldPoint = {
+    x: Math.sin(camera.yaw) * cosPitch * camera.distance,
+    y: Math.sin(camera.pitch) * camera.distance,
+    z: Math.cos(camera.yaw) * cosPitch * camera.distance,
+  };
+  const position: WorldPoint = {
+    x: camera.targetX + offset.x,
+    y: camera.targetY + offset.y,
+    z: camera.targetZ + offset.z,
+  };
+  const forward = normalize({
+    x: camera.targetX - position.x,
+    y: camera.targetY - position.y,
+    z: camera.targetZ - position.z,
+  });
+  const worldUp: WorldPoint = { x: 0, y: 1, z: 0 };
+  const right = normalize(cross(forward, worldUp));
+  const up = cross(right, forward);
+  return { position, right, up, forward };
+}
+
+export function projectWorldPoint(
+  camera: GraphCameraState,
+  viewport: SceneViewport,
+  point: WorldPoint,
+  basis: CameraBasis = cameraBasis(camera),
+): ProjectedPoint {
+  const relative: WorldPoint = {
+    x: point.x - basis.position.x,
+    y: point.y - basis.position.y,
+    z: point.z - basis.position.z,
+  };
+  const viewX = dot(relative, basis.right);
+  const viewY = dot(relative, basis.up);
+  const depth = dot(relative, basis.forward);
+  if (depth <= graphCameraNear * 0.5) {
+    return { x: Number.NaN, y: Number.NaN, depth, pixelsPerWorldUnit: 0, visible: false };
+  }
+  const f = 1 / Math.tan((graphCameraFovDegrees * Math.PI) / 360);
+  const aspect = viewport.width / Math.max(1, viewport.height);
+  const ndcX = (f / aspect) * (viewX / depth);
+  const ndcY = f * (viewY / depth);
+  const pixelsPerWorldUnit = (f * viewport.height) / (2 * depth);
+  return {
+    x: ((ndcX + 1) / 2) * viewport.width,
+    y: ((1 - ndcY) / 2) * viewport.height,
+    depth,
+    pixelsPerWorldUnit,
+    visible: true,
+  };
+}
+
+/** Ray from the camera through a screen pixel, in world space. */
+export function screenRay(
+  camera: GraphCameraState,
+  viewport: SceneViewport,
+  screenX: number,
+  screenY: number,
+): { origin: WorldPoint; direction: WorldPoint } {
+  const basis = cameraBasis(camera);
+  const f = 1 / Math.tan((graphCameraFovDegrees * Math.PI) / 360);
+  const aspect = viewport.width / Math.max(1, viewport.height);
+  const ndcX = (screenX / viewport.width) * 2 - 1;
+  const ndcY = 1 - (screenY / viewport.height) * 2;
+  const direction = normalize(add(
+    add(scale(basis.right, (ndcX * aspect) / f), scale(basis.up, ndcY / f)),
+    basis.forward,
+  ));
+  return { origin: basis.position, direction };
+}
+
+/**
+ * Intersect a screen ray with the camera-facing plane through `worldPoint`.
+ * This is the drag plane: moving a node keeps it at its current depth.
+ */
+export function unprojectToPlaneThroughPoint(
+  camera: GraphCameraState,
+  viewport: SceneViewport,
+  screenX: number,
+  screenY: number,
+  worldPoint: WorldPoint,
+): WorldPoint | null {
+  const basis = cameraBasis(camera);
+  const ray = screenRay(camera, viewport, screenX, screenY);
+  const planeNormal = basis.forward;
+  const denominator = dot(ray.direction, planeNormal);
+  if (Math.abs(denominator) < 1e-6) return null;
+  const t = dot(
+    { x: worldPoint.x - ray.origin.x, y: worldPoint.y - ray.origin.y, z: worldPoint.z - ray.origin.z },
+    planeNormal,
+  ) / denominator;
+  if (t <= 0) return null;
+  return add(ray.origin, scale(ray.direction, t));
+}
+
+export function panCamera(
+  camera: GraphCameraState,
+  viewport: SceneViewport,
+  deltaXPixels: number,
+  deltaYPixels: number,
+): GraphCameraState {
+  const basis = cameraBasis(camera);
+  const worldPerPixel = (2 * camera.distance * Math.tan((graphCameraFovDegrees * Math.PI) / 360)) / Math.max(1, viewport.height);
+  const shift = add(
+    scale(basis.right, -deltaXPixels * worldPerPixel),
+    scale(basis.up, deltaYPixels * worldPerPixel),
+  );
+  return {
+    ...camera,
+    targetX: camera.targetX + shift.x,
+    targetY: camera.targetY + shift.y,
+    targetZ: camera.targetZ + shift.z,
+  };
+}
+
+/**
+ * Dolly toward/away from the point under the cursor so zooming feels
+ * anchored to what the operator is pointing at.
+ */
+export function dollyCamera(
+  camera: GraphCameraState,
+  factor: number,
+  anchor?: { viewport: SceneViewport; screenX: number; screenY: number },
+): GraphCameraState {
+  const distance = clamp(camera.distance * factor, minCameraDistance, maxCameraDistance);
+  const applied = distance / camera.distance;
+  let { targetX, targetY, targetZ } = camera;
+  if (anchor && applied !== 1) {
+    const focus = unprojectToPlaneThroughPoint(
+      camera,
+      anchor.viewport,
+      anchor.screenX,
+      anchor.screenY,
+      { x: camera.targetX, y: camera.targetY, z: camera.targetZ },
+    );
+    if (focus) {
+      // Zooming in pulls the target toward the anchor point; zooming out
+      // releases it back. `1 - applied` is the fraction of the remaining
+      // gap the target travels.
+      const blend = 1 - applied;
+      targetX += (focus.x - targetX) * blend;
+      targetY += (focus.y - targetY) * blend;
+      targetZ += (focus.z - targetZ) * blend;
+    }
+  }
+  return { ...camera, distance, targetX, targetY, targetZ };
+}
+
+export function orbitCamera(
+  camera: GraphCameraState,
+  deltaYaw: number,
+  deltaPitch: number,
+): GraphCameraState {
+  return {
+    ...camera,
+    yaw: camera.yaw + deltaYaw,
+    pitch: clamp(camera.pitch + deltaPitch, -maxCameraPitch, maxCameraPitch),
+  };
+}
+
+export function frameWorldPoints(
+  points: readonly WorldPoint[],
+  viewport: SceneViewport,
+  previous?: Pick<GraphCameraState, "yaw" | "pitch">,
+  paddingFactor = 1.2,
+): GraphCameraState {
+  if (points.length === 0) {
+    return { targetX: 0, targetY: 0, targetZ: 0, distance: 900, yaw: previous?.yaw ?? 0, pitch: previous?.pitch ?? 0 };
+  }
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  let minZ = Number.POSITIVE_INFINITY;
+  let maxZ = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minY = Math.min(minY, point.y);
+    maxY = Math.max(maxY, point.y);
+    minZ = Math.min(minZ, point.z);
+    maxZ = Math.max(maxZ, point.z);
+  }
+  const center: WorldPoint = {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+    z: (minZ + maxZ) / 2,
+  };
+  const halfWidth = Math.max(40, (maxX - minX) / 2);
+  const halfHeight = Math.max(40, (maxY - minY) / 2);
+  const halfDepth = (maxZ - minZ) / 2;
+  // Box fit: distance where both the vertical and horizontal extents fill
+  // the frustum, pushed back by the content's depth so nothing near-clips.
+  const f = Math.tan((graphCameraFovDegrees * Math.PI) / 360);
+  const aspect = viewport.width / Math.max(1, viewport.height);
+  const fitHeight = halfHeight / f;
+  const fitWidth = halfWidth / (f * aspect);
+  return {
+    targetX: center.x,
+    targetY: center.y,
+    targetZ: center.z,
+    distance: clamp((Math.max(fitHeight, fitWidth) + halfDepth) * paddingFactor, minCameraDistance, maxCameraDistance),
+    yaw: previous?.yaw ?? 0,
+    pitch: previous?.pitch ?? 0,
+  };
+}
+
+/** Exponential approach toward a goal camera; returns done when settled. */
+export function advanceCameraToward(
+  current: GraphCameraState,
+  goal: GraphCameraState,
+  deltaSeconds: number,
+  reducedMotion = false,
+): { camera: GraphCameraState; done: boolean } {
+  if (reducedMotion) return { camera: goal, done: true };
+  const rate = 1 - Math.exp(-9 * Math.max(0, deltaSeconds));
+  const next: GraphCameraState = {
+    targetX: lerp(current.targetX, goal.targetX, rate),
+    targetY: lerp(current.targetY, goal.targetY, rate),
+    targetZ: lerp(current.targetZ, goal.targetZ, rate),
+    distance: lerp(current.distance, goal.distance, rate),
+    yaw: lerp(current.yaw, goal.yaw, rate),
+    pitch: lerp(current.pitch, goal.pitch, rate),
+  };
+  const settled = Math.abs(next.distance - goal.distance) < 0.5
+    && Math.hypot(next.targetX - goal.targetX, next.targetY - goal.targetY, next.targetZ - goal.targetZ) < 0.5
+    && Math.abs(next.yaw - goal.yaw) < 0.002
+    && Math.abs(next.pitch - goal.pitch) < 0.002;
+  return { camera: settled ? goal : next, done: settled };
+}
+
+// ─── World model ────────────────────────────────────────────────────────────
+
+export interface WorldNode extends WorldPoint {
+  nodeId: string;
+  radius: number;
+  label: string;
+  kind: string;
+  communityId?: string;
+  degree: number;
+}
+
+/** Map a layout node into centered, y-up world space with community depth. */
+export function worldNodesFor(
+  layout: GraphLayoutResult,
+  overrides: ReadonlyMap<string, { x: number; y: number }>,
+): WorldNode[] {
+  const degrees = new Map<string, number>();
+  for (const edge of layout.edges) {
+    degrees.set(edge.sourceId, (degrees.get(edge.sourceId) ?? 0) + 1);
+    degrees.set(edge.targetId, (degrees.get(edge.targetId) ?? 0) + 1);
+  }
+  return layout.nodes.map((node) => {
+    const override = overrides.get(node.nodeId);
+    const layoutX = override?.x ?? node.x;
+    const layoutY = override?.y ?? node.y;
+    return {
+      nodeId: node.nodeId,
+      x: layoutX - layout.width / 2,
+      y: layout.height / 2 - layoutY,
+      z: communityDepth(node.communityId, node.nodeId),
+      radius: node.radius,
+      label: node.label,
+      kind: node.kind,
+      communityId: node.communityId,
+      degree: degrees.get(node.nodeId) ?? 0,
+    };
+  });
+}
+
+/**
+ * Deterministic z per community band plus per-node jitter: clusters live on
+ * nearby depth planes so orbiting the camera separates them visibly.
+ */
+export function communityDepth(communityId: string | undefined, nodeId: string): number {
+  const band = communityId ? ((stringHash(communityId) % 7) - 3) * 42 : 0;
+  const jitter = ((stringHash(nodeId) % 1000) / 1000 - 0.5) * 30;
+  return band + jitter;
+}
+
+export function worldToLayout(layout: GraphLayoutResult, point: WorldPoint): { x: number; y: number } {
+  return { x: point.x + layout.width / 2, y: layout.height / 2 - point.y };
+}
+
+export function defaultCameraForLayout(
+  layout: GraphLayoutResult,
+  viewport: SceneViewport,
+): GraphCameraState {
+  const corners: WorldPoint[] = [
+    { x: -layout.width / 2, y: -layout.height / 2, z: 0 },
+    { x: layout.width / 2, y: layout.height / 2, z: 0 },
+  ];
+  return frameWorldPoints(corners, viewport, { yaw: 0, pitch: 0 }, 1.06);
+}
+
+// ─── Area hulls ─────────────────────────────────────────────────────────────
+
+export interface AreaHullModel {
+  areaId: string;
+  label: string;
+  memberNodeIds: string[];
+  /** Smooth closed outline in world space. */
+  outline: WorldPoint[];
+  centroid: WorldPoint;
+  color: string;
+}
+
+interface CommunityLike {
+  id: string;
+  label: string;
+  node_ids: readonly string[];
+}
+
+const hullPadding = 42;
+
+/**
+ * Diffuse cluster hulls. Membership comes from snapshot communities, which
+ * may list one node under several areas — a node in two areas simply feeds
+ * both hulls, so overlapping membership renders as overlapping translucent
+ * blobs rather than needing exclusive geometry.
+ */
+export function buildAreaHulls(
+  worldNodes: readonly WorldNode[],
+  communities: readonly CommunityLike[],
+): AreaHullModel[] {
+  const byId = new Map(worldNodes.map((node) => [node.nodeId, node]));
+  const hulls: AreaHullModel[] = [];
+  communities.forEach((community, index) => {
+    const members = community.node_ids
+      .map((nodeId) => byId.get(nodeId))
+      .filter((node): node is WorldNode => Boolean(node));
+    if (members.length === 0) return;
+    // A node can belong to several areas but only sits in one place, so a
+    // secondary area's hull would stretch across the canvas to reach it.
+    // Trim spatial outliers: the hull hugs the area's resident cluster and
+    // remote multi-area members surface through hover/tooltip instead.
+    const core = trimSpatialOutliers(members);
+    const centroid: WorldPoint = {
+      x: core.reduce((sum, node) => sum + node.x, 0) / core.length,
+      y: core.reduce((sum, node) => sum + node.y, 0) / core.length,
+      z: core.reduce((sum, node) => sum + node.z, 0) / core.length,
+    };
+    const ring = core.length === 1
+      ? circleOutline(core[0], hullPadding)
+      : paddedHullOutline(core, hullPadding);
+    hulls.push({
+      areaId: community.id,
+      label: community.label,
+      memberNodeIds: members.map((node) => node.nodeId),
+      outline: ring.map((point) => ({ ...point, z: centroid.z })),
+      centroid,
+      color: areaColor(community.id, index),
+    });
+  });
+  return hulls;
+}
+
+function trimSpatialOutliers<T extends WorldPoint>(members: readonly T[]): T[] {
+  if (members.length <= 3) return [...members];
+  const center = {
+    x: members.reduce((sum, point) => sum + point.x, 0) / members.length,
+    y: members.reduce((sum, point) => sum + point.y, 0) / members.length,
+  };
+  const distances = members
+    .map((point) => Math.hypot(point.x - center.x, point.y - center.y))
+    .sort((a, b) => a - b);
+  const median = distances[Math.floor(distances.length / 2)];
+  const cutoff = Math.max(120, median * 2);
+  const core = members.filter((point) => Math.hypot(point.x - center.x, point.y - center.y) <= cutoff);
+  return core.length >= 2 ? core : [...members];
+}
+
+function circleOutline(center: WorldPoint, radius: number): Array<{ x: number; y: number }> {
+  const points: Array<{ x: number; y: number }> = [];
+  for (let step = 0; step < 18; step += 1) {
+    const angle = (step / 18) * Math.PI * 2;
+    points.push({ x: center.x + Math.cos(angle) * radius, y: center.y + Math.sin(angle) * radius });
+  }
+  return points;
+}
+
+function paddedHullOutline(
+  members: readonly WorldPoint[],
+  padding: number,
+): Array<{ x: number; y: number }> {
+  const hull = convexHull(members.map((point) => ({ x: point.x, y: point.y })));
+  if (hull.length < 3) {
+    return circleOutline({ x: hull[0]?.x ?? 0, y: hull[0]?.y ?? 0, z: 0 }, padding);
+  }
+  const centroid = {
+    x: hull.reduce((sum, point) => sum + point.x, 0) / hull.length,
+    y: hull.reduce((sum, point) => sum + point.y, 0) / hull.length,
+  };
+  const padded = hull.map((point) => {
+    const dx = point.x - centroid.x;
+    const dy = point.y - centroid.y;
+    const length = Math.max(1e-3, Math.hypot(dx, dy));
+    return {
+      x: point.x + (dx / length) * padding,
+      y: point.y + (dy / length) * padding,
+    };
+  });
+  return chaikinSmooth(chaikinSmooth(padded));
+}
+
+/** Andrew's monotone chain; returns counter-clockwise hull. */
+export function convexHull(points: readonly { x: number; y: number }[]): Array<{ x: number; y: number }> {
+  const sorted = [...points].sort((a, b) => a.x - b.x || a.y - b.y);
+  if (sorted.length <= 2) return sorted;
+  const crossProduct = (o: { x: number; y: number }, a: { x: number; y: number }, b: { x: number; y: number }) =>
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+  const lower: Array<{ x: number; y: number }> = [];
+  for (const point of sorted) {
+    while (lower.length >= 2 && crossProduct(lower[lower.length - 2], lower[lower.length - 1], point) <= 0) {
+      lower.pop();
+    }
+    lower.push(point);
+  }
+  const upper: Array<{ x: number; y: number }> = [];
+  for (const point of [...sorted].reverse()) {
+    while (upper.length >= 2 && crossProduct(upper[upper.length - 2], upper[upper.length - 1], point) <= 0) {
+      upper.pop();
+    }
+    upper.push(point);
+  }
+  lower.pop();
+  upper.pop();
+  return [...lower, ...upper];
+}
+
+/** One round of Chaikin corner cutting over a closed polygon. */
+function chaikinSmooth(points: readonly { x: number; y: number }[]): Array<{ x: number; y: number }> {
+  if (points.length < 3) return [...points];
+  const smoothed: Array<{ x: number; y: number }> = [];
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index];
+    const next = points[(index + 1) % points.length];
+    smoothed.push(
+      { x: current.x * 0.75 + next.x * 0.25, y: current.y * 0.75 + next.y * 0.25 },
+      { x: current.x * 0.25 + next.x * 0.75, y: current.y * 0.25 + next.y * 0.75 },
+    );
+  }
+  return smoothed;
+}
+
+const areaPalette = [
+  "#4c7fb0",
+  "#7c66b8",
+  "#2f8f83",
+  "#b0762f",
+  "#a05577",
+  "#5f8f3d",
+  "#3f7fa8",
+  "#8a6b4f",
+];
+
+export function areaColor(areaId: string, index: number): string {
+  return areaPalette[(stringHash(areaId) + index) % areaPalette.length];
+}
+
+// ─── Scene assembly ─────────────────────────────────────────────────────────
+
+export interface SceneNode {
+  nodeId: string;
+  x: number;
+  y: number;
+  screenRadius: number;
+  depth: number;
+  color: string;
+  alpha: number;
+  labelText: string;
+  labelAlpha: number;
+  emphasis: "hovered" | "selected" | "neighbor" | "none" | "dimmed";
+  world: WorldPoint;
+}
+
+export interface SceneEdge {
+  edgeId: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  alpha: number;
+  emphasized: boolean;
+  depth: number;
+}
+
+export interface SceneHull {
+  areaId: string;
+  label: string;
+  color: string;
+  alpha: number;
+  labelAlpha: number;
+  outline: Array<{ x: number; y: number }>;
+  labelX: number;
+  labelY: number;
+  depth: number;
+}
+
+export interface GraphScene {
+  nodes: SceneNode[];
+  edges: SceneEdge[];
+  hulls: SceneHull[];
+  /** 0..1 — how "zoomed in" the camera is relative to the framed layout. */
+  zoomLevel: number;
+  hoveredNodeId: string | null;
+}
+
+export interface SceneBuildInput {
+  layout: GraphLayoutResult;
+  communities: readonly CommunityLike[];
+  camera: GraphCameraState;
+  viewport: SceneViewport;
+  overrides: ReadonlyMap<string, { x: number; y: number }>;
+  selectedNodeIds: readonly string[];
+  hoveredNodeId: string | null;
+  maxLabels?: number;
+}
+
+export function buildGraphScene(input: SceneBuildInput): GraphScene {
+  const basis = cameraBasis(input.camera);
+  const worldNodes = worldNodesFor(input.layout, input.overrides);
+  const hullModels = buildAreaHulls(worldNodes, input.communities);
+  const framedDistance = defaultCameraForLayout(input.layout, input.viewport).distance;
+  const zoomLevel = clamp(framedDistance / Math.max(1, input.camera.distance), 0.2, 8);
+
+  const selected = new Set(input.selectedNodeIds);
+  const neighborIds = new Set<string>();
+  if (input.hoveredNodeId) {
+    for (const edge of input.layout.edges) {
+      if (edge.sourceId === input.hoveredNodeId) neighborIds.add(edge.targetId);
+      if (edge.targetId === input.hoveredNodeId) neighborIds.add(edge.sourceId);
+    }
+  }
+
+  const projectedById = new Map<string, { node: WorldNode; point: ProjectedPoint }>();
+  for (const node of worldNodes) {
+    projectedById.set(node.nodeId, {
+      node,
+      point: projectWorldPoint(input.camera, input.viewport, node, basis),
+    });
+  }
+
+  const nodeLabelBudget = labelBudget(worldNodes, selected, input.hoveredNodeId, input.maxLabels ?? 80);
+  // At the framed default (zoomLevel 1) only area titles show; node labels
+  // fade in once the operator dollies past ~1.2x and take over by ~2x.
+  const nodeLabelFade = smoothstep(1.18, 2.1, zoomLevel);
+  const areaLabelFade = 1 - smoothstep(1.35, 2.2, zoomLevel);
+  const hoverActive = Boolean(input.hoveredNodeId);
+
+  const nodes: SceneNode[] = [];
+  for (const { node, point } of projectedById.values()) {
+    if (!point.visible) continue;
+    const emphasis = node.nodeId === input.hoveredNodeId
+      ? "hovered"
+      : selected.has(node.nodeId)
+        ? "selected"
+        : neighborIds.has(node.nodeId)
+          ? "neighbor"
+          : hoverActive
+            ? "dimmed"
+            : "none";
+    const fog = depthFog(point.depth, input.camera.distance);
+    const alpha = emphasis === "dimmed" ? 0.18 : fog;
+    // Degree feeds size so well-connected concepts read as landmarks at a
+    // glance, mirroring Obsidian's graph view.
+    const worldRadius = node.radius + Math.min(10, node.degree * 1.1);
+    const screenRadius = Math.max(3, worldRadius * point.pixelsPerWorldUnit * 1.45);
+    const labelEligible = nodeLabelBudget.has(node.nodeId) || emphasis === "hovered" || emphasis === "selected" || emphasis === "neighbor";
+    const labelAlpha = emphasis === "hovered" || emphasis === "selected"
+      ? 1
+      : emphasis === "neighbor"
+        ? Math.max(0.85, nodeLabelFade)
+        : hoverActive
+          ? 0
+          : labelEligible
+            ? nodeLabelFade * fog
+            : 0;
+    nodes.push({
+      nodeId: node.nodeId,
+      x: point.x,
+      y: point.y,
+      screenRadius,
+      depth: point.depth,
+      color: nodeColor(node.kind),
+      alpha,
+      labelText: node.label,
+      labelAlpha,
+      emphasis,
+      world: { x: node.x, y: node.y, z: node.z },
+    });
+  }
+  nodes.sort((a, b) => b.depth - a.depth);
+
+  const edges: SceneEdge[] = [];
+  for (const edge of input.layout.edges) {
+    const source = projectedById.get(edge.sourceId);
+    const target = projectedById.get(edge.targetId);
+    if (!source?.point.visible || !target?.point.visible) continue;
+    const emphasized = hoverActive
+      && (edge.sourceId === input.hoveredNodeId || edge.targetId === input.hoveredNodeId);
+    const depth = (source.point.depth + target.point.depth) / 2;
+    const alpha = emphasized
+      ? 0.92
+      : hoverActive
+        ? 0.05
+        : 0.32 * depthFog(depth, input.camera.distance);
+    edges.push({
+      edgeId: edge.edgeId,
+      x1: source.point.x,
+      y1: source.point.y,
+      x2: target.point.x,
+      y2: target.point.y,
+      alpha,
+      emphasized,
+      depth,
+    });
+  }
+  edges.sort((a, b) => b.depth - a.depth);
+
+  const hulls: SceneHull[] = hullModels.map((hull) => {
+    const outline = hull.outline
+      .map((point) => projectWorldPoint(input.camera, input.viewport, point, basis))
+      .filter((point) => point.visible)
+      .map((point) => ({ x: point.x, y: point.y }));
+    const labelPoint = projectWorldPoint(input.camera, input.viewport, hull.centroid, basis);
+    return {
+      areaId: hull.areaId,
+      label: hull.label,
+      color: hull.color,
+      alpha: hoverActive ? 0.04 : 0.07 + 0.07 * areaLabelFade,
+      labelAlpha: hoverActive ? 0 : areaLabelFade,
+      outline,
+      labelX: labelPoint.x,
+      labelY: labelPoint.y,
+      depth: labelPoint.depth,
+      };
+  }).filter((hull) => hull.outline.length >= 3);
+  hulls.sort((a, b) => b.depth - a.depth);
+
+  return { nodes, edges, hulls, zoomLevel, hoveredNodeId: input.hoveredNodeId };
+}
+
+function labelBudget(
+  worldNodes: readonly WorldNode[],
+  selected: ReadonlySet<string>,
+  hoveredNodeId: string | null,
+  maxLabels: number,
+): Set<string> {
+  const prioritized = [...worldNodes].sort((a, b) =>
+    priorityRank(b, selected, hoveredNodeId) - priorityRank(a, selected, hoveredNodeId)
+    || b.degree - a.degree
+    || a.nodeId.localeCompare(b.nodeId),
+  );
+  return new Set(prioritized.slice(0, maxLabels).map((node) => node.nodeId));
+}
+
+function priorityRank(
+  node: WorldNode,
+  selected: ReadonlySet<string>,
+  hoveredNodeId: string | null,
+): number {
+  if (node.nodeId === hoveredNodeId) return 3;
+  if (selected.has(node.nodeId)) return 2;
+  if (node.kind === "bundle" || node.kind === "community") return 1;
+  return 0;
+}
+
+function depthFog(depth: number, cameraDistance: number): number {
+  const near = cameraDistance * 0.55;
+  const far = cameraDistance * 1.9;
+  return 1 - 0.5 * smoothstep(near, far, depth);
+}
+
+export function hitTestScene(scene: GraphScene, x: number, y: number): string | null {
+  let best: { nodeId: string; distance: number; depth: number } | null = null;
+  for (const node of scene.nodes) {
+    const distance = Math.hypot(node.x - x, node.y - y);
+    const hitRadius = Math.max(9, node.screenRadius + 5);
+    if (distance > hitRadius) continue;
+    if (!best || distance < best.distance - 2 || (Math.abs(distance - best.distance) <= 2 && node.depth < best.depth)) {
+      best = { nodeId: node.nodeId, distance, depth: node.depth };
+    }
+  }
+  return best?.nodeId ?? null;
+}
+
+export function hitTestHull(scene: GraphScene, x: number, y: number): SceneHull | null {
+  // Front-most hull whose polygon contains the point.
+  for (let index = scene.hulls.length - 1; index >= 0; index -= 1) {
+    const hull = scene.hulls[index];
+    if (pointInPolygon(hull.outline, x, y)) return hull;
+  }
+  return null;
+}
+
+function pointInPolygon(polygon: readonly { x: number; y: number }[], x: number, y: number): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const a = polygon[i];
+    const b = polygon[j];
+    if ((a.y > y) !== (b.y > y) && x < ((b.x - a.x) * (y - a.y)) / (b.y - a.y) + a.x) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+export function nodeColor(kind: string): string {
+  switch (kind) {
+    case "concept":
+      return "#2c7da0";
+    case "bundle":
+      return "#334155";
+    case "tag":
+      return "#7c3aed";
+    case "source_ref":
+      return "#0f766e";
+    case "community":
+      return "#475569";
+    default:
+      return "#64748b";
+  }
+}
+
+export const nodeEmphasisColor = "#c2410c";
+
+// ─── Small vector helpers ───────────────────────────────────────────────────
+
+function dot(a: WorldPoint, b: WorldPoint): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function cross(a: WorldPoint, b: WorldPoint): WorldPoint {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function add(a: WorldPoint, b: WorldPoint): WorldPoint {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function scale(a: WorldPoint, factor: number): WorldPoint {
+  return { x: a.x * factor, y: a.y * factor, z: a.z * factor };
+}
+
+function normalize(a: WorldPoint): WorldPoint {
+  const length = Math.hypot(a.x, a.y, a.z) || 1;
+  return { x: a.x / length, y: a.y / length, z: a.z / length };
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function smoothstep(edge0: number, edge1: number, value: number): number {
+  const t = clamp((value - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+function stringHash(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}

--- a/packages/ui-core/src/knowledge-graph-scene.ts
+++ b/packages/ui-core/src/knowledge-graph-scene.ts
@@ -466,7 +466,10 @@ function paddedHullOutline(
 ): Array<{ x: number; y: number }> {
   const hull = convexHull(members.map((point) => ({ x: point.x, y: point.y })));
   if (hull.length < 3) {
-    return circleOutline({ x: hull[0]?.x ?? 0, y: hull[0]?.y ?? 0, z: 0 }, padding);
+    // Two members or collinear members: build a stadium around ALL points
+    // (hull of padded circles) so every member stays inside the blob.
+    const samples = members.flatMap((point) => circleOutline({ x: point.x, y: point.y, z: 0 }, padding));
+    return chaikinSmooth(convexHull(samples));
   }
   const centroid = {
     x: hull.reduce((sum, point) => sum + point.x, 0) / hull.length,


### PR DESCRIPTION
## Summary

Follow-on to the COE-531 (OSYM-870) hero-shell work: the graph surfaces now match the layout's ambition. The knowledge graph becomes a 3D navigation command center — draggable nodes, hover highlighting with tooltips, diffuse labeled area clusters when zoomed out with node labels fading in as you dolly closer, smooth eased camera transitions, and orbitable depth. Task-graph skip-level dependencies drop the conflating L-shaped rails for rounded, per-blocker lanes and hues. All of it is driven by shared deterministic fixtures wired into a documented `?fixtures` desktop workbench so graph-viz iteration stops recreating ad-hoc demo data.

## Changes

**Knowledge graph**
- New pure scene model (`packages/ui-core/src/knowledge-graph-scene.ts`): orbital perspective camera (pan, cursor-anchored dolly, yaw/pitch orbit with clamping), software projector that matches `THREE.PerspectiveCamera` (unit-tested parity), area hull geometry (convex hull + padding + Chaikin smoothing) with spatial outlier trimming so multi-area concepts feed several hulls without stretching any of them across the canvas, zoom-driven label opacities, hover adjacency emphasis, painter-sorted depth with fog, hit-testing, camera framing + eased animation.
- Renderer rewrite (`knowledge-graph-renderer.ts`): node dragging (ray/plane unprojection at the node's depth), hover tooltip (title, kind, degree, areas) with connected-node highlighting and non-neighbor dimming, double-click frames a node's neighborhood or an area hull, `⌥`-drag orbits, reduced-motion snaps. three.js rasterizes the projected screen-space scene; the 2D canvas fallback draws the identical scene; HTML overlays carry node labels (max-80 LOD budget prioritizing hovered/selected/high-degree), decluttered area titles, and the tooltip. Camera + drag overrides persist in `KnowledgeGraphViewState` across live refreshes.
- Force layout upgrade (`packages/graph`): Fruchterman–Reingold spacing with per-community anchor gravity and community-local seeding, short-range repulsion (no wall pinning), gentler annealing — clusters land in distinct regions instead of one center clump.
- Fixed a refresh bug the fixtures exposed: the graph reducer accepted same-partition same-sequence snapshots as new, forcing a full re-layout (and hover/zoom reset) every 5s poll.

**Task graph**
- Skip-level arrows route through a dedicated left gutter with one lane and one hue per blocker (rounded corners, colored arrowheads): same-source fans stay grouped, different blockers never share a rail. Hovering a task spotlights its incident arrows (pure class toggling, no re-render).

**Fixtures workbench**
- `packages/graph/src/viz-fixture.ts`: seeded ~100-node knowledge graph (7 areas, multi-area concepts, mixed kinds/degrees).
- `packages/api-client/src/graph-viz-demo.ts`: dependency-heavy task-graph demo + `createGraphVizDemoTransport()`.
- `apps/desktop`: `?fixtures` mounts the shell on the demo transport + fixture graph adapter (vite dev only; packaged builds carry no query string).
- Documented in `docs/graph-view.md` ("Graph visualization workbench") and referenced from `AGENTS.md` so future graph iterations reuse these fixtures.

## Evidence

### Test output

```
npx jest                                   → 36 suites, 612 passed (18 new scene tests + fixture determinism)
npx tsc --noEmit -p tsconfig.projects.json → clean
```

No Rust changes on this branch.

### Verification

Iterated live against the `?fixtures` workbench (vite + Chromium):
- Overview shows seven diffuse labeled area clusters, node labels hidden; dollying in crossfades area titles out and node labels in.
- Hover on a node dims everything else, emphasizes its edges/neighbors, and shows the tooltip; verified the tooltip survives live-refresh polls (previously the 5s snapshot re-accept reset the whole surface).
- Dragged a node +90/+45 px — position override applied and persisted, no accidental selection; `⌥`-drag orbit changes yaw/pitch with visible parallax (hull foreshortening); double-click reframes.
- Projector ↔ THREE parity asserted in unit tests (<0.75px over sample points), so hit-tests/labels/tooltips can't drift from the GPU raster.
- Task graph fixture renders 9 skip arrows across 5 lanes/hues; hovering a blocker highlights exactly its arrows.
- The Playwright WebGL smoke (`app-shell.test.ts`) still gates a nonblank WebGL canvas when `apps/web/dist` + Chromium are available.

## Checklist

- [x] Tests pass (`cargo test`) — n/a, no Rust changes; full jest suite green
- [x] Code is formatted (`cargo fmt`) — n/a
- [x] Clippy is clean (`cargo clippy`) — n/a
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Breaking changes

- `KnowledgeGraphViewState` changed from `{scale,dx,dy}` to `{camera, overrides}` (internal to ui-core consumers; app-shell is the only caller and was updated).
- `renderKnowledgeGraphSurface` no longer server-renders node labels; the renderer owns them imperatively (a11y keyboard navigation over the fallback list is unchanged).
- Skip-arrow SVG paths changed shape (rounded gutter lanes); the one test pinning the old L-shape was updated deliberately.

## Related issues

Follows COE-531 / OSYM-870 (workspace graph hero shell).

## Additional notes

Graph reducer dedup semantics: the `<=` (was `<`) same-partition sequence comparison means redelivered identical snapshots no longer count as updates — if a gateway ever republishes *different* data under the same cursor sequence, that now requires a sequence bump (which the cursor contract already implies).

