### PR TITLE
feat(graph): knowledge graph drill-down to memory capsules and deep links

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -14,6 +14,7 @@ import {
   graphVizFixtureCommunityList,
   graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
+  memoryDeepLinkPrefix,
   type MemoryBundleList,
   type MemoryCommunityList,
   type MemoryConceptDetail,
@@ -638,10 +639,15 @@ function fixtureWorkbenchRequested(): boolean {
  */
 function openMemoryDeepLinkFromLocation(app: OpenSymphonyAppHandle): void {
   try {
-    const link = new URLSearchParams(globalThis.location?.search ?? "").get("memory");
-    if (link) {
-      void app.openMemoryDeepLink(link);
-    }
+    // URLSearchParams.get() percent-decodes the value, which would collapse
+    // load-bearing %2F/%3A escapes inside a raw pasted link's bundle or
+    // community ids. Read the raw parameter instead; a link that was itself
+    // encodeURIComponent-ed as a whole (so it doesn't start with the plain
+    // scheme) is restored with one explicit decode.
+    const raw = /[?&]memory=([^&]*)/.exec(globalThis.location?.search ?? "")?.[1];
+    if (!raw) return;
+    const link = raw.startsWith(memoryDeepLinkPrefix) ? raw : decodeURIComponent(raw);
+    void app.openMemoryDeepLink(link);
   } catch {
     // No usable location (tests, packaged builds without query strings).
   }

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -12,6 +12,7 @@ import {
   createTauriNativeGraphAdapter,
   graphVizFixtureBundleList,
   graphVizFixtureCommunityList,
+  graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
   type MemoryBundleList,
   type MemoryCommunityList,
@@ -31,6 +32,7 @@ import {
   renderOpenSymphonyApp,
   type EditableProfileInput,
   type ModelProfileController,
+  type OpenSymphonyAppHandle,
   type ProfileController,
 } from "@opensymphony/ui-core";
 
@@ -629,9 +631,25 @@ function fixtureWorkbenchRequested(): boolean {
   }
 }
 
+/**
+ * `?memory=opensymphony://memory/...` opens the app on a memory deep link —
+ * the same entry point task-graph artifacts will use once they carry capsule
+ * links. Handy for testing links end to end from the fixture workbench.
+ */
+function openMemoryDeepLinkFromLocation(app: OpenSymphonyAppHandle): void {
+  try {
+    const link = new URLSearchParams(globalThis.location?.search ?? "").get("memory");
+    if (link) {
+      void app.openMemoryDeepLink(link);
+    }
+  } catch {
+    // No usable location (tests, packaged builds without query strings).
+  }
+}
+
 const root = document.getElementById("root");
 if (root && fixtureWorkbenchRequested()) {
-  renderOpenSymphonyApp({
+  const app = renderOpenSymphonyApp({
     root,
     mode: "desktop",
     title: "OpenSymphony Desktop (fixtures)",
@@ -640,13 +658,15 @@ if (root && fixtureWorkbenchRequested()) {
       bundles: graphVizFixtureBundleList,
       snapshot: graphVizFixtureSnapshot,
       communities: graphVizFixtureCommunityList,
+      conceptDetail: (_bundleId, conceptId) => graphVizFixtureConceptDetail(conceptId),
     }),
     modelProfileController: createDesktopModelProfileController(),
   });
+  openMemoryDeepLinkFromLocation(app);
 } else if (root) {
   const transport = createDesktopTransport();
   void transport.attach();
-  renderOpenSymphonyApp({
+  const app = renderOpenSymphonyApp({
     root,
     mode: "desktop",
     title: "OpenSymphony Desktop",
@@ -668,4 +688,5 @@ if (root && fixtureWorkbenchRequested()) {
     onGatewayUrlChanged: createTransportForGateway,
     onGraphGatewayUrlChanged: createDesktopGraphAdapter,
   });
+  openMemoryDeepLinkFromLocation(app);
 }

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -87,6 +87,48 @@ hovering a task spotlights its incident arrows. See
 `renderTaskGraphLink`/`buildTaskGraphLinks` in
 `packages/ui-core/src/app-shell.ts`.
 
+### Drill-down navigation
+
+The knowledge graph navigates through three levels, mirroring the Obsidian
+LLM-wiki experience (areas → concepts/tags → issue capsules) and back out:
+
+- **Atlas → area**: a stationary click on an area cloud (while zoomed out
+  enough that its title is visible) drills into that community — the view
+  re-lays out around only its members (`COMMUNITY_SELECTED` + community
+  filter). Dragging on the same cloud still pans.
+- **Area → capsule**: selecting a concept lazily fetches its memory capsule
+  through `GraphDataAdapter.getConceptDetail` and renders it in the
+  inspector: frontmatter chips, the markdown body
+  (`packages/ui-core/src/memory-markdown.ts`, escaped-first allowlist
+  renderer), linked concepts, citations, and source refs. Capsule links
+  (including `[[wiki-links]]` in the body) navigate the graph to their
+  target node, re-drilling across areas when needed.
+- **Back out**: a breadcrumb (`Atlas › area › concept`) pops individual
+  levels, Escape steps back one level at a time, and the "Show full graph"
+  button still jumps straight home.
+
+### Memory deep links
+
+`packages/graph/src/deep-link.ts` defines the stable address format for
+memory locations, designed to be embedded outside the graph UI (task-graph
+artifacts, notifications, docs):
+
+```
+opensymphony://memory/<bundleId>
+opensymphony://memory/<bundleId>/communities/<communityId>
+opensymphony://memory/<bundleId>/concepts/<conceptId>   # conceptId keeps its slashes: issues/COE-399
+```
+
+`formatMemoryDeepLink`/`parseMemoryDeepLink` round-trip these strictly
+(unknown shapes are rejected, never guessed). The app shell exposes
+`OpenSymphonyAppHandle.openMemoryDeepLink(url)` — it switches to the
+Knowledge Graph pane, loads the bundle, drills into the concept's area, and
+opens its capsule; this is the wiring point for task-graph artifact links.
+The inspector's "Copy deep link" button emits the same links. For manual
+testing, `?memory=<deep-link>` on the desktop dev server (composable with
+`?fixtures`) opens a link at boot, e.g.
+`?fixtures&memory=opensymphony://memory/viz-workbench/concepts/concepts/code-intelligence-01`.
+
 ### Tests that gate this area
 
 - `packages/ui-core/__tests__/knowledge-graph-scene.test.ts` — projector ↔
@@ -94,7 +136,15 @@ hovering a task spotlights its incident arrows. See
   label LOD, hover emphasis, hit-tests, fixture density/determinism.
 - `packages/ui-core/__tests__/app-shell.test.ts` — surface markup, LOD label
   budget through the real mount, arrow routing shape (`os-tg-hue-*`,
-  rounded gutter paths), WebGL smoke via Playwright when available.
+  rounded gutter paths), WebGL smoke via Playwright when available, plus the
+  drill-down flows: area-cloud click drilling, capsule fetch/render/retry,
+  capsule-link navigation, breadcrumbs, stepwise Escape, and
+  `openMemoryDeepLink` end to end.
+- `packages/graph/__tests__/deep-link.test.ts` — deep-link round-trips and
+  strict rejection, node addressing, fixture capsule determinism and link
+  resolvability.
+- `packages/ui-core/__tests__/memory-markdown.test.ts` — capsule markdown
+  allowlist rendering and escaping.
 
 When iterating on visuals, extend these fixtures and tests rather than
 creating throwaway data; `AGENTS.md` ("UI separation") points here.

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -102,7 +102,10 @@ LLM-wiki experience (areas → concepts/tags → issue capsules) and back out:
   (`packages/ui-core/src/memory-markdown.ts`, escaped-first allowlist
   renderer), linked concepts, citations, and source refs. Capsule links
   (including `[[wiki-links]]` in the body) navigate the graph to their
-  target node, re-drilling across areas when needed.
+  target node, re-drilling across areas when needed. The clickable entity
+  list and the inspector live in the resizable lower workspace columns
+  (narrow list left, capsule right), so the graph stage, the entities, and
+  the capsule content share the fold.
 - **Back out**: a breadcrumb (`Atlas › area › concept`) pops individual
   levels, Escape steps back one level at a time, and the "Show full graph"
   button still jumps straight home.

--- a/packages/graph/__tests__/deep-link.test.ts
+++ b/packages/graph/__tests__/deep-link.test.ts
@@ -63,6 +63,23 @@ describe("memory deep links", () => {
     expect(() => formatMemoryDeepLink({ bundleId: "" })).toThrow(/bundle id/);
   });
 
+  it("keeps bundle ids with slashes in a single segment", () => {
+    // Hosted/path-qualified bundle ids ("team/a") must round-trip: a second
+    // raw segment would be parsed as a collection name and rejected.
+    const link = formatMemoryDeepLink({ bundleId: "team/a", conceptId: "issues/COE-1" });
+    expect(link).toBe("opensymphony://memory/team%2Fa/concepts/issues/COE-1");
+    expect(parseMemoryDeepLink(link)).toEqual({
+      bundleId: "team/a",
+      conceptId: "issues/COE-1",
+      communityId: null,
+    });
+    expect(parseMemoryDeepLink(formatMemoryDeepLink({ bundleId: "team/a" }))).toEqual({
+      bundleId: "team/a",
+      conceptId: null,
+      communityId: null,
+    });
+  });
+
   it("keeps community ids with slashes in a single segment", () => {
     // Directory-derived communities ("directory:path/to") must round-trip:
     // multi-segment community paths are rejected by the parser.
@@ -130,6 +147,9 @@ describe("memory deep links", () => {
     });
     expect(communityState.mode).toBe("community");
     expect(communityState.bundleId).toBe("viz-workbench");
+    // Visibility filters on filters.communities, not mode: the restored
+    // state must install the community filter or the link shows the atlas.
+    expect(communityState.filters?.communities).toEqual(["area:gateway"]);
 
     const conceptState = memoryDeepLinkToGraphState({
       bundleId: "viz-workbench",
@@ -137,6 +157,7 @@ describe("memory deep links", () => {
       communityId: null,
     });
     expect(conceptState.mode).toBe("atlas");
+    expect(conceptState.filters?.communities).toEqual([]);
   });
 });
 
@@ -219,5 +240,27 @@ describe("fixture graph adapter concept resolution", () => {
     expect(cachedConceptDetail(state, detail.bundle_id, detail.concept_id)).toBeNull();
     state = graphReducer(state, { type: "CONCEPT_DETAIL_LOADED", detail });
     expect(cachedConceptDetail(state, detail.bundle_id, detail.concept_id)).toEqual(detail);
+  });
+
+  it("drops the bundle's cached details when a newer snapshot is accepted", () => {
+    const concept = graphVizFixtureSnapshot.nodes.find((node) => node.kind === "concept")!;
+    const detail = graphVizFixtureConceptDetail(concept.concept_id!)!;
+    const otherBundleDetail = { ...detail, bundle_id: "other-bundle" };
+    let state = graphReducer(createInitialGraphState(), { type: "SNAPSHOT_LOADED", snapshot: graphVizFixtureSnapshot });
+    state = graphReducer(state, { type: "CONCEPT_DETAIL_LOADED", detail });
+    state = graphReducer(state, { type: "CONCEPT_DETAIL_LOADED", detail: otherBundleDetail });
+
+    // A redelivered (same-sequence) snapshot keeps the cache.
+    state = graphReducer(state, { type: "SNAPSHOT_LOADED", snapshot: graphVizFixtureSnapshot });
+    expect(cachedConceptDetail(state, detail.bundle_id, detail.concept_id)).toEqual(detail);
+
+    // An accepted, strictly newer snapshot may reflect capsule edits: the
+    // bundle's cached details are invalidated, other bundles' survive.
+    state = graphReducer(state, {
+      type: "SNAPSHOT_LOADED",
+      snapshot: { ...graphVizFixtureSnapshot, cursor: { ...graphVizFixtureSnapshot.cursor, sequence: 2 } },
+    });
+    expect(cachedConceptDetail(state, detail.bundle_id, detail.concept_id)).toBeNull();
+    expect(cachedConceptDetail(state, "other-bundle", detail.concept_id)).toEqual(otherBundleDetail);
   });
 });

--- a/packages/graph/__tests__/deep-link.test.ts
+++ b/packages/graph/__tests__/deep-link.test.ts
@@ -1,4 +1,5 @@
 import {
+  applyGraphFilters,
   cachedConceptDetail,
   createFixtureGraphAdapter,
   createInitialGraphState,
@@ -6,6 +7,7 @@ import {
   graphReducer,
   graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
+  initialGraphFilters,
   memoryDeepLinkForGraphNode,
   memoryDeepLinkToGraphState,
   parseMemoryDeepLink,
@@ -61,6 +63,48 @@ describe("memory deep links", () => {
     expect(() => formatMemoryDeepLink({ bundleId: "" })).toThrow(/bundle id/);
   });
 
+  it("keeps community ids with slashes in a single segment", () => {
+    // Directory-derived communities ("directory:path/to") must round-trip:
+    // multi-segment community paths are rejected by the parser.
+    const link = formatMemoryDeepLink({ bundleId: "b", communityId: "directory:path/to" });
+    expect(link).toBe("opensymphony://memory/b/communities/directory%3Apath%2Fto");
+    expect(parseMemoryDeepLink(link)).toEqual({
+      bundleId: "b",
+      conceptId: null,
+      communityId: "directory:path/to",
+    });
+  });
+
+  it("strips the community graph-node prefix when addressing communities", () => {
+    // Server snapshots emit community nodes as "community:<id>" while the
+    // community list carries the bare id; links address the bare id.
+    const link = memoryDeepLinkForGraphNode("b", {
+      kind: "community",
+      id: "community:area:graph-view",
+      concept_id: undefined,
+    })!;
+    expect(parseMemoryDeepLink(link)?.communityId).toBe("area:graph-view");
+
+    const prefixedSnapshot = {
+      ...graphVizFixtureSnapshot,
+      nodes: [
+        ...graphVizFixtureSnapshot.nodes,
+        {
+          ...graphVizFixtureSnapshot.nodes[0],
+          id: "community:area:code-intelligence",
+          kind: "community" as const,
+          label: "Code Intelligence",
+        },
+      ],
+    };
+    const resolved = resolveMemoryDeepLinkNode(prefixedSnapshot, {
+      bundleId: prefixedSnapshot.bundle_id,
+      conceptId: null,
+      communityId: "area:code-intelligence",
+    });
+    expect(resolved?.id).toBe("community:area:code-intelligence");
+  });
+
   it("builds node deep links only for addressable node kinds", () => {
     const snapshot = graphVizFixtureSnapshot;
     const concept = snapshot.nodes.find((node) => node.kind === "concept")!;
@@ -93,6 +137,34 @@ describe("memory deep links", () => {
       communityId: null,
     });
     expect(conceptState.mode).toBe("atlas");
+  });
+});
+
+describe("community drill filtering", () => {
+  it("keeps secondary members when filtering by a community", () => {
+    // A multi-area concept carries only its primary community in metrics
+    // but belongs to every listed area's node_ids; drilling into the
+    // secondary area must keep it (it is part of the clicked hull).
+    const secondaryMember = graphVizFixtureSnapshot.nodes.find((node) => {
+      const areas = node.frontmatter_summary.areas as string[] | undefined;
+      return node.kind === "concept" && (areas?.length ?? 0) > 1;
+    });
+    expect(secondaryMember).toBeDefined();
+    const areas = secondaryMember!.frontmatter_summary.areas as string[];
+    const secondaryArea = `area:${areas[1]}`;
+    expect(secondaryMember!.metrics.community_id).not.toBe(secondaryArea);
+
+    const filtered = applyGraphFilters(graphVizFixtureSnapshot, {
+      ...initialGraphFilters,
+      communities: [secondaryArea],
+    });
+    const memberIds = new Set(filtered.nodes.map((node) => node.id));
+    expect(memberIds.has(secondaryMember!.id)).toBe(true);
+    // Every hull member survives the drill filter.
+    const community = graphVizFixtureSnapshot.communities.find((candidate) => candidate.id === secondaryArea)!;
+    for (const nodeId of community.node_ids) {
+      expect(memberIds.has(nodeId)).toBe(true);
+    }
   });
 });
 

--- a/packages/graph/__tests__/deep-link.test.ts
+++ b/packages/graph/__tests__/deep-link.test.ts
@@ -1,0 +1,151 @@
+import {
+  cachedConceptDetail,
+  createFixtureGraphAdapter,
+  createInitialGraphState,
+  formatMemoryDeepLink,
+  graphReducer,
+  graphVizFixtureConceptDetail,
+  graphVizFixtureSnapshot,
+  memoryDeepLinkForGraphNode,
+  memoryDeepLinkToGraphState,
+  parseMemoryDeepLink,
+  resolveMemoryDeepLinkNode,
+} from "@opensymphony/graph";
+
+describe("memory deep links", () => {
+  it("round-trips bundle, community, and concept links", () => {
+    const bundle = formatMemoryDeepLink({ bundleId: "viz-workbench" });
+    expect(bundle).toBe("opensymphony://memory/viz-workbench");
+    expect(parseMemoryDeepLink(bundle)).toEqual({
+      bundleId: "viz-workbench",
+      conceptId: null,
+      communityId: null,
+    });
+
+    const community = formatMemoryDeepLink({ bundleId: "viz-workbench", communityId: "area:memory-graph" });
+    expect(community).toBe("opensymphony://memory/viz-workbench/communities/area%3Amemory-graph");
+    expect(parseMemoryDeepLink(community)).toEqual({
+      bundleId: "viz-workbench",
+      conceptId: null,
+      communityId: "area:memory-graph",
+    });
+
+    const concept = formatMemoryDeepLink({ bundleId: "viz-workbench", conceptId: "issues/COE-399" });
+    expect(concept).toBe("opensymphony://memory/viz-workbench/concepts/issues/COE-399");
+    expect(parseMemoryDeepLink(concept)).toEqual({
+      bundleId: "viz-workbench",
+      conceptId: "issues/COE-399",
+      communityId: null,
+    });
+  });
+
+  it("percent-encodes hostile segment characters and decodes them back", () => {
+    const link = formatMemoryDeepLink({ bundleId: "bundle id", conceptId: "issues/COE 399?x=#y" });
+    expect(link).not.toMatch(/[ ?#]/);
+    expect(parseMemoryDeepLink(link)).toEqual({
+      bundleId: "bundle id",
+      conceptId: "issues/COE 399?x=#y",
+      communityId: null,
+    });
+  });
+
+  it("rejects malformed links instead of guessing", () => {
+    expect(parseMemoryDeepLink("https://example.com/memory/x")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/bundle/unknown/x")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/bundle/concepts")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/bundle/communities/a/b")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/bundle//concepts/x")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/bundle/concepts/x?query=1")).toBeNull();
+    expect(parseMemoryDeepLink("opensymphony://memory/bundle/concepts/%ZZ")).toBeNull();
+    expect(() => formatMemoryDeepLink({ bundleId: "" })).toThrow(/bundle id/);
+  });
+
+  it("builds node deep links only for addressable node kinds", () => {
+    const snapshot = graphVizFixtureSnapshot;
+    const concept = snapshot.nodes.find((node) => node.kind === "concept")!;
+    const conceptLink = memoryDeepLinkForGraphNode(snapshot.bundle_id, concept)!;
+    expect(conceptLink).toContain("/concepts/");
+
+    const parsed = parseMemoryDeepLink(conceptLink)!;
+    expect(resolveMemoryDeepLinkNode(snapshot, parsed)?.id).toBe(concept.id);
+
+    const tag = snapshot.nodes.find((node) => node.kind === "tag")!;
+    expect(memoryDeepLinkForGraphNode(snapshot.bundle_id, tag)).toBeNull();
+
+    const bundle = snapshot.nodes.find((node) => node.kind === "bundle")!;
+    const bundleLink = memoryDeepLinkForGraphNode(snapshot.bundle_id, bundle)!;
+    expect(resolveMemoryDeepLinkNode(snapshot, parseMemoryDeepLink(bundleLink)!)?.id).toBe(bundle.id);
+  });
+
+  it("maps deep links to HISTORY_RESTORED-compatible state", () => {
+    const communityState = memoryDeepLinkToGraphState({
+      bundleId: "viz-workbench",
+      conceptId: null,
+      communityId: "area:gateway",
+    });
+    expect(communityState.mode).toBe("community");
+    expect(communityState.bundleId).toBe("viz-workbench");
+
+    const conceptState = memoryDeepLinkToGraphState({
+      bundleId: "viz-workbench",
+      conceptId: "concepts/gateway-01",
+      communityId: null,
+    });
+    expect(conceptState.mode).toBe("atlas");
+  });
+});
+
+describe("viz fixture concept details", () => {
+  it("returns a deterministic capsule whose links resolve to snapshot nodes", () => {
+    const concept = graphVizFixtureSnapshot.nodes.find((node) => node.kind === "concept")!;
+    const detail = graphVizFixtureConceptDetail(concept.concept_id!)!;
+    expect(detail).not.toBeNull();
+    expect(detail.concept_id).toBe(concept.concept_id);
+    expect(detail.body_markdown).toContain("## Summary");
+    expect(graphVizFixtureConceptDetail(concept.concept_id!)).toEqual(detail);
+    // Also resolvable by node id.
+    expect(graphVizFixtureConceptDetail(concept.id)?.concept_id).toBe(concept.concept_id);
+
+    const conceptIds = new Set(
+      graphVizFixtureSnapshot.nodes
+        .filter((node) => node.kind === "concept")
+        .flatMap((node) => [node.id, node.concept_id ?? node.id]),
+    );
+    for (const link of detail.links) {
+      expect(conceptIds.has(link.target)).toBe(true);
+    }
+  });
+
+  it("covers every fixture concept and rejects unknown ids", () => {
+    const concepts = graphVizFixtureSnapshot.nodes.filter((node) => node.kind === "concept");
+    for (const concept of concepts) {
+      expect(graphVizFixtureConceptDetail(concept.concept_id!)).not.toBeNull();
+    }
+    expect(graphVizFixtureConceptDetail("concepts/does-not-exist")).toBeNull();
+  });
+});
+
+describe("fixture graph adapter concept resolution", () => {
+  it("supports resolver-style concept details and rejects missing concepts", async () => {
+    const adapter = createFixtureGraphAdapter({
+      snapshot: graphVizFixtureSnapshot,
+      conceptDetail: (_bundleId, conceptId) => graphVizFixtureConceptDetail(conceptId),
+    });
+    const concept = graphVizFixtureSnapshot.nodes.find((node) => node.kind === "concept")!;
+    const detail = await adapter.getConceptDetail(graphVizFixtureSnapshot.bundle_id, concept.concept_id!);
+    expect(detail.concept_id).toBe(concept.concept_id);
+    await expect(
+      adapter.getConceptDetail(graphVizFixtureSnapshot.bundle_id, "concepts/none"),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("caches loaded details behind cachedConceptDetail", () => {
+    const concept = graphVizFixtureSnapshot.nodes.find((node) => node.kind === "concept")!;
+    const detail = graphVizFixtureConceptDetail(concept.concept_id!)!;
+    let state = createInitialGraphState();
+    expect(cachedConceptDetail(state, detail.bundle_id, detail.concept_id)).toBeNull();
+    state = graphReducer(state, { type: "CONCEPT_DETAIL_LOADED", detail });
+    expect(cachedConceptDetail(state, detail.bundle_id, detail.concept_id)).toEqual(detail);
+  });
+});

--- a/packages/graph/src/deep-link.ts
+++ b/packages/graph/src/deep-link.ts
@@ -1,0 +1,130 @@
+import type { MemoryGraphNode, MemoryGraphSnapshot } from "@opensymphony/gateway-schema";
+import type { GraphDeepLinkState } from "./index.js";
+
+/**
+ * Memory deep links address a location in the knowledge graph — a bundle, a
+ * community (area), or a concept capsule — with a stable string that can be
+ * embedded outside the graph UI (task artifacts, notifications, docs) and
+ * later resolved back into graph navigation state.
+ *
+ * Format:
+ *   opensymphony://memory/<bundleId>
+ *   opensymphony://memory/<bundleId>/communities/<communityId>
+ *   opensymphony://memory/<bundleId>/concepts/<conceptId>
+ *
+ * Every path segment is percent-encoded; concept ids keep their internal
+ * slashes (`issues/COE-399` becomes `concepts/issues/COE-399`), matching the
+ * gateway's wildcard concept route. Parsing is strict: unknown collections,
+ * empty segments, or query/fragment suffixes are rejected rather than
+ * guessed at, so a link either resolves exactly or not at all.
+ */
+
+export const memoryDeepLinkPrefix = "opensymphony://memory/";
+
+export interface MemoryDeepLink {
+  bundleId: string;
+  conceptId: string | null;
+  communityId: string | null;
+}
+
+export function formatMemoryDeepLink(link: {
+  bundleId: string;
+  conceptId?: string | null;
+  communityId?: string | null;
+}): string {
+  if (!link.bundleId) {
+    throw new Error("Memory deep links require a bundle id");
+  }
+  const base = `${memoryDeepLinkPrefix}${encodeSegments(link.bundleId)}`;
+  if (link.conceptId) {
+    return `${base}/concepts/${encodeSegments(link.conceptId)}`;
+  }
+  if (link.communityId) {
+    return `${base}/communities/${encodeSegments(link.communityId)}`;
+  }
+  return base;
+}
+
+export function parseMemoryDeepLink(url: string): MemoryDeepLink | null {
+  if (!url.startsWith(memoryDeepLinkPrefix)) return null;
+  const rest = url.slice(memoryDeepLinkPrefix.length);
+  if (rest.length === 0 || /[?#]/.test(rest)) return null;
+  const segments = rest.split("/");
+  if (segments.some((segment) => segment.length === 0)) return null;
+  const decoded: string[] = [];
+  for (const segment of segments) {
+    try {
+      decoded.push(decodeURIComponent(segment));
+    } catch {
+      return null;
+    }
+  }
+  const [bundleId, collection, ...tail] = decoded;
+  if (collection === undefined) {
+    return { bundleId, conceptId: null, communityId: null };
+  }
+  if (collection === "concepts" && tail.length > 0) {
+    return { bundleId, conceptId: tail.join("/"), communityId: null };
+  }
+  if (collection === "communities" && tail.length === 1) {
+    return { bundleId, conceptId: null, communityId: tail[0] };
+  }
+  return null;
+}
+
+/**
+ * Deep link for a graph node, or null for node kinds that have no stable
+ * address (tags, resources, citations). Concept nodes link to their capsule;
+ * community nodes link to their area.
+ */
+export function memoryDeepLinkForGraphNode(
+  bundleId: string,
+  node: Pick<MemoryGraphNode, "kind" | "id" | "concept_id">,
+): string | null {
+  if (node.kind === "concept" && node.concept_id) {
+    return formatMemoryDeepLink({ bundleId, conceptId: node.concept_id });
+  }
+  if (node.kind === "community") {
+    return formatMemoryDeepLink({ bundleId, communityId: node.id });
+  }
+  if (node.kind === "bundle") {
+    return formatMemoryDeepLink({ bundleId });
+  }
+  return null;
+}
+
+/** Find the snapshot node a parsed deep link points at. */
+export function resolveMemoryDeepLinkNode(
+  snapshot: MemoryGraphSnapshot,
+  link: MemoryDeepLink,
+): MemoryGraphNode | null {
+  if (link.conceptId) {
+    return snapshot.nodes.find((node) => node.concept_id === link.conceptId)
+      ?? snapshot.nodes.find((node) => node.id === link.conceptId)
+      ?? null;
+  }
+  if (link.communityId) {
+    return snapshot.nodes.find((node) => node.id === link.communityId) ?? null;
+  }
+  return snapshot.nodes.find((node) => node.kind === "bundle" && node.bundle_id === link.bundleId) ?? null;
+}
+
+/**
+ * Translate a parsed deep link into the partial graph state applied through
+ * the HISTORY_RESTORED reducer action. Node resolution happens against the
+ * loaded snapshot (see resolveMemoryDeepLinkNode); this only carries the
+ * navigation shape.
+ */
+export function memoryDeepLinkToGraphState(link: MemoryDeepLink): Partial<GraphDeepLinkState> {
+  return {
+    mode: link.communityId ? "community" : "atlas",
+    bundleId: link.bundleId,
+    focusedNodeId: null,
+    selectedNodeIds: [],
+    searchQuery: "",
+  };
+}
+
+function encodeSegments(value: string): string {
+  return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}

--- a/packages/graph/src/deep-link.ts
+++ b/packages/graph/src/deep-link.ts
@@ -12,11 +12,14 @@ import type { GraphDeepLinkState } from "./index.js";
  *   opensymphony://memory/<bundleId>/communities/<communityId>
  *   opensymphony://memory/<bundleId>/concepts/<conceptId>
  *
- * Every path segment is percent-encoded; concept ids keep their internal
+ * Every path segment is percent-encoded. Concept ids keep their internal
  * slashes (`issues/COE-399` becomes `concepts/issues/COE-399`), matching the
- * gateway's wildcard concept route. Parsing is strict: unknown collections,
- * empty segments, or query/fragment suffixes are rejected rather than
- * guessed at, so a link either resolves exactly or not at all.
+ * gateway's wildcard concept route; community ids encode as a single segment
+ * (a directory-derived community like `directory:path/to` must round-trip
+ * through the one-segment `/communities/<id>` form). Parsing is strict:
+ * unknown collections, empty segments, or query/fragment suffixes are
+ * rejected rather than guessed at, so a link either resolves exactly or not
+ * at all.
  */
 
 export const memoryDeepLinkPrefix = "opensymphony://memory/";
@@ -40,7 +43,7 @@ export function formatMemoryDeepLink(link: {
     return `${base}/concepts/${encodeSegments(link.conceptId)}`;
   }
   if (link.communityId) {
-    return `${base}/communities/${encodeSegments(link.communityId)}`;
+    return `${base}/communities/${encodeURIComponent(link.communityId)}`;
   }
   return base;
 }
@@ -85,12 +88,20 @@ export function memoryDeepLinkForGraphNode(
     return formatMemoryDeepLink({ bundleId, conceptId: node.concept_id });
   }
   if (node.kind === "community") {
-    return formatMemoryDeepLink({ bundleId, communityId: node.id });
+    // Server snapshots prefix community graph nodes ("community:area:x")
+    // while the community list carries the bare id ("area:x"); links always
+    // address the bare community id.
+    return formatMemoryDeepLink({ bundleId, communityId: bareCommunityId(node.id) });
   }
   if (node.kind === "bundle") {
     return formatMemoryDeepLink({ bundleId });
   }
   return null;
+}
+
+/** Strip the graph-node prefix from a community node id, if present. */
+export function bareCommunityId(nodeId: string): string {
+  return nodeId.startsWith("community:") ? nodeId.slice("community:".length) : nodeId;
 }
 
 /** Find the snapshot node a parsed deep link points at. */
@@ -104,7 +115,9 @@ export function resolveMemoryDeepLinkNode(
       ?? null;
   }
   if (link.communityId) {
-    return snapshot.nodes.find((node) => node.id === link.communityId) ?? null;
+    return snapshot.nodes.find((node) => node.id === link.communityId)
+      ?? snapshot.nodes.find((node) => node.id === `community:${link.communityId}`)
+      ?? null;
   }
   return snapshot.nodes.find((node) => node.kind === "bundle" && node.bundle_id === link.bundleId) ?? null;
 }

--- a/packages/graph/src/deep-link.ts
+++ b/packages/graph/src/deep-link.ts
@@ -1,5 +1,5 @@
 import type { MemoryGraphNode, MemoryGraphSnapshot } from "@opensymphony/gateway-schema";
-import type { GraphDeepLinkState } from "./index.js";
+import { createInitialGraphFilters, type GraphDeepLinkState } from "./index.js";
 
 /**
  * Memory deep links address a location in the knowledge graph — a bundle, a
@@ -14,12 +14,12 @@ import type { GraphDeepLinkState } from "./index.js";
  *
  * Every path segment is percent-encoded. Concept ids keep their internal
  * slashes (`issues/COE-399` becomes `concepts/issues/COE-399`), matching the
- * gateway's wildcard concept route; community ids encode as a single segment
- * (a directory-derived community like `directory:path/to` must round-trip
- * through the one-segment `/communities/<id>` form). Parsing is strict:
- * unknown collections, empty segments, or query/fragment suffixes are
- * rejected rather than guessed at, so a link either resolves exactly or not
- * at all.
+ * gateway's wildcard concept route; bundle and community ids encode as a
+ * single segment (a hosted bundle id like `team/a` or a directory-derived
+ * community like `directory:path/to` must round-trip through their
+ * one-segment position). Parsing is strict: unknown collections, empty
+ * segments, or query/fragment suffixes are rejected rather than guessed at,
+ * so a link either resolves exactly or not at all.
  */
 
 export const memoryDeepLinkPrefix = "opensymphony://memory/";
@@ -38,7 +38,7 @@ export function formatMemoryDeepLink(link: {
   if (!link.bundleId) {
     throw new Error("Memory deep links require a bundle id");
   }
-  const base = `${memoryDeepLinkPrefix}${encodeSegments(link.bundleId)}`;
+  const base = `${memoryDeepLinkPrefix}${encodeURIComponent(link.bundleId)}`;
   if (link.conceptId) {
     return `${base}/concepts/${encodeSegments(link.conceptId)}`;
   }
@@ -126,7 +126,9 @@ export function resolveMemoryDeepLinkNode(
  * Translate a parsed deep link into the partial graph state applied through
  * the HISTORY_RESTORED reducer action. Node resolution happens against the
  * loaded snapshot (see resolveMemoryDeepLinkNode); this only carries the
- * navigation shape.
+ * navigation shape. Filters are always included: visibility is driven by
+ * `filters.communities` (mode alone filters nothing), so a community link
+ * must install its filter and every other link must clear a stale one.
  */
 export function memoryDeepLinkToGraphState(link: MemoryDeepLink): Partial<GraphDeepLinkState> {
   return {
@@ -135,6 +137,10 @@ export function memoryDeepLinkToGraphState(link: MemoryDeepLink): Partial<GraphD
     focusedNodeId: null,
     selectedNodeIds: [],
     searchQuery: "",
+    filters: {
+      ...createInitialGraphFilters(),
+      communities: link.communityId ? [link.communityId] : [],
+    },
   };
 }
 

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -471,9 +471,20 @@ export function applyGraphFilters(
   const neighborhood = mode === "neighborhood" && focusedNodeId
     ? collectNeighborhood(snapshot.edges, focusedNodeId, neighborhoodDepth)
     : null;
+  // Communities are membership lists, not just primary assignments: a
+  // multi-area concept carries one community in metrics but appears in every
+  // area's node_ids. Drilling into an area must keep those secondary members
+  // (they are part of the hull the operator clicked).
+  const communityMembers = normalized.communities.length > 0
+    ? new Set(
+      snapshot.communities
+        .filter((community) => normalized.communities.includes(community.id))
+        .flatMap((community) => community.node_ids),
+    )
+    : null;
   const nodes = snapshot.nodes.filter((node) => {
     if (neighborhood && !neighborhood.has(node.id)) return false;
-    return matchesNodeFilters(node, normalized);
+    return matchesNodeFilters(node, normalized, communityMembers);
   });
   const nodeKindById = new Map(nodes.map((node) => [node.id, node.kind]));
   const edges = snapshot.edges.filter((edge) => {
@@ -1035,7 +1046,11 @@ function mostCommon<T extends string>(values: readonly T[]): T | undefined {
   return [...counts.entries()].sort((a, b) => b[1] - a[1] || compareStrings(a[0], b[0]))[0]?.[0];
 }
 
-function matchesNodeFilters(node: MemoryGraphNode, filters: GraphFilters): boolean {
+function matchesNodeFilters(
+  node: MemoryGraphNode,
+  filters: GraphFilters,
+  communityMembers: ReadonlySet<string> | null = null,
+): boolean {
   if (filters.bundleIds.length > 0 && (!node.bundle_id || !filters.bundleIds.includes(node.bundle_id))) return false;
   if (filters.nodeKinds.length > 0 && !filters.nodeKinds.includes(node.kind)) return false;
   if (filters.tags.length > 0 && !filters.tags.some((tag) => node.tags.includes(tag))) return false;
@@ -1043,7 +1058,11 @@ function matchesNodeFilters(node: MemoryGraphNode, filters: GraphFilters): boole
   if (filters.freshness.length > 0 && (!node.freshness || !filters.freshness.includes(node.freshness))) return false;
   if (filters.warning === "with_warnings" && node.warning_count <= 0) return false;
   if (filters.warning === "without_warnings" && node.warning_count > 0) return false;
-  if (filters.communities.length > 0 && (!node.metrics?.community_id || !filters.communities.includes(node.metrics.community_id))) return false;
+  if (filters.communities.length > 0) {
+    const primaryMatch = node.metrics?.community_id !== undefined
+      && filters.communities.includes(node.metrics.community_id);
+    if (!primaryMatch && !communityMembers?.has(node.id)) return false;
+  }
   if (filters.areas.length > 0 && !hasAny(node, "area", filters.areas)) return false;
   if (filters.projects.length > 0 && !hasAny(node, "project", filters.projects)) return false;
   if (filters.milestones.length > 0 && !hasAny(node, "milestone", filters.milestones)) return false;

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -26,6 +26,7 @@ export type {
   MemoryBundleList,
   MemoryCommunityList,
   MemoryConceptDetail,
+  MemoryGraphNode,
   MemoryGraphSnapshot,
   MemorySearchResponse,
 } from "@opensymphony/gateway-schema";
@@ -40,8 +41,18 @@ export {
 export {
   graphVizFixtureBundleList,
   graphVizFixtureCommunityList,
+  graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
 } from "./viz-fixture.js";
+export {
+  formatMemoryDeepLink,
+  memoryDeepLinkForGraphNode,
+  memoryDeepLinkPrefix,
+  memoryDeepLinkToGraphState,
+  parseMemoryDeepLink,
+  resolveMemoryDeepLinkNode,
+  type MemoryDeepLink,
+} from "./deep-link.js";
 
 export type GraphMode =
   | "atlas"
@@ -374,6 +385,15 @@ export function currentGraphSnapshot(state: GraphState): MemoryGraphSnapshot | n
   return bundleId ? state.snapshots[bundleId] ?? null : null;
 }
 
+/** Cached capsule detail for a concept, or null until CONCEPT_DETAIL_LOADED lands. */
+export function cachedConceptDetail(
+  state: GraphState,
+  bundleId: string,
+  conceptId: string,
+): MemoryConceptDetail | null {
+  return state.conceptDetails[conceptDetailKey(bundleId, conceptId)] ?? null;
+}
+
 export function visibleGraphSnapshot(state: GraphState): MemoryGraphSnapshot | null {
   const snapshot = currentGraphSnapshot(state);
   if (!snapshot) return null;
@@ -656,7 +676,8 @@ export function createTauriNativeGraphAdapter(api: NativeGraphApi): GraphDataAda
 export function createFixtureGraphAdapter(fixtures: {
   bundles?: MemoryBundleList;
   snapshot?: MemoryGraphSnapshot;
-  conceptDetail?: MemoryConceptDetail;
+  /** Static detail for every concept, or a resolver (null → reject like a gateway 404). */
+  conceptDetail?: MemoryConceptDetail | ((bundleId: string, conceptId: string) => MemoryConceptDetail | null);
   communities?: MemoryCommunityList;
   search?: MemorySearchResponse;
 } = {}): GraphDataAdapter {
@@ -668,7 +689,13 @@ export function createFixtureGraphAdapter(fixtures: {
   return {
     listBundles: async () => bundles,
     getGraphSnapshot: async () => snapshot,
-    getConceptDetail: async () => conceptDetail,
+    getConceptDetail: async (bundleId, conceptId) => {
+      const detail = typeof conceptDetail === "function"
+        ? conceptDetail(bundleId, conceptId)
+        : conceptDetail;
+      if (!detail) throw new Error(`Concept not found: ${conceptId}`);
+      return detail;
+    },
     getCommunities: async () => communities,
     search: async (query, options) => {
       const results = options?.bundleId && options.bundleId !== snapshot.bundle_id

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -286,8 +286,15 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
         const warningBundleIds = action.snapshot.metrics && action.snapshot.metrics.warning_count > 0
           ? uniqueSorted([...state.warningBundleIds, action.snapshot.bundle_id])
           : state.warningBundleIds.filter((bundleId) => bundleId !== action.snapshot.bundle_id);
+        // An accepted (strictly newer) snapshot may reflect capsule edits:
+        // drop the bundle's cached concept details so open capsules refetch
+        // instead of rendering stale markdown against a current graph.
+        const conceptDetails = Object.fromEntries(
+          Object.entries(state.conceptDetails).filter(([key]) => !key.startsWith(`${action.snapshot.bundle_id}:`)),
+        );
         return {
           ...state,
+          conceptDetails,
           snapshots: { ...state.snapshots, [action.snapshot.bundle_id]: action.snapshot },
           selectedBundleId: state.selectedBundleId ?? action.snapshot.bundle_id,
           lastUpdatedAt: action.snapshot.generated_at,

--- a/packages/graph/src/viz-fixture.ts
+++ b/packages/graph/src/viz-fixture.ts
@@ -1,6 +1,7 @@
 import type {
   MemoryBundleList,
   MemoryCommunityList,
+  MemoryConceptDetail,
   MemoryGraphEdge,
   MemoryGraphNode,
   MemoryGraphSnapshot,
@@ -409,3 +410,77 @@ export const graphVizFixtureCommunityList: MemoryCommunityList = {
   communities: graphVizFixtureSnapshot.communities,
   generated_at,
 };
+
+/**
+ * Capsule detail for a fixture concept, derived from the snapshot's own
+ * edges so every link inside a capsule resolves to a real node in the graph.
+ * Returns null for unknown concept ids, mirroring the gateway's 404.
+ * Accepts either the concept_id ("concepts/memory-graph-01") or node id.
+ */
+export function graphVizFixtureConceptDetail(conceptId: string): MemoryConceptDetail | null {
+  const snapshot = graphVizFixtureSnapshot;
+  const node = snapshot.nodes.find(
+    (candidate) => candidate.kind === "concept"
+      && (candidate.concept_id === conceptId || candidate.id === conceptId),
+  );
+  if (!node) return null;
+  const nodesById = new Map(snapshot.nodes.map((candidate) => [candidate.id, candidate]));
+  const linkTargets: Array<{ target: string; label?: string }> = [];
+  const citations: MemoryConceptDetail["citations"] = [];
+  const sourceRefs: MemoryConceptDetail["source_refs"] = [];
+  for (const edge of snapshot.edges) {
+    if (edge.source_id !== node.id && edge.target_id !== node.id) continue;
+    const otherId = edge.source_id === node.id ? edge.target_id : edge.source_id;
+    const other = nodesById.get(otherId);
+    if (!other) continue;
+    if (edge.kind === "markdown_link" && other.kind === "concept") {
+      linkTargets.push({ target: other.concept_id ?? other.id, label: other.label });
+    } else if (edge.kind === "cites" && other.kind === "concept") {
+      citations.push({ id: `cite:${other.id}`, target: other.concept_id ?? other.id, label: other.label });
+    } else if (edge.kind === "source_supported_by" && other.kind === "source_ref") {
+      sourceRefs.push({ kind: "task", id: other.label, url: `https://example.invalid/tasks/${other.label}` });
+    }
+  }
+  const areas = (node.frontmatter_summary.areas as string[] | undefined) ?? [];
+  const related = linkTargets.slice(0, 4);
+  const body = [
+    `## Summary`,
+    ``,
+    `${node.label} — deterministic fixture capsule for drill-down and deep-link work. It plays the role of an issue memory capsule: frontmatter, sections, and links behave like the real vault content.`,
+    ``,
+    `## Decisions and actions`,
+    ``,
+    `- Anchored under ${areas.map((area) => `**${area}**`).join(", ") || "no area"} in the fixture graph.`,
+    `- Tagged ${node.tags.map((tag) => `\`${tag}\``).join(", ") || "with nothing"}.`,
+    ...(related.length > 0
+      ? [
+        ``,
+        `## Relationships`,
+        ``,
+        ...related.map((link) => `- Links to [[${link.target}]] (${link.label ?? link.target})`),
+      ]
+      : []),
+    ``,
+    `## Validation evidence`,
+    ``,
+    `- Deterministic content: regenerating the fixture never changes this capsule.`,
+  ].join("\n");
+  return {
+    schema_version,
+    bundle_id: bundleId,
+    concept_id: node.concept_id ?? node.id,
+    frontmatter_view: {
+      primary: { title: node.label, type: "issue-capsule" },
+      opensymphony: {
+        areas,
+        state: node.freshness === "stale" ? "Stale" : "Done",
+        visibility: node.visibility ?? "private",
+      },
+      unknown: {},
+    },
+    body_markdown: body,
+    links: linkTargets,
+    citations,
+    source_refs: sourceRefs,
+  };
+}

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@opensymphony/graph";
 import { schemaVersionV1 } from "@opensymphony/gateway-schema";
 import {
+  bindKnowledgeGraphListNavigation,
   createKnowledgeGraphViewState,
   disposeKnowledgeGraphRenderer,
   mountKnowledgeGraphRenderer,
@@ -1387,6 +1388,36 @@ describe("OpenSymphonyApp mount", () => {
       expect(after.pitch).toBeGreaterThan(before.pitch);
     } finally {
       disposeKnowledgeGraphRenderer(root);
+      root.remove();
+    }
+  });
+
+  it("flags only truncated entity-list names for the instant hover tooltip", () => {
+    const root = document.createElement("div");
+    root.innerHTML = renderKnowledgeGraphNodeList(fixtureGraphSnapshot, []);
+    document.body.appendChild(root);
+    try {
+      const buttons = Array.from(root.querySelectorAll<HTMLElement>(".os-kg-list [data-kg-node-id]"));
+      expect(buttons.length).toBeGreaterThan(1);
+      const [truncated, fitting] = buttons;
+      // jsdom has no layout; emulate one ellipsized and one fitting row.
+      Object.defineProperty(truncated, "scrollWidth", { value: 300, configurable: true });
+      Object.defineProperty(truncated, "clientWidth", { value: 180, configurable: true });
+      Object.defineProperty(fitting, "scrollWidth", { value: 120, configurable: true });
+      Object.defineProperty(fitting, "clientWidth", { value: 180, configurable: true });
+
+      bindKnowledgeGraphListNavigation(root, { onSelect: jest.fn(), onFocus: jest.fn() });
+      expect(truncated.dataset.kgOverflow).toBe(truncated.textContent);
+      expect(truncated.getAttribute("title")).toBe(truncated.textContent);
+      expect(fitting.dataset.kgOverflow).toBeUndefined();
+      expect(fitting.getAttribute("title")).toBeNull();
+
+      // A relayout that makes the name fit clears the tooltip again.
+      Object.defineProperty(truncated, "scrollWidth", { value: 100, configurable: true });
+      bindKnowledgeGraphListNavigation(root, { onSelect: jest.fn(), onFocus: jest.fn() });
+      expect(truncated.dataset.kgOverflow).toBeUndefined();
+      expect(truncated.getAttribute("title")).toBeNull();
+    } finally {
       root.remove();
     }
   });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -24,6 +24,8 @@ import {
   createKnowledgeGraphViewState,
   disposeKnowledgeGraphRenderer,
   mountKnowledgeGraphRenderer,
+  renderKnowledgeGraphInspector,
+  renderKnowledgeGraphNodeList,
   renderKnowledgeGraphSurface,
 } from "../src/knowledge-graph-renderer.js";
 import { hitTestHull, hitTestScene, type GraphScene } from "../src/knowledge-graph-scene.js";
@@ -861,9 +863,12 @@ describe("OpenSymphonyApp mount", () => {
       fallbackButtons[0]?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
       expect(nextFocus).toHaveBeenCalled();
       nextFocus.mockRestore();
-      expect(root.querySelector(".os-graph-hero-panel [data-kg-node-id='concept:coe-465']")).not.toBeNull();
-      expect(root.querySelector("[data-testid='knowledge-lower-list']")).not.toBeNull();
-      expect(root.querySelector("[data-testid='knowledge-lower-detail']")).not.toBeNull();
+      // Entity list and inspector live in the lower workspace columns, not
+      // inside the graph hero, so the stage keeps the full hero height.
+      expect(root.querySelector(".os-graph-hero-panel .os-kg-list")).toBeNull();
+      expect(root.querySelector(".os-graph-hero-panel [data-testid='knowledge-graph-inspector']")).toBeNull();
+      expect(root.querySelector(".os-knowledge-lower-panel [data-kg-node-id='concept:coe-465']")).not.toBeNull();
+      expect(root.querySelector(".os-knowledge-lower-panel [data-testid='knowledge-graph-inspector']")).not.toBeNull();
       expect(root.textContent).not.toContain("unknown_frontmatter");
       expect(root.textContent).not.toContain("frontmatter_summary");
       // TODO(COE-471): migrate the COE-468 search/filter/inspector/raw-frontmatter controls
@@ -933,11 +938,12 @@ describe("OpenSymphonyApp mount", () => {
 
       (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
       await flushUntil(() => root.querySelector("[data-kg-node-id='concept:coe-465']") !== null);
-      expect(lowerColumns().style.getPropertyValue("--os-left-column")).toBe("50%");
+      // Knowledge defaults to a narrow entity list beside the inspector.
+      expect(lowerColumns().style.getPropertyValue("--os-left-column")).toBe("34%");
       (root.querySelector("[data-kg-node-id='concept:coe-465']") as HTMLButtonElement).click();
       await flushUntil(() => root.querySelector(".os-kg-list li.is-selected [data-kg-node-id='concept:coe-465']") !== null);
       resizer().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
-      expect(lowerColumns().style.getPropertyValue("--os-left-column")).toBe("48%");
+      expect(lowerColumns().style.getPropertyValue("--os-left-column")).toBe("32%");
 
       (root.querySelector("[data-graph-view='code']") as HTMLButtonElement).click();
       await flushUntil(() => root.querySelector("[data-testid='code-graph-placeholder']") !== null);
@@ -950,7 +956,7 @@ describe("OpenSymphonyApp mount", () => {
 
       (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
       await flushUntil(() => root.querySelector(".os-kg-list li.is-selected [data-kg-node-id='concept:coe-465']") !== null);
-      expect(lowerColumns().style.getPropertyValue("--os-left-column")).toBe("48%");
+      expect(lowerColumns().style.getPropertyValue("--os-left-column")).toBe("32%");
     } finally {
       getContext.mockRestore();
       await handle.destroy();
@@ -1375,15 +1381,15 @@ describe("OpenSymphonyApp mount", () => {
     const layout = computeGraphLayout(snapshot, { kind: "force", width: 1280, height: 720 });
     const selectedNodeId = "concept:scale-1";
     const root = document.createElement("div");
-    root.innerHTML = renderKnowledgeGraphSurface({
-      snapshot,
-      layout,
-      state: {
-        ...initialGraphState,
-        selectedNodeIds: [selectedNodeId],
-        layoutStatus: "ready",
-      },
-    });
+    // The list and inspector render in the lower workspace columns; compose
+    // them alongside the surface the way the app shell does.
+    const composeView = (selectedIds: string[]) => {
+      const state = { ...initialGraphState, selectedNodeIds: selectedIds, layoutStatus: "ready" as const };
+      return renderKnowledgeGraphSurface({ snapshot, layout, state })
+        + renderKnowledgeGraphInspector({ snapshot, layout, state })
+        + renderKnowledgeGraphNodeList(snapshot, selectedIds);
+    };
+    root.innerHTML = composeView([selectedNodeId]);
     document.body.appendChild(root);
     // Labels are created imperatively by the renderer with zoom-based LOD;
     // the server-rendered surface starts with an empty overlay layer, and
@@ -1405,15 +1411,7 @@ describe("OpenSymphonyApp mount", () => {
     expect(root.querySelector("[data-testid='knowledge-graph-inspector'] dl")?.textContent).toContain("concept");
     expect(root.querySelector("[data-testid='knowledge-graph-inspector'] dl div")).toBeNull();
     expect(root.querySelector(".os-kg-list [data-kg-node-id='concept:scale-1']")?.getAttribute("aria-current")).toBe("true");
-    root.innerHTML = renderKnowledgeGraphSurface({
-      snapshot,
-      layout,
-      state: {
-        ...initialGraphState,
-        selectedNodeIds: [],
-        layoutStatus: "ready",
-      },
-    });
+    root.innerHTML = composeView([]);
     expect(root.querySelector("[data-testid='knowledge-graph-inspector']")?.textContent).toContain("No node selected");
 
     const originalMatchMedia = globalThis.matchMedia;

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1130,6 +1130,84 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("discards in-flight capsule responses superseded by an accepted graph refresh", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph,
+      runDetails: [runDetail],
+    });
+    let releaseFirstDetail: (() => void) | null = null;
+    const firstDetailGate = new Promise<void>((resolve) => {
+      releaseFirstDetail = resolve;
+    });
+    let snapshotReads = 0;
+    let detailCalls = 0;
+    const graphAdapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      async getGraphSnapshot() {
+        snapshotReads += 1;
+        return snapshotReads > 1
+          ? {
+              ...fixtureGraphSnapshot,
+              cursor: { ...fixtureGraphSnapshot.cursor, sequence: 2 },
+              metrics: { orphan_count: 0, broken_link_count: 0, stale_concept_count: 0, warning_count: 1 },
+            }
+          : fixtureGraphSnapshot;
+      },
+      async getConceptDetail(bundleId, conceptId) {
+        detailCalls += 1;
+        if (detailCalls === 1) await firstDetailGate;
+        return {
+          ...fixtureConceptDetail,
+          bundle_id: bundleId,
+          concept_id: conceptId,
+          body_markdown: `# capsule fetch ${detailCalls}`,
+        };
+      },
+    };
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport, graphAdapter });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-graph-view='knowledge']") !== null);
+      (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") !== null);
+
+      // Start the capsule fetch, then let an accepted refresh land while it
+      // is still in flight.
+      (root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") as HTMLButtonElement).click();
+      await flushUntil(() => detailCalls === 1);
+      transport.emit({
+        schema_version: schemaVersionV1(),
+        cursor: { sequence: 30, partition: "events" },
+        entity_ref: { kind: "unknown", id: "memory-graph:local-default" },
+        event_kind: "memory_graph_updated",
+        emitted_at: "2026-06-28T00:02:00Z",
+        payload: {
+          schema_version: schemaVersionV1(),
+          bundle_id: "local-default",
+          cursor: { sequence: 2, partition: "memory-graph:local-default" },
+          updated_at: "2026-06-28T00:02:00Z",
+        },
+      });
+      await flushUntil(() => snapshotReads === 2);
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-status']")?.textContent?.includes("Graph warnings") ?? false);
+
+      // The pre-refresh response must be discarded and refetched, not
+      // written back over the invalidated cache.
+      releaseFirstDetail?.();
+      await flushUntil(() =>
+        root.querySelector("[data-testid='knowledge-graph-capsule-body']")?.textContent?.includes("capsule fetch 2") ?? false,
+      );
+      expect(detailCalls).toBe(2);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("navigates memory deep links into a drilled capsule and steps back out with Escape", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
@@ -1186,6 +1264,14 @@ describe("OpenSymphonyApp mount", () => {
       // Community deep links drill straight into the area.
       expect(await handle.openMemoryDeepLink("opensymphony://memory/viz-workbench/communities/area%3Agateway")).toBe(true);
       await flushUntil(() => breadcrumb().includes("Gateway"));
+
+      // A community deep link into the already-drilled area lands on the
+      // area view: the stale capsule selection is cleared, not kept.
+      expect(await handle.openMemoryDeepLink("opensymphony://memory/viz-workbench/concepts/concepts/gateway-01")).toBe(true);
+      await flushUntil(() => breadcrumb().includes("Gateway DTO Boundary Checklist"));
+      expect(await handle.openMemoryDeepLink("opensymphony://memory/viz-workbench/communities/area%3Agateway")).toBe(true);
+      await flushUntil(() => !breadcrumb().includes("Gateway DTO Boundary Checklist"));
+      expect(breadcrumb()).toContain("Gateway");
     } finally {
       await handle.destroy();
     }

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -10,7 +10,12 @@ import {
   computeGraphLayout,
   createFixtureGraphAdapter,
   createScaleGraphSnapshot,
+  fixtureConceptDetail,
   fixtureGraphSnapshot,
+  graphVizFixtureBundleList,
+  graphVizFixtureCommunityList,
+  graphVizFixtureConceptDetail,
+  graphVizFixtureSnapshot,
   initialGraphState,
   type GraphDataAdapter,
 } from "@opensymphony/graph";
@@ -21,6 +26,7 @@ import {
   mountKnowledgeGraphRenderer,
   renderKnowledgeGraphSurface,
 } from "../src/knowledge-graph-renderer.js";
+import { hitTestHull, hitTestScene, type GraphScene } from "../src/knowledge-graph-scene.js";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type {
@@ -1037,6 +1043,145 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("renders the selected concept's memory capsule and follows capsule links", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+      graphAdapter: createFixtureGraphAdapter(),
+    });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-node-id='desktop-alpha']") !== null);
+      (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") !== null);
+
+      (root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule-body']") !== null);
+
+      const capsule = root.querySelector("[data-testid='knowledge-graph-capsule']");
+      expect(capsule?.textContent).toContain("Shared graph frontend package and reducers");
+      expect(capsule?.textContent).toContain("issue: COE-465");
+      expect(fixtureConceptDetail.links[0]?.target).toBe("tag:graph-view");
+
+      // The capsule carries a copyable deep link to itself.
+      const copy = root.querySelector<HTMLButtonElement>("[data-testid='knowledge-graph-copy-deeplink']");
+      expect(copy?.dataset.kgCopyDeeplink).toBe("opensymphony://memory/local-default/concepts/issues/COE-465");
+
+      // Breadcrumb reflects the drill trail back to the atlas.
+      expect(root.querySelector("[data-testid='knowledge-graph-breadcrumb']")?.textContent).toContain("COE-465");
+
+      // Following a capsule link selects the linked node.
+      (root.querySelector("[data-kg-link-target='tag:graph-view']") as HTMLButtonElement).click();
+      await flushUntil(() =>
+        root.querySelector("[data-testid='knowledge-graph-inspector'] h3")?.textContent === "graph-view",
+      );
+      expect(root.querySelector("[data-testid='knowledge-graph-inspector'] dl")?.textContent).toContain("tag");
+    } finally {
+      await handle.destroy();
+    }
+  });
+
+  it("surfaces capsule fetch failures with a retry that recovers", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    let failures = 1;
+    const graphAdapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      async getConceptDetail(bundleId, conceptId) {
+        if (failures > 0) {
+          failures -= 1;
+          throw new Error("capsule endpoint offline");
+        }
+        return { ...fixtureConceptDetail, bundle_id: bundleId, concept_id: conceptId };
+      },
+    };
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+      graphAdapter,
+    });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-node-id='desktop-alpha']") !== null);
+      (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") !== null);
+
+      (root.querySelector(".os-kg-list [data-kg-node-id='concept:coe-465']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule-error']") !== null);
+      expect(root.querySelector("[data-testid='knowledge-graph-capsule-error']")?.textContent).toContain("capsule endpoint offline");
+
+      (root.querySelector("[data-testid='knowledge-graph-capsule-retry']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule-body']") !== null);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
+  it("navigates memory deep links into a drilled capsule and steps back out with Escape", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport(),
+      graphAdapter: createFixtureGraphAdapter({
+        bundles: graphVizFixtureBundleList,
+        snapshot: graphVizFixtureSnapshot,
+        communities: graphVizFixtureCommunityList,
+        conceptDetail: (_bundleId, conceptId) => graphVizFixtureConceptDetail(conceptId),
+      }),
+    });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-node-id='desktop-alpha']") !== null);
+
+      expect(await handle.openMemoryDeepLink("not-a-deep-link")).toBe(false);
+      expect(await handle.openMemoryDeepLink("opensymphony://memory/viz-workbench/concepts/missing")).toBe(false);
+
+      const opened = await handle.openMemoryDeepLink(
+        "opensymphony://memory/viz-workbench/concepts/concepts/code-intelligence-01",
+      );
+      expect(opened).toBe(true);
+
+      // The deep link lands on the Knowledge Graph pane, drilled into the
+      // concept's area with the capsule open.
+      expect(root.querySelector("[data-testid='graph-hero']")?.getAttribute("data-active-graph-surface")).toBe("knowledge");
+      const breadcrumb = () => root.querySelector("[data-testid='knowledge-graph-breadcrumb']")?.textContent ?? "";
+      expect(breadcrumb()).toContain("Code Intelligence");
+      expect(breadcrumb()).toContain("Tree-sitter Provider Skeleton");
+      expect(root.querySelector("[data-testid='knowledge-graph-inspector'] h3")?.textContent)
+        .toBe("Tree-sitter Provider Skeleton");
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule-body']") !== null);
+      expect(root.querySelector("[data-testid='knowledge-graph-capsule-body']")?.textContent).toContain("Summary");
+
+      // The drilled view is filtered to the area's primary members (a
+      // multi-area concept keeps its primary community in metrics).
+      const areaConceptCount = graphVizFixtureSnapshot.nodes
+        .filter((node) => node.metrics.community_id === "area:code-intelligence").length;
+      expect(root.querySelectorAll("[data-testid='knowledge-graph-node-list'] li").length).toBe(areaConceptCount);
+
+      // Escape pops one level at a time: capsule → area → atlas.
+      root.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      await flushUntil(() => !breadcrumb().includes("Tree-sitter Provider Skeleton"));
+      expect(breadcrumb()).toContain("Code Intelligence");
+
+      root.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-breadcrumb']") === null);
+      expect(root.querySelectorAll("[data-testid='knowledge-graph-node-list'] li").length)
+        .toBe(graphVizFixtureSnapshot.nodes.length);
+
+      // Community deep links drill straight into the area.
+      expect(await handle.openMemoryDeepLink("opensymphony://memory/viz-workbench/communities/area%3Agateway")).toBe(true);
+      await flushUntil(() => breadcrumb().includes("Gateway"));
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("refreshes the Knowledge Graph on memory_graph_updated events", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
@@ -1164,6 +1309,63 @@ describe("OpenSymphonyApp mount", () => {
       } else {
         delete (globalThis as { cancelAnimationFrame?: typeof cancelAnimationFrame }).cancelAnimationFrame;
       }
+      root.remove();
+    }
+  });
+
+  it("drills into an area when a stationary click lands on its cloud", () => {
+    const root = document.createElement("div");
+    const layout = computeGraphLayout(graphVizFixtureSnapshot, { kind: "force", width: 1280, height: 900 });
+    root.innerHTML = renderKnowledgeGraphSurface({
+      snapshot: graphVizFixtureSnapshot,
+      layout,
+      state: { ...initialGraphState, layoutStatus: "ready" },
+    });
+    document.body.appendChild(root);
+    const onSelectArea = jest.fn();
+    try {
+      mountKnowledgeGraphRenderer(root, {
+        snapshot: graphVizFixtureSnapshot,
+        layout,
+        selectedNodeIds: [],
+        view: createKnowledgeGraphViewState(),
+        onSelect: jest.fn(),
+        onFocus: jest.fn(),
+        onSelectArea,
+      });
+      const canvas = root.querySelector<HTMLCanvasElement>("[data-testid='knowledge-graph-canvas']")!;
+      const scene = (canvas as HTMLCanvasElement & { __kgDebug?: { scene: GraphScene } }).__kgDebug!.scene;
+      expect(scene.hulls.length).toBeGreaterThan(0);
+
+      // Find a point that lies on an area cloud but not on any node, so the
+      // click resolves as a drill instead of a node selection.
+      let target: { x: number; y: number; areaId: string } | null = null;
+      for (let y = 4; y < 360 && !target; y += 8) {
+        for (let x = 4; x < 640 && !target; x += 8) {
+          const hull = hitTestHull(scene, x, y);
+          if (hull && hull.labelAlpha > 0.05 && hitTestScene(scene, x, y) === null) {
+            target = { x, y, areaId: hull.areaId };
+          }
+        }
+      }
+      expect(target).not.toBeNull();
+
+      // jsdom does not route dispatched pointer events through on* handler
+      // properties, so invoke the renderer's handlers directly.
+      const pointer = (type: string, x: number, y: number) =>
+        new MouseEvent(type, { clientX: x, clientY: y, button: 0, bubbles: true }) as PointerEvent;
+      canvas.onpointerdown!(pointer("pointerdown", target!.x, target!.y));
+      canvas.onpointerup!(pointer("pointerup", target!.x, target!.y));
+      expect(onSelectArea).toHaveBeenCalledWith(target!.areaId);
+
+      // The same gesture with movement stays a pan and never drills.
+      onSelectArea.mockClear();
+      canvas.onpointerdown!(pointer("pointerdown", target!.x, target!.y));
+      canvas.onpointermove!(pointer("pointermove", target!.x + 24, target!.y + 18));
+      canvas.onpointerup!(pointer("pointerup", target!.x + 24, target!.y + 18));
+      expect(onSelectArea).not.toHaveBeenCalled();
+    } finally {
+      disposeKnowledgeGraphRenderer(root);
       root.remove();
     }
   });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1080,12 +1080,14 @@ describe("OpenSymphonyApp mount", () => {
       // Breadcrumb reflects the drill trail back to the atlas.
       expect(root.querySelector("[data-testid='knowledge-graph-breadcrumb']")?.textContent).toContain("COE-465");
 
-      // Following a capsule link selects the linked node.
+      // Following a capsule link selects the linked node and drills into
+      // its area, even when starting from the atlas.
       (root.querySelector("[data-kg-link-target='tag:graph-view']") as HTMLButtonElement).click();
       await flushUntil(() =>
         root.querySelector("[data-testid='knowledge-graph-inspector'] h3")?.textContent === "graph-view",
       );
       expect(root.querySelector("[data-testid='knowledge-graph-inspector'] dl")?.textContent).toContain("tag");
+      expect(root.querySelector("[data-testid='knowledge-graph-breadcrumb']")?.textContent).toContain("Graph View");
     } finally {
       await handle.destroy();
     }
@@ -1165,11 +1167,11 @@ describe("OpenSymphonyApp mount", () => {
       await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule-body']") !== null);
       expect(root.querySelector("[data-testid='knowledge-graph-capsule-body']")?.textContent).toContain("Summary");
 
-      // The drilled view is filtered to the area's primary members (a
-      // multi-area concept keeps its primary community in metrics).
-      const areaConceptCount = graphVizFixtureSnapshot.nodes
-        .filter((node) => node.metrics.community_id === "area:code-intelligence").length;
-      expect(root.querySelectorAll("[data-testid='knowledge-graph-node-list'] li").length).toBe(areaConceptCount);
+      // The drilled view is filtered to the area's full membership,
+      // including multi-area concepts whose primary community differs.
+      const areaMemberCount = graphVizFixtureSnapshot.communities
+        .find((community) => community.id === "area:code-intelligence")!.node_ids.length;
+      expect(root.querySelectorAll("[data-testid='knowledge-graph-node-list'] li").length).toBe(areaMemberCount);
 
       // Escape pops one level at a time: capsule → area → atlas.
       root.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1370,6 +1370,20 @@ describe("OpenSymphonyApp mount", () => {
       canvas.onpointermove!(pointer("pointermove", target!.x + 24, target!.y + 18));
       canvas.onpointerup!(pointer("pointerup", target!.x + 24, target!.y + 18));
       expect(onSelectArea).not.toHaveBeenCalled();
+
+      // Option-drag orbits grab the scene: dragging right/down swings the
+      // camera the opposite way (yaw and pitch decrease), so the scene
+      // follows the cursor instead of moving against it.
+      const view = (canvas as HTMLCanvasElement & { __kgDebug?: { camera: { yaw: number; pitch: number } } }).__kgDebug!;
+      const before = { ...view.camera };
+      const orbitPointer = (type: string, x: number, y: number) =>
+        new MouseEvent(type, { clientX: x, clientY: y, button: 0, altKey: true, bubbles: true }) as PointerEvent;
+      canvas.onpointerdown!(orbitPointer("pointerdown", target!.x, target!.y));
+      canvas.onpointermove!(orbitPointer("pointermove", target!.x + 40, target!.y + 30));
+      canvas.onpointerup!(orbitPointer("pointerup", target!.x + 40, target!.y + 30));
+      const after = (canvas as HTMLCanvasElement & { __kgDebug?: { camera: { yaw: number; pitch: number } } }).__kgDebug!.camera;
+      expect(after.yaw).toBeLessThan(before.yaw);
+      expect(after.pitch).toBeLessThan(before.pitch);
     } finally {
       disposeKnowledgeGraphRenderer(root);
       root.remove();

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1371,9 +1371,10 @@ describe("OpenSymphonyApp mount", () => {
       canvas.onpointerup!(pointer("pointerup", target!.x + 24, target!.y + 18));
       expect(onSelectArea).not.toHaveBeenCalled();
 
-      // Option-drag orbits grab the scene: dragging right/down swings the
-      // camera the opposite way (yaw and pitch decrease), so the scene
-      // follows the cursor instead of moving against it.
+      // Option-drag orbits grab the scene: dragging right swings the scene
+      // right (yaw decreases, inverted from the raw delta) while dragging
+      // down tilts it down (pitch follows the raw delta) — tuned by feel,
+      // see the orbit handler comment.
       const view = (canvas as HTMLCanvasElement & { __kgDebug?: { camera: { yaw: number; pitch: number } } }).__kgDebug!;
       const before = { ...view.camera };
       const orbitPointer = (type: string, x: number, y: number) =>
@@ -1383,7 +1384,7 @@ describe("OpenSymphonyApp mount", () => {
       canvas.onpointerup!(orbitPointer("pointerup", target!.x + 40, target!.y + 30));
       const after = (canvas as HTMLCanvasElement & { __kgDebug?: { camera: { yaw: number; pitch: number } } }).__kgDebug!.camera;
       expect(after.yaw).toBeLessThan(before.yaw);
-      expect(after.pitch).toBeLessThan(before.pitch);
+      expect(after.pitch).toBeGreaterThan(before.pitch);
     } finally {
       disposeKnowledgeGraphRenderer(root);
       root.remove();

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1394,6 +1394,29 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("renders capsule citations as navigable graph links", () => {
+    const concept = graphVizFixtureSnapshot.nodes.find(
+      (node) => node.kind === "concept" && (graphVizFixtureConceptDetail(node.concept_id!)?.citations.length ?? 0) > 0,
+    );
+    expect(concept).toBeDefined();
+    const detail = graphVizFixtureConceptDetail(concept!.concept_id!)!;
+    const html = renderKnowledgeGraphInspector({
+      snapshot: graphVizFixtureSnapshot,
+      layout: null,
+      state: { ...initialGraphState, selectedNodeIds: [concept!.id] },
+      conceptDetail: detail,
+    });
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    const citationButtons = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-testid='knowledge-graph-capsule-citations'] [data-kg-link-target]"),
+    );
+    expect(citationButtons.length).toBe(detail.citations.length);
+    expect(citationButtons.map((button) => button.dataset.kgLinkTarget)).toEqual(
+      detail.citations.map((citation) => citation.target),
+    );
+  });
+
   it("flags only truncated entity-list names for the instant hover tooltip", () => {
     const root = document.createElement("div");
     root.innerHTML = renderKnowledgeGraphNodeList(fixtureGraphSnapshot, []);

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1130,6 +1130,60 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("resolves deep links whose bundle is queued behind an in-flight graph load", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const bundleB = {
+      ...fixtureGraphSnapshot,
+      bundle_id: "bundle-b",
+      cursor: { sequence: 1, partition: "memory-graph:bundle-b" },
+      nodes: fixtureGraphSnapshot.nodes.map((node) => ({ ...node, bundle_id: "bundle-b" })),
+    };
+    let releaseFirstSnapshot: (() => void) | null = null;
+    const firstSnapshotGate = new Promise<void>((resolve) => {
+      releaseFirstSnapshot = resolve;
+    });
+    let snapshotCalls = 0;
+    const graphAdapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      async listBundles() {
+        return {
+          schema_version: schemaVersionV1(),
+          bundles: [
+            { id: "local-default", title: "Default", okf_version: "0.1", visibility: "private" as const, concept_count: 1 },
+            { id: "bundle-b", title: "Bundle B", okf_version: "0.1", visibility: "private" as const, concept_count: 1 },
+          ],
+        };
+      },
+      async getGraphSnapshot(bundleId) {
+        snapshotCalls += 1;
+        if (snapshotCalls === 1) await firstSnapshotGate;
+        return bundleId === "bundle-b" ? bundleB : fixtureGraphSnapshot;
+      },
+      async getConceptDetail(bundleId, conceptId) {
+        return { ...fixtureConceptDetail, bundle_id: bundleId, concept_id: conceptId };
+      },
+    };
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport: buildTransport(), graphAdapter });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-graph-view='knowledge']") !== null);
+      // Opening the pane starts a default-bundle load; the deep link lands
+      // while that load is still in flight, so its bundle gets queued.
+      (root.querySelector("[data-graph-view='knowledge']") as HTMLButtonElement).click();
+      const openPromise = handle.openMemoryDeepLink("opensymphony://memory/bundle-b/concepts/issues/COE-465");
+      await flushAsync();
+      releaseFirstSnapshot?.();
+
+      expect(await openPromise).toBe(true);
+      expect(root.querySelector("[data-testid='knowledge-graph-inspector'] h3")?.textContent)
+        .toContain("COE-465");
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule-body']") !== null);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("discards in-flight capsule responses superseded by an accepted graph refresh", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
@@ -1478,6 +1532,72 @@ describe("OpenSymphonyApp mount", () => {
       disposeKnowledgeGraphRenderer(root);
       root.remove();
     }
+  });
+
+  it("resolves relative markdown capsule link targets against snapshot nodes", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    // OKF capsules can store link targets verbatim as relative markdown
+    // paths ("../concepts/x.md"); the graph snapshot only knows the
+    // resolved concept id ("concepts/x").
+    const graphAdapter = createFixtureGraphAdapter({
+      bundles: graphVizFixtureBundleList,
+      snapshot: graphVizFixtureSnapshot,
+      communities: graphVizFixtureCommunityList,
+      conceptDetail: (_bundleId, conceptId) => {
+        const detail = graphVizFixtureConceptDetail(conceptId);
+        if (!detail) return null;
+        return {
+          ...detail,
+          links: detail.links.map((link) => ({ ...link, target: `../${link.target}.md` })),
+        };
+      },
+    });
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport: buildTransport(), graphAdapter });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-node-id='desktop-alpha']") !== null);
+      expect(await handle.openMemoryDeepLink(
+        "opensymphony://memory/viz-workbench/concepts/concepts/code-intelligence-01",
+      )).toBe(true);
+      await flushUntil(() => root.querySelector("[data-testid='knowledge-graph-capsule'] [data-kg-link-target^='../']") !== null);
+
+      const link = root.querySelector<HTMLElement>("[data-testid='knowledge-graph-capsule'] [data-kg-link-target^='../']")!;
+      const target = link.dataset.kgLinkTarget!;
+      const resolvedConceptId = target.replace(/^(\.\.\/)+/, "").replace(/\.md$/, "");
+      const expectedLabel = graphVizFixtureSnapshot.nodes.find((node) => node.concept_id === resolvedConceptId)!.label;
+
+      link.click();
+      await flushUntil(() =>
+        root.querySelector("[data-testid='knowledge-graph-inspector'] h3")?.textContent === expectedLabel,
+      );
+    } finally {
+      await handle.destroy();
+    }
+  });
+
+  it("renders URL citation targets as external links, not graph buttons", () => {
+    const concept = fixtureGraphSnapshot.nodes.find((node) => node.kind === "concept")!;
+    const html = renderKnowledgeGraphInspector({
+      snapshot: fixtureGraphSnapshot,
+      layout: null,
+      state: { ...initialGraphState, selectedNodeIds: [concept.id] },
+      conceptDetail: {
+        ...fixtureConceptDetail,
+        citations: [
+          { id: "1", target: "https://linear.app/x/issue/COE-200", label: "COE-200" },
+          { id: "2", target: "issues/COE-465", label: "in-graph citation" },
+        ],
+      },
+    });
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    const citations = root.querySelector("[data-testid='knowledge-graph-capsule-citations']")!;
+    const anchor = citations.querySelector("a")!;
+    expect(anchor.getAttribute("href")).toBe("https://linear.app/x/issue/COE-200");
+    expect(anchor.textContent).toBe("COE-200");
+    const buttons = Array.from(citations.querySelectorAll<HTMLElement>("[data-kg-link-target]"));
+    expect(buttons.map((button) => button.dataset.kgLinkTarget)).toEqual(["issues/COE-465"]);
   });
 
   it("renders capsule citations as navigable graph links", () => {

--- a/packages/ui-core/__tests__/memory-markdown.test.ts
+++ b/packages/ui-core/__tests__/memory-markdown.test.ts
@@ -48,4 +48,22 @@ describe("renderMemoryMarkdown", () => {
     expect(attr).not.toContain("<img");
     expect(attr).toContain("&gt;");
   });
+
+  it("never reprocesses generated HTML with later inline passes", () => {
+    // A wiki target containing markdown-link syntax must land verbatim in
+    // the attribute, not be rewritten into a nested anchor.
+    const html = renderMemoryMarkdown("[[foo [docs](https://example.com)]]");
+    expect(html).toContain(`data-kg-link-target="foo [docs](https://example.com)"`);
+    expect(html).not.toContain("<a ");
+
+    // Bold/code markers inside link labels and hrefs also stay verbatim.
+    const bold = renderMemoryMarkdown("[**label**](https://example.com/a**b**c)");
+    expect(bold).toContain(`href="https://example.com/a**b**c"`);
+    expect(bold).not.toContain("<strong>");
+
+    // Stray NUL bytes in the source cannot alias placeholder tokens.
+    const nul = renderMemoryMarkdown("a\u00001\u0000b **x**");
+    expect(nul).toContain("a1b");
+    expect(nul).toContain("<strong>x</strong>");
+  });
 });

--- a/packages/ui-core/__tests__/memory-markdown.test.ts
+++ b/packages/ui-core/__tests__/memory-markdown.test.ts
@@ -66,4 +66,22 @@ describe("renderMemoryMarkdown", () => {
     expect(nul).toContain("a1b");
     expect(nul).toContain("<strong>x</strong>");
   });
+
+  it("keeps code span content literal against other inline syntax", () => {
+    // Code spans run first: markdown-looking content inside backticks must
+    // render as literal code, never as placeholders or nested markup.
+    const bold = renderMemoryMarkdown("run `**flag**` now");
+    expect(bold).toContain("<code>**flag**</code>");
+    expect(bold).not.toContain("\u0000");
+    expect(bold).not.toContain("<strong>");
+
+    const link = renderMemoryMarkdown("see `[docs](https://example.com)` here");
+    expect(link).toContain("<code>[docs](https://example.com)</code>");
+    expect(link).not.toContain("<a ");
+
+    // Placeholders nested inside later-stashed fragments still resolve.
+    const nested = renderMemoryMarkdown("[[target `code` name]] and `x`");
+    expect(nested).not.toContain("\u0000");
+    expect(nested).toContain("<code>x</code>");
+  });
 });

--- a/packages/ui-core/__tests__/memory-markdown.test.ts
+++ b/packages/ui-core/__tests__/memory-markdown.test.ts
@@ -1,0 +1,51 @@
+import { renderMemoryMarkdown } from "../src/memory-markdown.js";
+
+describe("renderMemoryMarkdown", () => {
+  it("renders headings, paragraphs, and lists at inspector scale", () => {
+    const html = renderMemoryMarkdown([
+      "## Summary",
+      "",
+      "First line",
+      "continued line.",
+      "",
+      "- item one",
+      "- item two",
+      "",
+      "# Top",
+      "### Deep",
+    ].join("\n"));
+    expect(html).toContain("<h5>Summary</h5>");
+    expect(html).toContain("<p>First line continued line.</p>");
+    expect(html).toContain("<ul><li>item one</li><li>item two</li></ul>");
+    expect(html).toContain("<h4>Top</h4>");
+    expect(html).toContain("<h6>Deep</h6>");
+  });
+
+  it("escapes HTML before reintroducing allowlisted constructs", () => {
+    const html = renderMemoryMarkdown("<script>alert(1)</script> **bold** `code`");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<code>code</code>");
+  });
+
+  it("renders wiki links as graph navigation buttons", () => {
+    const html = renderMemoryMarkdown("Links to [[issues/COE-399]] inline.");
+    expect(html).toContain(`data-kg-link-target="issues/COE-399"`);
+    expect(html).toContain(">COE-399</button>");
+  });
+
+  it("allows only http(s) markdown links and neutralizes everything else", () => {
+    const safe = renderMemoryMarkdown("[docs](https://example.com/a?b=1)");
+    expect(safe).toContain(`<a href="https://example.com/a?b=1" target="_blank" rel="noreferrer">docs</a>`);
+
+    // Non-http(s) schemes stay inert plain text: no anchor, no href.
+    const hostile = renderMemoryMarkdown("[x](javascript:alert(1))");
+    expect(hostile).not.toContain("<a ");
+    expect(hostile).not.toContain("href");
+
+    const attr = renderMemoryMarkdown(`[["><img src=x onerror=alert(1)>]]`);
+    expect(attr).not.toContain("<img");
+    expect(attr).toContain("&gt;");
+  });
+});

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -5029,10 +5029,13 @@ function appShellStyles(): string {
     .os-kg-tooltip em { color: #23566f; font-size: 11px; font-style: normal; }
     .os-kg-controls-hint { position: absolute; right: 8px; bottom: 6px; color: #8a97a3; font-size: 10.5px; letter-spacing: 0.02em; pointer-events: none; user-select: none; }
     .os-kg-list { display: grid; gap: 5px; list-style: none; margin: 0; padding: 0; max-height: 160px; overflow: auto; }
-    .os-kg-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; border: 1px solid #d8dee4; border-radius: 6px; padding: 6px 8px; background: #ffffff; }
+    .os-kg-list li { position: relative; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; border: 1px solid #d8dee4; border-radius: 6px; padding: 5px 8px; background: #ffffff; }
     .os-kg-list li.is-selected { border-color: #c2410c; background: #fff7ed; }
-    .os-kg-list button { min-width: 0; min-height: 24px; padding: 0; border: none; background: transparent; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .os-kg-list span { color: #667788; font-size: 11px; text-transform: uppercase; }
+    .os-kg-list button { min-width: 0; min-height: 22px; padding: 0; border: none; background: transparent; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11.5px; }
+    .os-kg-list span { color: #667788; font-size: 10px; text-transform: uppercase; }
+    /* Truncated entity names surface instantly on hover (data-kg-overflow is
+       set only for rows that actually ellipsize; title stays as fallback). */
+    .os-kg-list button[data-kg-overflow]:hover::after { content: attr(data-kg-overflow); position: absolute; left: 4px; top: calc(100% + 2px); z-index: 40; max-width: min(320px, 90vw); white-space: normal; background: #1d2833; color: #f2f7fb; font-size: 11.5px; line-height: 1.35; padding: 4px 8px; border-radius: 5px; box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25); pointer-events: none; }
     .os-kg-inspector { border: 1px solid #d8dee4; border-radius: 6px; padding: 8px 10px; background: #ffffff; }
     .os-kg-inspector h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0; }
     .os-kg-inspector dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 10px; margin: 0; }
@@ -5342,6 +5345,7 @@ function appShellStyles(): string {
       .os-kg-list li.is-selected button, .os-kg-inspector h3, .os-kg-inspector dd { color: #f2f7fb; }
       .os-kg-list li.is-selected span { color: #fdba74; }
       .os-kg-inspector dt, .os-kg-inspector p { color: #94a3b3; }
+      .os-kg-list button[data-kg-overflow]:hover::after { background: #2a3542; color: #f2f7fb; box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55); }
       .os-kg-breadcrumb button, .os-kg-capsule-link { color: #8bd0e6; }
       .os-kg-breadcrumb span[aria-current] { color: #f2f7fb; }
       .os-kg-crumb-sep { color: #5b6b7a; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -2664,13 +2664,21 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   /** Drill into an area cloud: community mode filtered to that area's members. */
   private drillIntoKnowledgeArea(areaId: string): void {
     const graph = this.state.knowledgeGraph;
-    if (graph.mode === "community" && graph.filters.communities.length === 1 && graph.filters.communities[0] === areaId) {
+    const alreadyDrilled = graph.mode === "community"
+      && graph.filters.communities.length === 1
+      && graph.filters.communities[0] === areaId;
+    if (alreadyDrilled && graph.selectedNodeIds.length === 0 && graph.focusedNodeId === null) {
       return;
     }
+    // Re-drilling into the current area still clears selection/focus (the
+    // requested destination is the area view, not the open capsule) — it
+    // just skips the redundant filter change and relayout.
     this.state.knowledgeGraph = graphReducer(graph, { type: "NODE_FOCUSED", nodeId: null });
     this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [] });
-    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: areaId });
-    this.invalidateKnowledgeGraphLayout();
+    if (!alreadyDrilled) {
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: areaId });
+      this.invalidateKnowledgeGraphLayout();
+    }
     this.render();
   }
 
@@ -2771,13 +2779,26 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const key = `${bundleId}:${conceptId}`;
     if (this.knowledgeCapsuleRequest === key || this.knowledgeCapsuleError?.key === key) return;
     this.knowledgeCapsuleRequest = key;
+    // Snapshot generation guard: an accepted refresh while this request is
+    // in flight invalidates the bundle's capsule cache, and this response
+    // may predate the refresh — writing it back would pin stale markdown
+    // against the current graph. Discard it instead; the follow-up render
+    // refetches against the new snapshot.
+    const cursorBefore = graph.snapshots[bundleId]?.cursor;
     try {
       const detail = await this.graphAdapter.getConceptDetail(bundleId, conceptId);
       if (this.destroyed) return;
-      // Cache under the id we asked for: a server echoing an alias id would
-      // otherwise miss the cache and refetch on every render.
-      const normalized = detail.concept_id === conceptId ? detail : { ...detail, concept_id: conceptId };
-      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "CONCEPT_DETAIL_LOADED", detail: normalized });
+      const cursorAfter = this.state.knowledgeGraph.snapshots[bundleId]?.cursor;
+      const superseded = cursorBefore === undefined
+        || cursorAfter === undefined
+        || cursorAfter.partition !== cursorBefore.partition
+        || cursorAfter.sequence !== cursorBefore.sequence;
+      if (!superseded) {
+        // Cache under the id we asked for: a server echoing an alias id
+        // would otherwise miss the cache and refetch on every render.
+        const normalized = detail.concept_id === conceptId ? detail : { ...detail, concept_id: conceptId };
+        this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "CONCEPT_DETAIL_LOADED", detail: normalized });
+      }
     } catch (error) {
       if (this.destroyed) return;
       this.knowledgeCapsuleError = { key, message: errorMessage(error) };

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -24,16 +24,21 @@ import type {
   MemoryGraphUpdatedEvent,
 } from "@opensymphony/gateway-schema";
 import {
+  cachedConceptDetail,
   createGraphLayoutAdapter,
   createInitialGraphState,
   graphLayoutKindForMode,
   graphReducer,
   currentGraphSnapshot,
+  parseMemoryDeepLink,
+  resolveMemoryDeepLinkNode,
   visibleGraphSnapshot,
   type GraphDataAdapter,
   type GraphLayoutAdapter,
   type GraphLayoutResult,
   type GraphState,
+  type MemoryConceptDetail,
+  type MemoryGraphNode,
 } from "@opensymphony/graph";
 import {
   authStateFromError,
@@ -184,6 +189,14 @@ export interface OpenSymphonyAppOptions {
 export interface OpenSymphonyAppHandle {
   refresh(): Promise<void>;
   destroy(): Promise<void>;
+  /**
+   * Navigate to a memory deep link (opensymphony://memory/...): switches to
+   * the Knowledge Graph pane, loads the linked bundle, drills into the
+   * community, and selects the linked concept capsule. Resolves false when
+   * the link does not parse or its target is not present in the graph.
+   * External surfaces (task graph artifacts, notifications) call this.
+   */
+  openMemoryDeepLink(url: string): Promise<boolean>;
 }
 
 type ConnectionMode = "connecting" | "connected" | "failed";
@@ -309,6 +322,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private graphLayoutRun = 0;
   private knowledgeGraphView: KnowledgeGraphViewState = createKnowledgeGraphViewState();
   private knowledgeGraphLayoutSize: { width: number; height: number } | null = null;
+  /** Concept-detail request currently in flight, keyed `${bundleId}:${conceptId}`. */
+  private knowledgeCapsuleRequest: string | null = null;
+  /** Last failed concept-detail request; keyed so a new selection is unaffected. */
+  private knowledgeCapsuleError: { key: string; message: string } | null = null;
   /**
    * Monotonic counter bumped by every user-initiated navigation (task click,
    * project switch, diff-file click, full refresh). Background work snapshots
@@ -397,8 +414,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       return;
     }
     const graph = this.state.knowledgeGraph;
-    if (graph.mode !== "atlas" || graph.focusedNodeId || graph.selectedNodeIds.length > 0) {
-      this.resetKnowledgeGraphView();
+    if (
+      graph.mode !== "atlas"
+      || graph.focusedNodeId
+      || graph.selectedNodeIds.length > 0
+      || graph.filters.communities.length > 0
+    ) {
+      // Escape pops one drill level (concept → area → atlas) instead of
+      // jumping straight home; repeated presses still land on the atlas.
+      this.stepBackKnowledgeGraphView();
     }
   };
 
@@ -646,6 +670,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.knowledgeGraphLayoutSize = null;
     this.knowledgeGraphLoadInFlight = null;
     this.knowledgeGraphLoadQueuedBundleId = undefined;
+    this.knowledgeCapsuleRequest = null;
+    this.knowledgeCapsuleError = null;
     // A different bundle/gateway is different content: drop the camera and
     // any node drag overrides along with the graph state.
     this.knowledgeGraphView = createKnowledgeGraphViewState();
@@ -1168,6 +1194,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private bindKnowledgeGraph(): void {
     const root = this.options.root.querySelector<HTMLElement>("[data-testid='knowledge-graph-renderer']");
     if (!root) return;
+    this.bindKnowledgeGraphNavigation(root);
+    void this.ensureSelectedConceptDetail();
     const snapshot = visibleGraphSnapshot(this.state.knowledgeGraph);
     const stageSize = measureKnowledgeGraphStage(root);
     if (
@@ -1199,10 +1227,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "NODE_FOCUSED", nodeId });
         this.render();
         if (this.state.knowledgeGraph.mode !== "neighborhood") return;
-        this.state.knowledgeGraphLayout = null;
-        this.knowledgeGraphLayoutSize = null;
-        this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
-        this.scheduleKnowledgeGraphLayout();
+        this.invalidateKnowledgeGraphLayout();
+      },
+      onSelectArea: (areaId) => {
+        this.drillIntoKnowledgeArea(areaId);
       },
     });
   }
@@ -2251,6 +2279,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           snapshot: visibleGraphSnapshot(this.state.knowledgeGraph),
           layout: this.state.knowledgeGraphLayout,
           state: this.state.knowledgeGraph,
+          ...this.selectedKnowledgeCapsule(),
         })
         : this.renderCodeGraphPlaceholder();
     return `
@@ -2590,11 +2619,241 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "NODE_FOCUSED", nodeId: null });
     this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: "atlas" });
     this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [] });
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "FILTERS_SET", filters: { communities: [] } });
     this.state.knowledgeGraphLayout = null;
     this.knowledgeGraphLayoutSize = null;
     this.knowledgeGraphView.camera = null;
     this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
     this.render();
+  }
+
+  /**
+   * One drill level back: selected concept → its area, drilled area → the
+   * atlas. Bound to Escape so the same key that narrows never strands the
+   * operator; the "Show full graph" button still jumps straight home.
+   */
+  private stepBackKnowledgeGraphView(): void {
+    const graph = this.state.knowledgeGraph;
+    const drilled = graph.filters.communities.length > 0;
+    if (graph.selectedNodeIds.length > 0 || graph.focusedNodeId !== null) {
+      const wasNeighborhood = graph.mode === "neighborhood";
+      this.state.knowledgeGraph = graphReducer(graph, { type: "NODE_FOCUSED", nodeId: null });
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [] });
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: drilled ? "community" : "atlas" });
+      if (wasNeighborhood) {
+        this.invalidateKnowledgeGraphLayout();
+      }
+      this.render();
+      return;
+    }
+    if (drilled) {
+      this.state.knowledgeGraph = graphReducer(graph, { type: "FILTERS_SET", filters: { communities: [] } });
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: "atlas" });
+      this.invalidateKnowledgeGraphLayout();
+      this.render();
+      return;
+    }
+    this.resetKnowledgeGraphView();
+  }
+
+  /** Drill into an area cloud: community mode filtered to that area's members. */
+  private drillIntoKnowledgeArea(areaId: string): void {
+    const graph = this.state.knowledgeGraph;
+    if (graph.mode === "community" && graph.filters.communities.length === 1 && graph.filters.communities[0] === areaId) {
+      return;
+    }
+    this.state.knowledgeGraph = graphReducer(graph, { type: "NODE_FOCUSED", nodeId: null });
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [] });
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: areaId });
+    this.invalidateKnowledgeGraphLayout();
+    this.render();
+  }
+
+  /**
+   * Follow a capsule link (wiki link or the Linked concepts list) to its
+   * node. Targets arrive as node ids ("tag:x"), concept ids
+   * ("issues/COE-399"), bare issue keys, or labels — resolve in that order.
+   * Following a link across areas re-drills into the target's community so
+   * the selected node is always visible.
+   */
+  private openKnowledgeCapsuleLink(target: string): void {
+    const snapshot = currentGraphSnapshot(this.state.knowledgeGraph);
+    if (!snapshot) return;
+    const node = snapshot.nodes.find((candidate) => candidate.id === target)
+      ?? snapshot.nodes.find((candidate) => candidate.concept_id === target)
+      ?? snapshot.nodes.find((candidate) => candidate.concept_id?.split("/").at(-1) === target)
+      ?? snapshot.nodes.find((candidate) => candidate.label === target)
+      ?? null;
+    if (!node) return;
+    this.selectKnowledgeNode(node);
+  }
+
+  private selectKnowledgeNode(node: MemoryGraphNode): void {
+    const graph = this.state.knowledgeGraph;
+    const targetCommunity = node.metrics?.community_id ?? null;
+    const currentCommunity = graph.filters.communities[0] ?? null;
+    let relayout = false;
+    this.state.knowledgeGraph = graphReducer(graph, { type: "NODE_FOCUSED", nodeId: null });
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: currentCommunity || targetCommunity ? "community" : "atlas" });
+    if (currentCommunity !== null && targetCommunity !== null && currentCommunity !== targetCommunity) {
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: targetCommunity });
+      relayout = true;
+    } else if (currentCommunity !== null && targetCommunity === null) {
+      // Target lives outside every area (e.g. the bundle node): widen back out.
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "FILTERS_SET", filters: { communities: [] } });
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: "atlas" });
+      relayout = true;
+    }
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [node.id] });
+    if (relayout) {
+      this.invalidateKnowledgeGraphLayout();
+    }
+    this.render();
+  }
+
+  private invalidateKnowledgeGraphLayout(): void {
+    this.state.knowledgeGraphLayout = null;
+    this.knowledgeGraphLayoutSize = null;
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "LAYOUT_STATUS_SET", status: "idle" });
+    this.scheduleKnowledgeGraphLayout();
+  }
+
+  /** Selected concept's capsule detail + error, for the inspector render. */
+  private selectedKnowledgeCapsule(): { conceptDetail: MemoryConceptDetail | null; conceptDetailError: string | null } {
+    const graph = this.state.knowledgeGraph;
+    const bundleId = graph.selectedBundleId;
+    const node = this.selectedKnowledgeConcept();
+    if (!bundleId || !node?.concept_id) {
+      return { conceptDetail: null, conceptDetailError: null };
+    }
+    const key = `${bundleId}:${node.concept_id}`;
+    return {
+      conceptDetail: cachedConceptDetail(graph, bundleId, node.concept_id),
+      conceptDetailError: this.knowledgeCapsuleError?.key === key ? this.knowledgeCapsuleError.message : null,
+    };
+  }
+
+  private selectedKnowledgeConcept(): MemoryGraphNode | null {
+    const snapshot = currentGraphSnapshot(this.state.knowledgeGraph);
+    if (!snapshot) return null;
+    const selected = new Set(this.state.knowledgeGraph.selectedNodeIds);
+    return snapshot.nodes.find((node) => selected.has(node.id) && node.kind === "concept" && node.concept_id) ?? null;
+  }
+
+  /**
+   * Lazily fetch the selected concept's capsule. Idempotent per render:
+   * cached details and in-flight or failed requests are not re-requested (the
+   * failure is keyed, so selecting a different node retries cleanly and the
+   * inline Retry button clears it explicitly).
+   */
+  private async ensureSelectedConceptDetail(): Promise<void> {
+    const graph = this.state.knowledgeGraph;
+    const bundleId = graph.selectedBundleId;
+    const node = this.selectedKnowledgeConcept();
+    if (!this.graphAdapter || !bundleId || !node?.concept_id) return;
+    const conceptId = node.concept_id;
+    if (cachedConceptDetail(graph, bundleId, conceptId)) return;
+    const key = `${bundleId}:${conceptId}`;
+    if (this.knowledgeCapsuleRequest === key || this.knowledgeCapsuleError?.key === key) return;
+    this.knowledgeCapsuleRequest = key;
+    try {
+      const detail = await this.graphAdapter.getConceptDetail(bundleId, conceptId);
+      if (this.destroyed) return;
+      // Cache under the id we asked for: a server echoing an alias id would
+      // otherwise miss the cache and refetch on every render.
+      const normalized = detail.concept_id === conceptId ? detail : { ...detail, concept_id: conceptId };
+      this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "CONCEPT_DETAIL_LOADED", detail: normalized });
+    } catch (error) {
+      if (this.destroyed) return;
+      this.knowledgeCapsuleError = { key, message: errorMessage(error) };
+    } finally {
+      if (this.knowledgeCapsuleRequest === key) {
+        this.knowledgeCapsuleRequest = null;
+      }
+    }
+    this.render();
+  }
+
+  /**
+   * Idempotent property handlers (the DOM morph preserves elements across
+   * renders) for the drill affordances that live outside the canvas:
+   * breadcrumbs, capsule links, capsule retry, and the deep-link copy button.
+   */
+  private bindKnowledgeGraphNavigation(root: HTMLElement): void {
+    root.querySelectorAll<HTMLElement>("[data-kg-crumb]").forEach((button) => {
+      button.onclick = () => {
+        if (button.dataset.kgCrumb === "atlas") {
+          this.resetKnowledgeGraphView();
+        } else {
+          this.stepBackKnowledgeGraphView();
+        }
+      };
+    });
+    root.querySelectorAll<HTMLElement>("[data-kg-link-target]").forEach((button) => {
+      button.onclick = () => {
+        const target = button.dataset.kgLinkTarget;
+        if (target) this.openKnowledgeCapsuleLink(target);
+      };
+    });
+    const retry = root.querySelector<HTMLElement>("[data-kg-capsule-retry]");
+    if (retry) {
+      retry.onclick = () => {
+        this.knowledgeCapsuleError = null;
+        void this.ensureSelectedConceptDetail();
+        this.render();
+      };
+    }
+    const copy = root.querySelector<HTMLButtonElement>("[data-kg-copy-deeplink]");
+    if (copy) {
+      copy.onclick = () => {
+        const link = copy.dataset.kgCopyDeeplink;
+        if (!link) return;
+        void navigator.clipboard?.writeText(link).catch(() => undefined);
+        copy.textContent = "Copied";
+        setTimeout(() => {
+          if (copy.isConnected) copy.textContent = "Copy deep link";
+        }, 1_200);
+      };
+    }
+  }
+
+  async openMemoryDeepLink(url: string): Promise<boolean> {
+    const link = parseMemoryDeepLink(url);
+    if (!link || !this.graphAdapter) return false;
+    this.state.activeView = "dashboard";
+    this.state.graphPaneView = "knowledge";
+    await this.loadKnowledgeGraph(link.bundleId);
+    if (this.destroyed) return false;
+    const snapshot = currentGraphSnapshot(this.state.knowledgeGraph);
+    if (!snapshot || snapshot.bundle_id !== link.bundleId) {
+      this.render();
+      return false;
+    }
+    if (link.communityId) {
+      if (!snapshot.communities.some((community) => community.id === link.communityId)) {
+        this.render();
+        return false;
+      }
+      this.drillIntoKnowledgeArea(link.communityId);
+      return true;
+    }
+    if (link.conceptId) {
+      const node = resolveMemoryDeepLinkNode(snapshot, link);
+      if (!node) {
+        this.render();
+        return false;
+      }
+      // Land drilled into the concept's area with the capsule open, exactly
+      // where manual navigation would have ended up.
+      if (node.metrics?.community_id) {
+        this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: node.metrics.community_id });
+        this.invalidateKnowledgeGraphLayout();
+      }
+      this.selectKnowledgeNode(node);
+      return true;
+    }
+    this.resetKnowledgeGraphView();
+    return true;
   }
 
   private setTaskGraphLinkEmphasis(nodeButton: HTMLElement, active: boolean): void {
@@ -4772,6 +5031,25 @@ function appShellStyles(): string {
     .os-kg-inspector dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 10px; margin: 0; }
     .os-kg-inspector dt { color: #667788; font-size: 11px; }
     .os-kg-inspector dd { margin: 2px 0 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+    .os-kg-breadcrumb { display: flex; align-items: center; gap: 6px; font-size: 12px; min-height: 20px; flex-wrap: wrap; }
+    .os-kg-breadcrumb button { border: none; background: transparent; padding: 0; color: #23566f; font-size: 12px; font-weight: 600; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
+    .os-kg-breadcrumb span[aria-current] { color: #1d2833; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 32ch; }
+    .os-kg-crumb-sep { color: #98a6b3; }
+    .os-kg-inspector-header { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+    .os-kg-inspector-header h3 { margin: 0 0 8px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .os-kg-copy-deeplink { flex: 0 0 auto; border: 1px solid #cdd6de; border-radius: 5px; background: #f4f7f9; color: #2c4356; font-size: 11px; padding: 2px 8px; cursor: pointer; }
+    .os-kg-capsule { margin-top: 8px; border-top: 1px solid #e3e8ee; padding-top: 8px; display: grid; gap: 6px; }
+    .os-kg-capsule h4 { margin: 4px 0 0; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #667788; }
+    .os-kg-capsule-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+    .os-kg-chip { border: 1px solid #d8dee4; border-radius: 999px; background: #f4f7f9; color: #405568; font-size: 11px; padding: 1px 8px; }
+    .os-kg-capsule-body { max-height: 220px; overflow: auto; font-size: 12px; line-height: 1.5; color: #2b3947; }
+    .os-kg-capsule-body h4, .os-kg-capsule-body h5, .os-kg-capsule-body h6 { margin: 8px 0 2px; font-size: 12px; text-transform: none; letter-spacing: 0; color: #1d2833; }
+    .os-kg-capsule-body p { margin: 4px 0; }
+    .os-kg-capsule-body ul { margin: 4px 0; padding-left: 18px; }
+    .os-kg-capsule-body code { background: #eef1f4; border-radius: 3px; padding: 0 3px; font-size: 11px; }
+    .os-kg-capsule-links, .os-kg-capsule-sources { display: flex; flex-wrap: wrap; gap: 4px 8px; list-style: none; margin: 0; padding: 0; font-size: 12px; }
+    .os-kg-capsule-link { border: none; background: transparent; padding: 0; color: #23566f; font-size: inherit; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
+    .os-kg-capsule-error { color: #b3372a; font-size: 12px; margin: 0; }
     .os-code-graph-placeholder { min-height: clamp(260px, 36vh, 460px); display: grid; place-content: center; gap: 5px; border: 1px dashed #afbac5; border-radius: 6px; background: #f8fafc; text-align: center; }
     .os-code-graph-placeholder strong { color: #23566f; font-size: 15px; }
     .os-code-graph-placeholder span { color: #667788; font-size: 12px; }
@@ -5052,6 +5330,17 @@ function appShellStyles(): string {
       .os-kg-list li.is-selected button, .os-kg-inspector h3, .os-kg-inspector dd { color: #f2f7fb; }
       .os-kg-list li.is-selected span { color: #fdba74; }
       .os-kg-inspector dt, .os-kg-inspector p { color: #94a3b3; }
+      .os-kg-breadcrumb button, .os-kg-capsule-link { color: #8bd0e6; }
+      .os-kg-breadcrumb span[aria-current] { color: #f2f7fb; }
+      .os-kg-crumb-sep { color: #5b6b7a; }
+      .os-kg-copy-deeplink { background: #111820; border-color: #2a3440; color: #d9e2ea; }
+      .os-kg-capsule { border-top-color: #2a3440; }
+      .os-kg-capsule h4 { color: #94a3b3; }
+      .os-kg-chip { background: #111820; border-color: #2a3440; color: #b8c6d2; }
+      .os-kg-capsule-body { color: #c4d0da; }
+      .os-kg-capsule-body h4, .os-kg-capsule-body h5, .os-kg-capsule-body h6 { color: #f2f7fb; }
+      .os-kg-capsule-body code { background: #1c2630; }
+      .os-kg-capsule-error { color: #fca5a5; }
       .os-run-meta-row code { color: #d9e2ea; }
       .os-run-meta-row a { color: #8bd0e6; }
       .os-run-meta-row em { color: #94a3b3; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -118,10 +118,13 @@ import {
   type PlanningEditState,
 } from "./planning-workspace-ui.js";
 import {
+  bindKnowledgeGraphListNavigation,
   createKnowledgeGraphViewState,
   disposeKnowledgeGraphRenderer,
   type KnowledgeGraphViewState,
   mountKnowledgeGraphRenderer,
+  renderKnowledgeGraphInspector,
+  renderKnowledgeGraphNodeList,
   renderKnowledgeGraphSurface,
 } from "./knowledge-graph-renderer.js";
 import { morphChildren } from "./dom-morph.js";
@@ -1194,7 +1197,13 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private bindKnowledgeGraph(): void {
     const root = this.options.root.querySelector<HTMLElement>("[data-testid='knowledge-graph-renderer']");
     if (!root) return;
-    this.bindKnowledgeGraphNavigation(root);
+    // Navigation affordances span the hero (breadcrumb) and the lower
+    // columns (entity list, inspector capsule), so bind at the app root.
+    this.bindKnowledgeGraphNavigation(this.options.root);
+    bindKnowledgeGraphListNavigation(this.options.root, {
+      onSelect: this.onKnowledgeNodeSelected,
+      onFocus: this.onKnowledgeNodeFocused,
+    });
     void this.ensureSelectedConceptDetail();
     const snapshot = visibleGraphSnapshot(this.state.knowledgeGraph);
     const stageSize = measureKnowledgeGraphStage(root);
@@ -1219,21 +1228,25 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       layout: this.state.knowledgeGraphLayout,
       selectedNodeIds: this.state.knowledgeGraph.selectedNodeIds,
       view: this.knowledgeGraphView,
-      onSelect: (nodeId) => {
-        this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [nodeId] });
-        this.render();
-      },
-      onFocus: (nodeId) => {
-        this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "NODE_FOCUSED", nodeId });
-        this.render();
-        if (this.state.knowledgeGraph.mode !== "neighborhood") return;
-        this.invalidateKnowledgeGraphLayout();
-      },
+      onSelect: this.onKnowledgeNodeSelected,
+      onFocus: this.onKnowledgeNodeFocused,
       onSelectArea: (areaId) => {
         this.drillIntoKnowledgeArea(areaId);
       },
     });
   }
+
+  private onKnowledgeNodeSelected = (nodeId: string): void => {
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "SELECTION_SET", nodeIds: [nodeId] });
+    this.render();
+  };
+
+  private onKnowledgeNodeFocused = (nodeId: string): void => {
+    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "NODE_FOCUSED", nodeId });
+    this.render();
+    if (this.state.knowledgeGraph.mode !== "neighborhood") return;
+    this.invalidateKnowledgeGraphLayout();
+  };
 
   private installBrowserGraphLayoutAdapter(): void {
     if (typeof Worker === "undefined") return;
@@ -2279,7 +2292,6 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           snapshot: visibleGraphSnapshot(this.state.knowledgeGraph),
           layout: this.state.knowledgeGraphLayout,
           state: this.state.knowledgeGraph,
-          ...this.selectedKnowledgeCapsule(),
         })
         : this.renderCodeGraphPlaceholder();
     return `
@@ -2397,38 +2409,31 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     }
   }
 
+  /**
+   * Narrow lower-left column: the clickable entity list for the visible
+   * graph (drilled views list only the drilled area's members). Lives beside
+   * the inspector so the graph stage, the entities, and the selected
+   * capsule all share the fold.
+   */
   private renderKnowledgeGraphListColumn(): string {
     const snapshot = visibleGraphSnapshot(this.state.knowledgeGraph);
-    const selected = new Set(this.state.knowledgeGraph.selectedNodeIds);
-    const nodes = snapshot?.nodes.slice(0, 12).map((node) => `
-      <li class="${selected.has(node.id) ? "is-selected" : ""}">
-        <strong>${escapeHtml(node.label)}</strong>
-        <span>${escapeHtml(node.kind)}</span>
-      </li>
-    `).join("");
     return panel(
-      "Neighborhood",
-      nodes
-        ? `<ul class="os-surface-list" data-testid="knowledge-lower-list">${nodes}</ul>`
-        : `<div class="os-empty" data-testid="knowledge-lower-list">Load the Knowledge Graph to populate this surface list</div>`,
+      "Entities",
+      renderKnowledgeGraphNodeList(snapshot, this.state.knowledgeGraph.selectedNodeIds),
       "os-knowledge-lower-panel",
     );
   }
 
+  /** Lower-right column: the selected node's inspector card and memory capsule. */
   private renderKnowledgeGraphDetailColumn(): string {
-    const snapshot = visibleGraphSnapshot(this.state.knowledgeGraph);
-    const selectedId = this.state.knowledgeGraph.selectedNodeIds[0] ?? null;
-    const node = selectedId ? snapshot?.nodes.find((candidate) => candidate.id === selectedId) : null;
     return panel(
-      "Concept",
-      node
-        ? `
-          <div class="os-surface-detail" data-testid="knowledge-lower-detail">
-            <strong>${escapeHtml(node.label)}</strong>
-            <span>${escapeHtml(node.kind)}</span>
-          </div>
-        `
-        : `<div class="os-empty" data-testid="knowledge-lower-detail">Select a Knowledge Graph node to inspect it here</div>`,
+      "Inspector",
+      renderKnowledgeGraphInspector({
+        snapshot: visibleGraphSnapshot(this.state.knowledgeGraph),
+        layout: this.state.knowledgeGraphLayout,
+        state: this.state.knowledgeGraph,
+        ...this.selectedKnowledgeCapsule(),
+      }),
       "os-knowledge-lower-panel",
     );
   }
@@ -3884,7 +3889,9 @@ function isWorkspacePaneResizeHandle(value: string | undefined): value is Worksp
 function createDefaultWorkspacePaneSizes(): WorkspacePaneSizesBySurface {
   return {
     task: { ...defaultWorkspacePaneSizes },
-    knowledge: { ...defaultWorkspacePaneSizes },
+    // Entity list left, inspector capsule right: the list only needs to fit
+    // titles, the capsule carries the content.
+    knowledge: { left: 34, right: 66 },
     code: { ...defaultWorkspacePaneSizes },
   };
 }
@@ -5050,6 +5057,11 @@ function appShellStyles(): string {
     .os-kg-capsule-links, .os-kg-capsule-sources { display: flex; flex-wrap: wrap; gap: 4px 8px; list-style: none; margin: 0; padding: 0; font-size: 12px; }
     .os-kg-capsule-link { border: none; background: transparent; padding: 0; color: #23566f; font-size: inherit; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
     .os-kg-capsule-error { color: #b3372a; font-size: 12px; margin: 0; }
+    /* Lower-column layout: the panel is the single scroll context — inner
+       caps (sized for the old in-hero inspector) would nest scrollbars. */
+    .os-knowledge-lower-panel .os-kg-list { max-height: none; overflow: visible; }
+    .os-knowledge-lower-panel .os-kg-inspector { border: none; padding: 0; background: transparent; }
+    .os-knowledge-lower-panel .os-kg-capsule-body { max-height: none; overflow: visible; }
     .os-code-graph-placeholder { min-height: clamp(260px, 36vh, 460px); display: grid; place-content: center; gap: 5px; border: 1px dashed #afbac5; border-radius: 6px; background: #f8fafc; text-align: center; }
     .os-code-graph-placeholder strong { color: #23566f; font-size: 15px; }
     .os-code-graph-placeholder span { color: #667788; font-size: 12px; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -2693,18 +2693,28 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.selectKnowledgeNode(node);
   }
 
+  /**
+   * Select a node reached by navigation (capsule link, deep link) and land
+   * where manual drilling would have: inside the node's area. From the
+   * atlas this drills in; from another area it re-drills — unless the node
+   * is already visible in the current area (secondary membership counts).
+   * Nodes outside every area (e.g. the bundle node) widen back to the atlas.
+   */
   private selectKnowledgeNode(node: MemoryGraphNode): void {
     const graph = this.state.knowledgeGraph;
     const targetCommunity = node.metrics?.community_id ?? null;
     const currentCommunity = graph.filters.communities[0] ?? null;
+    const snapshot = currentGraphSnapshot(graph);
+    const visibleInCurrentArea = currentCommunity !== null && (
+      targetCommunity === currentCommunity
+      || (snapshot?.communities.find((community) => community.id === currentCommunity)?.node_ids.includes(node.id) ?? false)
+    );
     let relayout = false;
     this.state.knowledgeGraph = graphReducer(graph, { type: "NODE_FOCUSED", nodeId: null });
-    this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: currentCommunity || targetCommunity ? "community" : "atlas" });
-    if (currentCommunity !== null && targetCommunity !== null && currentCommunity !== targetCommunity) {
+    if (targetCommunity !== null && !visibleInCurrentArea) {
       this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: targetCommunity });
-      relayout = true;
-    } else if (currentCommunity !== null && targetCommunity === null) {
-      // Target lives outside every area (e.g. the bundle node): widen back out.
+      relayout = currentCommunity !== targetCommunity;
+    } else if (targetCommunity === null && currentCommunity !== null) {
       this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "FILTERS_SET", filters: { communities: [] } });
       this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "MODE_SET", mode: "atlas" });
       relayout = true;
@@ -2848,12 +2858,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         this.render();
         return false;
       }
-      // Land drilled into the concept's area with the capsule open, exactly
+      // Lands drilled into the concept's area with the capsule open, exactly
       // where manual navigation would have ended up.
-      if (node.metrics?.community_id) {
-        this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "COMMUNITY_SELECTED", communityId: node.metrics.community_id });
-        this.invalidateKnowledgeGraphLayout();
-      }
       this.selectKnowledgeNode(node);
       return true;
     }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -2692,9 +2692,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private openKnowledgeCapsuleLink(target: string): void {
     const snapshot = currentGraphSnapshot(this.state.knowledgeGraph);
     if (!snapshot) return;
+    // OKF capsules store link targets verbatim, often as relative markdown
+    // paths ("../issues/COE-124.md") that the snapshot has already resolved
+    // to bare ids ("issues/COE-124") — normalize before matching.
+    const normalized = target.replace(/^(\.\.?\/)+/, "").replace(/\.md$/i, "");
+    const tail = normalized.split("/").at(-1) ?? normalized;
     const node = snapshot.nodes.find((candidate) => candidate.id === target)
       ?? snapshot.nodes.find((candidate) => candidate.concept_id === target)
-      ?? snapshot.nodes.find((candidate) => candidate.concept_id?.split("/").at(-1) === target)
+      ?? snapshot.nodes.find((candidate) => candidate.concept_id === normalized)
+      ?? snapshot.nodes.find((candidate) => candidate.concept_id?.split("/").at(-1) === tail)
       ?? snapshot.nodes.find((candidate) => candidate.label === target)
       ?? null;
     if (!node) return;

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -56,6 +56,7 @@ export type { ActionBarItem } from "./run-actions.js";
 export {
   renderOpenSymphonyApp,
 } from "./app-shell.js";
+export { renderMemoryMarkdown } from "./memory-markdown.js";
 export type {
   EditableProfileInput,
   GatewayReader,

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -1090,7 +1090,11 @@ function renderCapsule(node: MemoryGraphNode, surface: KnowledgeGraphSurface): s
       <h4>Citations</h4>
       <ul class="os-kg-capsule-links" data-testid="knowledge-graph-capsule-citations">
         ${detail.citations.map((citation) => `
-          <li><button type="button" class="os-kg-capsule-link" data-kg-link-target="${escapeAttr(citation.target)}">${escapeHtml(citation.label ?? citation.target)}</button></li>
+          <li>${/^https?:\/\//.test(citation.target)
+            // Real OKF citations often carry a URL target with a short
+            // label; those are external evidence, not graph nodes.
+            ? `<a href="${escapeAttr(citation.target)}" target="_blank" rel="noreferrer">${escapeHtml(citation.label ?? citation.id)}</a>`
+            : `<button type="button" class="os-kg-capsule-link" data-kg-link-target="${escapeAttr(citation.target)}">${escapeHtml(citation.label ?? citation.target)}</button>`}</li>
         `).join("")}
       </ul>
     `

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -1,10 +1,14 @@
-import type {
-  GraphLayoutResult,
-  GraphState,
-  MemoryGraphSnapshot,
+import {
+  memoryDeepLinkForGraphNode,
+  type GraphLayoutResult,
+  type GraphState,
+  type MemoryConceptDetail,
+  type MemoryGraphNode,
+  type MemoryGraphSnapshot,
 } from "@opensymphony/graph";
 import * as THREE from "three";
 import { escapeAttr, escapeHtml } from "./html.js";
+import { renderMemoryMarkdown } from "./memory-markdown.js";
 import {
   advanceCameraToward,
   buildGraphScene,
@@ -35,6 +39,9 @@ export interface KnowledgeGraphSurface {
   snapshot: MemoryGraphSnapshot | null;
   layout: GraphLayoutResult | null;
   state: GraphState;
+  /** Cached capsule detail for the selected concept (null while loading). */
+  conceptDetail?: MemoryConceptDetail | null;
+  conceptDetailError?: string | null;
 }
 
 export interface KnowledgeGraphMountOptions {
@@ -44,6 +51,8 @@ export interface KnowledgeGraphMountOptions {
   view: KnowledgeGraphViewState;
   onSelect(nodeId: string): void;
   onFocus(nodeId: string): void;
+  /** Click on an area cloud in the zoomed-out view: drill into that community. */
+  onSelectArea?(areaId: string): void;
 }
 
 export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): string {
@@ -72,14 +81,49 @@ export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): str
         ${resetButton}
         ${renderStatus(surface.state)}
       </div>
+      ${renderBreadcrumb(surface)}
       <div class="os-knowledge-stage" data-kg-stage>
         <canvas class="os-knowledge-canvas" data-testid="knowledge-graph-canvas" aria-label="Knowledge Graph canvas"></canvas>
         <div class="os-knowledge-labels" data-kg-labels data-morph-ignore-children></div>
-        <span class="os-kg-controls-hint" aria-hidden="true">drag pan &middot; &#8997;-drag orbit &middot; scroll zoom &middot; double-click frame</span>
+        <span class="os-kg-controls-hint" aria-hidden="true">drag pan &middot; &#8997;-drag orbit &middot; scroll zoom &middot; click area to drill in &middot; esc to back out</span>
       </div>
-      ${renderSelectedInspector(snapshot, surface.state.selectedNodeIds)}
+      ${renderSelectedInspector(surface)}
       ${renderFallbackList(snapshot, surface.state.selectedNodeIds)}
     </div>
+  `;
+}
+
+/**
+ * Drill trail: Atlas › area › concept. Each ancestor is a button that pops
+ * the view back to that level; the current level renders as plain text.
+ * Hidden entirely at the atlas level so the default view stays quiet.
+ */
+function renderBreadcrumb(surface: KnowledgeGraphSurface): string {
+  const { snapshot, state } = surface;
+  const communityId = state.filters.communities[0] ?? null;
+  const community = communityId
+    ? snapshot?.communities.find((candidate) => candidate.id === communityId) ?? null
+    : null;
+  const selected = new Set(state.selectedNodeIds);
+  const node = snapshot?.nodes.find((candidate) => selected.has(candidate.id)) ?? null;
+  if (!community && !node) return "";
+  const crumbs: string[] = [
+    `<button type="button" data-kg-crumb="atlas">Atlas</button>`,
+  ];
+  if (community) {
+    crumbs.push(
+      node
+        ? `<button type="button" data-kg-crumb="community">${escapeHtml(community.label)}</button>`
+        : `<span aria-current="location">${escapeHtml(community.label)}</span>`,
+    );
+  }
+  if (node) {
+    crumbs.push(`<span aria-current="location">${escapeHtml(node.label)}</span>`);
+  }
+  return `
+    <nav class="os-kg-breadcrumb" data-testid="knowledge-graph-breadcrumb" aria-label="Knowledge Graph drill path">
+      ${crumbs.join(`<span class="os-kg-crumb-sep" aria-hidden="true">&rsaquo;</span>`)}
+    </nav>
   `;
 }
 
@@ -293,7 +337,7 @@ function attachCanvasHandlers(
         state.hoveredNodeId = nodeId;
         drawFrame(canvas, root, stage, state);
       }
-      canvas.style.cursor = nodeId ? "pointer" : "grab";
+      canvas.style.cursor = nodeId || drillableHullAt(scene, point.x, point.y) ? "pointer" : "grab";
       return;
     }
     const deltaX = event.clientX - state.pointer.lastX;
@@ -342,6 +386,16 @@ function attachCanvasHandlers(
     canvas.style.cursor = "grab";
     if (!moved && mode === "drag-node" && nodeId) {
       state.options.onSelect(nodeId);
+      return;
+    }
+    if (!moved && mode === "pan") {
+      // A stationary click on an area cloud drills into that community; the
+      // same gesture with movement stays a pan.
+      const viewport = canvasViewport(stage);
+      const scene = state.lastScene ?? rebuildScene(state, viewport);
+      const point = canvasPointFromEvent(canvas, event);
+      const hull = drillableHullAt(scene, point.x, point.y);
+      if (hull) state.options.onSelectArea?.(hull.areaId);
     }
   };
   canvas.onpointerleave = () => {
@@ -387,6 +441,17 @@ function attachCanvasHandlers(
     state.goal = defaultCameraForLayout(layout, viewport);
     startAnimation(canvas, root, stage, state);
   };
+}
+
+/**
+ * Hull under the cursor, but only while the view is zoomed out enough that
+ * areas read as navigable clouds (their titles are visible). Zoomed in, the
+ * hulls still exist underneath every node and a background click should not
+ * yank the operator into a different community.
+ */
+function drillableHullAt(scene: GraphScene, x: number, y: number): { areaId: string } | null {
+  const hull = hitTestHull(scene, x, y);
+  return hull && hull.labelAlpha > 0.05 ? hull : null;
 }
 
 function bindListNavigation(root: HTMLElement, options: KnowledgeGraphMountOptions): void {
@@ -916,8 +981,9 @@ function renderStatus(state: GraphState): string {
   return `<span class="os-kg-status" data-testid="knowledge-graph-status">Idle</span>`;
 }
 
-function renderSelectedInspector(snapshot: MemoryGraphSnapshot | null, selectedNodeIds: readonly string[]): string {
-  const selected = new Set(selectedNodeIds);
+function renderSelectedInspector(surface: KnowledgeGraphSurface): string {
+  const { snapshot, state } = surface;
+  const selected = new Set(state.selectedNodeIds);
   const node = snapshot?.nodes.find((candidate) => selected.has(candidate.id)) ?? null;
   if (!node) {
     return `<section class="os-kg-inspector" data-testid="knowledge-graph-inspector"><h3>Inspector</h3><p>No node selected</p></section>`;
@@ -925,17 +991,91 @@ function renderSelectedInspector(snapshot: MemoryGraphSnapshot | null, selectedN
   const community = node.metrics?.community_id
     ? snapshot?.communities.find((candidate) => candidate.id === node.metrics.community_id)?.label ?? node.metrics.community_id
     : "None";
+  const deepLink = snapshot ? memoryDeepLinkForGraphNode(snapshot.bundle_id, node) : null;
+  const deepLinkButton = deepLink
+    ? `<button type="button" class="os-kg-copy-deeplink" data-kg-copy-deeplink="${escapeAttr(deepLink)}" data-testid="knowledge-graph-copy-deeplink" title="Copy a deep link to this capsule">Copy deep link</button>`
+    : "";
   return `
     <section class="os-kg-inspector" data-testid="knowledge-graph-inspector">
-      <h3>${escapeHtml(node.label)}</h3>
+      <div class="os-kg-inspector-header">
+        <h3>${escapeHtml(node.label)}</h3>
+        ${deepLinkButton}
+      </div>
       <dl>
         <dt>Kind</dt><dd>${escapeHtml(node.kind)}</dd>
         <dt>Visibility</dt><dd>${escapeHtml(node.visibility ?? "unknown")}</dd>
         <dt>Community</dt><dd>${escapeHtml(community)}</dd>
         <dt>Tags</dt><dd>${escapeHtml(node.tags.join(", ") || "None")}</dd>
       </dl>
+      ${renderCapsule(node, surface)}
     </section>
   `;
+}
+
+/**
+ * Capsule pane inside the inspector: the concept's memory capsule fetched
+ * from the concept-detail endpoint. Non-concept nodes have no capsule; for
+ * concepts the pane moves through loading → detail (or error with retry).
+ */
+function renderCapsule(node: MemoryGraphNode, surface: KnowledgeGraphSurface): string {
+  if (node.kind !== "concept" || !node.concept_id) return "";
+  if (surface.conceptDetailError) {
+    return `
+      <div class="os-kg-capsule" data-testid="knowledge-graph-capsule">
+        <p class="os-kg-capsule-error" data-testid="knowledge-graph-capsule-error">Capsule unavailable: ${escapeHtml(surface.conceptDetailError)}</p>
+        <button type="button" data-kg-capsule-retry data-testid="knowledge-graph-capsule-retry">Retry</button>
+      </div>
+    `;
+  }
+  const detail = surface.conceptDetail ?? null;
+  if (!detail || detail.concept_id !== node.concept_id) {
+    return `<div class="os-kg-capsule" data-testid="knowledge-graph-capsule"><p data-testid="knowledge-graph-capsule-loading">Loading capsule&hellip;</p></div>`;
+  }
+  const frontmatter = { ...detail.frontmatter_view.primary, ...detail.frontmatter_view.opensymphony };
+  const chips = Object.entries(frontmatter)
+    .filter(([key, value]) => key !== "title" && isChipValue(value))
+    .slice(0, 8)
+    .map(([key, value]) => `<span class="os-kg-chip">${escapeHtml(key)}: ${escapeHtml(chipText(value))}</span>`)
+    .join("");
+  const links = detail.links.length > 0
+    ? `
+      <h4>Linked concepts</h4>
+      <ul class="os-kg-capsule-links">
+        ${detail.links.map((link) => `
+          <li><button type="button" class="os-kg-capsule-link" data-kg-link-target="${escapeAttr(link.target)}">${escapeHtml(link.label ?? link.target)}</button></li>
+        `).join("")}
+      </ul>
+    `
+    : "";
+  const sources = detail.source_refs.length > 0
+    ? `
+      <h4>Sources</h4>
+      <ul class="os-kg-capsule-sources">
+        ${detail.source_refs.map((ref) => `
+          <li>${ref.url && /^https?:\/\//.test(ref.url)
+            ? `<a href="${escapeAttr(ref.url)}" target="_blank" rel="noreferrer">${escapeHtml(ref.kind)}: ${escapeHtml(ref.id)}</a>`
+            : `${escapeHtml(ref.kind)}: ${escapeHtml(ref.id)}`}</li>
+        `).join("")}
+      </ul>
+    `
+    : "";
+  return `
+    <div class="os-kg-capsule" data-testid="knowledge-graph-capsule">
+      ${chips ? `<div class="os-kg-capsule-chips">${chips}</div>` : ""}
+      <div class="os-kg-capsule-body" data-testid="knowledge-graph-capsule-body">${renderMemoryMarkdown(detail.body_markdown)}</div>
+      ${links}
+      ${sources}
+    </div>
+  `;
+}
+
+function isChipValue(value: unknown): boolean {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+    || (Array.isArray(value) && value.every((entry) => typeof entry === "string"));
+}
+
+function chipText(value: unknown): string {
+  return Array.isArray(value) ? value.join(", ") : String(value);
 }
 
 function renderFallbackList(snapshot: MemoryGraphSnapshot | null, selectedNodeIds: readonly string[]): string {

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -87,8 +87,6 @@ export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): str
         <div class="os-knowledge-labels" data-kg-labels data-morph-ignore-children></div>
         <span class="os-kg-controls-hint" aria-hidden="true">drag pan &middot; &#8997;-drag orbit &middot; scroll zoom &middot; click area to drill in &middot; esc to back out</span>
       </div>
-      ${renderSelectedInspector(surface)}
-      ${renderFallbackList(snapshot, surface.state.selectedNodeIds)}
     </div>
   `;
 }
@@ -454,16 +452,28 @@ function drillableHullAt(scene: GraphScene, x: number, y: number): { areaId: str
   return hull && hull.labelAlpha > 0.05 ? hull : null;
 }
 
-function bindListNavigation(root: HTMLElement, options: KnowledgeGraphMountOptions): void {
-  // Handler properties (not addEventListener) so re-mounting after every
-  // render stays idempotent: the DOM morph preserves these buttons across
-  // renders, and stacked listeners would fire once per past render.
+/** The subset of mount callbacks the node list/labels need. */
+export interface KnowledgeGraphListOptions {
+  onSelect(nodeId: string): void;
+  onFocus(nodeId: string): void;
+}
+
+/**
+ * Bind click/keyboard/focus behavior for every node button under `root`
+ * (overlay labels and the entity-list column alike). Handler properties
+ * (not addEventListener) so re-binding after every render stays idempotent:
+ * the DOM morph preserves these buttons across renders, and stacked
+ * listeners would fire once per past render.
+ */
+export function bindKnowledgeGraphListNavigation(root: HTMLElement, options: KnowledgeGraphListOptions): void {
   root.querySelectorAll<HTMLElement>("[data-kg-node-id]").forEach((button) => {
     bindNodeButton(root, button, options);
   });
 }
 
-function bindNodeButton(root: HTMLElement, button: HTMLElement, options: KnowledgeGraphMountOptions): void {
+const bindListNavigation = bindKnowledgeGraphListNavigation;
+
+function bindNodeButton(root: HTMLElement, button: HTMLElement, options: KnowledgeGraphListOptions): void {
   button.onclick = () => {
     const nodeId = button.dataset.kgNodeId;
     if (nodeId) options.onSelect(nodeId);
@@ -981,7 +991,12 @@ function renderStatus(state: GraphState): string {
   return `<span class="os-kg-status" data-testid="knowledge-graph-status">Idle</span>`;
 }
 
-function renderSelectedInspector(surface: KnowledgeGraphSurface): string {
+/**
+ * Inspector card for the selected node: metadata, frontmatter chips, and the
+ * concept's memory capsule. Rendered in the lower-right workspace column so
+ * the graph stage and capsule content share the fold.
+ */
+export function renderKnowledgeGraphInspector(surface: KnowledgeGraphSurface): string {
   const { snapshot, state } = surface;
   const selected = new Set(state.selectedNodeIds);
   const node = snapshot?.nodes.find((candidate) => selected.has(candidate.id)) ?? null;
@@ -1078,7 +1093,12 @@ function chipText(value: unknown): string {
   return Array.isArray(value) ? value.join(", ") : String(value);
 }
 
-function renderFallbackList(snapshot: MemoryGraphSnapshot | null, selectedNodeIds: readonly string[]): string {
+/**
+ * Clickable entity list for the visible snapshot (also the keyboard/screen-
+ * reader path into the graph). Rendered in the narrow lower-left workspace
+ * column; bind with bindKnowledgeGraphListNavigation.
+ */
+export function renderKnowledgeGraphNodeList(snapshot: MemoryGraphSnapshot | null, selectedNodeIds: readonly string[]): string {
   if (!snapshot || snapshot.nodes.length === 0) {
     return `<div class="os-empty">No graph data available.</div>`;
   }

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -473,7 +473,25 @@ export interface KnowledgeGraphListOptions {
 export function bindKnowledgeGraphListNavigation(root: HTMLElement, options: KnowledgeGraphListOptions): void {
   root.querySelectorAll<HTMLElement>("[data-kg-node-id]").forEach((button) => {
     bindNodeButton(root, button, options);
+    markTruncatedListLabel(button);
   });
+}
+
+/**
+ * Entity-list rows ellipsize long names; flag the ones that actually
+ * overflow so CSS can surface the full name in an instant (no-delay)
+ * hover tooltip. `title` is kept in sync as the assistive/native fallback.
+ */
+function markTruncatedListLabel(button: HTMLElement): void {
+  if (!button.closest(".os-kg-list")) return;
+  const label = button.textContent ?? "";
+  if (button.scrollWidth > button.clientWidth && label) {
+    button.dataset.kgOverflow = label;
+    button.title = label;
+  } else {
+    delete button.dataset.kgOverflow;
+    button.removeAttribute("title");
+  }
 }
 
 const bindListNavigation = bindKnowledgeGraphListNavigation;

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -347,7 +347,11 @@ function attachCanvasHandlers(
       state.camera = panCamera(state.camera, viewport, deltaX, deltaY);
       state.goal = state.camera;
     } else if (state.pointer.mode === "orbit") {
-      state.camera = orbitCamera(state.camera, deltaX * 0.005, deltaY * 0.004);
+      // Grab-the-scene orbit: dragging right swings the scene right (the
+      // camera orbits the opposite way), matching pan and common
+      // orbit-controls conventions. Mapping drag deltas straight onto
+      // yaw/pitch felt reversed on both axes.
+      state.camera = orbitCamera(state.camera, -deltaX * 0.005, -deltaY * 0.004);
       state.goal = state.camera;
     } else if (state.pointer.mode === "drag-node" && state.pointer.nodeId && state.options.layout) {
       const worldNode = worldNodesFor(state.options.layout, state.options.view.overrides)

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -347,11 +347,12 @@ function attachCanvasHandlers(
       state.camera = panCamera(state.camera, viewport, deltaX, deltaY);
       state.goal = state.camera;
     } else if (state.pointer.mode === "orbit") {
-      // Grab-the-scene orbit: dragging right swings the scene right (the
-      // camera orbits the opposite way), matching pan and common
-      // orbit-controls conventions. Mapping drag deltas straight onto
-      // yaw/pitch felt reversed on both axes.
-      state.camera = orbitCamera(state.camera, -deltaX * 0.005, -deltaY * 0.004);
+      // Grab-the-scene orbit, tuned by feel: dragging right swings the
+      // scene right (yaw inverted from the raw delta), and dragging up
+      // tilts the scene away/up (pitch follows the raw delta). Signs are
+      // deliberate — both once mapped straight onto yaw/pitch and read
+      // reversed horizontally; a full inversion read reversed vertically.
+      state.camera = orbitCamera(state.camera, -deltaX * 0.005, deltaY * 0.004);
       state.goal = state.camera;
     } else if (state.pointer.mode === "drag-node" && state.pointer.nodeId && state.options.layout) {
       const worldNode = worldNodesFor(state.options.layout, state.options.view.overrides)

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -1085,6 +1085,16 @@ function renderCapsule(node: MemoryGraphNode, surface: KnowledgeGraphSurface): s
       </ul>
     `
     : "";
+  const citations = detail.citations.length > 0
+    ? `
+      <h4>Citations</h4>
+      <ul class="os-kg-capsule-links" data-testid="knowledge-graph-capsule-citations">
+        ${detail.citations.map((citation) => `
+          <li><button type="button" class="os-kg-capsule-link" data-kg-link-target="${escapeAttr(citation.target)}">${escapeHtml(citation.label ?? citation.target)}</button></li>
+        `).join("")}
+      </ul>
+    `
+    : "";
   const sources = detail.source_refs.length > 0
     ? `
       <h4>Sources</h4>
@@ -1102,6 +1112,7 @@ function renderCapsule(node: MemoryGraphNode, surface: KnowledgeGraphSurface): s
       ${chips ? `<div class="os-kg-capsule-chips">${chips}</div>` : ""}
       <div class="os-kg-capsule-body" data-testid="knowledge-graph-capsule-body">${renderMemoryMarkdown(detail.body_markdown)}</div>
       ${links}
+      ${citations}
       ${sources}
     </div>
   `;

--- a/packages/ui-core/src/memory-markdown.ts
+++ b/packages/ui-core/src/memory-markdown.ts
@@ -65,18 +65,31 @@ function renderInline(text: string): string {
   // The whole line is escaped up front (escapeHtml also covers quotes), so
   // captured fragments are already safe in both text and attribute position;
   // escaping again here would double-encode ampersands.
-  let html = escapeHtml(text);
-  // Wiki links first: their targets may contain characters the other
-  // patterns would otherwise chew on.
-  html = html.replace(/\[\[([^\]]+)\]\]/g, (_match, target: string) => {
+  //
+  // Each pass stashes its generated HTML behind a NUL-delimited placeholder
+  // so later passes only ever see source text — otherwise a wiki target
+  // containing markdown-link/bold/code syntax would be rewritten inside the
+  // generated attribute markup and corrupt it. NUL cannot occur
+  // legitimately; incoming ones are stripped so they cannot alias a
+  // placeholder.
+  const generated: string[] = [];
+  const stash = (html: string): string => {
+    generated.push(html);
+    return `\u0000${generated.length - 1}\u0000`;
+  };
+  let html = escapeHtml(text).replaceAll("\u0000", "");
+  // Non-greedy up to the first "]]" so targets may contain single brackets
+  // (e.g. markdown-link syntax inside a title) without escaping the wiki
+  // pass and getting chewed by the passes below.
+  html = html.replace(/\[\[(.+?)\]\]/g, (_match, target: string) => {
     const label = target.split("/").at(-1) ?? target;
-    return `<button type="button" class="os-kg-capsule-link" data-kg-link-target="${target}">${label}</button>`;
+    return stash(`<button type="button" class="os-kg-capsule-link" data-kg-link-target="${target}">${label}</button>`);
   });
   html = html.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (match, label: string, href: string) => {
     if (!/^https?:\/\//.test(href)) return match;
-    return `<a href="${href}" target="_blank" rel="noreferrer">${label}</a>`;
+    return stash(`<a href="${href}" target="_blank" rel="noreferrer">${label}</a>`);
   });
-  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
-  return html;
+  html = html.replace(/\*\*([^*]+)\*\*/g, (_match, body: string) => stash(`<strong>${body}</strong>`));
+  html = html.replace(/`([^`]+)`/g, (_match, body: string) => stash(`<code>${body}</code>`));
+  return html.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => generated[Number(index)]);
 }

--- a/packages/ui-core/src/memory-markdown.ts
+++ b/packages/ui-core/src/memory-markdown.ts
@@ -78,6 +78,9 @@ function renderInline(text: string): string {
     return `\u0000${generated.length - 1}\u0000`;
   };
   let html = escapeHtml(text).replaceAll("\u0000", "");
+  // Code spans first: their content is literal, so markdown-looking text
+  // inside backticks must be hidden before any other pass can rewrite it.
+  html = html.replace(/`([^`]+)`/g, (_match, body: string) => stash(`<code>${body}</code>`));
   // Non-greedy up to the first "]]" so targets may contain single brackets
   // (e.g. markdown-link syntax inside a title) without escaping the wiki
   // pass and getting chewed by the passes below.
@@ -90,6 +93,12 @@ function renderInline(text: string): string {
     return stash(`<a href="${href}" target="_blank" rel="noreferrer">${label}</a>`);
   });
   html = html.replace(/\*\*([^*]+)\*\*/g, (_match, body: string) => stash(`<strong>${body}</strong>`));
-  html = html.replace(/`([^`]+)`/g, (_match, body: string) => stash(`<code>${body}</code>`));
-  return html.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => generated[Number(index)]);
+  // A stashed fragment can itself contain an earlier pass's placeholder
+  // (e.g. a code span captured inside a wiki target), so restore until no
+  // markers remain; indices only ever point at earlier tokens, so this
+  // terminates within generated.length rounds.
+  for (let round = 0; round <= generated.length && html.includes("\u0000"); round += 1) {
+    html = html.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => generated[Number(index)]);
+  }
+  return html;
 }

--- a/packages/ui-core/src/memory-markdown.ts
+++ b/packages/ui-core/src/memory-markdown.ts
@@ -1,0 +1,82 @@
+import { escapeHtml } from "./html.js";
+
+/**
+ * Minimal, dependency-free markdown renderer for memory capsule bodies.
+ *
+ * Capsules are trusted-source but round-trip through external systems
+ * (Linear narratives, PR comments), so everything is HTML-escaped first and
+ * only an allowlisted set of constructs is re-introduced:
+ *
+ * - `#`–`###` headings (rendered as h4/h5/h6 so they nest inside the inspector)
+ * - `-`/`*` unordered lists
+ * - paragraphs split on blank lines
+ * - `**bold**`, `` `code` `` spans
+ * - `[label](https://…)` external links (http/https only; anything else
+ *   renders as plain text)
+ * - `[[target]]` wiki links, rendered as graph-navigation buttons carrying
+ *   `data-kg-link-target` so the shell can resolve them to nodes
+ */
+export function renderMemoryMarkdown(markdown: string): string {
+  const blocks: string[] = [];
+  let paragraph: string[] = [];
+  let list: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    blocks.push(`<p>${renderInline(paragraph.join(" "))}</p>`);
+    paragraph = [];
+  };
+  const flushList = () => {
+    if (list.length === 0) return;
+    blocks.push(`<ul>${list.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ul>`);
+    list = [];
+  };
+
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    const heading = /^(#{1,3})\s+(.*)$/.exec(line);
+    if (heading) {
+      flushParagraph();
+      flushList();
+      const level = Math.min(6, heading[1].length + 3);
+      blocks.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+      continue;
+    }
+    const listItem = /^[-*]\s+(.*)$/.exec(line);
+    if (listItem) {
+      flushParagraph();
+      list.push(listItem[1]);
+      continue;
+    }
+    if (line.trim().length === 0) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+    flushList();
+    paragraph.push(line.trim());
+  }
+  flushParagraph();
+  flushList();
+  return blocks.join("");
+}
+
+function renderInline(text: string): string {
+  // The whole line is escaped up front (escapeHtml also covers quotes), so
+  // captured fragments are already safe in both text and attribute position;
+  // escaping again here would double-encode ampersands.
+  let html = escapeHtml(text);
+  // Wiki links first: their targets may contain characters the other
+  // patterns would otherwise chew on.
+  html = html.replace(/\[\[([^\]]+)\]\]/g, (_match, target: string) => {
+    const label = target.split("/").at(-1) ?? target;
+    return `<button type="button" class="os-kg-capsule-link" data-kg-link-target="${target}">${label}</button>`;
+  });
+  html = html.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (match, label: string, href: string) => {
+    if (!/^https?:\/\//.test(href)) return match;
+    return `<a href="${href}" target="_blank" rel="noreferrer">${label}</a>`;
+  });
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  return html;
+}


### PR DESCRIPTION
## Summary

Fills in the knowledge graph clouds so navigation runs seamlessly from top-level areas → concepts/tags → individual issue memory capsules → and back out, matching the Obsidian LLM-wiki experience at every level. Also ships the memory deep-link mechanism as a standalone capability, ready to be wired into task-graph artifacts when the new task graph visualization lands.

### Drill-down navigation
- **Atlas → area**: a stationary click on an area cloud (while zoomed out enough that its title is visible) drills into that community — the graph re-lays out around only its members. Dragging on the same cloud still pans; the cursor turns to a pointer over drillable clouds.
- **Area → capsule**: selecting a concept lazily fetches its memory capsule through the previously-unused `GraphDataAdapter.getConceptDetail` endpoint and renders it in the inspector: frontmatter chips, markdown body, linked concepts, citations, and source refs — with loading and keyed error/retry states.
- **Capsule → capsule**: capsule links (the Linked concepts list and `[[wiki-links]]` inside the body) navigate the graph to their target node, automatically re-drilling into the target's community when the link crosses areas.
- **Back out**: a breadcrumb (`Atlas › area › concept`) pops individual levels, **Escape steps back one level at a time** (concept → area → atlas), and the "Show full graph" home button still jumps straight to the atlas.

### Memory deep links
- `packages/graph/src/deep-link.ts`: stable addresses for memory locations —
  `opensymphony://memory/<bundleId>[/concepts/<conceptId> | /communities/<communityId>]` — with strict `format`/`parse` round-trips (unknown shapes are rejected, never guessed; concept ids keep their slashes, matching the gateway's wildcard concept route).
- `OpenSymphonyAppHandle.openMemoryDeepLink(url)`: switches to the Knowledge Graph pane, loads the bundle, drills into the concept's area, and opens its capsule. **This is the wiring point for task-graph artifact links** (deliberately not wired into the task graph yet, per scope).
- The inspector's **Copy deep link** button emits the same links; `?memory=<link>` on the desktop dev server (composable with `?fixtures`) opens one at boot for end-to-end testing.

### Fixtures & safety
- Deterministic per-concept capsule details derived from the viz snapshot's own edges, so every capsule link resolves to a real node; the fixture adapter accepts a resolver and rejects unknown ids like a gateway 404.
- Capsule markdown renders through a dependency-free escape-first allowlist renderer (`memory-markdown.ts`): headings, lists, bold/code, http(s)-only links, wiki-link buttons — hostile HTML/`javascript:` payloads stay inert (covered by tests).

## Verification
- `npm run type-check` clean; 637 jest tests across 38 suites pass (existing + new).
- New tests: deep-link round-trips and strict rejection, fixture capsule determinism/link-resolvability, hull-click drilling (with pan-not-drill guard), capsule fetch/render/retry, capsule-link navigation, breadcrumbs, stepwise Escape, `openMemoryDeepLink` end to end, markdown escaping.
- Verified live in the `?fixtures` workbench: cloud click → drill → capsule → cross-area link hop → Escape ×2 back to atlas, plus `?fixtures&memory=opensymphony://memory/viz-workbench/concepts/concepts/code-intelligence-01` landing drilled-in with the capsule open. No console errors.

## Docs
- `docs/graph-view.md`: new "Drill-down navigation" and "Memory deep links" sections plus updated test-gate list.