### PR TITLE
feat(task-graph): three-pane task surface — Completed, Current, Backlog

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1089,6 +1089,26 @@ pub async fn memory_search(
     gateway_get_json(state, &path).await
 }
 
+/// List completed tasks (memory-capsule backed) through the active gateway.
+#[command]
+pub async fn memory_completed_tasks(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    query: Option<String>,
+    sort: Option<String>,
+    limit: Option<u64>,
+    offset: Option<u64>,
+    visibility: Option<String>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "query", query.as_deref());
+    push_query_param(&mut params, "sort", sort.as_deref());
+    push_query_param_value(&mut params, "limit", limit);
+    push_query_param_value(&mut params, "offset", offset);
+    push_query_param(&mut params, "visibility", visibility.as_deref());
+    let path = path_with_query("/api/v1/memory/completed-tasks", &params);
+    gateway_get_json(state, &path).await
+}
+
 /// Get task graph for a project.
 #[command]
 pub async fn task_graph(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn run() {
             commands::memory_concept_detail,
             commands::memory_communities,
             commands::memory_search,
+            commands::memory_completed_tasks,
             commands::task_graph,
             commands::run_detail,
             commands::run_files,

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -12,11 +12,13 @@ import {
   createTauriNativeGraphAdapter,
   graphVizFixtureBundleList,
   graphVizFixtureCommunityList,
+  graphVizFixtureCompletedTasks,
   graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
   memoryDeepLinkPrefix,
   type MemoryBundleList,
   type MemoryCommunityList,
+  type MemoryCompletedTaskPage,
   type MemoryConceptDetail,
   type MemoryGraphSnapshot,
   type MemorySearchResponse,
@@ -114,6 +116,14 @@ function createDesktopNativeGraphApi(invoke: TauriInvoke): NativeGraphApi {
         query,
         limit: options?.limit ?? null,
         bundleId: options?.bundleId ?? null,
+        visibility: options?.visibility ?? null,
+      }),
+    getCompletedTasks: (options) =>
+      invoke<MemoryCompletedTaskPage>("memory_completed_tasks", {
+        query: options?.query ?? null,
+        sort: options?.sort ?? null,
+        limit: options?.limit ?? null,
+        offset: options?.offset ?? null,
         visibility: options?.visibility ?? null,
       }),
   };
@@ -665,6 +675,7 @@ if (root && fixtureWorkbenchRequested()) {
       snapshot: graphVizFixtureSnapshot,
       communities: graphVizFixtureCommunityList,
       conceptDetail: (_bundleId, conceptId) => graphVizFixtureConceptDetail(conceptId),
+      completedTasks: graphVizFixtureCompletedTasks,
     }),
     modelProfileController: createDesktopModelProfileController(),
   });

--- a/crates/opensymphony-gateway-schema/src/memory_graph.rs
+++ b/crates/opensymphony-gateway-schema/src/memory_graph.rs
@@ -205,6 +205,69 @@ pub struct MemoryGraphNodeMetrics {
     pub community_id: Option<String>,
 }
 
+/// One page of completed tasks projected from the memory catalog (primary
+/// source: DuckDB issue capsules) merged with orchestrator-known completed
+/// issues that have not been captured yet. Serves the task graph's
+/// "Completed" pane without touching the Linear API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryCompletedTaskPage {
+    pub schema_version: SchemaVersion,
+    pub bundle_id: String,
+    pub tasks: Vec<MemoryCompletedTask>,
+    /// Total row count after filtering, before pagination.
+    pub total: usize,
+    pub offset: usize,
+    pub limit: usize,
+    pub sort: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryCompletedTask {
+    pub issue_key: String,
+    /// OKF concept id (e.g. `issues/COE-123`) when the task has a captured
+    /// memory capsule; empty when the row comes from the orchestrator only.
+    #[serde(default)]
+    pub concept_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_id: Option<String>,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub milestone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub prs: Vec<MemoryTaskPullRequest>,
+    pub source: MemoryCompletedTaskSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryTaskPullRequest {
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub merged: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merged_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryCompletedTaskSource {
+    /// Row backed by a captured memory capsule (has concept_id / PR evidence).
+    Memory,
+    /// Row known only to the orchestrator control plane (not yet captured).
+    Orchestrator,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MemoryGraphUpdatedEvent {
     pub schema_version: SchemaVersion,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3034,8 +3034,17 @@ async fn get_task_graph(
         .collect::<Vec<_>>();
 
     let Some(linear_task_graph) = state.linear_task_graph.as_ref() else {
+        // With no Linear client there is nothing to expand and no backlog to
+        // discover, so an empty control plane is a valid empty project (200),
+        // not a service failure. 503 is reserved for the case where the
+        // control plane tracks issues that a missing client cannot resolve.
+        let status = if identifiers.is_empty() {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        };
         return (
-            StatusCode::SERVICE_UNAVAILABLE,
+            status,
             Json(TaskGraphSnapshot {
                 schema_version: SchemaVersion::v1(),
                 project_id,
@@ -3047,9 +3056,9 @@ async fn get_task_graph(
             .into_response();
     };
 
-    // No early return on empty identifiers: even with nothing tracked by the
-    // control plane, the project can still have backlog-state issues that the
-    // task graph renders in its Backlog pane.
+    // No early return on empty identifiers when a client exists: even with
+    // nothing tracked by the control plane, the project can still have
+    // backlog-state issues that the task graph renders in its Backlog pane.
     let linear_issues = match linear_task_graph.task_graph_issues(&identifiers).await {
         Ok(issues) => issues,
         Err(error) => {

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -131,10 +131,7 @@ pub trait LinearTaskGraphClient: Send + Sync + 'static {
     /// The requested identifiers plus every backlog-state issue in the
     /// project, from one scan. Defaults to the plain identifier lookup so
     /// fakes without backlog data keep working unchanged.
-    async fn task_graph_issues(
-        &self,
-        identifiers: &[String],
-    ) -> Result<Vec<TrackerIssue>, String> {
+    async fn task_graph_issues(&self, identifiers: &[String]) -> Result<Vec<TrackerIssue>, String> {
         self.issues_by_identifiers(identifiers).await
     }
 }
@@ -150,10 +147,7 @@ impl LinearTaskGraphClient for crate::opensymphony_linear::LinearClient {
             .map_err(|error| error.to_string())
     }
 
-    async fn task_graph_issues(
-        &self,
-        identifiers: &[String],
-    ) -> Result<Vec<TrackerIssue>, String> {
+    async fn task_graph_issues(&self, identifiers: &[String]) -> Result<Vec<TrackerIssue>, String> {
         self.project_task_graph_issues(identifiers)
             .await
             .map_err(|error| error.to_string())
@@ -1318,8 +1312,10 @@ async fn get_memory_completed_tasks(
         .map(|row| row.issue_key.to_ascii_uppercase())
         .collect::<HashSet<_>>();
     for issue in &envelope.snapshot.issues {
-        if !matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Completed)
-            || captured.contains(&issue.identifier.to_ascii_uppercase())
+        if !matches!(
+            issue.runtime_state,
+            ControlPlaneIssueRuntimeState::Completed
+        ) || captured.contains(&issue.identifier.to_ascii_uppercase())
         {
             continue;
         }
@@ -4267,18 +4263,24 @@ mod tests {
         ];
         sort_completed_tasks(&mut rows, CompletedTasksSort::CompletedDesc);
         assert_eq!(
-            rows.iter().map(|row| row.issue_key.as_str()).collect::<Vec<_>>(),
+            rows.iter()
+                .map(|row| row.issue_key.as_str())
+                .collect::<Vec<_>>(),
             vec!["COE-99", "COE-100", "COE-2"],
         );
         sort_completed_tasks(&mut rows, CompletedTasksSort::CompletedAsc);
         assert_eq!(
-            rows.iter().map(|row| row.issue_key.as_str()).collect::<Vec<_>>(),
+            rows.iter()
+                .map(|row| row.issue_key.as_str())
+                .collect::<Vec<_>>(),
             vec!["COE-100", "COE-99", "COE-2"],
         );
         // Natural key order: COE-99 before COE-100 despite lexicographic order.
         sort_completed_tasks(&mut rows, CompletedTasksSort::IdAsc);
         assert_eq!(
-            rows.iter().map(|row| row.issue_key.as_str()).collect::<Vec<_>>(),
+            rows.iter()
+                .map(|row| row.issue_key.as_str())
+                .collect::<Vec<_>>(),
             vec!["COE-2", "COE-99", "COE-100"],
         );
     }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -42,10 +42,10 @@ use crate::opensymphony_gateway_schema::{
     },
 };
 use crate::opensymphony_memory::{
-    MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphCommunityOptions,
-    MemoryGraphProjectionError, memory_concept_detail, memory_graph_bundles,
-    memory_graph_communities_with_options, memory_graph_search as search_memory_graph,
-    memory_graph_snapshot_with_options,
+    DEFAULT_MEMORY_GRAPH_BUNDLE_ID, MemoryConfig, MemoryError, MemoryGraphAccess,
+    MemoryGraphCommunityOptions, MemoryGraphProjectionError, memory_completed_task_rows,
+    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
+    memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
 };
 
 pub mod action_handler;
@@ -84,8 +84,9 @@ pub use crate::opensymphony_gateway_schema::{
     cursor::PageCursor,
     event_journal::{EventPage as GatewayEventPage, JournalError as EventJournalError},
     memory_graph::{
-        MemoryBundleList, MemoryCommunityList, MemoryConceptDetail, MemoryGraphSnapshot,
-        MemoryGraphUpdatedEvent, MemorySearchResponse,
+        MemoryBundleList, MemoryCommunityList, MemoryCompletedTask, MemoryCompletedTaskPage,
+        MemoryCompletedTaskSource, MemoryConceptDetail, MemoryGraphSnapshot,
+        MemoryGraphUpdatedEvent, MemorySearchResponse, MemoryTaskPullRequest,
     },
     model_settings::{
         CodexCliProbe, CodexLocalReadiness, CredentialStatusResponse, ModelSettingsResponse,
@@ -126,6 +127,16 @@ pub trait LinearTaskGraphClient: Send + Sync + 'static {
         &self,
         identifiers: &[String],
     ) -> Result<Vec<TrackerIssue>, String>;
+
+    /// The requested identifiers plus every backlog-state issue in the
+    /// project, from one scan. Defaults to the plain identifier lookup so
+    /// fakes without backlog data keep working unchanged.
+    async fn task_graph_issues(
+        &self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, String> {
+        self.issues_by_identifiers(identifiers).await
+    }
 }
 
 #[async_trait]
@@ -135,6 +146,15 @@ impl LinearTaskGraphClient for crate::opensymphony_linear::LinearClient {
         identifiers: &[String],
     ) -> Result<Vec<TrackerIssue>, String> {
         self.project_issues_by_identifiers(identifiers)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn task_graph_issues(
+        &self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, String> {
+        self.project_task_graph_issues(identifiers)
             .await
             .map_err(|error| error.to_string())
     }
@@ -699,6 +719,10 @@ impl GatewayServer {
                 get(get_memory_communities),
             )
             .route("/api/v1/memory/search", get(search_memory))
+            .route(
+                "/api/v1/memory/completed-tasks",
+                get(get_memory_completed_tasks),
+            )
             .route("/api/v1/projects", get(list_projects))
             .route("/api/v1/projects/{project_id}", get(get_project))
             .route(
@@ -1261,6 +1285,228 @@ async fn search_memory(
     search_memory_graph(config, &query, params.limit.unwrap_or(10), access)
         .map(Json)
         .map_err(memory_graph_error)
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct MemoryCompletedTasksQuery {
+    q: Option<String>,
+    query: Option<String>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+    sort: Option<String>,
+    visibility: Option<String>,
+}
+
+const MEMORY_COMPLETED_TASKS_DEFAULT_LIMIT: usize = 25;
+const MEMORY_COMPLETED_TASKS_MAX_LIMIT: usize = 100;
+
+/// Completed tasks for the task graph's "Completed" pane. Rows come from
+/// the memory catalog first (capsules carry PR evidence and survive Linear
+/// archival) merged with orchestrator-known completed issues that have not
+/// been captured yet — the Linear API is never touched on this path.
+async fn get_memory_completed_tasks(
+    State(state): State<GatewayState>,
+    Query(params): Query<MemoryCompletedTasksQuery>,
+) -> Result<Json<MemoryCompletedTaskPage>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_memory(&state)?;
+    let access = memory_graph_access(params.visibility.as_deref())?;
+    let mut rows = memory_completed_task_rows(config, access).map_err(memory_graph_error)?;
+
+    let envelope = state.store.current().await;
+    let captured = rows
+        .iter()
+        .map(|row| row.issue_key.to_ascii_uppercase())
+        .collect::<HashSet<_>>();
+    for issue in &envelope.snapshot.issues {
+        if !matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Completed)
+            || captured.contains(&issue.identifier.to_ascii_uppercase())
+        {
+            continue;
+        }
+        rows.push(MemoryCompletedTask {
+            issue_key: issue.identifier.clone(),
+            concept_id: String::new(),
+            bundle_id: None,
+            title: issue.title.clone(),
+            state: Some(issue.tracker_state.clone()),
+            milestone: None,
+            url: None,
+            completed_at: issue.finished_at.or(Some(issue.last_event_at)),
+            prs: issue
+                .pr_url
+                .as_deref()
+                .map(pull_request_from_url)
+                .into_iter()
+                .collect(),
+            source: MemoryCompletedTaskSource::Orchestrator,
+        });
+    }
+
+    let query = params
+        .query
+        .or(params.q)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if let Some(query) = &query {
+        let needle = query.to_ascii_lowercase();
+        rows.retain(|row| completed_task_matches(row, &needle));
+    }
+
+    let sort = parse_completed_tasks_sort(params.sort.as_deref());
+    sort_completed_tasks(&mut rows, sort);
+
+    let total = rows.len();
+    let limit = params
+        .limit
+        .unwrap_or(MEMORY_COMPLETED_TASKS_DEFAULT_LIMIT)
+        .clamp(1, MEMORY_COMPLETED_TASKS_MAX_LIMIT);
+    let offset = params.offset.unwrap_or(0).min(total);
+    let tasks = rows.into_iter().skip(offset).take(limit).collect();
+
+    Ok(Json(MemoryCompletedTaskPage {
+        schema_version: SchemaVersion::v1(),
+        bundle_id: DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string(),
+        tasks,
+        total,
+        offset,
+        limit,
+        sort: sort.as_str().to_string(),
+        query,
+        generated_at: Utc::now(),
+    }))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompletedTasksSort {
+    CompletedDesc,
+    CompletedAsc,
+    IdAsc,
+    IdDesc,
+    TitleAsc,
+    TitleDesc,
+    PrDesc,
+    PrAsc,
+}
+
+impl CompletedTasksSort {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CompletedDesc => "completed_desc",
+            Self::CompletedAsc => "completed_asc",
+            Self::IdAsc => "id_asc",
+            Self::IdDesc => "id_desc",
+            Self::TitleAsc => "title_asc",
+            Self::TitleDesc => "title_desc",
+            Self::PrDesc => "pr_desc",
+            Self::PrAsc => "pr_asc",
+        }
+    }
+}
+
+fn parse_completed_tasks_sort(value: Option<&str>) -> CompletedTasksSort {
+    match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("completed_asc") => CompletedTasksSort::CompletedAsc,
+        Some("id_asc") => CompletedTasksSort::IdAsc,
+        Some("id_desc") => CompletedTasksSort::IdDesc,
+        Some("title_asc") => CompletedTasksSort::TitleAsc,
+        Some("title_desc") => CompletedTasksSort::TitleDesc,
+        Some("pr_desc") => CompletedTasksSort::PrDesc,
+        Some("pr_asc") => CompletedTasksSort::PrAsc,
+        _ => CompletedTasksSort::CompletedDesc,
+    }
+}
+
+fn sort_completed_tasks(rows: &mut [MemoryCompletedTask], sort: CompletedTasksSort) {
+    match sort {
+        // Rows without a completion date sort last in either direction (the
+        // leading `is_none()` key), instead of `Option`'s None-first order.
+        CompletedTasksSort::CompletedDesc => rows.sort_by_key(|row| {
+            (
+                row.completed_at.is_none(),
+                std::cmp::Reverse(row.completed_at),
+                std::cmp::Reverse(issue_key_sort_key(&row.issue_key)),
+            )
+        }),
+        CompletedTasksSort::CompletedAsc => rows.sort_by_key(|row| {
+            (
+                row.completed_at.is_none(),
+                row.completed_at,
+                issue_key_sort_key(&row.issue_key),
+            )
+        }),
+        CompletedTasksSort::IdAsc => {
+            rows.sort_by_key(|row| issue_key_sort_key(&row.issue_key));
+        }
+        CompletedTasksSort::IdDesc => {
+            rows.sort_by_key(|row| std::cmp::Reverse(issue_key_sort_key(&row.issue_key)));
+        }
+        CompletedTasksSort::TitleAsc => rows.sort_by(|left, right| {
+            left.title
+                .to_ascii_lowercase()
+                .cmp(&right.title.to_ascii_lowercase())
+        }),
+        CompletedTasksSort::TitleDesc => rows.sort_by(|left, right| {
+            right
+                .title
+                .to_ascii_lowercase()
+                .cmp(&left.title.to_ascii_lowercase())
+        }),
+        CompletedTasksSort::PrDesc => {
+            rows.sort_by_key(|row| std::cmp::Reverse(latest_pr_number(row)));
+        }
+        CompletedTasksSort::PrAsc => {
+            rows.sort_by_key(latest_pr_number);
+        }
+    }
+}
+
+/// Natural sort key so `COE-99` orders before `COE-100`.
+fn issue_key_sort_key(issue_key: &str) -> (String, u64) {
+    let (prefix, number) = issue_key
+        .rfind(['-', '_'])
+        .map(|at| (&issue_key[..at], &issue_key[at + 1..]))
+        .unwrap_or((issue_key, ""));
+    (
+        prefix.to_ascii_uppercase(),
+        number.parse::<u64>().unwrap_or(0),
+    )
+}
+
+fn latest_pr_number(row: &MemoryCompletedTask) -> u64 {
+    row.prs.iter().map(|pr| pr.number).max().unwrap_or(0)
+}
+
+fn completed_task_matches(row: &MemoryCompletedTask, needle: &str) -> bool {
+    row.issue_key.to_ascii_lowercase().contains(needle)
+        || row.title.to_ascii_lowercase().contains(needle)
+        || row
+            .state
+            .as_deref()
+            .is_some_and(|state| state.to_ascii_lowercase().contains(needle))
+        || row
+            .milestone
+            .as_deref()
+            .is_some_and(|milestone| milestone.to_ascii_lowercase().contains(needle))
+        || row.prs.iter().any(|pr| {
+            pr.title.to_ascii_lowercase().contains(needle)
+                || format!("#{}", pr.number).contains(needle)
+        })
+}
+
+fn pull_request_from_url(url: &str) -> MemoryTaskPullRequest {
+    let number = url
+        .rsplit('/')
+        .find_map(|segment| segment.parse::<u64>().ok())
+        .unwrap_or(0);
+    MemoryTaskPullRequest {
+        number,
+        title: String::new(),
+        url: Some(url.to_string()),
+        // No merge evidence on this path; the memory-backed row replaces
+        // this one after capture and carries the real merge state.
+        merged: true,
+        merged_at: None,
+    }
 }
 
 fn configured_memory(
@@ -2783,20 +3029,6 @@ async fn get_task_graph(
         .map(|issue| issue.identifier.clone())
         .collect::<Vec<_>>();
 
-    if identifiers.is_empty() {
-        return (
-            StatusCode::OK,
-            Json(TaskGraphSnapshot {
-                schema_version: SchemaVersion::v1(),
-                project_id,
-                generated_at,
-                nodes: Vec::new(),
-                root_ids: Vec::new(),
-            }),
-        )
-            .into_response();
-    }
-
     let Some(linear_task_graph) = state.linear_task_graph.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -2811,7 +3043,10 @@ async fn get_task_graph(
             .into_response();
     };
 
-    let linear_issues = match linear_task_graph.issues_by_identifiers(&identifiers).await {
+    // No early return on empty identifiers: even with nothing tracked by the
+    // control plane, the project can still have backlog-state issues that the
+    // task graph renders in its Backlog pane.
+    let linear_issues = match linear_task_graph.task_graph_issues(&identifiers).await {
         Ok(issues) => issues,
         Err(error) => {
             tracing::warn!(error = %error, "failed to load task graph dependencies from Linear");
@@ -4003,6 +4238,50 @@ mod tests {
     use crate::opensymphony_gateway_schema::event_journal::{
         EventActor, EventKind, StreamErrorType,
     };
+
+    #[test]
+    fn completed_tasks_sort_puts_undated_rows_last_in_both_directions() {
+        fn row(issue_key: &str, completed_at: Option<&str>) -> MemoryCompletedTask {
+            MemoryCompletedTask {
+                issue_key: issue_key.to_string(),
+                concept_id: String::new(),
+                bundle_id: None,
+                title: issue_key.to_string(),
+                state: None,
+                milestone: None,
+                url: None,
+                completed_at: completed_at.map(|value| {
+                    chrono::DateTime::parse_from_rfc3339(value)
+                        .expect("test timestamp")
+                        .with_timezone(&Utc)
+                }),
+                prs: Vec::new(),
+                source: MemoryCompletedTaskSource::Memory,
+            }
+        }
+
+        let mut rows = vec![
+            row("COE-2", None),
+            row("COE-100", Some("2026-06-01T00:00:00Z")),
+            row("COE-99", Some("2026-06-03T00:00:00Z")),
+        ];
+        sort_completed_tasks(&mut rows, CompletedTasksSort::CompletedDesc);
+        assert_eq!(
+            rows.iter().map(|row| row.issue_key.as_str()).collect::<Vec<_>>(),
+            vec!["COE-99", "COE-100", "COE-2"],
+        );
+        sort_completed_tasks(&mut rows, CompletedTasksSort::CompletedAsc);
+        assert_eq!(
+            rows.iter().map(|row| row.issue_key.as_str()).collect::<Vec<_>>(),
+            vec!["COE-100", "COE-99", "COE-2"],
+        );
+        // Natural key order: COE-99 before COE-100 despite lexicographic order.
+        sort_completed_tasks(&mut rows, CompletedTasksSort::IdAsc);
+        assert_eq!(
+            rows.iter().map(|row| row.issue_key.as_str()).collect::<Vec<_>>(),
+            vec!["COE-2", "COE-99", "COE-100"],
+        );
+    }
 
     #[test]
     fn journal_error_mapping_preserves_invalid_cursor_sequence() {

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3170,7 +3170,11 @@ fn map_runtime_state_to_graph_category(
         ControlPlaneIssueRuntimeState::RetryQueued => TaskGraphStateCategory::InProgress,
         ControlPlaneIssueRuntimeState::Releasing => TaskGraphStateCategory::InProgress,
         ControlPlaneIssueRuntimeState::Completed => TaskGraphStateCategory::Done,
-        ControlPlaneIssueRuntimeState::Failed => TaskGraphStateCategory::Done,
+        // A failed run is not completed work: `done` would banish the issue
+        // to the Completed pane's domain (which only merges Completed rows),
+        // hiding it from every pane. `todo` keeps it in the Current pane
+        // where its run card and evidence stay reachable for retry/triage.
+        ControlPlaneIssueRuntimeState::Failed => TaskGraphStateCategory::Todo,
     }
 }
 

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1306,16 +1306,24 @@ async fn get_memory_completed_tasks(
     let access = memory_graph_access(params.visibility.as_deref())?;
     let mut rows = memory_completed_task_rows(config, access).map_err(memory_graph_error)?;
 
+    // Control-plane issues carry no visibility metadata, and `captured` is
+    // built from the access-filtered rows — merging them under
+    // `visibility=public` would reintroduce privately-captured tasks (title
+    // and PR URL) as `orchestrator` rows. Public views therefore serve
+    // memory-backed rows only.
+    let merge_orchestrator = access == MemoryGraphAccess::AllAccessible;
     let envelope = state.store.current().await;
     let captured = rows
         .iter()
         .map(|row| row.issue_key.to_ascii_uppercase())
         .collect::<HashSet<_>>();
     for issue in &envelope.snapshot.issues {
-        if !matches!(
-            issue.runtime_state,
-            ControlPlaneIssueRuntimeState::Completed
-        ) || captured.contains(&issue.identifier.to_ascii_uppercase())
+        if !merge_orchestrator
+            || !matches!(
+                issue.runtime_state,
+                ControlPlaneIssueRuntimeState::Completed
+            )
+            || captured.contains(&issue.identifier.to_ascii_uppercase())
         {
             continue;
         }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -4247,7 +4247,7 @@ mod tests {
                 milestone: None,
                 url: None,
                 completed_at: completed_at.map(|value| {
-                    chrono::DateTime::parse_from_rfc3339(value)
+                    DateTime::parse_from_rfc3339(value)
                         .expect("test timestamp")
                         .with_timezone(&Utc)
                 }),

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1302,9 +1302,15 @@ async fn get_memory_completed_tasks(
     State(state): State<GatewayState>,
     Query(params): Query<MemoryCompletedTasksQuery>,
 ) -> Result<Json<MemoryCompletedTaskPage>, (StatusCode, Json<serde_json::Value>)> {
-    let config = configured_memory(&state)?;
     let access = memory_graph_access(params.visibility.as_deref())?;
-    let mut rows = memory_completed_task_rows(config, access).map_err(memory_graph_error)?;
+    // Memory is optional here: a local run with no catalog still has
+    // orchestrator-known completions to show. Without it we serve an empty
+    // memory row set rather than 503, since the desktop Completed pane is
+    // the only place `done` nodes surface.
+    let mut rows = match state.memory_config.as_ref() {
+        Some(config) => memory_completed_task_rows(config, access).map_err(memory_graph_error)?,
+        None => Vec::new(),
+    };
 
     // Control-plane issues carry no visibility metadata, and `captured` is
     // built from the access-filtered rows — merging them under

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2337,6 +2337,55 @@ async fn gateway_serves_memory_completed_tasks() {
     server_task.abort();
 }
 
+#[tokio::test]
+async fn gateway_completed_tasks_serve_orchestrator_rows_without_memory_catalog() {
+    // No memory catalog configured: a local run's completed issues must
+    // still surface as `orchestrator` rows (the desktop Completed pane is
+    // the only place `done` nodes appear), not 503.
+    let mut snapshot = fixture_snapshot(0);
+    let mut completed_issue = snapshot.issues[0].clone();
+    completed_issue.identifier = "COE-370".to_owned();
+    completed_issue.title = "Local completion".to_owned();
+    completed_issue.tracker_state = "Done".to_owned();
+    completed_issue.runtime_state = IssueRuntimeState::Completed;
+    completed_issue.finished_at = Some(Utc::now());
+    completed_issue.pr_url = Some("https://github.com/kumanday/OpenSymphony/pull/370".to_owned());
+    snapshot.issues.push(completed_issue);
+
+    // GatewayServer::new leaves memory_config unset.
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{address}/api/v1/memory/completed-tasks"))
+        .send()
+        .await
+        .expect("fetch completed tasks");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let page = response
+        .json::<MemoryCompletedTaskPage>()
+        .await
+        .expect("decode completed tasks");
+    assert_eq!(page.total, 1);
+    assert_eq!(page.tasks[0].issue_key, "COE-370");
+    assert_eq!(
+        page.tasks[0].source,
+        opensymphony::opensymphony_gateway_schema::memory_graph::MemoryCompletedTaskSource::Orchestrator,
+    );
+
+    server_task.abort();
+}
+
 fn write_completed_tasks_fixture(repo: &std::path::Path) -> MemoryConfig {
     let config_path = repo.join("opensymphony-memory.yaml");
     std::fs::write(

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2218,10 +2218,10 @@ async fn gateway_serves_memory_completed_tasks() {
         .await
         .expect("decode completed tasks");
     assert_eq!(page.schema_version.major, 1);
-    assert_eq!(page.total, 2);
+    assert_eq!(page.total, 3);
     assert_eq!(page.sort, "completed_desc");
     // Freshest completion first: the orchestrator row finished just now,
-    // the memory capsule's timestamp is in the past.
+    // the memory capsules' timestamps are in the past.
     assert_eq!(page.tasks[0].issue_key, "COE-370");
     assert_eq!(
         page.tasks[0].source,
@@ -2236,8 +2236,28 @@ async fn gateway_serves_memory_completed_tasks() {
     );
     assert_eq!(page.tasks[1].concept_id, "issues/COE-300");
     assert_eq!(page.tasks[1].state.as_deref(), Some("Done"));
+    assert_eq!(page.tasks[2].issue_key, "COE-302");
     // The In Progress capsule must not leak into the completed list.
     assert!(page.tasks.iter().all(|task| task.issue_key != "COE-301"));
+
+    // Public views serve only public memory capsules: the private COE-302
+    // stays out, and so do orchestrator rows — the control plane has no
+    // visibility metadata, so merging them would reintroduce
+    // privately-captured tasks past the filter.
+    let public = client
+        .get(format!("{base}?visibility=public"))
+        .send()
+        .await
+        .expect("fetch public completed tasks")
+        .json::<MemoryCompletedTaskPage>()
+        .await
+        .expect("decode public completed tasks");
+    assert_eq!(public.total, 1);
+    assert_eq!(public.tasks[0].issue_key, "COE-300");
+    assert_eq!(
+        public.tasks[0].source,
+        opensymphony::opensymphony_gateway_schema::memory_graph::MemoryCompletedTaskSource::Memory,
+    );
 
     // Search narrows on title/key, pagination clamps.
     let filtered = client
@@ -2261,7 +2281,7 @@ async fn gateway_serves_memory_completed_tasks() {
         .json::<MemoryCompletedTaskPage>()
         .await
         .expect("decode second page");
-    assert_eq!(second_page.total, 2);
+    assert_eq!(second_page.total, 3);
     assert_eq!(second_page.tasks.len(), 1);
     assert_eq!(second_page.tasks[0].issue_key, "COE-300");
 
@@ -2337,6 +2357,30 @@ Active body.
 "#,
     )
     .expect("active capsule should write");
+    std::fs::write(
+        issues_dir.join("COE-302.md"),
+        r#"---
+type: issue-capsule
+title: "COE-302: Private completed capsule"
+description: Completed but private.
+state: Done
+timestamp: 2026-06-19T10:00:00Z
+tags: [memory]
+opensymphony:
+  visibility: private
+  scope_refs:
+    - kind: work_item
+      id: COE-302
+    - kind: area
+      id: graph-view
+---
+
+# COE-302: Private completed capsule
+
+Private completed body.
+"#,
+    )
+    .expect("private completed capsule should write");
     MemoryConfig::load(repo, Some(&config_path)).expect("memory config should load")
 }
 

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2462,6 +2462,44 @@ async fn gateway_task_graph_requires_linear_reader() {
 }
 
 #[tokio::test]
+async fn gateway_task_graph_empty_project_without_linear_returns_empty_ok() {
+    // A control-plane-only/local run with no tracked issues has nothing to
+    // expand and no backlog to discover, so a missing Linear client is a
+    // valid empty project (200), not a 503.
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues.clear();
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body = response
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+    assert!(body.nodes.is_empty());
+    assert!(body.root_ids.is_empty());
+
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn gateway_serves_run_detail() {
     let store = SnapshotStore::new(fixture_snapshot(0));
     let server = GatewayServer::new(store.clone());

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -23,8 +23,8 @@ use opensymphony::opensymphony_gateway_schema::action::{
 };
 use opensymphony::opensymphony_gateway_schema::envelope::EntityKind;
 use opensymphony::opensymphony_gateway_schema::memory_graph::{
-    MemoryBundleList, MemoryCommunityList, MemoryConceptDetail, MemoryGraphEdgeKind,
-    MemoryGraphSnapshot, MemorySearchResponse,
+    MemoryBundleList, MemoryCommunityList, MemoryCompletedTaskPage, MemoryConceptDetail,
+    MemoryGraphEdgeKind, MemoryGraphSnapshot, MemorySearchResponse,
 };
 use opensymphony::opensymphony_gateway_schema::model_settings::{
     CodexCliProbe, CodexLocalReadiness, CredentialStatusKind, CredentialStatusResponse,
@@ -61,6 +61,41 @@ impl LinearTaskGraphClient for FakeLinearTaskGraphClient {
                     .cloned()
             })
             .collect())
+    }
+}
+
+/// Fake that mirrors the real client's task-graph contract: requested
+/// identifiers plus every backlog-state issue from the project scan.
+#[derive(Clone)]
+struct BacklogLinearTaskGraphClient {
+    issues: Vec<TrackerIssue>,
+    backlog: Vec<TrackerIssue>,
+}
+
+#[async_trait]
+impl LinearTaskGraphClient for BacklogLinearTaskGraphClient {
+    async fn issues_by_identifiers(
+        &self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, String> {
+        Ok(identifiers
+            .iter()
+            .filter_map(|identifier| {
+                self.issues
+                    .iter()
+                    .find(|issue| issue.identifier == *identifier)
+                    .cloned()
+            })
+            .collect())
+    }
+
+    async fn task_graph_issues(
+        &self,
+        identifiers: &[String],
+    ) -> Result<Vec<TrackerIssue>, String> {
+        let mut issues = self.issues_by_identifiers(identifiers).await?;
+        issues.extend(self.backlog.iter().cloned());
+        Ok(issues)
     }
 }
 
@@ -2051,6 +2086,262 @@ async fn gateway_task_graph_skips_completed_issues_without_project_metadata() {
     assert_eq!(response.nodes[0].identifier, "COE-255");
 
     server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_task_graph_includes_backlog_issues_with_cross_edges() {
+    let snapshot = fixture_snapshot(0);
+    let issues = snapshot
+        .issues
+        .iter()
+        .map(|issue| tracker_issue_from_snapshot(issue, &[]))
+        .collect::<Vec<_>>();
+    let now = Utc::now();
+    let backlog_issue = TrackerIssue {
+        id: "COE-900".to_owned(),
+        identifier: "COE-900".to_owned(),
+        url: "https://linear.app/kumanday/issue/COE-900".to_owned(),
+        title: "Backlog follow-up".to_owned(),
+        description: None,
+        priority: None,
+        state: "Backlog".to_owned(),
+        state_kind: TrackerIssueStateKind::Backlog,
+        branch_name: None,
+        pr_url: None,
+        labels: Vec::new(),
+        project_id: Some("proj-open".to_owned()),
+        project_slug: Some("opensymphony-bootstrap".to_owned()),
+        project_name: Some("OpenSymphony".to_owned()),
+        parent_id: None,
+        parent: None,
+        project_milestone: None,
+        blocked_by: vec![TrackerIssueBlocker {
+            id: "COE-255".to_owned(),
+            identifier: "COE-255".to_owned(),
+            title: "Observability and FrankenTUI".to_owned(),
+            state: TrackerIssueState {
+                id: "state-COE-255".to_owned(),
+                name: "In Progress".to_owned(),
+                tracker_type: "started".to_owned(),
+                kind: TrackerIssueStateKind::Started,
+            },
+        }],
+        sub_issues: Vec::new(),
+        created_at: now,
+        updated_at: now,
+    };
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store).with_linear_task_graph(Some(std::sync::Arc::new(
+        BacklogLinearTaskGraphClient {
+            issues,
+            backlog: vec![backlog_issue],
+        },
+    )));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    assert_eq!(response.nodes.len(), 2);
+    let backlog_node = response
+        .nodes
+        .iter()
+        .find(|node| node.identifier == "COE-900")
+        .expect("backlog issue should be present in the task graph");
+    assert_eq!(
+        backlog_node.state_category,
+        opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphStateCategory::Backlog,
+    );
+    // The blocked_by edge crosses from the backlog node to the tracked
+    // current node — the UI draws it as a Current → Backlog edge.
+    assert_eq!(backlog_node.blocked_by, vec!["COE-255".to_owned()]);
+    assert!(backlog_node.runtime_overlay.is_none());
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_memory_completed_tasks() {
+    let repo = tempfile::tempdir().expect("memory repo");
+    let config = write_completed_tasks_fixture(repo.path());
+    refresh_memory_index_from_okf(&config, &repo.path().join(".opensymphony/memory"))
+        .expect("fixture should reindex");
+
+    // The control plane knows one freshly completed issue that memory has
+    // not captured yet — it must appear as an `orchestrator` row.
+    let mut snapshot = fixture_snapshot(0);
+    let mut completed_issue = snapshot.issues[0].clone();
+    completed_issue.identifier = "COE-370".to_owned();
+    completed_issue.title = "Fresh completion".to_owned();
+    completed_issue.tracker_state = "Done".to_owned();
+    completed_issue.runtime_state = IssueRuntimeState::Completed;
+    completed_issue.finished_at = Some(Utc::now());
+    completed_issue.pr_url =
+        Some("https://github.com/kumanday/OpenSymphony/pull/370".to_owned());
+    snapshot.issues.push(completed_issue);
+
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store).with_memory_config(Some(config));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://{address}/api/v1/memory/completed-tasks");
+
+    let page = client
+        .get(&base)
+        .send()
+        .await
+        .expect("fetch completed tasks")
+        .json::<MemoryCompletedTaskPage>()
+        .await
+        .expect("decode completed tasks");
+    assert_eq!(page.schema_version.major, 1);
+    assert_eq!(page.total, 2);
+    assert_eq!(page.sort, "completed_desc");
+    // Freshest completion first: the orchestrator row finished just now,
+    // the memory capsule's timestamp is in the past.
+    assert_eq!(page.tasks[0].issue_key, "COE-370");
+    assert_eq!(
+        page.tasks[0].source,
+        opensymphony::opensymphony_gateway_schema::memory_graph::MemoryCompletedTaskSource::Orchestrator,
+    );
+    assert_eq!(page.tasks[0].prs.len(), 1);
+    assert_eq!(page.tasks[0].prs[0].number, 370);
+    assert_eq!(page.tasks[1].issue_key, "COE-300");
+    assert_eq!(
+        page.tasks[1].source,
+        opensymphony::opensymphony_gateway_schema::memory_graph::MemoryCompletedTaskSource::Memory,
+    );
+    assert_eq!(page.tasks[1].concept_id, "issues/COE-300");
+    assert_eq!(page.tasks[1].state.as_deref(), Some("Done"));
+    // The In Progress capsule must not leak into the completed list.
+    assert!(page.tasks.iter().all(|task| task.issue_key != "COE-301"));
+
+    // Search narrows on title/key, pagination clamps.
+    let filtered = client
+        .get(format!("{base}?query=fresh&limit=1&sort=id_asc"))
+        .send()
+        .await
+        .expect("fetch filtered completed tasks")
+        .json::<MemoryCompletedTaskPage>()
+        .await
+        .expect("decode filtered completed tasks");
+    assert_eq!(filtered.total, 1);
+    assert_eq!(filtered.tasks[0].issue_key, "COE-370");
+    assert_eq!(filtered.sort, "id_asc");
+    assert_eq!(filtered.query.as_deref(), Some("fresh"));
+
+    let second_page = client
+        .get(format!("{base}?limit=1&offset=1"))
+        .send()
+        .await
+        .expect("fetch second page")
+        .json::<MemoryCompletedTaskPage>()
+        .await
+        .expect("decode second page");
+    assert_eq!(second_page.total, 2);
+    assert_eq!(second_page.tasks.len(), 1);
+    assert_eq!(second_page.tasks[0].issue_key, "COE-300");
+
+    server_task.abort();
+}
+
+fn write_completed_tasks_fixture(repo: &std::path::Path) -> MemoryConfig {
+    let config_path = repo.join("opensymphony-memory.yaml");
+    std::fs::write(
+        &config_path,
+        r#"
+areas:
+  graph-view:
+    title: Graph View
+    docs_target: docs/graph-view.md
+    status: stable
+    confidence: 90
+"#,
+    )
+    .expect("memory config should write");
+    let memory_root = repo.join(".opensymphony/memory");
+    let issues_dir = memory_root.join("issues");
+    std::fs::create_dir_all(&issues_dir).expect("memory issues dir should write");
+    std::fs::write(
+        issues_dir.join("COE-300.md"),
+        r#"---
+type: issue-capsule
+title: "COE-300: Completed capsule"
+description: Completed task fixture.
+state: Done
+timestamp: 2026-06-20T10:00:00Z
+tags: [memory]
+opensymphony:
+  visibility: public
+  scope_refs:
+    - kind: work_item
+      id: COE-300
+    - kind: area
+      id: graph-view
+  source_refs:
+    - kind: linear_issue
+      id: COE-300
+      url: https://linear.app/example/issue/COE-300
+---
+
+# COE-300: Completed capsule
+
+Completed body.
+"#,
+    )
+    .expect("completed capsule should write");
+    std::fs::write(
+        issues_dir.join("COE-301.md"),
+        r#"---
+type: issue-capsule
+title: "COE-301: Active capsule"
+description: Not completed yet.
+state: In Progress
+timestamp: 2026-06-21T10:00:00Z
+tags: [memory]
+opensymphony:
+  visibility: public
+  scope_refs:
+    - kind: work_item
+      id: COE-301
+    - kind: area
+      id: graph-view
+---
+
+# COE-301: Active capsule
+
+Active body.
+"#,
+    )
+    .expect("active capsule should write");
+    MemoryConfig::load(repo, Some(&config_path)).expect("memory config should load")
 }
 
 #[tokio::test]

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -89,10 +89,7 @@ impl LinearTaskGraphClient for BacklogLinearTaskGraphClient {
             .collect())
     }
 
-    async fn task_graph_issues(
-        &self,
-        identifiers: &[String],
-    ) -> Result<Vec<TrackerIssue>, String> {
+    async fn task_graph_issues(&self, identifiers: &[String]) -> Result<Vec<TrackerIssue>, String> {
         let mut issues = self.issues_by_identifiers(identifiers).await?;
         issues.extend(self.backlog.iter().cloned());
         Ok(issues)
@@ -2193,8 +2190,7 @@ async fn gateway_serves_memory_completed_tasks() {
     completed_issue.tracker_state = "Done".to_owned();
     completed_issue.runtime_state = IssueRuntimeState::Completed;
     completed_issue.finished_at = Some(Utc::now());
-    completed_issue.pr_url =
-        Some("https://github.com/kumanday/OpenSymphony/pull/370".to_owned());
+    completed_issue.pr_url = Some("https://github.com/kumanday/OpenSymphony/pull/370".to_owned());
     snapshot.issues.push(completed_issue);
 
     let store = SnapshotStore::new(snapshot);

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2175,6 +2175,55 @@ async fn gateway_task_graph_includes_backlog_issues_with_cross_edges() {
 }
 
 #[tokio::test]
+async fn gateway_task_graph_keeps_failed_issues_visible_as_todo() {
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].runtime_state = IssueRuntimeState::Failed;
+    snapshot.issues[0].last_outcome = WorkerOutcome::Failed;
+    let issues = snapshot
+        .issues
+        .iter()
+        .map(|issue| tracker_issue_from_snapshot(issue, &[]))
+        .collect::<Vec<_>>();
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store).with_linear_task_graph(Some(std::sync::Arc::new(
+        FakeLinearTaskGraphClient { issues },
+    )));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    // A failed run is not completed work: `done` would hide the issue from
+    // every pane (the Completed table only merges Completed rows), so it
+    // categorizes as `todo` and keeps its run entry point in Current.
+    assert_eq!(response.nodes.len(), 1);
+    assert_eq!(response.nodes[0].identifier, "COE-255");
+    assert_eq!(
+        response.nodes[0].state_category,
+        opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphStateCategory::Todo,
+    );
+
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn gateway_serves_memory_completed_tasks() {
     let repo = tempfile::tempdir().expect("memory repo");
     let config = write_completed_tasks_fixture(repo.path());

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -436,10 +436,27 @@ impl LinearClient {
                 None => missing_issue_ids.push(identifier.clone()),
             }
         }
-        if !missing_issue_ids.is_empty() {
-            return Err(LinearError::MissingIssueIds {
-                issue_ids: missing_issue_ids,
-            });
+
+        // A tracked issue can sit outside the configured project scan — moved
+        // to another project, or lacking project metadata — while the control
+        // plane still tracks it (e.g. a failed run). Resolve those by
+        // identifier so a single miss does not fail the whole task graph;
+        // anything still unresolvable is omitted (its node and edges simply
+        // drop out) rather than 502-ing the graph.
+        for identifier in missing_issue_ids {
+            match self
+                .issues_by_identifiers(std::slice::from_ref(&identifier))
+                .await
+            {
+                Ok(mut resolved) => issues.append(&mut resolved),
+                Err(LinearError::MissingIssueIds { .. }) => {
+                    debug!(
+                        identifier = %identifier,
+                        "task graph identifier not found in project scan or by lookup; omitting"
+                    );
+                }
+                Err(error) => return Err(error),
+            }
         }
 
         backlog.sort_by(|left, right| left.identifier.cmp(&right.identifier));

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -397,6 +397,56 @@ impl LinearClient {
         }
     }
 
+    /// Task-graph issue set from a single project scan: every requested
+    /// identifier plus all backlog-state issues. Backlog issues never enter
+    /// the control plane (they are not in `active_states`), so the task
+    /// graph endpoint asks for them here without a second Linear pass.
+    pub async fn project_task_graph_issues<S>(
+        &self,
+        identifiers: &[S],
+    ) -> Result<Vec<TrackerIssue>, LinearError>
+    where
+        S: AsRef<str>,
+    {
+        let identifiers = normalize_strings(identifiers);
+        let requested_keys = identifiers
+            .iter()
+            .map(|identifier| identifier.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+
+        let mut issues_by_identifier = HashMap::new();
+        let mut backlog = Vec::new();
+        for issue in self.project_issues(false).await? {
+            let key = issue.identifier.to_ascii_uppercase();
+            if requested_keys.contains(&key) {
+                issues_by_identifier.insert(key, issue);
+            } else if matches!(
+                issue.state_kind,
+                crate::opensymphony_domain::TrackerIssueStateKind::Backlog
+            ) {
+                backlog.push(issue);
+            }
+        }
+
+        let mut issues = Vec::new();
+        let mut missing_issue_ids = Vec::new();
+        for identifier in &identifiers {
+            match issues_by_identifier.remove(&identifier.to_ascii_uppercase()) {
+                Some(issue) => issues.push(issue),
+                None => missing_issue_ids.push(identifier.clone()),
+            }
+        }
+        if !missing_issue_ids.is_empty() {
+            return Err(LinearError::MissingIssueIds {
+                issue_ids: missing_issue_ids,
+            });
+        }
+
+        backlog.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+        issues.extend(backlog);
+        Ok(issues)
+    }
+
     async fn project_issues(
         &self,
         include_archived: bool,

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -377,6 +377,75 @@ async fn project_task_graph_issues_return_requested_and_backlog_from_one_scan() 
 }
 
 #[tokio::test]
+async fn project_task_graph_issues_resolve_out_of_project_ids_by_identifier() {
+    // Project scan returns only COE-260. COE-999 is tracked but sits outside
+    // the project (moved / no project metadata); it resolves via the
+    // per-identifier fallback rather than failing the whole task graph.
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(project_issues_response_with_states(&[(
+            "issue-260",
+            "COE-260",
+            "In-project issue",
+            "In Progress",
+            "started",
+        )])),
+        QueuedResponse::json(issue_by_identifier_response(
+            "issue-999",
+            "COE-999",
+            "Out-of-project issue",
+            "In Progress",
+            "started",
+        )),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should work");
+
+    let issues = client
+        .project_task_graph_issues(&["COE-260", "COE-999"])
+        .await
+        .expect("task graph lookup should resolve the out-of-project id");
+
+    let identifiers = issues
+        .iter()
+        .map(|issue| issue.identifier.as_str())
+        .collect::<Vec<_>>();
+    assert!(identifiers.contains(&"COE-260"));
+    assert!(identifiers.contains(&"COE-999"));
+}
+
+#[tokio::test]
+async fn project_task_graph_issues_omit_unresolvable_ids_instead_of_failing() {
+    // COE-404 is neither in the project scan nor resolvable by identifier
+    // (deleted/inaccessible); it is omitted so the rest of the task graph
+    // still renders instead of the endpoint 502-ing.
+    let server = MockGraphqlServer::start(vec![
+        QueuedResponse::json(project_issues_response_with_states(&[(
+            "issue-260",
+            "COE-260",
+            "In-project issue",
+            "In Progress",
+            "started",
+        )])),
+        QueuedResponse::json(issue_not_found_response()),
+    ])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should work");
+
+    let issues = client
+        .project_task_graph_issues(&["COE-260", "COE-404"])
+        .await
+        .expect("task graph lookup should not fail on an unresolvable id");
+
+    let identifiers = issues
+        .iter()
+        .map(|issue| issue.identifier.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(identifiers, vec!["COE-260"]);
+}
+
+#[tokio::test]
 async fn candidate_issues_fetch_all_label_pages() {
     let server = MockGraphqlServer::start(vec![
         QueuedResponse::json(include_str!(
@@ -1241,6 +1310,40 @@ fn project_issues_response_with_states(issues: &[(&str, &str, &str, &str, &str)]
   }}
 }}"#
     )
+}
+
+fn issue_by_identifier_response(
+    issue_id: &str,
+    identifier: &str,
+    title: &str,
+    state_name: &str,
+    state_type: &str,
+) -> String {
+    format!(
+        r#"{{
+  "data": {{
+    "issue": {{
+      "id": "{issue_id}",
+      "identifier": "{identifier}",
+      "url": "https://linear.app/example/issue/{identifier}",
+      "title": "{title}",
+      "description": "Issue resolved by identifier fallback.",
+      "priority": 0.0,
+      "createdAt": "2026-03-20T10:00:00Z",
+      "updatedAt": "2026-03-21T12:00:00Z",
+      "state": {{ "id": "state-{identifier}", "name": "{state_name}", "type": "{state_type}" }},
+      "parent": null,
+      "children": {{ "nodes": [] }},
+      "labels": {{ "nodes": [], "pageInfo": {{ "hasNextPage": false, "endCursor": null }} }},
+      "inverseRelations": {{ "nodes": [], "pageInfo": {{ "hasNextPage": false, "endCursor": null }} }}
+    }}
+  }}
+}}"#
+    )
+}
+
+fn issue_not_found_response() -> String {
+    r#"{"data":{"issue":null}}"#.to_string()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -1176,7 +1176,9 @@ fn project_issues_response(issues: &[(&str, &str, &str)]) -> String {
     project_issues_response_with_states(
         &issues
             .iter()
-            .map(|(issue_id, identifier, title)| (*issue_id, *identifier, *title, "Done", "completed"))
+            .map(|(issue_id, identifier, title)| {
+                (*issue_id, *identifier, *title, "Done", "completed")
+            })
             .collect::<Vec<_>>(),
     )
 }

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -322,6 +322,61 @@ async fn project_issues_by_identifiers_fetches_project_issue_details_in_one_quer
 }
 
 #[tokio::test]
+async fn project_task_graph_issues_return_requested_and_backlog_from_one_scan() {
+    let server = MockGraphqlServer::start(vec![QueuedResponse::json(
+        project_issues_response_with_states(&[
+            (
+                "issue-260",
+                "COE-260",
+                "Domain model and orchestrator state machine",
+                "In Progress",
+                "started",
+            ),
+            (
+                "issue-300",
+                "COE-300",
+                "Deferred backlog polish",
+                "Backlog",
+                "backlog",
+            ),
+            (
+                "issue-310",
+                "COE-310",
+                "Unrequested todo issue",
+                "Todo",
+                "unstarted",
+            ),
+        ]),
+    )])
+    .await;
+    let client = LinearClient::new(test_config(server.base_url()))
+        .expect("client configuration should work");
+
+    let issues = client
+        .project_task_graph_issues(&["COE-260"])
+        .await
+        .expect("task graph lookup should succeed");
+
+    // Requested identifiers first, then backlog issues; issues that are
+    // neither requested nor backlog-state stay out of the task graph set.
+    assert_eq!(
+        issues
+            .iter()
+            .map(|issue| issue.identifier.as_str())
+            .collect::<Vec<_>>(),
+        vec!["COE-260", "COE-300"],
+    );
+    let requests = server.recorded_requests().await;
+    assert_eq!(requests.len(), 1, "one project scan serves both buckets");
+    assert!(
+        requests[0].body["query"]
+            .as_str()
+            .expect("query should be a string")
+            .contains("query ProjectIssues")
+    );
+}
+
+#[tokio::test]
 async fn candidate_issues_fetch_all_label_pages() {
     let server = MockGraphqlServer::start(vec![
         QueuedResponse::json(include_str!(
@@ -1118,9 +1173,18 @@ fn test_config(base_url: &str) -> LinearConfig {
 }
 
 fn project_issues_response(issues: &[(&str, &str, &str)]) -> String {
+    project_issues_response_with_states(
+        &issues
+            .iter()
+            .map(|(issue_id, identifier, title)| (*issue_id, *identifier, *title, "Done", "completed"))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn project_issues_response_with_states(issues: &[(&str, &str, &str, &str, &str)]) -> String {
     let nodes = issues
         .iter()
-        .map(|(issue_id, identifier, title)| {
+        .map(|(issue_id, identifier, title, state_name, state_type)| {
             format!(
                 r#"{{
       "id": "{issue_id}",
@@ -1132,9 +1196,9 @@ fn project_issues_response(issues: &[(&str, &str, &str)]) -> String {
       "createdAt": "2026-03-20T10:00:00Z",
       "updatedAt": "2026-03-21T12:00:00Z",
       "state": {{
-        "id": "state-done",
-        "name": "Done",
-        "type": "completed"
+        "id": "state-{identifier}",
+        "name": "{state_name}",
+        "type": "{state_type}"
       }},
       "parent": null,
       "children": {{

--- a/crates/opensymphony-memory/src/capture_render.rs
+++ b/crates/opensymphony-memory/src/capture_render.rs
@@ -606,6 +606,11 @@ fn render_issue_capsule(
                 .filter_map(|pr| pr.merge_sha.clone())
                 .collect(),
         },
+        timestamp: plan
+            .issue
+            .completed_at
+            .or(plan.issue.updated_at)
+            .map(|value| value.to_rfc3339()),
         captured_at: Utc::now(),
         docs_sync: DocsSyncFrontmatter {
             status: "pending".to_string(),
@@ -703,6 +708,12 @@ struct IssueCapsuleFrontmatter {
     prs: Vec<CapsulePr>,
     areas: Vec<String>,
     source_refs: SourceRefs,
+    // The OKF canonical completion timestamp. Persisted so a reindex
+    // (`refresh_memory_index_from_okf`) rebuilds `completion_time` — and
+    // thus the Completed pane's date/sort — instead of losing it because
+    // only `captured_at` survived in the frontmatter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<String>,
     captured_at: DateTime<Utc>,
     docs_sync: DocsSyncFrontmatter,
 }

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -496,7 +496,7 @@ pub fn memory_completed_task_rows(
                 state: issue.state.clone(),
                 milestone: issue.milestone.clone(),
                 url: linear_issue_url(&issue).map(|url| redact_for_dto(config, &url)),
-                completed_at: indexed_issue_updated_at(&issue),
+                completed_at: completed_at_timestamp(&issue),
                 prs: prs
                     .into_iter()
                     .map(|pr| MemoryTaskPullRequest {
@@ -530,6 +530,19 @@ fn is_completed_indexed_issue(issue: &IndexedIssue) -> bool {
         Some(state) => matches!(state.as_str(), "done" | "completed" | "closed" | "merged"),
         None => issue.completion_time.is_some(),
     }
+}
+
+/// The task's actual completion date, from the recorded completion
+/// timestamp only. Unlike `indexed_issue_updated_at`, this never falls back
+/// to `captured_at`: reporting the capture/reindex time as the done date
+/// would corrupt the Completed table's dates and completed-date sorting for
+/// legacy or manually authored capsules that carry no completion timestamp.
+fn completed_at_timestamp(issue: &IndexedIssue) -> Option<DateTime<Utc>> {
+    issue
+        .completion_time
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
 }
 
 fn linear_issue_url(issue: &IndexedIssue) -> Option<String> {

--- a/crates/opensymphony-memory/src/graph.rs
+++ b/crates/opensymphony-memory/src/graph.rs
@@ -3,12 +3,13 @@ use std::{fmt::Write as _, sync::atomic::{AtomicU64, Ordering}};
 use crate::opensymphony_gateway_schema::{
     cursor::StreamCursor,
     memory_graph::{
-        MemoryBundleList, MemoryBundleSummary, MemoryCommunityList, MemoryConceptDetail,
-        MemoryFrontmatterView, MemoryGraphCitation, MemoryGraphCommunity, MemoryGraphEdge,
-        MemoryGraphEdgeKind, MemoryGraphFreshness, MemoryGraphLink, MemoryGraphNode,
-        MemoryGraphNodeKind, MemoryGraphNodeMetrics, MemoryGraphSnapshot, MemoryGraphSourceRef,
+        MemoryBundleList, MemoryBundleSummary, MemoryCommunityList, MemoryCompletedTask,
+        MemoryCompletedTaskSource, MemoryConceptDetail, MemoryFrontmatterView,
+        MemoryGraphCitation, MemoryGraphCommunity, MemoryGraphEdge, MemoryGraphEdgeKind,
+        MemoryGraphFreshness, MemoryGraphLink, MemoryGraphNode, MemoryGraphNodeKind,
+        MemoryGraphNodeMetrics, MemoryGraphSnapshot, MemoryGraphSourceRef,
         MemoryGraphSnapshotMetrics, MemoryGraphUpdatedEvent, MemoryGraphVisibility,
-        MemorySearchResponse, MemorySearchResult,
+        MemorySearchResponse, MemorySearchResult, MemoryTaskPullRequest,
     },
     version::SchemaVersion,
 };
@@ -469,6 +470,74 @@ pub fn memory_graph_search(
         bundle_id: Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string()),
         results,
     })
+}
+
+/// Unpaginated completed-task rows backed by captured memory capsules,
+/// including their normalized pull-request evidence. The gateway merges
+/// these with orchestrator-known completed issues and applies
+/// search/sort/pagination for `/api/v1/memory/completed-tasks`; keeping
+/// rows unpaginated here lets that merge happen before slicing.
+pub fn memory_completed_task_rows(
+    config: &MemoryConfig,
+    access: MemoryGraphAccess,
+) -> Result<Vec<MemoryCompletedTask>, MemoryGraphProjectionError> {
+    let issues = accessible_issues(config, access)?;
+    let mut prs_by_issue = load_pull_requests_by_issue(config)?;
+    Ok(issues
+        .into_iter()
+        .filter(is_completed_indexed_issue)
+        .map(|issue| {
+            let prs = prs_by_issue.remove(&issue.issue_key).unwrap_or_default();
+            MemoryCompletedTask {
+                issue_key: issue.issue_key.clone(),
+                concept_id: issue.concept_id.clone(),
+                bundle_id: Some(DEFAULT_MEMORY_GRAPH_BUNDLE_ID.to_string()),
+                title: redact_for_dto(config, &issue.title),
+                state: issue.state.clone(),
+                milestone: issue.milestone.clone(),
+                url: linear_issue_url(&issue).map(|url| redact_for_dto(config, &url)),
+                completed_at: indexed_issue_updated_at(&issue),
+                prs: prs
+                    .into_iter()
+                    .map(|pr| MemoryTaskPullRequest {
+                        number: pr.number,
+                        title: redact_for_dto(config, &pr.title),
+                        url: pr.url.as_ref().map(|url| redact_for_dto(config, url)),
+                        merged: pr.merged_at.is_some() || pr.merge_sha.is_some(),
+                        merged_at: pr.merged_at,
+                    })
+                    .collect(),
+                source: MemoryCompletedTaskSource::Memory,
+            }
+        })
+        .collect())
+}
+
+fn is_completed_indexed_issue(issue: &IndexedIssue) -> bool {
+    // Only issue capsules count as tasks; topic docs and generic concepts
+    // also live in the catalog but are not completed work items.
+    if issue.concept_type != "issue-capsule" {
+        return false;
+    }
+    // The state, when present, is authoritative: OKF reindexing fills
+    // `completion_time` from the frontmatter timestamp, so a bare
+    // timestamp on an "In Progress" capsule must not read as completed.
+    match issue
+        .state
+        .as_deref()
+        .map(|state| state.trim().to_ascii_lowercase())
+    {
+        Some(state) => matches!(state.as_str(), "done" | "completed" | "closed" | "merged"),
+        None => issue.completion_time.is_some(),
+    }
+}
+
+fn linear_issue_url(issue: &IndexedIssue) -> Option<String> {
+    issue
+        .source_refs
+        .iter()
+        .find(|source| source.kind == "linear_issue")
+        .and_then(|source| source.url.clone())
 }
 
 pub fn memory_graph_updated_event(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -1326,10 +1326,16 @@ impl OkfIndexRow {
 /// links after `refresh_memory_index_from_okf`, not just after a live
 /// capture. Malformed entries are skipped rather than failing the reindex.
 fn okf_index_prs(frontmatter: &OkfFrontmatter) -> Vec<PullRequestEvidence> {
-    let Some(value) = frontmatter.extra.get("prs") else {
+    let Some(serde_yaml::Value::Sequence(entries)) = frontmatter.extra.get("prs") else {
         return Vec::new();
     };
-    serde_yaml::from_value::<Vec<PullRequestEvidence>>(value.clone()).unwrap_or_default()
+    // Parse entries individually so one malformed or newer-format entry
+    // (e.g. a renamed `number`) drops only itself, not every valid PR for
+    // the issue — reindex must preserve the good rows.
+    entries
+        .iter()
+        .filter_map(|entry| serde_yaml::from_value::<PullRequestEvidence>(entry.clone()).ok())
+        .collect()
 }
 
 fn okf_issue_key(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -1185,6 +1185,25 @@ pub fn refresh_memory_index_from_okf(
                     source,
                 })?;
         }
+        for pr in &row.prs {
+            transaction
+                .execute(
+                    "INSERT INTO pull_requests (issue_key, number, title, url, branch, merge_sha, merged_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        row.issue_key,
+                        pr.number as i64,
+                        pr.title.clone(),
+                        pr.url.clone(),
+                        pr.branch.clone(),
+                        pr.merge_sha.clone(),
+                        pr.merged_at.map(|value| value.to_rfc3339()),
+                    ],
+                )
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?;
+        }
     }
     transaction
         .commit()
@@ -1232,6 +1251,7 @@ struct OkfIndexRow {
     freshness: MemoryFreshness,
     warnings_json: String,
     areas: Vec<String>,
+    prs: Vec<PullRequestEvidence>,
 }
 
 impl OkfIndexRow {
@@ -1295,8 +1315,21 @@ impl OkfIndexRow {
             freshness: okf_index_freshness(&concept),
             warnings_json,
             areas: okf_index_areas(&scope_refs),
+            prs: okf_index_prs(&concept.frontmatter),
         })
     }
+}
+
+/// Pull-request evidence carried in an issue capsule's `prs` frontmatter
+/// (number/url/merge_sha, per `render_issue_capsule`). OKF reindex rewrites
+/// the `pull_requests` table from these so completed rows keep their PR
+/// links after `refresh_memory_index_from_okf`, not just after a live
+/// capture. Malformed entries are skipped rather than failing the reindex.
+fn okf_index_prs(frontmatter: &OkfFrontmatter) -> Vec<PullRequestEvidence> {
+    let Some(value) = frontmatter.extra.get("prs") else {
+        return Vec::new();
+    };
+    serde_yaml::from_value::<Vec<PullRequestEvidence>>(value.clone()).unwrap_or_default()
 }
 
 fn okf_issue_key(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -859,6 +859,59 @@ fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, Memor
     Ok(issues)
 }
 
+/// Pull-request evidence grouped by issue key, ordered by PR number. Only
+/// the columns persisted in the `pull_requests` table are populated; the
+/// nested commit/file/check/review evidence stays empty.
+fn load_pull_requests_by_issue(
+    config: &MemoryConfig,
+) -> Result<BTreeMap<String, Vec<PullRequestEvidence>>, MemoryError> {
+    if !config.index_path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let connection = open_index_read_only(config)?;
+    let mut statement = connection
+        .prepare(
+            "SELECT issue_key, number, title, url, branch, merge_sha, merged_at FROM pull_requests ORDER BY issue_key, number",
+        )
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let rows = statement
+        .query_map([], |row| {
+            let merged_at: Option<String> = row.get(6)?;
+            Ok((
+                row.get::<_, String>(0)?,
+                PullRequestEvidence {
+                    number: row.get::<_, i64>(1)?.max(0) as u64,
+                    title: row.get(2)?,
+                    url: row.get(3)?,
+                    branch: row.get(4)?,
+                    merge_sha: row.get(5)?,
+                    merged_at: merged_at
+                        .as_deref()
+                        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+                        .map(|value| value.with_timezone(&Utc)),
+                    ..PullRequestEvidence::default()
+                },
+            ))
+        })
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+
+    let mut by_issue = BTreeMap::<String, Vec<PullRequestEvidence>>::new();
+    for row in rows {
+        let (issue_key, pr) = row.map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+        by_issue.entry(issue_key).or_default().push(pr);
+    }
+    Ok(by_issue)
+}
+
 fn load_issue_areas(
     connection: &Connection,
     issue_key: &str,

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1249,6 +1249,53 @@ prs:
     }
 
     #[test]
+    fn memory_completed_task_rows_omit_completed_at_without_a_completion_timestamp() {
+        let repo = TempDir::new().expect("temp repo");
+        ensure_memory_initialized(repo.path(), None).expect("memory init");
+        let config = MemoryConfig::load(repo.path(), None).expect("config should load");
+        let issues_dir = config.memory_root.join("issues");
+        fs::create_dir_all(&issues_dir).expect("issues dir");
+        // A Done capsule with no `timestamp`/completion frontmatter: the
+        // completed date must stay null rather than borrowing captured_at
+        // (the reindex time), which would corrupt the Completed table's
+        // date column and completed-date sorting.
+        fs::write(
+            issues_dir.join("COE-700.md"),
+            r#"---
+type: issue-capsule
+title: "COE-700: Legacy done capsule"
+description: Completed but timestamp-less.
+state: Done
+opensymphony:
+  visibility: private
+  scope_refs:
+    - kind: work_item
+      id: COE-700
+---
+
+# COE-700: Legacy done capsule
+
+Body.
+"#,
+        )
+        .expect("capsule should write");
+        refresh_memory_index_from_okf(&config, &config.memory_root)
+            .expect("reindex should succeed");
+
+        let rows = memory_completed_task_rows(&config, MemoryGraphAccess::AllAccessible)
+            .expect("completed rows should project");
+        let row = rows
+            .iter()
+            .find(|row| row.issue_key == "COE-700")
+            .expect("completed capsule should project as a completed task");
+        assert_eq!(row.state.as_deref(), Some("Done"));
+        assert_eq!(
+            row.completed_at, None,
+            "no completion timestamp must leave completed_at null, not fall back to captured_at",
+        );
+    }
+
+    #[test]
     fn okf_parses_legacy_issue_capsule_without_losing_metadata() {
         let repo = TempDir::new().expect("temp repo");
         let capsule = r#"---

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1301,6 +1301,69 @@ prs:
         // Frontmatter carries merge_sha (not merged_at), so the merged flag is
         // derived from the SHA.
         assert!(row.prs[1].merged);
+        // The completion timestamp is persisted in the capsule frontmatter,
+        // so the Completed pane's date/sort survive reindex instead of the
+        // row becoming undated.
+        assert_eq!(
+            row.completed_at,
+            Some(
+                chrono::DateTime::parse_from_rfc3339("2026-06-13T17:00:00Z")
+                    .expect("test timestamp")
+                    .with_timezone(&Utc)
+            ),
+        );
+    }
+
+    #[test]
+    fn okf_reindex_keeps_valid_prs_when_one_entry_is_malformed() {
+        let repo = TempDir::new().expect("temp repo");
+        ensure_memory_initialized(repo.path(), None).expect("memory init");
+        let config = MemoryConfig::load(repo.path(), None).expect("config should load");
+        let issues_dir = config.memory_root.join("issues");
+        fs::create_dir_all(&issues_dir).expect("issues dir");
+        // One well-formed PR entry and one malformed (no `number`): the good
+        // one must survive rather than the whole list being dropped.
+        fs::write(
+            issues_dir.join("COE-800.md"),
+            r#"---
+type: issue-capsule
+title: "COE-800: Mixed PR frontmatter"
+state: Done
+timestamp: 2026-06-15T10:00:00Z
+prs:
+  - number: 512
+    url: https://github.com/example/repo/pull/512
+    merge_sha: deadbeef
+  - note: "malformed entry with no number"
+opensymphony:
+  visibility: private
+  scope_refs:
+    - kind: work_item
+      id: COE-800
+---
+
+# COE-800: Mixed PR frontmatter
+
+Body.
+"#,
+        )
+        .expect("capsule should write");
+        refresh_memory_index_from_okf(&config, &config.memory_root)
+            .expect("reindex should succeed");
+
+        let rows = memory_completed_task_rows(&config, MemoryGraphAccess::AllAccessible)
+            .expect("completed rows should project");
+        let row = rows
+            .iter()
+            .find(|row| row.issue_key == "COE-800")
+            .expect("capsule should project");
+        assert_eq!(
+            row.prs.len(),
+            1,
+            "the valid PR must survive a malformed sibling"
+        );
+        assert_eq!(row.prs[0].number, 512);
+        assert!(row.prs[0].merged);
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1188,6 +1188,67 @@ mod tests {
     }
 
     #[test]
+    fn memory_completed_task_rows_join_pull_request_evidence() {
+        let repo = TempDir::new().expect("temp repo");
+        ensure_memory_initialized(repo.path(), None).expect("memory init");
+        let config = MemoryConfig::load(repo.path(), None).expect("config should load");
+        let source: SourceFile = serde_yaml::from_str(
+            r#"
+issues:
+  - identifier: COE-123
+    title: WebSocket reconnect recovery
+    url: https://linear.app/example/issue/COE-123
+    state: Done
+    completed_at: 2026-06-13T17:00:00Z
+    labels: [runtime]
+    linked_prs: [456, 490]
+prs:
+  - number: 456
+    title: COE-123 first attempt
+    url: https://github.com/example/repo/pull/456
+    branch: coe-123-attempt-1
+  - number: 490
+    title: COE-123 recover websocket reconnects
+    url: https://github.com/example/repo/pull/490
+    branch: coe-123-reconnect
+    merge_sha: abcdef1234567890
+    merged_at: 2026-06-13T16:00:00Z
+"#,
+        )
+        .expect("source yaml should parse");
+        let selection = IssueSelection {
+            identifiers: vec!["COE-123".to_string()],
+            ..IssueSelection::default()
+        };
+        let plan =
+            plan_capture(&config, &source, &selection, true, false).expect("capture should plan");
+        write_capture_plan(&config, &plan, false).expect("capture should write");
+
+        let rows = memory_completed_task_rows(&config, MemoryGraphAccess::AllAccessible)
+            .expect("completed rows should project");
+
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.issue_key, "COE-123");
+        assert_eq!(row.concept_id, "issues/COE-123");
+        assert_eq!(row.state.as_deref(), Some("Done"));
+        assert!(row.completed_at.is_some());
+        // Freshly captured rows have empty source_refs in the index (they
+        // are rebuilt from capsule frontmatter on OKF reindex), so no
+        // Linear URL yet — the row is still fully usable.
+        assert_eq!(row.url, None);
+        assert_eq!(row.prs.len(), 2);
+        // The abandoned PR carries no merge evidence; the merged one keeps
+        // its merged_at so the UI can bold the most recent PR and strike
+        // through unmerged ones.
+        assert_eq!(row.prs[0].number, 456);
+        assert!(!row.prs[0].merged);
+        assert_eq!(row.prs[1].number, 490);
+        assert!(row.prs[1].merged);
+        assert!(row.prs[1].merged_at.is_some());
+    }
+
+    #[test]
     fn okf_parses_legacy_issue_capsule_without_losing_metadata() {
         let repo = TempDir::new().expect("temp repo");
         let capsule = r#"---

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1307,7 +1307,7 @@ prs:
         assert_eq!(
             row.completed_at,
             Some(
-                chrono::DateTime::parse_from_rfc3339("2026-06-13T17:00:00Z")
+                DateTime::parse_from_rfc3339("2026-06-13T17:00:00Z")
                     .expect("test timestamp")
                     .with_timezone(&Utc)
             ),

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -1249,6 +1249,61 @@ prs:
     }
 
     #[test]
+    fn memory_completed_task_rows_keep_prs_after_okf_reindex() {
+        let repo = TempDir::new().expect("temp repo");
+        ensure_memory_initialized(repo.path(), None).expect("memory init");
+        let config = MemoryConfig::load(repo.path(), None).expect("config should load");
+        let source: SourceFile = serde_yaml::from_str(
+            r#"
+issues:
+  - identifier: COE-123
+    title: WebSocket reconnect recovery
+    url: https://linear.app/example/issue/COE-123
+    state: Done
+    completed_at: 2026-06-13T17:00:00Z
+    linked_prs: [456, 490]
+prs:
+  - number: 456
+    title: COE-123 first attempt
+    url: https://github.com/example/repo/pull/456
+  - number: 490
+    title: COE-123 recover websocket reconnects
+    url: https://github.com/example/repo/pull/490
+    merge_sha: abcdef1234567890
+    merged_at: 2026-06-13T16:00:00Z
+"#,
+        )
+        .expect("source yaml should parse");
+        let selection = IssueSelection {
+            identifiers: vec!["COE-123".to_string()],
+            ..IssueSelection::default()
+        };
+        let plan =
+            plan_capture(&config, &source, &selection, true, false).expect("capture should plan");
+        write_capture_plan(&config, &plan, false).expect("capture should write");
+
+        // Reindex from the OKF bundle: this clears the pull_requests table and
+        // rebuilds it from the capsule frontmatter. PR links must survive so
+        // the Completed pane is not blanked after `memory import-okf`.
+        refresh_memory_index_from_okf(&config, &config.memory_root)
+            .expect("reindex should succeed");
+
+        let rows = memory_completed_task_rows(&config, MemoryGraphAccess::AllAccessible)
+            .expect("completed rows should project");
+        let row = rows
+            .iter()
+            .find(|row| row.issue_key == "COE-123")
+            .expect("completed capsule should project after reindex");
+        assert_eq!(row.prs.len(), 2, "PR evidence must survive OKF reindex");
+        assert_eq!(row.prs[0].number, 456);
+        assert!(!row.prs[0].merged);
+        assert_eq!(row.prs[1].number, 490);
+        // Frontmatter carries merge_sha (not merged_at), so the merged flag is
+        // derived from the SHA.
+        assert!(row.prs[1].merged);
+    }
+
+    #[test]
     fn memory_completed_task_rows_omit_completed_at_without_a_completion_timestamp() {
         let repo = TempDir::new().expect("temp repo");
         ensure_memory_initialized(repo.path(), None).expect("memory init");

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -127,6 +127,18 @@ Cross-pane edges live in a measured SVG overlay
 repositioned on scroll, resize, and collapse; endpoints scrolled out of
 their pane hide instead of drawing across headers.
 
+**Live status reflection.** The Current and Backlog panes are pure
+functions of the latest task-graph snapshot — `renderTaskGraphPanes`
+re-partitions the fresh nodes on every render — so a status change moves a
+task between panes on the next live refresh with no restart: Backlog→Todo
+lands it in Current, Todo→Backlog returns it, and a completion drops it from
+Current. The Completed pane loads separately, so `refreshLiveGatewayData`
+reloads it whenever `completedTasksSignature` changes — a signature over
+both the task graph's done nodes and the dashboard snapshot's control-plane
+completed count, so completions surface even when the finished issue is
+absent from the task graph (e.g. no project metadata). `memory_graph_updated`
+events reload it too, for capsule/PR evidence captured after completion.
+
 ### Drill-down navigation
 
 The knowledge graph navigates through three levels, mirroring the Obsidian

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -47,8 +47,14 @@ test sees the same graph:
 - `packages/api-client/src/graph-viz-demo.ts` — matching task-graph demo
   (`graphVizDemoTaskGraph`) whose dependency shapes stress the arrow
   routing: several skip-level dependencies fanning out from one blocker plus
-  overlapping skips from different blockers. `createGraphVizDemoTransport()`
-  wraps it all in a `MockGatewayTransport`.
+  overlapping skips from different blockers, and a backlog tier (VIZ-114…120)
+  with cross-pane blockers and multi-hop chains that exercise ancestry
+  critical-path highlighting. `createGraphVizDemoTransport()` wraps it all in
+  a `MockGatewayTransport`.
+- `graphVizFixtureCompletedTasks` (in `viz-fixture.ts`) — 31 completed tasks
+  with PR evidence (including abandoned unmerged PRs) whose capsule ids
+  resolve to real fixture concepts, feeding the Completed pane's table,
+  search, sorting, and pagination in the workbench.
 
 ### Running the workbench
 
@@ -86,6 +92,39 @@ with one lane and one hue per blocker (rounded corners, colored arrowheads);
 hovering a task spotlights its incident arrows. See
 `renderTaskGraphLink`/`buildTaskGraphLinks` in
 `packages/ui-core/src/app-shell.ts`.
+
+### Three-pane task graph
+
+The desktop task surface splits into three panes
+(`renderTaskGraphPanes` in `packages/ui-core/src/app-shell.ts`):
+
+- **Completed** (collapsible, left) — a searchable, sortable, paginated
+  table served by `GET /api/v1/memory/completed-tasks`. Rows come from the
+  memory server's DuckDB catalog first (issue capsules with their
+  normalized `pull_requests` evidence — completed tasks survive Linear
+  archival and the Linear API is never queried on this path), merged with
+  orchestrator-known completions not yet captured (`source:
+  "orchestrator"`). Each row lists all of its PRs — the newest bold,
+  unmerged ones struck through — plus a memory-capsule button that opens
+  the task's capsule through `openMemoryDeepLink`.
+- **Current** (center, never collapses) — the dispatchable dependency graph
+  as before (Todo / In Progress / Human Review / Rework). Selecting or
+  hovering a task boldens its incoming and outgoing edges, including
+  outgoing edges that leave the pane's right side toward blocked Backlog
+  tasks.
+- **Backlog** (collapsible, right) — backlog-state Linear issues, now
+  included in the task-graph snapshot (`LinearClient::project_task_graph_issues`
+  returns them from the same single project scan that already served the
+  identifier lookup). Cards use the Current pane's grammar with faded
+  edges; hovering or selecting a backlog task boldens its full **ancestry
+  critical path** — every unfinished upstream chain that must complete to
+  unblock it — across both panes, and dims unrelated backlog cards.
+
+Cross-pane edges live in a measured SVG overlay
+(`positionTaskGraphCrossLinks`): paths carry the same
+`data-link-from`/`data-link-to` contract as in-pane edges and are
+repositioned on scroll, resize, and collapse; endpoints scrolled out of
+their pane hide instead of drawing across headers.
 
 ### Drill-down navigation
 
@@ -148,6 +187,18 @@ testing, `?memory=<deep-link>` on the desktop dev server (composable with
   resolvability.
 - `packages/ui-core/__tests__/memory-markdown.test.ts` — capsule markdown
   allowlist rendering and escaping.
+- `packages/graph/__tests__/completed-tasks.test.ts` — completed-task
+  paging/sorting/search (`pageCompletedTasks`, the fixture adapter's twin of
+  the gateway endpoint) and fixture-row determinism.
+- The three-pane suite inside `app-shell.test.ts` — pane rendering,
+  Completed search/sort/pagination, PR emphasis, capsule deep links,
+  ancestry critical-path emphasis, and pane collapse.
+- Rust: `crates/opensymphony-gateway/tests/gateway.rs`
+  (`gateway_task_graph_includes_backlog_issues_with_cross_edges`,
+  `gateway_serves_memory_completed_tasks`),
+  `crates/opensymphony-linear/tests/linear_client.rs`
+  (`project_task_graph_issues_return_requested_and_backlog_from_one_scan`),
+  and the memory crate's PR-evidence projection unit test.
 
 When iterating on visuals, extend these fixtures and tests rather than
 creating throwaway data; `AGENTS.md` ("UI separation") points here.

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -108,10 +108,11 @@ The desktop task surface splits into three panes
   unmerged ones struck through — plus a memory-capsule button that opens
   the task's capsule through `openMemoryDeepLink`.
 - **Current** (center, never collapses) — the dispatchable dependency graph
-  as before (Todo / In Progress / Human Review / Rework). Selecting or
-  hovering a task boldens its incoming and outgoing edges, including
-  outgoing edges that leave the pane's right side toward blocked Backlog
-  tasks.
+  as before (Todo / In Progress / Human Review / Rework). Canceled nodes
+  also stay here (they have no other pane, and the Canceled state filter
+  must still surface them). Selecting or hovering a task boldens its
+  incoming and outgoing edges, including outgoing edges that leave the
+  pane's right side toward blocked Backlog tasks.
 - **Backlog** (collapsible, right) — backlog-state Linear issues, now
   included in the task-graph snapshot (`LinearClient::project_task_graph_issues`
   returns them from the same single project scan that already served the

--- a/packages/api-client/src/graph-viz-demo.ts
+++ b/packages/api-client/src/graph-viz-demo.ts
@@ -29,7 +29,7 @@ const projectId = "viz-workbench";
 interface DemoIssue {
   id: string;
   title: string;
-  state: "Todo" | "In Progress" | "Human Review" | "Done";
+  state: "Todo" | "In Progress" | "Human Review" | "Done" | "Backlog";
   blockedBy?: string[];
   running?: boolean;
 }
@@ -62,14 +62,27 @@ const demoIssues: DemoIssue[] = [
   { id: "VIZ-111", title: "Playwright visual sweep", state: "Todo", blockedBy: ["VIZ-107", "VIZ-108"] },
   { id: "VIZ-112", title: "Reduced motion audit", state: "Todo", blockedBy: ["VIZ-108"] },
   { id: "VIZ-113", title: "Release notes and demo capture", state: "Todo", blockedBy: ["VIZ-104", "VIZ-109", "VIZ-111"] },
+  // Backlog tier (three-pane task graph): cross-pane edges from Current
+  // blockers into the Backlog pane, plus backlog-internal chains so
+  // ancestry critical-path highlighting has real depth to walk
+  // (e.g. VIZ-117 ← VIZ-116 ← VIZ-114/115 ← VIZ-103).
+  { id: "VIZ-114", title: "Changelog & publish", state: "Backlog", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-115", title: "Frame budget analysis", state: "Backlog", blockedBy: ["VIZ-103"] },
+  { id: "VIZ-116", title: "Memory & leak audit", state: "Backlog", blockedBy: ["VIZ-114", "VIZ-115"] },
+  { id: "VIZ-117", title: "Release evidence pack", state: "Backlog", blockedBy: ["VIZ-104", "VIZ-116"] },
+  { id: "VIZ-118", title: "Packaging fallback polish", state: "Backlog", blockedBy: ["VIZ-116"] },
+  { id: "VIZ-119", title: "Docs site update", state: "Backlog", blockedBy: ["VIZ-108"] },
+  { id: "VIZ-120", title: "Post-release validation", state: "Backlog", blockedBy: ["VIZ-117", "VIZ-119"] },
 ];
 
 function demoNode(issue: DemoIssue): TaskGraphNode {
   const stateCategory = issue.state === "Done"
     ? "done"
-    : issue.state === "Todo"
-      ? "todo"
-      : "in_progress";
+    : issue.state === "Backlog"
+      ? "backlog"
+      : issue.state === "Todo"
+        ? "todo"
+        : "in_progress";
   return {
     schema_version,
     node_id: issue.id.toLowerCase(),

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -30,6 +30,9 @@ export type {
   MemoryBundleList,
   MemoryBundleSummary,
   MemoryCommunityList,
+  MemoryCompletedTask,
+  MemoryCompletedTaskPage,
+  MemoryCompletedTaskSource,
   MemoryConceptDetail,
   MemoryFrontmatterView,
   MemoryGraphCitation,
@@ -48,6 +51,7 @@ export type {
   MemoryGraphVisibility,
   MemorySearchResponse,
   MemorySearchResult,
+  MemoryTaskPullRequest,
 } from "./memory_graph.js";
 
 // run

--- a/packages/gateway-schema/src/memory_graph.ts
+++ b/packages/gateway-schema/src/memory_graph.ts
@@ -85,6 +85,49 @@ export interface MemorySearchResult {
   areas: string[];
 }
 
+/**
+ * One page of completed tasks for the task graph's Completed pane.
+ * Primary source is the memory catalog (DuckDB issue capsules with PR
+ * evidence); orchestrator-known completed issues not yet captured are
+ * merged in with `source: "orchestrator"`.
+ */
+export interface MemoryCompletedTaskPage {
+  schema_version: SchemaVersion;
+  bundle_id: string;
+  tasks: MemoryCompletedTask[];
+  /** Total row count after filtering, before pagination. */
+  total: number;
+  offset: number;
+  limit: number;
+  sort: string;
+  query?: string;
+  generated_at: string;
+}
+
+export interface MemoryCompletedTask {
+  issue_key: string;
+  /** OKF concept id (e.g. `issues/COE-123`); empty for orchestrator rows. */
+  concept_id: string;
+  bundle_id?: string;
+  title: string;
+  state?: string;
+  milestone?: string;
+  url?: string;
+  completed_at?: string;
+  prs: MemoryTaskPullRequest[];
+  source: MemoryCompletedTaskSource;
+}
+
+export interface MemoryTaskPullRequest {
+  number: number;
+  title: string;
+  url?: string;
+  merged: boolean;
+  merged_at?: string;
+}
+
+export type MemoryCompletedTaskSource = "memory" | "orchestrator";
+
 export interface MemoryGraphNode {
   id: string;
   kind: MemoryGraphNodeKind;

--- a/packages/graph/__tests__/completed-tasks.test.ts
+++ b/packages/graph/__tests__/completed-tasks.test.ts
@@ -1,0 +1,123 @@
+import type { MemoryCompletedTask } from "@opensymphony/gateway-schema";
+import {
+  createFixtureGraphAdapter,
+  graphVizFixtureCompletedTasks,
+  graphVizFixtureSnapshot,
+  pageCompletedTasks,
+} from "../src/index.js";
+
+const rows: MemoryCompletedTask[] = [
+  {
+    issue_key: "COE-99",
+    concept_id: "issues/COE-99",
+    bundle_id: "local-default",
+    title: "Ninety-nine",
+    state: "Done",
+    milestone: "M1",
+    completed_at: "2026-06-01T10:00:00Z",
+    prs: [
+      { number: 120, title: "COE-99 fix", url: "https://example.com/pull/120", merged: true, merged_at: "2026-06-01T09:00:00Z" },
+    ],
+    source: "memory",
+  },
+  {
+    issue_key: "COE-100",
+    concept_id: "issues/COE-100",
+    bundle_id: "local-default",
+    title: "One hundred",
+    state: "Done",
+    milestone: "M2",
+    completed_at: "2026-06-03T10:00:00Z",
+    prs: [
+      { number: 90, title: "COE-100 first attempt", url: "https://example.com/pull/90", merged: false },
+      { number: 130, title: "COE-100 landed", url: "https://example.com/pull/130", merged: true, merged_at: "2026-06-03T09:00:00Z" },
+    ],
+    source: "memory",
+  },
+  {
+    issue_key: "COE-101",
+    concept_id: "",
+    title: "Uncaptured completion",
+    state: "Done",
+    prs: [],
+    source: "orchestrator",
+  },
+];
+
+describe("pageCompletedTasks", () => {
+  it("defaults to newest completion first with missing dates last", () => {
+    const page = pageCompletedTasks(rows);
+    expect(page.tasks.map((task) => task.issue_key)).toEqual(["COE-100", "COE-99", "COE-101"]);
+    expect(page.sort).toBe("completed_desc");
+    expect(page.total).toBe(3);
+  });
+
+  it("sorts issue keys naturally so COE-99 precedes COE-100", () => {
+    const page = pageCompletedTasks(rows, { sort: "id_asc" });
+    expect(page.tasks.map((task) => task.issue_key)).toEqual(["COE-99", "COE-100", "COE-101"]);
+    const descending = pageCompletedTasks(rows, { sort: "id_desc" });
+    expect(descending.tasks.map((task) => task.issue_key)).toEqual(["COE-101", "COE-100", "COE-99"]);
+  });
+
+  it("sorts by latest PR number", () => {
+    const page = pageCompletedTasks(rows, { sort: "pr_desc" });
+    expect(page.tasks.map((task) => task.issue_key)).toEqual(["COE-100", "COE-99", "COE-101"]);
+  });
+
+  it("searches issue key, title, milestone, and PR text", () => {
+    expect(pageCompletedTasks(rows, { query: "hundred" }).tasks.map((task) => task.issue_key))
+      .toEqual(["COE-100"]);
+    expect(pageCompletedTasks(rows, { query: "m1" }).tasks.map((task) => task.issue_key))
+      .toEqual(["COE-99"]);
+    expect(pageCompletedTasks(rows, { query: "#130" }).tasks.map((task) => task.issue_key))
+      .toEqual(["COE-100"]);
+    expect(pageCompletedTasks(rows, { query: "uncaptured" }).tasks.map((task) => task.issue_key))
+      .toEqual(["COE-101"]);
+  });
+
+  it("paginates with clamped offsets and reports totals", () => {
+    const page = pageCompletedTasks(rows, { limit: 2, offset: 2, sort: "id_asc" });
+    expect(page.total).toBe(3);
+    expect(page.tasks.map((task) => task.issue_key)).toEqual(["COE-101"]);
+    expect(page.offset).toBe(2);
+    expect(page.limit).toBe(2);
+    const beyond = pageCompletedTasks(rows, { limit: 2, offset: 99 });
+    expect(beyond.tasks).toEqual([]);
+    expect(beyond.offset).toBe(3);
+  });
+
+  it("falls back to the default sort for unknown sort keys", () => {
+    expect(pageCompletedTasks(rows, { sort: "nonsense" }).sort).toBe("completed_desc");
+  });
+});
+
+describe("fixture graph adapter completed tasks", () => {
+  it("serves paginated fixture rows like the gateway endpoint", async () => {
+    const adapter = createFixtureGraphAdapter({ completedTasks: graphVizFixtureCompletedTasks });
+    const first = await adapter.getCompletedTasks!({ limit: 25 });
+    expect(first.total).toBe(graphVizFixtureCompletedTasks.length);
+    expect(first.tasks).toHaveLength(25);
+    expect(first.tasks[0].issue_key).toBe("VIZ-100");
+    const second = await adapter.getCompletedTasks!({ limit: 25, offset: 25 });
+    expect(second.tasks.length).toBe(graphVizFixtureCompletedTasks.length - 25);
+  });
+
+  it("keeps deterministic fixture rows whose capsules resolve in the viz snapshot", () => {
+    const conceptIds = new Set(
+      graphVizFixtureSnapshot.nodes
+        .filter((node) => node.kind === "concept")
+        .map((node) => node.concept_id),
+    );
+    for (const task of graphVizFixtureCompletedTasks) {
+      expect(conceptIds.has(task.concept_id)).toBe(true);
+      expect(task.prs.length).toBeGreaterThan(0);
+    }
+    // The multi-PR presentation (bold newest, strike unmerged) has fixture
+    // coverage: some tasks carry an earlier abandoned PR.
+    const multiPr = graphVizFixtureCompletedTasks.filter((task) => task.prs.length > 1);
+    expect(multiPr.length).toBeGreaterThan(0);
+    for (const task of multiPr) {
+      expect(task.prs.some((pr) => !pr.merged)).toBe(true);
+    }
+  });
+});

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,6 +1,8 @@
 import type {
   MemoryBundleList,
   MemoryCommunityList,
+  MemoryCompletedTask,
+  MemoryCompletedTaskPage,
   MemoryConceptDetail,
   MemoryGraphEdge,
   MemoryGraphEdgeKind,
@@ -25,10 +27,13 @@ import {
 export type {
   MemoryBundleList,
   MemoryCommunityList,
+  MemoryCompletedTask,
+  MemoryCompletedTaskPage,
   MemoryConceptDetail,
   MemoryGraphNode,
   MemoryGraphSnapshot,
   MemorySearchResponse,
+  MemoryTaskPullRequest,
 } from "@opensymphony/gateway-schema";
 export {
   fixtureBundleList,
@@ -41,6 +46,7 @@ export {
 export {
   graphVizFixtureBundleList,
   graphVizFixtureCommunityList,
+  graphVizFixtureCompletedTasks,
   graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
 } from "./viz-fixture.js";
@@ -139,6 +145,12 @@ export interface GraphDataAdapter {
   getConceptDetail(bundleId: string, conceptId: string, options?: GraphRequestOptions): Promise<MemoryConceptDetail>;
   getCommunities(bundleId: string, options?: GraphRequestOptions): Promise<MemoryCommunityList>;
   search(query: string, options?: GraphSearchOptions): Promise<MemorySearchResponse>;
+  /**
+   * Paginated completed tasks (memory capsules with PR evidence, merged
+   * with orchestrator-known completions). Optional so lean adapters keep
+   * working; surfaces without it render an empty Completed pane.
+   */
+  getCompletedTasks?(options?: GraphCompletedTasksOptions): Promise<MemoryCompletedTaskPage>;
 }
 
 export interface GraphRequestOptions {
@@ -148,6 +160,13 @@ export interface GraphRequestOptions {
 export interface GraphSearchOptions extends GraphRequestOptions {
   limit?: number;
   bundleId?: string;
+}
+
+export interface GraphCompletedTasksOptions extends GraphRequestOptions {
+  query?: string;
+  sort?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export interface GraphAdapterPolicy {
@@ -585,7 +604,127 @@ export function createHttpGraphAdapter(
       if (options?.bundleId) params.set("bundle_id", options.bundleId);
       return read<MemorySearchResponse>("/api/v1/memory/search", params);
     },
+    getCompletedTasks: (options) => {
+      const params = visibilityParams(options, policy);
+      if (options?.query) params.set("query", options.query);
+      if (options?.sort) params.set("sort", options.sort);
+      if (options?.limit !== undefined) params.set("limit", String(options.limit));
+      if (options?.offset !== undefined) params.set("offset", String(options.offset));
+      return read<MemoryCompletedTaskPage>("/api/v1/memory/completed-tasks", params);
+    },
   };
+}
+
+/**
+ * Client-side twin of the gateway's completed-tasks search/sort/pagination,
+ * used by the fixture adapter (and tests) so the workbench behaves like the
+ * real endpoint.
+ */
+export function pageCompletedTasks(
+  rows: readonly MemoryCompletedTask[],
+  options: GraphCompletedTasksOptions = {},
+): MemoryCompletedTaskPage {
+  const query = options.query?.trim() ?? "";
+  const needle = query.toLowerCase();
+  const filtered = needle
+    ? rows.filter((row) =>
+      row.issue_key.toLowerCase().includes(needle)
+      || row.title.toLowerCase().includes(needle)
+      || (row.state?.toLowerCase().includes(needle) ?? false)
+      || (row.milestone?.toLowerCase().includes(needle) ?? false)
+      || row.prs.some((pr) => pr.title.toLowerCase().includes(needle) || `#${pr.number}`.includes(needle)))
+    : [...rows];
+
+  const sort = normalizeCompletedTasksSort(options.sort);
+  filtered.sort(completedTaskComparator(sort));
+
+  const total = filtered.length;
+  const limit = Math.min(Math.max(options.limit ?? 25, 1), 100);
+  const offset = Math.min(Math.max(options.offset ?? 0, 0), total);
+  return {
+    schema_version: { major: 1, minor: 0, patch: 0 },
+    bundle_id: "local-default",
+    tasks: filtered.slice(offset, offset + limit),
+    total,
+    offset,
+    limit,
+    sort,
+    query: query || undefined,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+export const completedTaskSorts = [
+  "completed_desc",
+  "completed_asc",
+  "id_asc",
+  "id_desc",
+  "title_asc",
+  "title_desc",
+  "pr_desc",
+  "pr_asc",
+] as const;
+export type CompletedTaskSort = (typeof completedTaskSorts)[number];
+
+function normalizeCompletedTasksSort(sort: string | undefined): CompletedTaskSort {
+  return (completedTaskSorts as readonly string[]).includes(sort ?? "")
+    ? sort as CompletedTaskSort
+    : "completed_desc";
+}
+
+function completedTaskComparator(sort: CompletedTaskSort): (a: MemoryCompletedTask, b: MemoryCompletedTask) => number {
+  switch (sort) {
+    case "completed_asc":
+      return (a, b) => missingDatesLast(a.completed_at, b.completed_at)
+        || compareNullableStrings(a.completed_at, b.completed_at)
+        || compareIssueKeys(a.issue_key, b.issue_key);
+    case "id_asc":
+      return (a, b) => compareIssueKeys(a.issue_key, b.issue_key);
+    case "id_desc":
+      return (a, b) => compareIssueKeys(b.issue_key, a.issue_key);
+    case "title_asc":
+      return (a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+    case "title_desc":
+      return (a, b) => b.title.localeCompare(a.title, undefined, { sensitivity: "base" });
+    case "pr_desc":
+      return (a, b) => latestPrNumber(b) - latestPrNumber(a);
+    case "pr_asc":
+      return (a, b) => latestPrNumber(a) - latestPrNumber(b);
+    default:
+      return (a, b) => missingDatesLast(a.completed_at, b.completed_at)
+        || compareNullableStrings(b.completed_at, a.completed_at)
+        || compareIssueKeys(b.issue_key, a.issue_key);
+  }
+}
+
+/** Rows without a completion date sort after dated rows in either direction. */
+function missingDatesLast(a: string | undefined, b: string | undefined): number {
+  if ((a === undefined) === (b === undefined)) return 0;
+  return a === undefined ? 1 : -1;
+}
+
+function latestPrNumber(row: MemoryCompletedTask): number {
+  return row.prs.reduce((max, pr) => Math.max(max, pr.number), 0);
+}
+
+function compareNullableStrings(a: string | undefined, b: string | undefined): number {
+  if (a === b) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Natural compare so `COE-99` orders before `COE-100`. */
+function compareIssueKeys(a: string, b: string): number {
+  const splitKey = (key: string): [string, number] => {
+    const at = Math.max(key.lastIndexOf("-"), key.lastIndexOf("_"));
+    if (at < 0) return [key.toUpperCase(), 0];
+    const numeric = Number.parseInt(key.slice(at + 1), 10);
+    return [key.slice(0, at).toUpperCase(), Number.isNaN(numeric) ? 0 : numeric];
+  };
+  const [prefixA, numberA] = splitKey(a);
+  const [prefixB, numberB] = splitKey(b);
+  return prefixA.localeCompare(prefixB) || numberA - numberB;
 }
 
 export const createGatewayGraphAdapter = createHttpGraphAdapter;
@@ -698,13 +837,17 @@ export function createFixtureGraphAdapter(fixtures: {
   conceptDetail?: MemoryConceptDetail | ((bundleId: string, conceptId: string) => MemoryConceptDetail | null);
   communities?: MemoryCommunityList;
   search?: MemorySearchResponse;
+  /** Full row set; the adapter applies query/sort/pagination like the gateway. */
+  completedTasks?: readonly MemoryCompletedTask[];
 } = {}): GraphDataAdapter {
   const bundles = fixtures.bundles ?? fixtureBundleList;
   const snapshot = fixtures.snapshot ?? fixtureGraphSnapshot;
   const conceptDetail = fixtures.conceptDetail ?? fixtureConceptDetail;
   const communities = fixtures.communities ?? fixtureCommunityList;
   const search = fixtures.search ?? fixtureSearchResponse;
+  const completedTasks = fixtures.completedTasks ?? [];
   return {
+    getCompletedTasks: async (options) => pageCompletedTasks(completedTasks, options),
     listBundles: async () => bundles,
     getGraphSnapshot: async () => snapshot,
     getConceptDetail: async (bundleId, conceptId) => {

--- a/packages/graph/src/viz-fixture.ts
+++ b/packages/graph/src/viz-fixture.ts
@@ -1,10 +1,12 @@
 import type {
   MemoryBundleList,
   MemoryCommunityList,
+  MemoryCompletedTask,
   MemoryConceptDetail,
   MemoryGraphEdge,
   MemoryGraphNode,
   MemoryGraphSnapshot,
+  MemoryTaskPullRequest,
 } from "@opensymphony/gateway-schema";
 
 /**
@@ -410,6 +412,88 @@ export const graphVizFixtureCommunityList: MemoryCommunityList = {
   communities: graphVizFixtureSnapshot.communities,
   generated_at,
 };
+
+/** Named completed tasks matching the three-pane design mocks (newest first). */
+const completedTaskTitles: ReadonlyArray<readonly [string, string]> = [
+  ["VIZ-100", "Scene model spike"],
+  ["VIZ-099", "Data pipeline setup"],
+  ["VIZ-098", "Graph schema v1"],
+  ["VIZ-097", "Tokenization service"],
+  ["VIZ-096", "Auth integration"],
+  ["VIZ-095", "Build system config"],
+  ["VIZ-094", "Logging baseline"],
+  ["VIZ-093", "Local runner"],
+  ["VIZ-092", "CLI scaffolding"],
+  ["VIZ-091", "Config loader"],
+  ["VIZ-090", "Health checks"],
+  ["VIZ-089", "Metrics exporter"],
+  ["VIZ-088", "Cache layer"],
+  ["VIZ-087", "Test harness"],
+  ["VIZ-086", "Palette tokens pass"],
+  ["VIZ-085", "Renderer profiling hooks"],
+  ["VIZ-084", "Snapshot cursor plumbing"],
+  ["VIZ-083", "Diff pager batching"],
+  ["VIZ-082", "Fixture transport shims"],
+  ["VIZ-081", "Event journal replay"],
+  ["VIZ-080", "Keyboard focus audit"],
+  ["VIZ-079", "Session token refresh"],
+  ["VIZ-078", "Approval banner polish"],
+  ["VIZ-077", "Workspace scan cache"],
+  ["VIZ-076", "Terminal frame budget"],
+  ["VIZ-075", "Retry queue telemetry"],
+  ["VIZ-074", "Capability probe matrix"],
+  ["VIZ-073", "Run detail parity sweep"],
+  ["VIZ-072", "Dark theme contrast pass"],
+  ["VIZ-071", "Icon set consolidation"],
+  ["VIZ-070", "Bootstrap CLI docs"],
+];
+
+function buildCompletedTasks(): MemoryCompletedTask[] {
+  const concepts = buildVizConcepts();
+  return completedTaskTitles.map(([issueKey, title], index) => {
+    const issueNumber = Number.parseInt(issueKey.slice(4), 10);
+    // One completion per weekday-ish cadence walking back from May 1.
+    const completedAt = new Date(Date.UTC(2026, 4, 1, 17, 0, 0) - index * 86_400_000).toISOString();
+    const prNumber = issueNumber + 1;
+    const prs: MemoryTaskPullRequest[] = [
+      {
+        number: prNumber,
+        title: `${issueKey} ${title.toLowerCase()}`,
+        url: `https://github.com/example/opensymphony/pull/${prNumber}`,
+        merged: true,
+        merged_at: completedAt,
+      },
+    ];
+    // Every fifth task carries an earlier abandoned PR (never merged) so the
+    // multi-PR presentation — newest bold, unmerged struck through — is
+    // exercised by the fixture.
+    if (index % 5 === 4) {
+      prs.unshift({
+        number: prNumber - 40,
+        title: `${issueKey} first attempt (superseded)`,
+        url: `https://github.com/example/opensymphony/pull/${prNumber - 40}`,
+        merged: false,
+      });
+    }
+    const concept = concepts[(index * 7) % concepts.length];
+    return {
+      issue_key: issueKey,
+      // Reuse real fixture concepts so capsule deep links resolve inside the
+      // workbench's knowledge graph.
+      concept_id: concept.id.replace("concept:", "concepts/"),
+      bundle_id: bundleId,
+      title,
+      state: "Done",
+      milestone: "M13",
+      url: `https://linear.app/example/issue/${issueKey}`,
+      completed_at: completedAt,
+      prs,
+      source: "memory",
+    };
+  });
+}
+
+export const graphVizFixtureCompletedTasks: MemoryCompletedTask[] = buildCompletedTasks();
 
 /**
  * Capsule detail for a fixture concept, derived from the snapshot's own

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -3721,6 +3721,92 @@ describe("three-pane task graph", () => {
     await handle.destroy();
   });
 
+  it("bolds the newest PR by number even when an older PR is the merged one", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const rows: MemoryCompletedTask[] = [
+      {
+        issue_key: "COE-500",
+        concept_id: "",
+        title: "Merged then abandoned",
+        state: "Done",
+        completed_at: "2026-06-10T00:00:00Z",
+        // Older PR merged; newer PR abandoned (unmerged, no merged_at).
+        prs: [
+          { number: 100, title: "first, merged", url: "https://example.com/pull/100", merged: true, merged_at: "2026-06-10T00:00:00Z" },
+          { number: 200, title: "second, abandoned", url: "https://example.com/pull/200", merged: false },
+        ],
+        source: "memory",
+      },
+    ];
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ taskGraph: threePaneTaskGraph }),
+      graphAdapter: createFixtureGraphAdapter({ completedTasks: rows }),
+    });
+    await flushUntil(() => root.querySelector("[data-task-key='COE-500']") !== null);
+
+    const prLinks = Array.from(
+      root.querySelector("[data-task-key='COE-500']")?.querySelectorAll(".os-tg-pr") ?? [],
+    );
+    // Newest by number first, and it is the bold "latest" chip even though
+    // it is the unmerged one (struck through).
+    expect(prLinks.map((pr) => pr.textContent)).toEqual(["#200", "#100"]);
+    expect(prLinks[0]?.classList.contains("os-tg-pr-latest")).toBe(true);
+    expect(prLinks[0]?.classList.contains("os-tg-pr-unmerged")).toBe(true);
+    expect(prLinks[1]?.classList.contains("os-tg-pr-latest")).toBe(false);
+
+    await handle.destroy();
+  });
+
+  it("does not enter focused edge-dimming when the selection transitions to done", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph: threePaneTaskGraph,
+      runDetails: [runDetail],
+    });
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport,
+      graphAdapter: createFixtureGraphAdapter({ completedTasks: [] }),
+    });
+    await flushUntil(() => root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']") !== null);
+
+    // Select the Current task, then complete it via a live event.
+    (root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']") as HTMLButtonElement).click();
+    await flushUntil(() => root.querySelector("[data-node-id='desktop-alpha']")?.classList.contains("is-selected") ?? false);
+
+    transport.setTaskGraph({
+      ...threePaneTaskGraph,
+      nodes: threePaneTaskGraph.nodes.map((node) =>
+        node.node_id === "desktop-alpha"
+          ? { ...node, state: "Done", state_category: "done" as const }
+          : node,
+      ),
+    });
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 1, partition: "events" },
+      entity_ref: { kind: "run", id: "COE-449" },
+      event_kind: "run.completed",
+      emitted_at: "2026-07-01T00:00:01Z",
+      payload: { run_id: "COE-449" },
+    });
+    await flushUntil(() => root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']") === null);
+
+    // The selection now points at a hidden (done) node; the panes must not
+    // be stuck in focused mode dimming every edge with nothing highlighted.
+    expect(root.querySelector("[data-tg-panes]")?.classList.contains("os-tg-focused")).toBe(false);
+
+    await handle.destroy();
+  });
+
   it("abandons an in-flight completed-tasks request across a context reset", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -3720,4 +3720,95 @@ describe("three-pane task graph", () => {
 
     await handle.destroy();
   });
+
+  it("clears Completed rows when a context change hits a gateway without the endpoint", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ taskGraph: threePaneTaskGraph }),
+      // Bare fixture adapter: no getCompletedTasks (models a gateway with
+      // no memory endpoint) but seeded with a stale prior page.
+      graphAdapter: {
+        ...createFixtureGraphAdapter(),
+        getCompletedTasks: undefined,
+      },
+    });
+    await flushUntil(() => root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']") !== null);
+
+    // The Completed table shows its unavailable state, never rows from a
+    // different context.
+    expect(root.querySelector("[data-testid='completed-tasks-unavailable']")).not.toBeNull();
+    expect(root.querySelector("[data-testid='completed-task-row']")).toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("reloads the Completed page when a done row's PR or date changes while staying done", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const rows: MemoryCompletedTask[] = [
+      {
+        issue_key: "COE-448",
+        concept_id: "issues/COE-465",
+        bundle_id: "local-default",
+        title: "Completed prerequisite",
+        state: "Done",
+        completed_at: "2026-06-10T00:00:00Z",
+        prs: [{ number: 700, title: "COE-448 landed", url: "https://example.com/pull/700", merged: true, merged_at: "2026-06-10T00:00:00Z" }],
+        source: "memory",
+      },
+    ];
+    let completedCalls = 0;
+    const adapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      getCompletedTasks: async (options) => {
+        completedCalls += 1;
+        return pageCompletedTasks(rows, options);
+      },
+    };
+    // Snapshot where the prerequisite is already Done (renders in Completed).
+    const doneGraph: TaskGraphSnapshot = {
+      ...threePaneTaskGraph,
+      nodes: threePaneTaskGraph.nodes.map((node) =>
+        node.node_id === "completed-prereq"
+          ? { ...node, url: "https://linear.app/example/issue/COE-448" }
+          : node,
+      ),
+    };
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph: doneGraph,
+      runDetails: [runDetail],
+    });
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport, graphAdapter: adapter });
+    await flushUntil(() => root.querySelector("[data-task-key='COE-448']") !== null);
+    const callsBefore = completedCalls;
+
+    // The done node stays done, but its URL changes (e.g. a PR link landed).
+    // The fingerprint includes row-relevant fields, so the page reloads.
+    rows[0] = { ...rows[0], prs: [...rows[0].prs, { number: 701, title: "COE-448 follow-up", url: "https://example.com/pull/701", merged: true, merged_at: "2026-06-11T00:00:00Z" }] };
+    transport.setTaskGraph({
+      ...doneGraph,
+      nodes: doneGraph.nodes.map((node) =>
+        node.node_id === "completed-prereq"
+          ? { ...node, updated_at: "2026-06-11T00:00:00Z" }
+          : node,
+      ),
+    });
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 1, partition: "events" },
+      entity_ref: { kind: "issue", id: "completed-prereq", identifier: "COE-448" },
+      event_kind: "issue.updated",
+      emitted_at: "2026-06-11T00:00:01Z",
+      payload: {},
+    });
+    await flushUntil(() => completedCalls > callsBefore, 200);
+
+    await handle.destroy();
+  });
 });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -3721,6 +3721,59 @@ describe("three-pane task graph", () => {
     await handle.destroy();
   });
 
+  it("abandons an in-flight completed-tasks request across a context reset", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    let releaseFirst: (() => void) | null = null;
+    let calls = 0;
+    const adapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      getCompletedTasks: async (options) => {
+        calls += 1;
+        if (calls === 1) {
+          // Hold the first (prior-context) request open until after the
+          // reset so it resolves late.
+          await new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          });
+          return pageCompletedTasks(
+            [{
+              issue_key: "STALE-1",
+              concept_id: "",
+              title: "Stale prior-context row",
+              state: "Done",
+              completed_at: "2026-06-01T00:00:00Z",
+              prs: [],
+              source: "orchestrator",
+            }],
+            options,
+          );
+        }
+        return pageCompletedTasks([], options);
+      },
+    };
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ taskGraph: threePaneTaskGraph }),
+      graphAdapter: adapter,
+    });
+    await flushUntil(() => calls >= 1);
+
+    // A context reset (gateway switch / disconnect) clears and invalidates.
+    const internal = handle as unknown as { resetCompletedTasks?: () => void };
+    expect(typeof internal.resetCompletedTasks).toBe("function");
+    internal.resetCompletedTasks!();
+    // Now let the prior-context request resolve; its stale seq must prevent
+    // it from repopulating the cleared page.
+    releaseFirst?.();
+    await flushMicrotasks();
+    expect(root.querySelector("[data-task-key='STALE-1']")).toBeNull();
+    expect(root.textContent).not.toContain("Stale prior-context row");
+
+    await handle.destroy();
+  });
+
   it("clears Completed rows when a context change hits a gateway without the endpoint", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -17,7 +17,9 @@ import {
   graphVizFixtureConceptDetail,
   graphVizFixtureSnapshot,
   initialGraphState,
+  pageCompletedTasks,
   type GraphDataAdapter,
+  type MemoryCompletedTask,
 } from "@opensymphony/graph";
 import { schemaVersionV1 } from "@opensymphony/gateway-schema";
 import {
@@ -3608,6 +3610,101 @@ describe("three-pane task graph", () => {
       root.querySelectorAll("[data-testid='completed-task-row']").length === 25
       && root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-a']") !== null,
     );
+
+    await handle.destroy();
+  });
+
+  it("keeps a backlog selection across refresh without probing its run", async () => {
+    const { root, handle } = await mountThreePane();
+
+    (root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-b']") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelector("[data-node-id='backlog-b']")?.classList.contains("is-selected") ?? false,
+    );
+
+    await handle.refresh();
+    await flushUntil(() =>
+      root.querySelector("[data-node-id='backlog-b']")?.classList.contains("is-selected") ?? false,
+    );
+    // The preserved backlog selection must not trigger an openRun probe
+    // against /runs/{backlog identifier}.
+    expect(root.textContent).not.toContain("Run COE-461 unavailable");
+
+    await handle.destroy();
+  });
+
+  it("refreshes the Completed pane when live updates complete a task or touch memory", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const rows: MemoryCompletedTask[] = [...completedRows];
+    let completedCalls = 0;
+    const adapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      getCompletedTasks: async (options) => {
+        completedCalls += 1;
+        return pageCompletedTasks(rows, options);
+      },
+    };
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph: threePaneTaskGraph,
+      runDetails: [runDetail],
+    });
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport, graphAdapter: adapter });
+    await flushUntil(() =>
+      root.querySelector("[data-task-key='COE-448']") !== null
+      && root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']") !== null,
+    );
+
+    // A run completing moves its node to `done` and captures a fresh
+    // completed row: the live refresh must reload the Completed page.
+    rows.unshift({
+      issue_key: "COE-449",
+      concept_id: "",
+      title: "Replace stubs with functional app",
+      state: "Done",
+      completed_at: "2026-07-01T00:00:00Z",
+      prs: [],
+      source: "orchestrator",
+    });
+    transport.setTaskGraph({
+      ...threePaneTaskGraph,
+      nodes: threePaneTaskGraph.nodes.map((node) =>
+        node.node_id === "desktop-alpha"
+          ? { ...node, state: "Done", state_category: "done" as const }
+          : node,
+      ),
+    });
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 1, partition: "events" },
+      entity_ref: { kind: "run", id: "COE-449" },
+      event_kind: "run.completed",
+      emitted_at: "2026-07-01T00:00:01Z",
+      payload: { run_id: "COE-449" },
+    });
+    await flushUntil(() => root.querySelector("[data-task-key='COE-449']") !== null, 200);
+    expect(root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']")).toBeNull();
+
+    // Memory updates can add capsules/PR evidence for completed tasks: the
+    // page reloads on memory_graph_updated too.
+    const callsBeforeMemory = completedCalls;
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 2, partition: "events" },
+      entity_ref: { kind: "unknown", id: "memory-graph:local-default" },
+      event_kind: "memory_graph_updated",
+      emitted_at: "2026-07-01T00:00:02Z",
+      payload: {
+        schema_version: schemaVersionV1(),
+        bundle_id: "local-default",
+        cursor: { sequence: 2, partition: "memory-graph:local-default" },
+        updated_at: "2026-07-01T00:00:02Z",
+      },
+    });
+    await flushUntil(() => completedCalls > callsBeforeMemory, 200);
 
     await handle.destroy();
   });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -3398,6 +3398,19 @@ describe("three-pane task graph", () => {
       blocked_by: [],
       labels: ["backlog"],
     },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "canceled-node",
+      kind: "issue" as const,
+      identifier: "COE-463",
+      title: "Canceled experiment",
+      state: "Canceled",
+      state_category: "canceled" as const,
+      parent_id: "m7-milestone",
+      children: [],
+      blocked_by: [],
+      labels: [],
+    },
   ];
   const threePaneTaskGraph: TaskGraphSnapshot = {
     ...taskGraph,
@@ -3477,6 +3490,9 @@ describe("three-pane task graph", () => {
     expect(root.querySelector("[data-tg-pane='current'] [data-node-id='completed-prereq']")).toBeNull();
     expect(root.querySelector("[data-tg-pane='current'] [data-node-id='backlog-a']")).toBeNull();
     expect(root.querySelectorAll("[data-tg-pane='backlog'] [data-node-id]").length).toBe(3);
+    // Canceled nodes have no other pane: they stay visible in Current so
+    // the Canceled state filter can still surface them.
+    expect(root.querySelector("[data-tg-pane='current'] [data-node-id='canceled-node']")).not.toBeNull();
 
     // Backlog dependency suffix names the Current blocker instead of
     // calling it hidden: both graph panes count as visible.

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -463,6 +463,7 @@ class LiveEventTransport extends MockGatewayTransport {
   private queuedEvents: Array<GatewayEnvelope | null> = [];
   private resolveNext: ((event: GatewayEnvelope | null) => void) | null = null;
   private liveTaskGraph: TaskGraphSnapshot | null = null;
+  private liveSnapshot: DashboardSnapshot | null = null;
   private nextSnapshotError: Error | null = null;
 
   emit(event: GatewayEnvelope): void {
@@ -477,6 +478,10 @@ class LiveEventTransport extends MockGatewayTransport {
     this.push(null);
   }
 
+  setSnapshot(snapshot: DashboardSnapshot): void {
+    this.liveSnapshot = snapshot;
+  }
+
   override async snapshot(): Promise<DashboardSnapshot> {
     this.snapshotReads += 1;
     if (this.nextSnapshotError) {
@@ -484,7 +489,7 @@ class LiveEventTransport extends MockGatewayTransport {
       this.nextSnapshotError = null;
       throw error;
     }
-    return super.snapshot();
+    return this.liveSnapshot ?? super.snapshot();
   }
 
   setTaskGraph(snapshot: TaskGraphSnapshot): void {
@@ -3717,6 +3722,107 @@ describe("three-pane task graph", () => {
       root.querySelector("[data-testid='knowledge-graph-capsule']") !== null
       || (root.querySelector(".os-kg-breadcrumb")?.textContent?.includes("COE-465") ?? false),
     );
+
+    await handle.destroy();
+  });
+
+  it("moves a task between Backlog and Current as its status changes, both ways", async () => {
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph: threePaneTaskGraph,
+      runDetails: [runDetail],
+    });
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport,
+      graphAdapter: createFixtureGraphAdapter({ completedTasks: [] }),
+    });
+    await flushUntil(() => root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-a']") !== null);
+    // Starts in Backlog, absent from Current.
+    expect(root.querySelector("[data-tg-pane='current'] [data-node-id='backlog-a']")).toBeNull();
+
+    // Backlog -> Todo: the refreshed snapshot recategorizes the node.
+    const promoted = (category: "todo" | "backlog") => ({
+      ...threePaneTaskGraph,
+      nodes: threePaneTaskGraph.nodes.map((node) =>
+        node.node_id === "backlog-a"
+          ? { ...node, state: category === "todo" ? "Todo" : "Backlog", state_category: category }
+          : node,
+      ),
+    });
+    transport.setTaskGraph(promoted("todo"));
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 1, partition: "events" },
+      entity_ref: { kind: "issue", id: "backlog-a", identifier: "COE-460" },
+      event_kind: "issue.updated",
+      emitted_at: "2026-07-01T00:00:01Z",
+      payload: {},
+    });
+    await flushUntil(() => root.querySelector("[data-tg-pane='current'] [data-node-id='backlog-a']") !== null);
+    expect(root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-a']")).toBeNull();
+
+    // Todo -> Backlog: it must return to the Backlog pane and leave Current.
+    transport.setTaskGraph(promoted("backlog"));
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 2, partition: "events" },
+      entity_ref: { kind: "issue", id: "backlog-a", identifier: "COE-460" },
+      event_kind: "issue.updated",
+      emitted_at: "2026-07-01T00:00:02Z",
+      payload: {},
+    });
+    await flushUntil(() => root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-a']") !== null);
+    expect(root.querySelector("[data-tg-pane='current'] [data-node-id='backlog-a']")).toBeNull();
+
+    await handle.destroy();
+  });
+
+  it("reloads Completed when the control-plane completed count rises even if the issue leaves the graph", async () => {
+    let completedCalls = 0;
+    const adapter: GraphDataAdapter = {
+      ...createFixtureGraphAdapter(),
+      getCompletedTasks: async (options) => {
+        completedCalls += 1;
+        return pageCompletedTasks([], options);
+      },
+    };
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph: threePaneTaskGraph,
+      runDetails: [runDetail],
+    });
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport, graphAdapter: adapter });
+    await flushUntil(() => root.querySelector("[data-tg-pane='current']") !== null && completedCalls >= 1);
+    const callsBefore = completedCalls;
+
+    // Simulate a completion whose issue is not present in the task graph
+    // (e.g. no project metadata): the task graph is unchanged, but the
+    // control-plane completed_count rises. The Completed pane must reload.
+    transport.setSnapshot({
+      ...dashboard,
+      projects: dashboard.projects.map((project, index) =>
+        index === 0 ? { ...project, completed_count: project.completed_count + 1 } : project,
+      ),
+    });
+    transport.emit({
+      schema_version: schemaVersionV1(),
+      cursor: { sequence: 1, partition: "events" },
+      entity_ref: { kind: "project", id: dashboard.projects[0].project_id },
+      event_kind: "snapshot_published",
+      emitted_at: "2026-07-01T00:00:01Z",
+      payload: {},
+    });
+    await flushUntil(() => completedCalls > callsBefore, 200);
 
     await handle.destroy();
   });

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1965,7 +1965,9 @@ describe("OpenSymphonyApp mount", () => {
       expect.stringContaining("alpha-project | Alpha Project"),
       expect.stringContaining("beta-project | Beta Project"),
     ]);
-    expect(headings[0]?.textContent).toContain("issues=4 running=1 todo=2");
+    // Done nodes (completed-prereq) render in the Completed pane, not the
+    // Current pane's project groups.
+    expect(headings[0]?.textContent).toContain("issues=3 running=1 todo=2");
     expect(headings[0]?.textContent).toContain("blocked=1");
     expect(headings[1]?.textContent).toContain("issues=2 running=0 todo=2");
     expect(headings[1]?.textContent).toContain("blocked=2");
@@ -1982,7 +1984,13 @@ describe("OpenSymphonyApp mount", () => {
       ...projectSetTaskGraph.nodes.find((node) => node.node_id === "desktop-alpha")!,
       project_name: undefined,
     };
-    const alphaNamed = projectSetTaskGraph.nodes.find((node) => node.node_id === "completed-prereq")!;
+    // Not Done here: a terminal state would drop the node from the Current
+    // pane and this test is about mixed project metadata, not state buckets.
+    const alphaNamed = {
+      ...projectSetTaskGraph.nodes.find((node) => node.node_id === "completed-prereq")!,
+      state: "Todo",
+      state_category: "todo" as const,
+    };
     const beta = projectSetTaskGraph.nodes.find((node) => node.node_id === "hosted-auth")!;
     const unassigned = {
       ...taskGraph.nodes.find((node) => node.node_id === "follow-up")!,
@@ -2100,7 +2108,7 @@ describe("OpenSymphonyApp mount", () => {
     const restoredAlphaNodes = Array.from(
       root.querySelectorAll("[data-project-group='alpha-project'] [data-node-id]"),
     ).map((node) => node.getAttribute("data-node-id"));
-    expect(restoredAlphaNodes).toEqual(["m7-milestone", "app-shell", "desktop-alpha", "follow-up", "completed-prereq"]);
+    expect(restoredAlphaNodes).toEqual(["m7-milestone", "app-shell", "desktop-alpha", "follow-up"]);
     expect(root.querySelector(".os-run-head strong")?.textContent).toBe("COE-449");
 
     await handle.destroy();
@@ -2132,7 +2140,7 @@ describe("OpenSymphonyApp mount", () => {
       expect.stringContaining("unassigned"),
     ]);
     expect(headings[0]).toContain("issues=2 running=1 todo=1 blocked=1");
-    expect(headings[1]).toContain("issues=3 running=0 todo=2 blocked=1");
+    expect(headings[1]).toContain("issues=2 running=0 todo=2 blocked=1");
     expect(headings[2]).toContain("issues=1 running=0 todo=1 blocked=0");
     expect(root.querySelector("[data-project-group='__opensymphony_unassigned__'] [data-node-id='COE-705']")).not.toBeNull();
     expect(root.querySelector("[data-node-id='COE-700'] [data-testid='dependency-suffix']")?.textContent).toContain("blocks COE-701");
@@ -2257,7 +2265,9 @@ describe("OpenSymphonyApp mount", () => {
       expect(root.textContent).not.toContain("src/config.ts");
       expect(root.textContent).not.toContain("Live data stale");
       expect(root.querySelector(".os-pill")?.textContent).toBe("released");
-      expect(root.querySelector("[data-node-id='desktop-alpha']")?.textContent).toContain("Done");
+      // Once the task reaches Done it leaves the Current pane (three-pane
+      // task graph): the card must no longer render among current tasks.
+      expect(root.querySelector("[data-node-id='desktop-alpha']")).toBeNull();
       expect(root.querySelector("[data-testid='changed-file-item']")?.getAttribute("data-path")).toBe("src/live-update.ts");
     } finally {
       warnSpy.mockRestore();
@@ -3343,6 +3353,258 @@ describe("OpenSymphonyApp mount", () => {
     expect(select).not.toBeNull();
     // Without a profile controller the shell uses the default UI profile.
     expect(select.options.length).toBeGreaterThan(0);
+    await handle.destroy();
+  });
+});
+
+describe("three-pane task graph", () => {
+  const backlogNodes = [
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "backlog-a",
+      kind: "issue" as const,
+      identifier: "COE-460",
+      title: "Backlog changelog & publish",
+      state: "Backlog",
+      state_category: "backlog" as const,
+      parent_id: "m7-milestone",
+      children: [],
+      blocked_by: ["COE-449"],
+      labels: ["backlog"],
+    },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "backlog-b",
+      kind: "issue" as const,
+      identifier: "COE-461",
+      title: "Backlog release evidence",
+      state: "Backlog",
+      state_category: "backlog" as const,
+      parent_id: "m7-milestone",
+      children: [],
+      blocked_by: ["COE-460"],
+      labels: ["backlog"],
+    },
+    {
+      schema_version: schemaVersionV1(),
+      node_id: "backlog-c",
+      kind: "issue" as const,
+      identifier: "COE-462",
+      title: "Backlog unrelated polish",
+      state: "Backlog",
+      state_category: "backlog" as const,
+      parent_id: "m7-milestone",
+      children: [],
+      blocked_by: [],
+      labels: ["backlog"],
+    },
+  ];
+  const threePaneTaskGraph: TaskGraphSnapshot = {
+    ...taskGraph,
+    nodes: [...taskGraph.nodes, ...backlogNodes],
+  };
+  const completedRows = [
+    {
+      issue_key: "COE-448",
+      concept_id: "issues/COE-465",
+      bundle_id: "local-default",
+      title: "Completed prerequisite",
+      state: "Done",
+      milestone: "M7",
+      url: "https://linear.app/example/issue/COE-448",
+      completed_at: "2026-06-10T00:00:00Z",
+      prs: [
+        {
+          number: 700,
+          title: "COE-448 first attempt",
+          url: "https://github.com/example/repo/pull/700",
+          merged: false,
+        },
+        {
+          number: 720,
+          title: "COE-448 landed",
+          url: "https://github.com/example/repo/pull/720",
+          merged: true,
+          merged_at: "2026-06-10T00:00:00Z",
+        },
+      ],
+      source: "memory" as const,
+    },
+    ...Array.from({ length: 30 }, (_, index) => ({
+      issue_key: `COE-${400 + index}`,
+      concept_id: `issues/COE-${400 + index}`,
+      bundle_id: "local-default",
+      title: `Historical task ${400 + index}`,
+      state: "Done",
+      completed_at: new Date(Date.UTC(2026, 4, 1) - index * 86_400_000).toISOString(),
+      prs: [
+        {
+          number: 500 + index,
+          title: `COE-${400 + index} landed`,
+          url: `https://github.com/example/repo/pull/${500 + index}`,
+          merged: true,
+          merged_at: new Date(Date.UTC(2026, 4, 1) - index * 86_400_000).toISOString(),
+        },
+      ],
+      source: "memory" as const,
+    })),
+  ];
+
+  async function mountThreePane() {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ taskGraph: threePaneTaskGraph }),
+      graphAdapter: createFixtureGraphAdapter({ completedTasks: completedRows }),
+    });
+    await flushUntil(() =>
+      root.querySelectorAll("[data-testid='completed-task-row']").length > 0
+      && root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-a']") !== null,
+    );
+    return { root, handle };
+  }
+
+  it("renders Completed, Current, and Backlog panes with cross-pane edges", async () => {
+    const { root, handle } = await mountThreePane();
+
+    expect(root.querySelector("[data-testid='task-pane-done']")).not.toBeNull();
+    expect(root.querySelector("[data-testid='task-pane-current']")).not.toBeNull();
+    expect(root.querySelector("[data-testid='task-pane-backlog']")).not.toBeNull();
+
+    // Done nodes leave the Current pane; backlog nodes render in their own.
+    expect(root.querySelector("[data-tg-pane='current'] [data-node-id='completed-prereq']")).toBeNull();
+    expect(root.querySelector("[data-tg-pane='current'] [data-node-id='backlog-a']")).toBeNull();
+    expect(root.querySelectorAll("[data-tg-pane='backlog'] [data-node-id]").length).toBe(3);
+
+    // Backlog dependency suffix names the Current blocker instead of
+    // calling it hidden: both graph panes count as visible.
+    expect(
+      root.querySelector("[data-node-id='backlog-a'] [data-testid='dependency-suffix']")?.textContent,
+    ).toContain("blocked by COE-449");
+
+    // The cross-pane edge from the Current blocker into the Backlog exists
+    // with the shared link data contract (geometry is measured in-browser).
+    const cross = root.querySelector("[data-testid='task-graph-cross-link']");
+    expect(cross?.getAttribute("data-link-from")).toBe("desktop-alpha");
+    expect(cross?.getAttribute("data-link-to")).toBe("backlog-a");
+
+    // First page: newest completion first, 25 rows per page.
+    const rows = Array.from(root.querySelectorAll("[data-testid='completed-task-row']"));
+    expect(rows).toHaveLength(25);
+    expect(rows[0]?.getAttribute("data-task-key")).toBe("COE-448");
+
+    // Multi-PR presentation: newest PR emphasized, unmerged struck through.
+    const firstRowPrs = Array.from(rows[0]?.querySelectorAll(".os-tg-pr") ?? []);
+    expect(firstRowPrs.map((pr) => pr.textContent)).toEqual(["#720", "#700"]);
+    expect(firstRowPrs[0]?.classList.contains("os-tg-pr-latest")).toBe(true);
+    expect(firstRowPrs[1]?.classList.contains("os-tg-pr-unmerged")).toBe(true);
+
+    // Capsule deep link carries the wired opensymphony://memory URL.
+    expect(rows[0]?.querySelector("[data-tg-capsule]")?.getAttribute("data-tg-capsule"))
+      .toBe("opensymphony://memory/local-default/concepts/issues/COE-465");
+
+    await handle.destroy();
+  });
+
+  it("searches, sorts, and paginates the Completed pane", async () => {
+    const { root, handle } = await mountThreePane();
+
+    (root.querySelector("[data-tg-done-page='next']") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelectorAll("[data-testid='completed-task-row']").length === completedRows.length - 25,
+    );
+
+    (root.querySelector("[data-tg-done-sort='id']") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelector("[data-testid='completed-task-row']")?.getAttribute("data-task-key") === "COE-400",
+    );
+    expect(
+      root.querySelector("[data-tg-done-sort='id']")?.closest("th")?.getAttribute("aria-sort"),
+    ).toBe("ascending");
+
+    const search = root.querySelector("[data-tg-done-search]") as HTMLInputElement;
+    search.value = "prerequisite";
+    search.dispatchEvent(new Event("input", { bubbles: true }));
+    // The search input debounces (~180ms) before hitting the adapter, so
+    // this wait needs more head-room than the default flush window.
+    await flushUntil(
+      () => root.querySelectorAll("[data-testid='completed-task-row']").length === 1,
+      600,
+    );
+    expect(
+      root.querySelector("[data-testid='completed-task-row']")?.getAttribute("data-task-key"),
+    ).toBe("COE-448");
+
+    await handle.destroy();
+  });
+
+  it("boldens the ancestry critical path when a backlog task is selected", async () => {
+    const { root, handle } = await mountThreePane();
+
+    (root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-b']") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelector("[data-node-id='backlog-b']")?.classList.contains("is-selected") ?? false,
+    );
+
+    const ancestry = Array.from(root.querySelectorAll(".is-ancestry"))
+      .map((path) => `${path.getAttribute("data-link-from")}->${path.getAttribute("data-link-to")}`)
+      .sort();
+    expect(ancestry).toEqual(["backlog-a->backlog-b", "desktop-alpha->backlog-a"]);
+    expect(root.querySelector("[data-node-id='backlog-c']")?.classList.contains("os-tg-dim")).toBe(true);
+    expect(root.querySelector("[data-node-id='desktop-alpha']")?.classList.contains("os-tg-ancestry")).toBe(true);
+    // Selecting a backlog task never opens a run: the Current selection's
+    // run detail panel is untouched.
+    expect(root.querySelector(".os-run-head strong")?.textContent).toBe("COE-449");
+
+    // Hovering a Current task spotlights only its own edges, then restores
+    // the pinned ancestry emphasis on leave.
+    const currentCard = root.querySelector("[data-tg-pane='current'] [data-node-id='desktop-alpha']") as HTMLElement;
+    currentCard.dispatchEvent(new Event("pointerenter"));
+    const active = Array.from(root.querySelectorAll(".os-task-graph-link.is-active, .os-tg-cross-link.is-active"))
+      .map((path) => `${path.getAttribute("data-link-from")}->${path.getAttribute("data-link-to")}`);
+    expect(active).toContain("desktop-alpha->backlog-a");
+    currentCard.dispatchEvent(new Event("pointerleave"));
+    expect(root.querySelectorAll(".os-task-graph-link.is-active, .os-tg-cross-link.is-active").length).toBe(0);
+    expect(root.querySelectorAll(".is-ancestry").length).toBe(2);
+
+    await handle.destroy();
+  });
+
+  it("collapses and expands the Completed and Backlog panes", async () => {
+    const { root, handle } = await mountThreePane();
+
+    (root.querySelector("[data-tg-pane-toggle='done']") as HTMLButtonElement).click();
+    await flushUntil(() => root.querySelector("[data-tg-pane='done'][data-collapsed]") !== null);
+    expect(root.querySelector("[data-testid='completed-task-row']")).toBeNull();
+    expect(root.querySelector("[data-tg-pane='done'] .os-tg-pane-vertical-label")?.textContent).toBe("Completed");
+
+    (root.querySelector("[data-tg-pane-toggle='backlog']") as HTMLButtonElement).click();
+    await flushUntil(() => root.querySelector("[data-tg-pane='backlog'][data-collapsed]") !== null);
+    expect(root.querySelector("[data-tg-pane='backlog'] [data-node-id]")).toBeNull();
+    // The Current pane has no collapse affordance.
+    expect(root.querySelector("[data-tg-pane-toggle='current']")).toBeNull();
+
+    (root.querySelector("[data-tg-pane-toggle='done']") as HTMLButtonElement).click();
+    (root.querySelector("[data-tg-pane-toggle='backlog']") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelectorAll("[data-testid='completed-task-row']").length === 25
+      && root.querySelector("[data-tg-pane='backlog'] [data-node-id='backlog-a']") !== null,
+    );
+
+    await handle.destroy();
+  });
+
+  it("opens the memory capsule from a completed row via the deep link", async () => {
+    const { root, handle } = await mountThreePane();
+
+    (root.querySelector("[data-tg-capsule]") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelector("[data-testid='knowledge-graph-capsule']") !== null
+      || (root.querySelector(".os-kg-breadcrumb")?.textContent?.includes("COE-465") ?? false),
+    );
+
     await handle.destroy();
   });
 });

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -707,6 +707,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    * tasks — titles, PR URLs — never linger beside a new task graph.
    */
   private resetCompletedTasks(): void {
+    // Bump the sequence so any in-flight completed-tasks request is
+    // abandoned rather than repopulating the cleared page after a context
+    // change (its seq check will now fail).
+    this.completedTasksSeq += 1;
     this.state.completedTasks = null;
     this.state.completedTasksError = null;
     this.state.completedTasksParams = { ...defaultCompletedTasksParams };
@@ -845,16 +849,16 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private async loadCompletedTasks(contextChanged = false): Promise<void> {
     const adapter = this.graphAdapter;
     if (contextChanged) {
-      this.state.completedTasks = null;
-      this.state.completedTasksError = null;
-      this.state.completedTasksParams = { ...defaultCompletedTasksParams };
+      // resetCompletedTasks bumps completedTasksSeq, so an in-flight request
+      // from the previous context can no longer repopulate the page.
+      this.resetCompletedTasks();
     }
     if (!adapter?.getCompletedTasks) {
       // A gateway without a memory endpoint has no completed tasks: never
-      // leave the prior context's rows on screen.
-      if (contextChanged || this.state.completedTasks) {
-        this.state.completedTasks = null;
-        this.state.completedTasksError = null;
+      // leave the prior context's rows on screen, and invalidate any
+      // still-in-flight request so it cannot land after this return.
+      if (contextChanged || this.state.completedTasks || this.state.completedTasksError) {
+        this.resetCompletedTasks();
       }
       return;
     }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1172,10 +1172,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
     // A task finishing (or reopening) moves it between the Current pane and
     // the Completed table, whose data loads separately — refresh that page
-    // whenever the set of done nodes changes so it never goes stale until a
-    // manual reload.
+    // whenever the completed set could have changed so it never goes stale
+    // until a manual reload. The signature watches both the task graph's
+    // done nodes (so a done node appearing/leaving triggers it) and the
+    // control-plane completed count (so a completion whose issue is absent
+    // from the task graph — e.g. no project metadata — still triggers it).
     const completedSetChanged = this.options.mode === "desktop"
-      && doneTaskGraphKey(this.state.taskGraph) !== doneTaskGraphKey(taskGraph);
+      && completedTasksSignature(this.state.snapshot, this.state.taskGraph)
+        !== completedTasksSignature(snapshot, taskGraph);
 
     // Apply everything atomically: the previous data stays on screen until
     // the replacement is fully loaded, so panels never flash empty.
@@ -5602,6 +5606,25 @@ function isCurrentPaneTaskNode(node: TaskGraphNode): boolean {
  * not just IDs, so a completed issue whose PR or dates change while
  * staying done still triggers a reload.
  */
+/**
+ * Change signal for the separately-loaded Completed pane. Combines the
+ * task graph's done nodes (a done node appearing or leaving) with the
+ * control-plane completed count from the dashboard snapshot (a completion
+ * whose issue never surfaces in the task graph — e.g. no project metadata —
+ * still bumps this count). When it differs across a live refresh, the
+ * Completed page is reloaded.
+ */
+function completedTasksSignature(
+  snapshot: DashboardSnapshot | null,
+  taskGraph: TaskGraphSnapshot | null,
+): string {
+  const completedCount = (snapshot?.projects ?? []).reduce(
+    (sum, project) => sum + project.completed_count,
+    0,
+  );
+  return `${completedCount}\n${doneTaskGraphKey(taskGraph)}`;
+}
+
 function doneTaskGraphKey(taskGraph: TaskGraphSnapshot | null): string {
   return (taskGraph?.nodes ?? [])
     .filter((node) => node.state_category === "done")

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -685,6 +685,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   private clearGatewayData(): void {
     this.stopLiveRefreshTimer();
+    this.resetCompletedTasks();
     this.state.snapshot = null;
     this.state.taskGraph = null;
     this.state.selectedProjectId = null;
@@ -700,7 +701,19 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runApprovals = null;
   }
 
+  /**
+   * Drop the current gateway's Completed-pane rows. Called on any context
+   * change (gateway switch, disconnect) so another gateway's completed
+   * tasks — titles, PR URLs — never linger beside a new task graph.
+   */
+  private resetCompletedTasks(): void {
+    this.state.completedTasks = null;
+    this.state.completedTasksError = null;
+    this.state.completedTasksParams = { ...defaultCompletedTasksParams };
+  }
+
   private resetKnowledgeGraph(): void {
+    this.resetCompletedTasks();
     this.state.knowledgeGraph = createInitialGraphState();
     this.state.knowledgeGraphLayout = null;
     this.knowledgeGraphLayoutSize = null;
@@ -795,8 +808,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.selectedDiffPath = null;
     if (this.options.mode === "desktop") {
       // Completed pane data loads independently: a memory-server hiccup must
-      // not delay the Current/Backlog graph.
-      void this.loadCompletedTasks();
+      // not delay the Current/Backlog graph. A project switch
+      // (!preserveSelection) is a context change, so drop the prior page up
+      // front rather than showing it beside the new project's graph.
+      void this.loadCompletedTasks(!preserveSelection);
     }
     await Promise.all([
       this.fetchRunOverlays(taskGraph).then((overlays) => {
@@ -818,12 +833,29 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   /**
    * Fetch the Completed pane's current page from the memory-backed
-   * completed-tasks endpoint. Newer requests supersede in-flight ones; a
-   * failure keeps the last good page and surfaces the error inline.
+   * completed-tasks endpoint. Newer requests supersede in-flight ones.
+   *
+   * `contextChanged` (gateway/project switch) drops the previous context's
+   * rows up front and resets paging/search, so the new Current/Backlog
+   * graph never renders beside another gateway's completed tasks (titles,
+   * PR URLs) while the fetch is in flight or if it fails. In-context
+   * reloads keep the last good page on failure and surface the error
+   * inline.
    */
-  private async loadCompletedTasks(): Promise<void> {
+  private async loadCompletedTasks(contextChanged = false): Promise<void> {
     const adapter = this.graphAdapter;
+    if (contextChanged) {
+      this.state.completedTasks = null;
+      this.state.completedTasksError = null;
+      this.state.completedTasksParams = { ...defaultCompletedTasksParams };
+    }
     if (!adapter?.getCompletedTasks) {
+      // A gateway without a memory endpoint has no completed tasks: never
+      // leave the prior context's rows on screen.
+      if (contextChanged || this.state.completedTasks) {
+        this.state.completedTasks = null;
+        this.state.completedTasksError = null;
+      }
       return;
     }
     const seq = ++this.completedTasksSeq;
@@ -5551,15 +5583,25 @@ function isCurrentPaneTaskNode(node: TaskGraphNode): boolean {
 
 /**
  * Fingerprint of a snapshot's done nodes; when it changes across a live
- * refresh, a task moved between the Current pane and the Completed table,
- * so the separately-loaded Completed page must refresh too.
+ * refresh, the Completed table (loaded separately) may be stale, so it
+ * reloads. Includes the row-relevant fields — title, PR URL, timestamps —
+ * not just IDs, so a completed issue whose PR or dates change while
+ * staying done still triggers a reload.
  */
 function doneTaskGraphKey(taskGraph: TaskGraphSnapshot | null): string {
   return (taskGraph?.nodes ?? [])
     .filter((node) => node.state_category === "done")
-    .map((node) => node.node_id)
+    .map((node) =>
+      JSON.stringify([
+        node.node_id,
+        node.identifier,
+        node.title,
+        node.url ?? "",
+        node.updated_at ?? "",
+      ]),
+    )
     .sort()
-    .join("|");
+    .join("\n");
 }
 
 function stateToneForTaskNode(node: TaskGraphNode): string {

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -808,7 +808,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         }
         this.state.runOverlays = overlays;
       }),
-      initialNode ? this.openRun(initialNode) : Promise.resolve(),
+      // A preserved backlog selection stays selected but has no run to
+      // open — probing it would only produce "Run unavailable" noise.
+      initialNode && initialNode.state_category !== "backlog"
+        ? this.openRun(initialNode)
+        : Promise.resolve(),
     ]);
   }
 
@@ -1017,6 +1021,12 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           this.state.knowledgeGraph = graphReducer(this.state.knowledgeGraph, { type: "GRAPH_UPDATED", event: envelope.payload });
           this.render();
         }
+        // A memory update can add capsules or PR evidence for completed
+        // tasks; refresh the Completed pane's page (seq-guarded, no-op
+        // without an adapter).
+        if (this.options.mode === "desktop") {
+          void this.loadCompletedTasks();
+        }
       }
     }
     if (!handledMemoryGraphUpdate && !this.eventAffectsCurrentView(envelope)) {
@@ -1116,9 +1126,20 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
     const [overlays, selectedRun] = await Promise.all([
       this.fetchRunOverlays(taskGraph),
-      selectedNode ? this.fetchSelectedRunRefresh(selectedNode) : Promise.resolve(null),
+      // Backlog selections have no run: probing /runs/{backlog id} would
+      // only surface a spurious "Run unavailable" message.
+      selectedNode && selectedNode.state_category !== "backlog"
+        ? this.fetchSelectedRunRefresh(selectedNode)
+        : Promise.resolve(null),
     ]);
     if (abandoned()) return;
+
+    // A task finishing (or reopening) moves it between the Current pane and
+    // the Completed table, whose data loads separately — refresh that page
+    // whenever the set of done nodes changes so it never goes stale until a
+    // manual reload.
+    const completedSetChanged = this.options.mode === "desktop"
+      && doneTaskGraphKey(this.state.taskGraph) !== doneTaskGraphKey(taskGraph);
 
     // Apply everything atomically: the previous data stays on screen until
     // the replacement is fully loaded, so panels never flash empty.
@@ -1131,6 +1152,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.runDetail = selectedRun.runDetail;
       this.state.runOverlays.set(selectedRun.runDetail.run_id, selectedRun.runDetail);
       this.applyRunDetailBundle(selectedRun.bundle);
+    }
+    if (completedSetChanged) {
+      void this.loadCompletedTasks();
     }
     if (this.state.graphPaneView === "knowledge") {
       await this.loadKnowledgeGraph();
@@ -3312,7 +3336,13 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
             void this.openRun(node);
           } else {
             // Backlog tasks have no run to open; selecting one pins its
-            // ancestry critical path instead.
+            // ancestry critical path instead. Still a navigation: bump the
+            // guards so an in-flight openRun or live refresh cannot land a
+            // stale run detail (or probe /runs/{backlog id}) over this
+            // selection.
+            this.interactionEpoch += 1;
+            this.runOpenSeq += 1;
+            this.diffSelectSeq += 1;
             this.state.selectedNodeId = node.node_id;
             this.render();
           }
@@ -5517,6 +5547,19 @@ function initialSelectedTaskNode(nodes: TaskGraphNode[], rootIds: string[]): Tas
  */
 function isCurrentPaneTaskNode(node: TaskGraphNode): boolean {
   return node.state_category !== "backlog" && node.state_category !== "done";
+}
+
+/**
+ * Fingerprint of a snapshot's done nodes; when it changes across a live
+ * refresh, a task moved between the Current pane and the Completed table,
+ * so the separately-loaded Completed page must refresh too.
+ */
+function doneTaskGraphKey(taskGraph: TaskGraphSnapshot | null): string {
+  return (taskGraph?.nodes ?? [])
+    .filter((node) => node.state_category === "done")
+    .map((node) => node.node_id)
+    .sort()
+    .join("|");
 }
 
 function stateToneForTaskNode(node: TaskGraphNode): string {

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -27,6 +27,7 @@ import {
   cachedConceptDetail,
   createGraphLayoutAdapter,
   createInitialGraphState,
+  formatMemoryDeepLink,
   graphLayoutKindForMode,
   graphReducer,
   currentGraphSnapshot,
@@ -37,8 +38,11 @@ import {
   type GraphLayoutAdapter,
   type GraphLayoutResult,
   type GraphState,
+  type MemoryCompletedTask,
+  type MemoryCompletedTaskPage,
   type MemoryConceptDetail,
   type MemoryGraphNode,
+  type MemoryTaskPullRequest,
 } from "@opensymphony/graph";
 import {
   authStateFromError,
@@ -242,6 +246,11 @@ interface AppState {
   activeView: "dashboard" | "planning";
   // Task graph editor state
   taskGraphFilter: TaskGraphFilter;
+  // Three-pane task graph (desktop): Completed | Current | Backlog
+  taskPaneCollapsed: { done: boolean; backlog: boolean };
+  completedTasks: MemoryCompletedTaskPage | null;
+  completedTasksError: string | null;
+  completedTasksParams: { query: string; sort: string; page: number };
   collapsedProjectGroups: Set<string>;
   inlineEdit: InlineEditState;
   createDialog: EditorDialogState;
@@ -293,6 +302,8 @@ const liveRefreshFailureThreshold = 2;
 const liveRefreshPollIntervalMs = 5_000;
 const defaultWorkspacePaneSizes: WorkspacePaneSizes = { left: 50, right: 50 };
 const minWorkspacePaneSizes: WorkspacePaneSizes = { left: 30, right: 30 };
+const completedTasksPageSize = 25;
+const defaultCompletedTasksParams = { query: "", sort: "completed_desc", page: 1 } as const;
 
 export function renderOpenSymphonyApp(
   options: OpenSymphonyAppOptions,
@@ -327,6 +338,12 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private knowledgeGraphLayoutSize: { width: number; height: number } | null = null;
   /** Concept-detail request currently in flight, keyed `${bundleId}:${conceptId}`. */
   private knowledgeCapsuleRequest: string | null = null;
+  /** Guards in-flight completed-tasks pages (superseded by newer queries). */
+  private completedTasksSeq = 0;
+  /** Debounce for the Completed pane's search input. */
+  private completedTasksSearchTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Cross-pane edge repositioning is rAF-coalesced per burst of scroll/resize. */
+  private crossLinksFrame: number | null = null;
   /** Last failed concept-detail request; keyed so a new selection is unaffected. */
   private knowledgeCapsuleError: { key: string; message: string } | null = null;
   /**
@@ -394,6 +411,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       loading: true,
       activeView: "dashboard",
       taskGraphFilter: { ...defaultTaskGraphFilter },
+      taskPaneCollapsed: { done: false, backlog: false },
+      completedTasks: null,
+      completedTasksError: null,
+      completedTasksParams: { ...defaultCompletedTasksParams },
       collapsedProjectGroups: new Set(),
       inlineEdit: { ...emptyInlineEdit },
       createDialog: { ...emptyEditorDialog },
@@ -410,7 +431,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     // Document-level so Escape works even when focus sits on the body (the
     // graph canvas itself is not focusable). Removed in destroy().
     this.options.root.ownerDocument.addEventListener("keydown", this.onDocumentKeydown);
+    // Cross-pane task edges are measured from live card positions, so any
+    // viewport resize must recompute them. Removed in destroy().
+    this.options.root.ownerDocument.defaultView?.addEventListener("resize", this.onWindowResize);
   }
+
+  private onWindowResize = (): void => {
+    this.scheduleCrossLinksReposition();
+  };
 
   private onDocumentKeydown = (event: KeyboardEvent): void => {
     if (this.destroyed || event.key !== "Escape" || this.state.graphPaneView !== "knowledge") {
@@ -533,6 +561,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   async destroy(): Promise<void> {
     this.destroyed = true;
     this.options.root.ownerDocument.removeEventListener("keydown", this.onDocumentKeydown);
+    this.options.root.ownerDocument.defaultView?.removeEventListener("resize", this.onWindowResize);
+    if (this.completedTasksSearchTimer !== null) {
+      clearTimeout(this.completedTasksSearchTimer);
+      this.completedTasksSearchTimer = null;
+    }
     this.stopLiveRefreshTimer();
     this.stopEventSubscription();
     this.graphLayoutAdapter.dispose();
@@ -760,6 +793,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runValidation = null;
     this.state.runApprovals = null;
     this.state.selectedDiffPath = null;
+    if (this.options.mode === "desktop") {
+      // Completed pane data loads independently: a memory-server hiccup must
+      // not delay the Current/Backlog graph.
+      void this.loadCompletedTasks();
+    }
     await Promise.all([
       this.fetchRunOverlays(taskGraph).then((overlays) => {
         // A concurrently opened run may already have stored a fresher detail.
@@ -772,6 +810,39 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       }),
       initialNode ? this.openRun(initialNode) : Promise.resolve(),
     ]);
+  }
+
+  /**
+   * Fetch the Completed pane's current page from the memory-backed
+   * completed-tasks endpoint. Newer requests supersede in-flight ones; a
+   * failure keeps the last good page and surfaces the error inline.
+   */
+  private async loadCompletedTasks(): Promise<void> {
+    const adapter = this.graphAdapter;
+    if (!adapter?.getCompletedTasks) {
+      return;
+    }
+    const seq = ++this.completedTasksSeq;
+    const { query, sort, page } = this.state.completedTasksParams;
+    try {
+      const result = await adapter.getCompletedTasks({
+        query: query || undefined,
+        sort,
+        limit: completedTasksPageSize,
+        offset: (page - 1) * completedTasksPageSize,
+      });
+      if (this.destroyed || seq !== this.completedTasksSeq) {
+        return;
+      }
+      this.state.completedTasks = result;
+      this.state.completedTasksError = null;
+    } catch (error) {
+      if (this.destroyed || seq !== this.completedTasksSeq) {
+        return;
+      }
+      this.state.completedTasksError = errorMessage(error);
+    }
+    this.render();
   }
 
   private async loadKnowledgeGraph(bundleId?: string): Promise<void> {
@@ -2341,19 +2412,162 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     if (this.options.mode === "web") {
       return this.renderEditableTaskGraph(taskGraph, filtered, getOverlay);
     }
-    const dependencySignals = buildDependencySignals(taskGraph.nodes, filtered);
-    const graph = renderTaskGraphVisualization(
-      filtered,
-      this.state.selectedNodeId,
-      getOverlay,
-      dependencySignals,
-      this.state.collapsedProjectGroups,
-      this.options.mode === "desktop",
-    );
-
     const filters = renderTaskGraphFilters(this.state.taskGraphFilter);
+    return `${filters}${this.renderTaskGraphPanes(taskGraph, filtered, getOverlay)}`;
+  }
 
-    return `${filters}${graph}`;
+  /**
+   * Desktop task surface: three panes — Completed (memory-backed table),
+   * Current (dispatchable dependency graph), Backlog (same grammar, faded
+   * edges). Cross-pane dependency edges render in an absolutely positioned
+   * overlay whose paths are measured after mount (positionTaskGraphCrossLinks).
+   */
+  private renderTaskGraphPanes(
+    taskGraph: TaskGraphSnapshot,
+    filtered: TaskGraphNode[],
+    getOverlay: (node: TaskGraphNode) => ReturnType<typeof buildRuntimeOverlay>,
+  ): string {
+    const currentNodes = filtered.filter(isCurrentPaneTaskNode);
+    const backlogNodes = filtered.filter((node) => node.state_category === "backlog");
+    // Dependency suffixes treat both graph panes as visible: a backlog task
+    // blocked by a Current task reads "blocked by VIZ-103", not "1 hidden".
+    // In-pane edge building still only links nodes present in that pane;
+    // cross-pane pairs render through the measured overlay instead.
+    const visibleAcrossPanes = [...currentNodes, ...backlogNodes];
+    const currentSignals = buildDependencySignals(taskGraph.nodes, visibleAcrossPanes);
+    const backlogSignals = currentSignals;
+    const collapsed = this.state.taskPaneCollapsed;
+
+    const currentGraph = currentNodes.length > 0
+      ? renderTaskGraphVisualization(
+        currentNodes,
+        this.state.selectedNodeId,
+        getOverlay,
+        currentSignals,
+        this.state.collapsedProjectGroups,
+        true,
+      )
+      : `<div class="os-empty">No dispatchable tasks match the current filters</div>`;
+    const backlogGraph = backlogNodes.length > 0
+      ? renderTaskGraphVisualization(
+        backlogNodes,
+        this.state.selectedNodeId,
+        getOverlay,
+        backlogSignals,
+        new Set(),
+        false,
+        "backlog",
+      )
+      : `<div class="os-empty">No backlog tasks</div>`;
+
+    const donePane = collapsed.done
+      ? renderCollapsedTaskPane("done", "Completed", this.state.completedTasks?.total ?? null)
+      : `
+        <section class="os-tg-pane os-tg-pane-done" data-tg-pane="done" data-testid="task-pane-done">
+          ${renderTaskPaneHeader("done", "Completed", this.state.completedTasks?.total ?? null)}
+          <div class="os-tg-pane-body" data-tg-pane-body="done">
+            ${this.renderCompletedTasksBody()}
+          </div>
+        </section>
+      `;
+    const backlogPane = collapsed.backlog
+      ? renderCollapsedTaskPane("backlog", "Backlog", backlogNodes.length)
+      : `
+        <section class="os-tg-pane os-tg-pane-backlog" data-tg-pane="backlog" data-testid="task-pane-backlog">
+          ${renderTaskPaneHeader("backlog", "Backlog", backlogNodes.length)}
+          <div class="os-tg-pane-body" data-tg-pane-body="backlog">
+            ${backlogGraph}
+          </div>
+        </section>
+      `;
+
+    const crossLinks = renderTaskGraphCrossLinks(taskGraph.nodes, currentNodes, backlogNodes);
+
+    return `
+      <div class="os-tg-panes" data-tg-panes>
+        ${donePane}
+        <section class="os-tg-pane os-tg-pane-current" data-tg-pane="current" data-testid="task-pane-current">
+          <header class="os-tg-pane-head">
+            <span class="os-tg-dot os-tg-dot-current" aria-hidden="true"></span>
+            <strong>Current</strong>
+            <span class="os-tg-count os-tg-count-current">${currentNodes.filter((node) => node.kind !== "milestone").length} current</span>
+          </header>
+          <div class="os-tg-pane-body" data-tg-pane-body="current">
+            ${currentGraph}
+          </div>
+        </section>
+        ${backlogPane}
+        ${crossLinks}
+      </div>
+    `;
+  }
+
+  /** Search box, sortable table, and pagination for the Completed pane. */
+  private renderCompletedTasksBody(): string {
+    if (!this.graphAdapter?.getCompletedTasks) {
+      return `<div class="os-empty" data-testid="completed-tasks-unavailable">Completed tasks need a memory-server connection</div>`;
+    }
+    const page = this.state.completedTasks;
+    const error = this.state.completedTasksError
+      ? `<p class="os-tg-done-error" data-testid="completed-tasks-error" role="alert">Completed tasks unavailable: ${escapeHtml(this.state.completedTasksError)}</p>`
+      : "";
+    const params = this.state.completedTasksParams;
+    const search = `
+      <input
+        type="search"
+        class="os-tg-done-search"
+        data-tg-done-search
+        placeholder="Search completed tasks"
+        aria-label="Search completed tasks"
+        value="${escapeAttr(params.query)}"
+      />
+    `;
+    if (!page) {
+      return `${search}${error || `<div class="os-empty" data-testid="completed-tasks-loading">Loading completed tasks…</div>`}`;
+    }
+    const rows = page.tasks.map((task) => this.renderCompletedTaskRow(task)).join("");
+    const table = page.tasks.length > 0
+      ? `
+        <table class="os-tg-done-table" data-testid="completed-tasks-table">
+          <thead>
+            <tr>
+              ${renderCompletedSortHeader("id", "ID", params.sort)}
+              ${renderCompletedSortHeader("title", "Title", params.sort)}
+              ${renderCompletedSortHeader("pr", "PR", params.sort)}
+              ${renderCompletedSortHeader("completed", "Done", params.sort)}
+              <th scope="col">Capsule</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      `
+      : `<div class="os-empty">No completed tasks${params.query ? " match the search" : ""}</div>`;
+    return `${search}${error}${table}${renderCompletedTasksPagination(page)}`;
+  }
+
+  private renderCompletedTaskRow(task: MemoryCompletedTask): string {
+    const completed = task.completed_at ? formatCompletedDate(task.completed_at) : "—";
+    const capsule = task.concept_id
+      ? `<button
+          type="button"
+          class="os-tg-capsule-button"
+          data-tg-capsule="${escapeAttr(formatMemoryDeepLink({ bundleId: task.bundle_id ?? "local-default", conceptId: task.concept_id }))}"
+          title="Open memory capsule ${escapeAttr(task.concept_id)}"
+          aria-label="Open memory capsule for ${escapeAttr(task.issue_key)}"
+        >◈</button>`
+      : `<span class="os-tg-capsule-missing" title="No memory capsule captured yet (${escapeAttr(task.source)})">—</span>`;
+    const title = task.url
+      ? `<a href="${escapeAttr(task.url)}" target="_blank" rel="noreferrer noopener" title="${escapeAttr(task.title)}">${escapeHtml(task.title)}</a>`
+      : `<span title="${escapeAttr(task.title)}">${escapeHtml(task.title)}</span>`;
+    return `
+      <tr data-testid="completed-task-row" data-task-key="${escapeAttr(task.issue_key)}">
+        <td class="os-tg-done-id">${escapeHtml(task.issue_key)}</td>
+        <td class="os-tg-done-title">${title}</td>
+        <td class="os-tg-done-prs">${renderCompletedTaskPrs(task.prs)}</td>
+        <td class="os-tg-done-date">${escapeHtml(completed)}</td>
+        <td class="os-tg-done-capsule">${capsule}</td>
+      </tr>
+    `;
   }
 
   private renderEditableTaskGraph(
@@ -2894,22 +3108,125 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     return true;
   }
 
-  private setTaskGraphLinkEmphasis(nodeButton: HTMLElement, active: boolean): void {
-    const nodeId = nodeButton.dataset.nodeId;
-    const svg = nodeButton.closest(".os-task-graph-stage")?.querySelector<SVGElement>(".os-task-graph-links");
-    if (!nodeId || !svg) {
+  /**
+   * Emphasize dependency edges for a hovered or selected task, across all
+   * three panes. Pure class toggling on the already-rendered DOM — hover
+   * must never trigger a re-render.
+   *
+   * - Current-pane focus: its incoming and outgoing edges (including
+   *   cross-pane edges into the Backlog) bolden; everything else recedes.
+   * - Backlog focus: the full ancestry critical path boldens — every
+   *   unfinished upstream edge chain that must complete to unblock it —
+   *   and unrelated backlog cards dim.
+   */
+  private applyTaskGraphEmphasis(focusId: string | null): void {
+    const container = this.options.root.querySelector<HTMLElement>("[data-tg-panes]");
+    if (!container) {
       return;
     }
-    svg.classList.toggle("os-links-hover", active);
-    svg.querySelectorAll(".os-task-graph-link.is-active").forEach((path) => {
-      path.classList.remove("is-active");
-    });
-    if (active) {
-      const escaped = cssEscape(nodeId);
-      svg.querySelectorAll(`[data-link-from="${escaped}"], [data-link-to="${escaped}"]`).forEach((path) => {
-        path.classList.add("is-active");
-      });
+    const paths = container.querySelectorAll<SVGPathElement>(".os-task-graph-link, .os-tg-cross-link");
+    const cards = container.querySelectorAll<HTMLElement>("[data-node-id]");
+    paths.forEach((path) => path.classList.remove("is-active", "is-ancestry"));
+    cards.forEach((card) => card.classList.remove("os-tg-dim", "os-tg-ancestry"));
+    const graph = this.state.taskGraph;
+    const node = focusId ? graph?.nodes.find((candidate) => candidate.node_id === focusId) : undefined;
+    container.classList.toggle("os-tg-focused", Boolean(node));
+    if (!graph || !node) {
+      return;
     }
+    if (node.state_category === "backlog") {
+      const ancestry = collectAncestryEdges(graph.nodes, node);
+      paths.forEach((path) => {
+        const key = `${path.dataset.linkFrom}->${path.dataset.linkTo}`;
+        if (ancestry.edges.has(key)) {
+          path.classList.add("is-ancestry");
+        }
+      });
+      cards.forEach((card) => {
+        const id = card.dataset.nodeId ?? "";
+        if (ancestry.members.has(id)) {
+          card.classList.add("os-tg-ancestry");
+        } else if (card.closest("[data-tg-pane='backlog']")) {
+          card.classList.add("os-tg-dim");
+        }
+      });
+      return;
+    }
+    paths.forEach((path) => {
+      if (path.dataset.linkFrom === focusId || path.dataset.linkTo === focusId) {
+        path.classList.add("is-active");
+      }
+    });
+  }
+
+  /** Coalesce cross-link repositioning to one measurement per frame. */
+  private scheduleCrossLinksReposition(): void {
+    if (this.destroyed || this.crossLinksFrame !== null) {
+      return;
+    }
+    const raf = this.options.root.ownerDocument.defaultView?.requestAnimationFrame?.bind(
+      this.options.root.ownerDocument.defaultView,
+    );
+    if (!raf) {
+      this.positionTaskGraphCrossLinks();
+      return;
+    }
+    this.crossLinksFrame = raf(() => {
+      this.crossLinksFrame = null;
+      this.positionTaskGraphCrossLinks();
+    });
+  }
+
+  /**
+   * Give every cross-pane edge its geometry: from the right edge of the
+   * blocking card in the Current pane to the left edge of the blocked card
+   * in the Backlog pane, measured against the live layout. Edges whose
+   * endpoint scrolled out of its pane (or whose pane is collapsed) hide
+   * instead of drawing across headers.
+   */
+  private positionTaskGraphCrossLinks(): void {
+    const container = this.options.root.querySelector<HTMLElement>("[data-tg-panes]");
+    const svg = container?.querySelector<SVGSVGElement>("[data-tg-cross-links]");
+    if (!container || !svg) {
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    if (containerRect.width <= 0 || containerRect.height <= 0) {
+      return;
+    }
+    svg.setAttribute("viewBox", `0 0 ${containerRect.width} ${containerRect.height}`);
+    const paneBodyRect = (pane: string): DOMRect | null =>
+      container.querySelector(`[data-tg-pane-body="${pane}"]`)?.getBoundingClientRect() ?? null;
+    const currentBody = paneBodyRect("current");
+    const backlogBody = paneBodyRect("backlog");
+    svg.querySelectorAll<SVGPathElement>(".os-tg-cross-link").forEach((path) => {
+      const fromId = path.dataset.linkFrom;
+      const toId = path.dataset.linkTo;
+      const from = fromId ? container.querySelector(`[data-node-id="${cssEscape(fromId)}"]`) : null;
+      const to = toId ? container.querySelector(`[data-node-id="${cssEscape(toId)}"]`) : null;
+      if (!from || !to || !currentBody || !backlogBody) {
+        path.style.display = "none";
+        return;
+      }
+      const fromRect = from.getBoundingClientRect();
+      const toRect = to.getBoundingClientRect();
+      const y1 = fromRect.top + fromRect.height / 2;
+      const y2 = toRect.top + toRect.height / 2;
+      const fromVisible = y1 >= currentBody.top - 4 && y1 <= currentBody.bottom + 4;
+      const toVisible = y2 >= backlogBody.top - 4 && y2 <= backlogBody.bottom + 4;
+      if (!fromVisible || !toVisible) {
+        path.style.display = "none";
+        return;
+      }
+      const x1 = Math.min(fromRect.right, currentBody.right) - containerRect.left;
+      const x2 = toRect.left - containerRect.left;
+      const bend = Math.max(28, (x2 - x1) * 0.45);
+      path.setAttribute(
+        "d",
+        `M ${x1} ${y1 - containerRect.top} C ${x1 + bend} ${y1 - containerRect.top}, ${x2 - bend} ${y2 - containerRect.top}, ${x2} ${y2 - containerRect.top}`,
+      );
+      path.style.display = "";
+    });
   }
 
   private bindEvents(): void {
@@ -2991,21 +3308,24 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           (candidate) => candidate.node_id === button.dataset.nodeId,
         );
         if (node) {
-          if (this.options.mode === "desktop") {
+          if (this.options.mode === "desktop" && node.state_category !== "backlog") {
             void this.openRun(node);
           } else {
+            // Backlog tasks have no run to open; selecting one pins its
+            // ancestry critical path instead.
             this.state.selectedNodeId = node.node_id;
             this.render();
           }
         }
       });
-      // Hovering a task spotlights its dependency arrows: pure class
-      // toggling on the already-rendered SVG, no re-render involved.
+      // Hovering a task spotlights its dependency edges (and for backlog
+      // tasks the full ancestry path): pure class toggling on the
+      // already-rendered SVG, no re-render involved.
       this.listen(button, "node-id-hover", "pointerenter", () => {
-        this.setTaskGraphLinkEmphasis(button, true);
+        this.applyTaskGraphEmphasis(button.dataset.nodeId ?? null);
       });
       this.listen(button, "node-id-hover", "pointerleave", () => {
-        this.setTaskGraphLinkEmphasis(button, false);
+        this.applyTaskGraphEmphasis(this.state.selectedNodeId);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-project-group-toggle]").forEach((button) => {
@@ -3101,6 +3421,80 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       });
     });
 
+
+    // Three-pane task graph: collapse toggles, completed-tasks controls,
+    // capsule deep links, and cross-pane edge geometry.
+    this.options.root.querySelectorAll<HTMLElement>("[data-tg-pane-toggle]").forEach((button) => {
+      this.listen(button, "tg-pane-toggle", "click", () => {
+        const pane = button.dataset.tgPaneToggle;
+        if (pane !== "done" && pane !== "backlog") return;
+        this.state.taskPaneCollapsed = {
+          ...this.state.taskPaneCollapsed,
+          [pane]: !this.state.taskPaneCollapsed[pane],
+        };
+        this.render();
+      });
+    });
+    this.listen(this.options.root.querySelector("[data-tg-done-search]"), "tg-done-search", "input", (event) => {
+      const value = (event.target as HTMLInputElement).value;
+      if (this.completedTasksSearchTimer !== null) {
+        clearTimeout(this.completedTasksSearchTimer);
+      }
+      // Debounced so every keystroke does not hit the memory server; the
+      // seq guard in loadCompletedTasks handles any remaining races.
+      this.completedTasksSearchTimer = setTimeout(() => {
+        this.completedTasksSearchTimer = null;
+        if (this.destroyed || this.state.completedTasksParams.query === value) return;
+        this.state.completedTasksParams = { ...this.state.completedTasksParams, query: value, page: 1 };
+        void this.loadCompletedTasks();
+      }, 180);
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-tg-done-sort]").forEach((button) => {
+      this.listen(button, "tg-done-sort", "click", () => {
+        const column = button.dataset.tgDoneSort;
+        const sorts = column ? completedSortColumns[column] : undefined;
+        if (!sorts) return;
+        const active = this.state.completedTasksParams.sort;
+        const next = active === sorts.first
+          ? (sorts.first === sorts.asc ? sorts.desc : sorts.asc)
+          : sorts.first;
+        this.state.completedTasksParams = { ...this.state.completedTasksParams, sort: next, page: 1 };
+        void this.loadCompletedTasks();
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-tg-done-page]").forEach((button) => {
+      this.listen(button, "tg-done-page", "click", () => {
+        const value = button.dataset.tgDonePage;
+        const params = this.state.completedTasksParams;
+        const total = this.state.completedTasks?.total ?? 0;
+        const pageCount = Math.max(1, Math.ceil(total / completedTasksPageSize));
+        const nextPage = value === "prev"
+          ? params.page - 1
+          : value === "next"
+            ? params.page + 1
+            : Number.parseInt(value ?? "", 10);
+        if (!Number.isFinite(nextPage) || nextPage < 1 || nextPage > pageCount || nextPage === params.page) return;
+        this.state.completedTasksParams = { ...params, page: nextPage };
+        void this.loadCompletedTasks();
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-tg-capsule]").forEach((button) => {
+      this.listen(button, "tg-capsule", "click", () => {
+        const link = button.dataset.tgCapsule;
+        if (link) {
+          void this.openMemoryDeepLink(link);
+        }
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-tg-pane-body], .os-task-graph-stage").forEach((element) => {
+      this.listen(element, "tg-cross-scroll", "scroll", () => this.scheduleCrossLinksReposition());
+    });
+    if (this.options.mode === "desktop" && this.state.graphPaneView === "task") {
+      // Selection emphasis and cross-pane geometry re-apply after every
+      // morph; hover emphasis stays purely event-driven.
+      this.applyTaskGraphEmphasis(this.state.selectedNodeId);
+      this.scheduleCrossLinksReposition();
+    }
 
     // Task graph filters
     this.options.root.querySelectorAll<HTMLElement>("[data-tg-filter]").forEach((control) => {
@@ -3843,6 +4237,9 @@ const shellScrollSelectors = [
   ".os-knowledge-lower-panel",
   ".os-code-graph-lower-panel",
   ".os-task-graph-stage",
+  '[data-tg-pane-body="done"]',
+  '[data-tg-pane-body="current"]',
+  '[data-tg-pane-body="backlog"]',
   ".os-run-activity",
 ] as const;
 
@@ -4539,6 +4936,7 @@ function renderTaskGraphVisualization(
   signals: Map<string, DependencySignal>,
   collapsedProjectGroups = new Set<string>(),
   groupByProject = false,
+  variant: "current" | "backlog" = "current",
 ): string {
   if (nodes.length === 0) {
     return `<div class="os-empty">No tasks match the current filters</div>`;
@@ -4549,7 +4947,7 @@ function renderTaskGraphVisualization(
       const collapsed = collapsedProjectGroups.has(group.key);
       const body = collapsed
         ? ""
-        : renderTaskGraphVisualization(group.nodes, selectedNodeId, getOverlay, signals, collapsedProjectGroups, false);
+        : renderTaskGraphVisualization(group.nodes, selectedNodeId, getOverlay, signals, collapsedProjectGroups, false, variant);
       const title = projectGroupTitle(group);
       return `
         <section class="os-project-group" id="${escapeAttr(projectGroupDomId(group.key))}" role="region" aria-label="${escapeAttr(title)}" data-project-group="${escapeAttr(group.key)}">
@@ -4571,9 +4969,11 @@ function renderTaskGraphVisualization(
     selectedNodeId,
     getOverlay(model.node),
   )).join("");
+  const stageClass = variant === "backlog" ? "os-task-graph-stage os-tg-stage-backlog" : "os-task-graph-stage";
+  const stageTestId = variant === "backlog" ? "task-graph-backlog" : "task-graph-visualization";
 
   return `
-    <div class="os-task-graph-stage" data-testid="task-graph-visualization" style="--os-graph-height: ${graphHeight}px; --os-graph-width: ${graphWidth}px; --os-tg-gutter: ${gutterWidth}px;">
+    <div class="${stageClass}" data-testid="${stageTestId}" style="--os-graph-height: ${graphHeight}px; --os-graph-width: ${graphWidth}px; --os-tg-gutter: ${gutterWidth}px;">
       <svg class="os-task-graph-links" data-testid="task-graph-links" viewBox="0 0 ${graphWidth} ${graphHeight}" preserveAspectRatio="none" aria-hidden="true">
         <defs>
           <marker id="os-task-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
@@ -4589,6 +4989,202 @@ function renderTaskGraphVisualization(
       <div class="os-node-list os-node-graph-list" style="min-height: ${graphHeight}px;">${renderedNodes}</div>
     </div>
   `;
+}
+
+/** Header shared by the collapsible Completed and Backlog panes. */
+function renderTaskPaneHeader(pane: "done" | "backlog", label: string, count: number | null): string {
+  const countChip = count !== null
+    ? `<span class="os-tg-count os-tg-count-${pane}">${count} ${pane === "done" ? "done" : "backlog"}</span>`
+    : "";
+  return `
+    <header class="os-tg-pane-head">
+      <span class="os-tg-dot os-tg-dot-${pane}" aria-hidden="true"></span>
+      <strong>${escapeHtml(label)}</strong>
+      ${countChip}
+      <button
+        type="button"
+        class="os-tg-pane-toggle"
+        data-tg-pane-toggle="${pane}"
+        aria-expanded="true"
+        aria-label="Collapse ${escapeAttr(label)} pane"
+        title="Collapse ${escapeAttr(label)} pane"
+      >${pane === "done" ? "‹" : "›"}</button>
+    </header>
+  `;
+}
+
+/** Narrow vertical strip shown while a side pane is collapsed. */
+function renderCollapsedTaskPane(pane: "done" | "backlog", label: string, count: number | null): string {
+  return `
+    <section class="os-tg-pane os-tg-pane-collapsed" data-tg-pane="${pane}" data-collapsed data-testid="task-pane-${pane}">
+      <button
+        type="button"
+        class="os-tg-pane-toggle"
+        data-tg-pane-toggle="${pane}"
+        aria-expanded="false"
+        aria-label="Expand ${escapeAttr(label)} pane"
+        title="Expand ${escapeAttr(label)} pane"
+      >${pane === "done" ? "›" : "‹"}</button>
+      <span class="os-tg-dot os-tg-dot-${pane}" aria-hidden="true"></span>
+      <span class="os-tg-pane-vertical-label">${escapeHtml(label)}</span>
+      ${count !== null ? `<span class="os-tg-count os-tg-count-${pane}">${count}</span>` : ""}
+    </section>
+  `;
+}
+
+const completedSortColumns: Record<string, { asc: string; desc: string; first: string }> = {
+  id: { asc: "id_asc", desc: "id_desc", first: "id_asc" },
+  title: { asc: "title_asc", desc: "title_desc", first: "title_asc" },
+  pr: { asc: "pr_asc", desc: "pr_desc", first: "pr_desc" },
+  completed: { asc: "completed_asc", desc: "completed_desc", first: "completed_desc" },
+};
+
+function renderCompletedSortHeader(column: string, label: string, activeSort: string): string {
+  const sorts = completedSortColumns[column];
+  const direction = activeSort === sorts.asc ? "ascending" : activeSort === sorts.desc ? "descending" : null;
+  const arrow = direction === "ascending" ? " ↑" : direction === "descending" ? " ↓" : " ↕";
+  return `
+    <th scope="col" ${direction ? `aria-sort="${direction}"` : ""}>
+      <button type="button" class="os-tg-done-sort ${direction ? "is-active" : ""}" data-tg-done-sort="${escapeAttr(column)}">${escapeHtml(label)}<span aria-hidden="true">${arrow}</span></button>
+    </th>
+  `;
+}
+
+function renderCompletedTaskPrs(prs: MemoryTaskPullRequest[]): string {
+  if (prs.length === 0) {
+    return `<span class="os-tg-capsule-missing">—</span>`;
+  }
+  // Newest first; the newest PR is emphasized, unmerged ones struck through.
+  const ordered = [...prs].sort((a, b) =>
+    (b.merged_at ?? "").localeCompare(a.merged_at ?? "") || b.number - a.number);
+  const latest = ordered[0];
+  return ordered.map((pr) => {
+    const classes = [
+      "os-tg-pr",
+      pr === latest ? "os-tg-pr-latest" : "",
+      pr.merged ? "" : "os-tg-pr-unmerged",
+    ].filter(Boolean).join(" ");
+    const title = `${pr.title || `PR #${pr.number}`}${pr.merged ? "" : " (not merged)"}`;
+    return pr.url
+      ? `<a class="${classes}" href="${escapeAttr(pr.url)}" target="_blank" rel="noreferrer noopener" title="${escapeAttr(title)}">#${pr.number}</a>`
+      : `<span class="${classes}" title="${escapeAttr(title)}">#${pr.number}</span>`;
+  }).join(" ");
+}
+
+function renderCompletedTasksPagination(page: MemoryCompletedTaskPage): string {
+  const pageCount = Math.max(1, Math.ceil(page.total / Math.max(1, page.limit)));
+  const currentPage = Math.floor(page.offset / Math.max(1, page.limit)) + 1;
+  if (pageCount <= 1) {
+    return `<div class="os-tg-done-pagination" data-testid="completed-tasks-pagination"><span class="os-tg-done-page-size">${page.total} task${page.total === 1 ? "" : "s"}</span></div>`;
+  }
+  // Window of at most 7 numbered buttons centered on the current page.
+  const windowStart = Math.max(1, Math.min(currentPage - 3, pageCount - 6));
+  const windowEnd = Math.min(pageCount, windowStart + 6);
+  const numbers: string[] = [];
+  for (let pageNumber = windowStart; pageNumber <= windowEnd; pageNumber += 1) {
+    numbers.push(`
+      <button
+        type="button"
+        class="os-tg-done-page ${pageNumber === currentPage ? "is-active" : ""}"
+        data-tg-done-page="${pageNumber}"
+        ${pageNumber === currentPage ? `aria-current="page"` : ""}
+      >${pageNumber}</button>
+    `);
+  }
+  return `
+    <div class="os-tg-done-pagination" data-testid="completed-tasks-pagination">
+      <button type="button" class="os-tg-done-page" data-tg-done-page="prev" ${currentPage <= 1 ? "disabled" : ""} aria-label="Previous page">‹</button>
+      ${numbers.join("")}
+      <button type="button" class="os-tg-done-page" data-tg-done-page="next" ${currentPage >= pageCount ? "disabled" : ""} aria-label="Next page">›</button>
+      <span class="os-tg-done-page-size">${page.limit} / page</span>
+    </div>
+  `;
+}
+
+function formatCompletedDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "2-digit" });
+}
+
+/**
+ * Cross-pane dependency edges (Current → Backlog). Paths carry the same
+ * data-link-from/to contract as in-pane edges but start with empty geometry:
+ * positionTaskGraphCrossLinks measures the live card positions after mount
+ * and on every scroll/resize/collapse.
+ */
+function renderTaskGraphCrossLinks(
+  allNodes: TaskGraphNode[],
+  currentNodes: TaskGraphNode[],
+  backlogNodes: TaskGraphNode[],
+): string {
+  const currentIds = new Set(currentNodes.map((node) => node.node_id));
+  const pairs: Array<{ from: string; to: string }> = [];
+  for (const backlogNode of backlogNodes) {
+    for (const blockerRef of backlogNode.blocked_by) {
+      const blocker = findNodeByRef(allNodes, blockerRef);
+      if (blocker && currentIds.has(blocker.node_id)) {
+        pairs.push({ from: blocker.node_id, to: backlogNode.node_id });
+      }
+    }
+  }
+  if (pairs.length === 0) {
+    return "";
+  }
+  const hueBySource = new Map<string, number>();
+  for (const pair of pairs) {
+    if (!hueBySource.has(pair.from)) {
+      hueBySource.set(pair.from, hueBySource.size % taskGraphLinkHues.length);
+    }
+  }
+  const paths = pairs.map((pair) => {
+    const hue = hueBySource.get(pair.from) ?? 0;
+    return `<path class="os-tg-cross-link os-tg-hue-${hue}" data-testid="task-graph-cross-link" data-link-from="${escapeAttr(pair.from)}" data-link-to="${escapeAttr(pair.to)}" d="" marker-end="url(#os-tg-cross-arrow-${hue})"></path>`;
+  }).join("");
+  return `
+    <svg class="os-tg-cross-links" data-tg-cross-links aria-hidden="true">
+      <defs>
+        ${taskGraphLinkHues.map((hue, index) => `
+        <marker id="os-tg-cross-arrow-${index}" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+          <path d="M 0 0 L 8 4 L 0 8 z" fill="${escapeAttr(hue)}"></path>
+        </marker>`).join("")}
+      </defs>
+      ${paths}
+    </svg>
+  `;
+}
+
+/**
+ * Edges on the "ancestry critical path" of a backlog task: every
+ * non-terminal blocked_by edge reachable walking upstream from the task.
+ * These are the tasks that must complete to unblock it.
+ */
+function collectAncestryEdges(
+  nodes: TaskGraphNode[],
+  target: TaskGraphNode,
+): { edges: Set<string>; members: Set<string> } {
+  const edges = new Set<string>();
+  const members = new Set<string>([target.node_id]);
+  const queue = [target];
+  const visited = new Set<string>([target.node_id]);
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    for (const blockerRef of node.blocked_by) {
+      const blocker = findNodeByRef(nodes, blockerRef);
+      if (!blocker || isTerminalTaskNode(blocker)) {
+        continue;
+      }
+      edges.add(`${blocker.node_id}->${node.node_id}`);
+      members.add(blocker.node_id);
+      if (!visited.has(blocker.node_id)) {
+        visited.add(blocker.node_id);
+        queue.push(blocker);
+      }
+    }
+  }
+  return { edges, members };
 }
 
 interface ProjectGroup {
@@ -4901,11 +5497,21 @@ function initialSelectedTaskNode(nodes: TaskGraphNode[], rootIds: string[]): Tas
     ...rootIds.map((id) => findNodeByRef(nodes, id)).filter((node): node is TaskGraphNode => Boolean(node)),
     ...nodes,
   ];
-  return ordered.find((node) => node.kind !== "milestone" && node.state_category === "in_progress")
-    ?? ordered.find((node) => node.kind !== "milestone" && node.run_id)
-    ?? ordered.find((node) => node.kind !== "milestone")
-    ?? ordered[0]
+  // Backlog and terminal nodes live in the side panes and have no run to
+  // open, so the initial selection sticks to the Current pane.
+  const current = ordered.filter(isCurrentPaneTaskNode);
+  return current.find((node) => node.kind !== "milestone" && node.state_category === "in_progress")
+    ?? current.find((node) => node.kind !== "milestone" && node.run_id)
+    ?? current.find((node) => node.kind !== "milestone")
+    ?? current[0]
     ?? null;
+}
+
+/** Nodes rendered in the Current pane: dispatchable states, not backlog/terminal. */
+function isCurrentPaneTaskNode(node: TaskGraphNode): boolean {
+  return node.state_category !== "backlog"
+    && node.state_category !== "done"
+    && node.state_category !== "canceled";
 }
 
 function stateToneForTaskNode(node: TaskGraphNode): string {
@@ -5039,6 +5645,72 @@ function appShellStyles(): string {
     .os-task-graph-links marker path:not([fill]) { fill: #39708f; }
     /* Reserve the skip-arrow routing gutter (taskGraphRouteGutterWidth). */
     .os-node-graph-list { position: relative; z-index: 1; min-width: var(--os-graph-width); gap: 8px; padding-left: var(--os-tg-gutter, 62px); }
+    /* Three-pane task graph: Completed | Current | Backlog. */
+    .os-tg-panes { position: relative; display: flex; align-items: stretch; gap: 10px; min-width: 0; }
+    .os-tg-pane { display: flex; flex-direction: column; min-width: 0; border: 1px solid #d8dee4; border-radius: 10px; background: #fbfcfe; }
+    .os-tg-pane-done { flex: 0 0 clamp(300px, 30%, 460px); }
+    .os-tg-pane-current { flex: 1 1 auto; }
+    .os-tg-pane-backlog { flex: 0 0 clamp(260px, 26%, 420px); }
+    .os-tg-pane-collapsed { flex: 0 0 44px; align-items: center; gap: 8px; padding: 8px 0; }
+    .os-tg-pane-head { display: flex; align-items: center; gap: 8px; padding: 9px 12px; border-bottom: 1px solid #e3e8ee; }
+    .os-tg-pane-head strong { font-size: 13px; }
+    .os-tg-dot { width: 9px; height: 9px; border-radius: 999px; flex: 0 0 auto; }
+    .os-tg-dot-done { background: #16a34a; }
+    .os-tg-dot-current { background: #2563eb; }
+    .os-tg-dot-backlog { background: #7c3aed; }
+    .os-tg-count { border-radius: 999px; font-size: 11px; padding: 1px 8px; }
+    .os-tg-count-done { background: #dcfce7; color: #166534; }
+    .os-tg-count-current { background: #dbeafe; color: #1e40af; }
+    .os-tg-count-backlog { background: #ede9fe; color: #5b21b6; }
+    .os-tg-pane-toggle { margin-left: auto; min-height: 24px; min-width: 26px; padding: 0 6px; border-radius: 6px; font-size: 13px; line-height: 1; }
+    .os-tg-pane-collapsed .os-tg-pane-toggle { margin-left: 0; }
+    .os-tg-pane-vertical-label { writing-mode: vertical-rl; font-size: 12px; font-weight: 600; color: #405568; letter-spacing: 0.04em; }
+    .os-tg-pane-body { min-height: 0; max-height: clamp(360px, 56vh, 720px); overflow: auto; padding: 10px; }
+    /* Cross-pane dependency edges: measured overlay, never intercepts input. */
+    .os-tg-cross-links { position: absolute; inset: 0; width: 100%; height: 100%; z-index: 4; pointer-events: none; overflow: visible; }
+    .os-tg-cross-link { fill: none; stroke-width: 1.9; stroke-linecap: round; opacity: 0.34; transition: opacity 0.14s ease, stroke-width 0.14s ease; }
+    .os-tg-cross-link.os-tg-hue-0 { stroke: #39708f; }
+    .os-tg-cross-link.os-tg-hue-1 { stroke: #7c3aed; }
+    .os-tg-cross-link.os-tg-hue-2 { stroke: #0f766e; }
+    .os-tg-cross-link.os-tg-hue-3 { stroke: #b0762f; }
+    .os-tg-cross-link.os-tg-hue-4 { stroke: #a05577; }
+    /* Backlog edges read as "not yet actionable" until emphasized. */
+    .os-tg-stage-backlog .os-task-graph-link { opacity: 0.26; }
+    [data-tg-panes].os-tg-focused .os-task-graph-link:not(.is-active):not(.is-ancestry) { opacity: 0.1; }
+    [data-tg-panes].os-tg-focused .os-tg-cross-link:not(.is-active):not(.is-ancestry) { opacity: 0.08; }
+    [data-tg-panes] .os-task-graph-link.is-active,
+    [data-tg-panes] .os-task-graph-link.is-ancestry,
+    [data-tg-panes] .os-tg-cross-link.is-active,
+    [data-tg-panes] .os-tg-cross-link.is-ancestry { opacity: 1; stroke-width: 2.8; }
+    [data-tg-panes] .os-node.os-tg-dim { opacity: 0.42; }
+    [data-tg-panes] .os-node.os-tg-ancestry { border-color: #7c3aed; box-shadow: 0 0 0 1px rgba(124, 58, 237, 0.25); }
+    /* Completed pane: search + sortable table + pagination. */
+    .os-tg-done-search { width: 100%; box-sizing: border-box; min-height: 32px; margin-bottom: 8px; border: 1px solid #cbd5df; border-radius: 6px; padding: 5px 9px; background: #ffffff; color: #17202a; font: inherit; font-size: 12px; }
+    .os-tg-done-error { color: #b3372a; font-size: 12px; margin: 0 0 8px; }
+    .os-tg-done-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    .os-tg-done-table th { text-align: left; padding: 4px 6px; border-bottom: 1px solid #d8dee4; color: #536170; font-size: 11px; white-space: nowrap; }
+    .os-tg-done-table td { padding: 6px; border-bottom: 1px solid #eef1f4; vertical-align: top; }
+    .os-tg-done-sort { border: none; background: transparent; min-height: 22px; padding: 0; color: inherit; font: inherit; font-size: 11px; font-weight: 600; cursor: pointer; }
+    .os-tg-done-sort span { color: #98a6b3; }
+    .os-tg-done-sort.is-active, .os-tg-done-sort.is-active span { color: #23566f; }
+    .os-tg-done-id { font-weight: 600; white-space: nowrap; color: #17202a; }
+    .os-tg-done-title { max-width: 0; width: 55%; }
+    .os-tg-done-title a, .os-tg-done-title span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: inherit; text-decoration: none; }
+    .os-tg-done-title a:hover { text-decoration: underline; }
+    .os-tg-done-prs { white-space: nowrap; }
+    .os-tg-pr { color: #23566f; text-decoration: none; }
+    .os-tg-pr:hover { text-decoration: underline; }
+    .os-tg-pr-latest { font-weight: 700; }
+    .os-tg-pr-unmerged { text-decoration: line-through; color: #98a6b3; }
+    .os-tg-pr-unmerged:hover { text-decoration: line-through underline; }
+    .os-tg-done-date { white-space: nowrap; color: #536170; }
+    .os-tg-capsule-button { min-height: 22px; min-width: 26px; padding: 0 4px; border: 1px solid #cdd6de; border-radius: 5px; background: #f4f7f9; color: #5b21b6; font-size: 13px; line-height: 1; cursor: pointer; }
+    .os-tg-capsule-button:hover { border-color: #7c3aed; background: #ede9fe; }
+    .os-tg-capsule-missing { color: #98a6b3; }
+    .os-tg-done-pagination { display: flex; align-items: center; gap: 4px; margin-top: 10px; flex-wrap: wrap; }
+    .os-tg-done-page { min-height: 26px; min-width: 28px; padding: 0 7px; font-size: 12px; border-radius: 6px; }
+    .os-tg-done-page.is-active { border-color: #39708f; background: #e7f1f5; font-weight: 700; }
+    .os-tg-done-page-size { margin-left: auto; color: #667788; font-size: 11px; }
     .os-knowledge-graph { display: grid; gap: 10px; min-width: 0; }
     .os-knowledge-toolbar { display: flex; justify-content: space-between; gap: 10px; align-items: center; min-width: 0; }
     .os-knowledge-toolbar div { display: grid; gap: 2px; min-width: 0; }
@@ -5405,6 +6077,24 @@ function appShellStyles(): string {
       button:hover:not(:disabled), .os-list-item:hover, .os-node:hover, .os-changed-file:hover, .is-selected { background: #18303a; border-color: #5ca0b8; }
       .os-task-graph-link { stroke: #5ca0b8; opacity: 0.82; }
       .os-task-graph-links marker path { fill: #5ca0b8; }
+      .os-tg-pane { background: #131920; border-color: #2a3440; }
+      .os-tg-pane-head { border-color: #2a3440; }
+      .os-tg-count-done { background: #14351f; color: #86efac; }
+      .os-tg-count-current { background: #16283f; color: #93c5fd; }
+      .os-tg-count-backlog { background: #271c3f; color: #c4b5fd; }
+      .os-tg-pane-vertical-label { color: #b8c4cf; }
+      .os-tg-stage-backlog .os-task-graph-link { opacity: 0.3; }
+      [data-tg-panes] .os-node.os-tg-ancestry { border-color: #a78bfa; box-shadow: 0 0 0 1px rgba(167, 139, 250, 0.35); }
+      .os-tg-done-search { background: #101720; border-color: #2a3440; color: #e6edf3; }
+      .os-tg-done-table th { border-color: #2a3440; color: #94a3b3; }
+      .os-tg-done-table td { border-color: #1e2731; }
+      .os-tg-done-id { color: #e6edf3; }
+      .os-tg-done-sort.is-active, .os-tg-done-sort.is-active span { color: #8bd0e6; }
+      .os-tg-pr { color: #8bd0e6; }
+      .os-tg-pr-unmerged { color: #64748b; }
+      .os-tg-capsule-button { background: #1a2230; border-color: #2f3b4c; color: #c4b5fd; }
+      .os-tg-capsule-button:hover { border-color: #a78bfa; background: #271c3f; }
+      .os-tg-done-page.is-active { background: #18303a; border-color: #5ca0b8; }
       .os-node-gutter { background: #10232c; box-shadow: 0 0 0 1px rgba(92, 160, 184, 0.3); }
       .os-node-gutter:empty { background: transparent; box-shadow: 0 0 0 1px rgba(92, 160, 184, 0.22); }
       .os-node-has-upstream .os-node-gutter { background: #3a2414; color: #fbbf24; box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.34); }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -3190,8 +3190,16 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     cards.forEach((card) => card.classList.remove("os-tg-dim", "os-tg-ancestry"));
     const graph = this.state.taskGraph;
     const node = focusId ? graph?.nodes.find((candidate) => candidate.node_id === focusId) : undefined;
-    container.classList.toggle("os-tg-focused", Boolean(node));
-    if (!graph || !node) {
+    // Only enter focused mode when the focused node actually has a rendered
+    // card. A selection that transitioned to `done` during a live refresh
+    // moved to the Completed table, so its node still exists in the snapshot
+    // but no card is drawn — focusing it would dim every edge with nothing
+    // highlighted until the user picks another visible task.
+    const hasRenderedCard = Boolean(
+      focusId && container.querySelector(`[data-node-id="${cssEscape(focusId)}"]`),
+    );
+    container.classList.toggle("os-tg-focused", Boolean(node) && hasRenderedCard);
+    if (!graph || !node || !hasRenderedCard) {
       return;
     }
     if (node.state_category === "backlog") {
@@ -5120,9 +5128,11 @@ function renderCompletedTaskPrs(prs: MemoryTaskPullRequest[]): string {
   if (prs.length === 0) {
     return `<span class="os-tg-capsule-missing">—</span>`;
   }
-  // Newest first; the newest PR is emphasized, unmerged ones struck through.
-  const ordered = [...prs].sort((a, b) =>
-    (b.merged_at ?? "").localeCompare(a.merged_at ?? "") || b.number - a.number);
+  // Newest first by PR number — matching the gateway/fixture ordering — so
+  // the bold "latest" chip is genuinely the newest PR even when it is a
+  // later abandoned/unmerged attempt after an older merged one. Unmerged
+  // PRs are struck through.
+  const ordered = [...prs].sort((a, b) => b.number - a.number);
   const latest = ordered[0];
   return ordered.map((pr) => {
     const classes = [

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -5497,21 +5497,26 @@ function initialSelectedTaskNode(nodes: TaskGraphNode[], rootIds: string[]): Tas
     ...rootIds.map((id) => findNodeByRef(nodes, id)).filter((node): node is TaskGraphNode => Boolean(node)),
     ...nodes,
   ];
-  // Backlog and terminal nodes live in the side panes and have no run to
-  // open, so the initial selection sticks to the Current pane.
+  // Side-pane nodes (backlog, done) have no run to open, so the initial
+  // selection sticks to the Current pane and prefers non-terminal work —
+  // a canceled node only wins when nothing else renders there.
   const current = ordered.filter(isCurrentPaneTaskNode);
   return current.find((node) => node.kind !== "milestone" && node.state_category === "in_progress")
-    ?? current.find((node) => node.kind !== "milestone" && node.run_id)
+    ?? current.find((node) => node.kind !== "milestone" && node.run_id && !isTerminalTaskNode(node))
+    ?? current.find((node) => node.kind !== "milestone" && !isTerminalTaskNode(node))
     ?? current.find((node) => node.kind !== "milestone")
     ?? current[0]
     ?? null;
 }
 
-/** Nodes rendered in the Current pane: dispatchable states, not backlog/terminal. */
+/**
+ * Nodes rendered in the Current pane. Done nodes move to the Completed
+ * pane and backlog nodes to the Backlog pane; canceled nodes stay here —
+ * they have no other pane (the Completed endpoint serves done work only),
+ * so dropping them would make the "Canceled" state filter show nothing.
+ */
 function isCurrentPaneTaskNode(node: TaskGraphNode): boolean {
-  return node.state_category !== "backlog"
-    && node.state_category !== "done"
-    && node.state_category !== "canceled";
+  return node.state_category !== "backlog" && node.state_category !== "done";
 }
 
 function stateToneForTaskNode(node: TaskGraphNode): string {


### PR DESCRIPTION
## Summary

Implements the enhanced Task Graph from the v2 design concepts (`docs/specs/task-graph-phases/concept-17…20-v2-*.png`, loose reference): the desktop task surface now shows **all** work — completed, dispatchable, and backlog — in three panes.

### Completed (collapsible, left)
- New endpoint `GET /api/v1/memory/completed-tasks`: rows come from the memory server's DuckDB catalog first (issue capsules joined with their normalized `pull_requests` evidence — completed tasks survive Linear archival and **the Linear API is never queried on this path**), merged with orchestrator-known completions not yet captured (`source: "orchestrator"`, PR parsed from the control-plane `pr_url`).
- Server-side search, sort (natural issue-key order, undated rows always last), and pagination (25/page, capped at 100); mirrored client-side by `pageCompletedTasks` so the fixture workbench behaves like the gateway.
- Each row lists **all** PRs — newest bold, non-merged struck through — and a capsule button that opens the task's memory capsule through the `openMemoryDeepLink` wiring point from #198.

### Current (center, never collapses)
- Same dispatchable dependency graph as before; Done nodes now live in the Completed pane instead of lingering in the list.
- Selecting or hovering a task boldens its incoming and outgoing edges, including outgoing edges leaving the pane's right side toward blocked Backlog tasks (measured SVG overlay, repositioned on scroll/resize/collapse; endpoints scrolled out of view hide instead of drawing across headers).

### Backlog (collapsible, right)
- Backlog-state Linear issues now ride the task-graph snapshot: `LinearClient::project_task_graph_issues` returns requested identifiers **plus** every backlog issue from the same single project scan `project_issues_by_identifiers` already performed — no extra Linear traffic, no rate-limit exposure.
- Cards share the Current pane's geometry with faded edges. Hovering or selecting a backlog task boldens its full **ancestry critical path** — every unfinished upstream chain that must complete to unblock it — across both panes, and dims unrelated backlog cards. Dependency suffixes treat both panes as visible ("blocked by VIZ-103", not "1 hidden").

### Plumbing
- Rust DTOs (`MemoryCompletedTaskPage`/`MemoryCompletedTask`/`MemoryTaskPullRequest`) + TS mirrors; `GraphDataAdapter.getCompletedTasks` (HTTP, Tauri `memory_completed_tasks` command, fixture adapter).
- `?fixtures` workbench: backlog tier VIZ-114…120 with cross-pane blockers and multi-hop chains, plus 31 deterministic completed tasks (some with abandoned unmerged PRs) whose capsules resolve to real fixture concepts.
- `docs/graph-view.md` documents the three-pane surface and its test gates.

## Testing

- `npm run type-check` clean; `npx jest` 663 tests / 39 suites pass (new: `completed-tasks.test.ts`, three-pane app-shell suite covering pane rendering, search/sort/pagination, PR emphasis, capsule deep links, ancestry emphasis, collapse).
- `cargo test --workspace` passes (new: gateway backlog + completed-tasks endpoint integration tests, Linear single-scan test, memory PR-evidence projection unit test, sort-ordering unit test).
- Live-verified in the `?fixtures` workbench: three panes, cross-pane edge geometry + scroll hiding, ancestry path VIZ-117 ← {104,116} ← {114,115} ← 103 ← {101,102} with the Done blocker excluded, Completed search/sort/pagination with focus preservation, capsule deep link landing drilled on the capsule, pane collapse strips.