### PR TITLE
Add stable code symbol read model

### DIFF
--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -2950,13 +2950,38 @@ fn code_intel_document_input(
     source: String,
     summary: ParsedDocumentSummary,
     symbols: &BTreeSet<String>,
-    symbol_limit: usize,
+    _symbol_limit: usize,
 ) -> CodeIntelDocumentInput {
     let language = source_language_id(summary.source.language).to_string();
     let parser_version = format!(
         "{}:{}",
         summary.versions.grammar, summary.versions.tree_sitter
     );
+    let all_symbols = summary
+        .symbols
+        .iter()
+        .filter(|symbol| symbols.is_empty() || symbols.contains(symbol_kind_id(&symbol.kind)))
+        .map(|symbol| {
+            let snippet = source
+                .get(symbol.span.start_byte..symbol.span.end_byte)
+                .unwrap_or(symbol.name.as_str());
+            CodeIntelSymbolInput {
+                kind: symbol_kind_id(&symbol.kind).to_string(),
+                name: symbol.name.clone(),
+                container_chain: symbol.container_chain.clone(),
+                signature: None,
+                start_line: symbol.span.start_line,
+                start_col: symbol.span.start_column,
+                end_line: symbol.span.end_line,
+                end_col: symbol.span.end_column,
+                start_byte: symbol.span.start_byte,
+                end_byte: symbol.span.end_byte,
+                selection_start_line: symbol.span.start_line,
+                selection_end_line: symbol.span.end_line,
+                snippet_sha256: sha256_hex(snippet),
+            }
+        })
+        .collect::<Vec<_>>();
     CodeIntelDocumentInput {
         path,
         language,
@@ -2966,32 +2991,7 @@ fn code_intel_document_input(
         query_pack_version: summary.versions.query_pack.clone(),
         byte_len: summary.source.bytes,
         line_count: source.lines().count(),
-        symbols: summary
-            .symbols
-            .iter()
-            .filter(|symbol| symbols.is_empty() || symbols.contains(symbol_kind_id(&symbol.kind)))
-            .take(symbol_limit)
-            .map(|symbol| {
-                let snippet = source
-                    .get(symbol.span.start_byte..symbol.span.end_byte)
-                    .unwrap_or(symbol.name.as_str());
-                CodeIntelSymbolInput {
-                    kind: symbol_kind_id(&symbol.kind).to_string(),
-                    name: symbol.name.clone(),
-                    container_chain: symbol.container_chain.clone(),
-                    signature: None,
-                    start_line: symbol.span.start_line,
-                    start_col: symbol.span.start_column,
-                    end_line: symbol.span.end_line,
-                    end_col: symbol.span.end_column,
-                    start_byte: symbol.span.start_byte,
-                    end_byte: symbol.span.end_byte,
-                    selection_start_line: symbol.span.start_line,
-                    selection_end_line: symbol.span.end_line,
-                    snippet_sha256: sha256_hex(snippet),
-                }
-            })
-            .collect(),
+        symbols: all_symbols,
         edges: summary
             .captures
             .iter()
@@ -4953,12 +4953,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn memory_ingest_code_intel_limit_caps_persisted_symbols() {
+    async fn memory_ingest_code_intel_limit_does_not_cap_persisted_symbols() {
         let repo = TempDir::new().expect("temp repo");
         std::fs::create_dir_all(repo.path().join("src")).expect("src dir");
         std::fs::write(
             repo.path().join("src/lib.rs"),
-            "pub fn one() -> u8 { 1 }\npub fn two() -> u8 { 2 }\n",
+            "pub fn one() -> u8 { two() }\nfn two() -> u8 { 2 }\n",
         )
         .expect("source");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
@@ -4977,7 +4977,15 @@ mod tests {
         assert_eq!(result["persisted"], true);
         let connection = Connection::open(repo.path().join(".opensymphony/memory/memory.duckdb"))
             .expect("index opens");
-        assert_eq!(count_rows(&connection, "code_symbols", "current"), 1);
+        assert_eq!(count_rows(&connection, "code_symbols", "current"), 2);
+        let resolved_edges: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM code_edges WHERE freshness = 'current' AND source_symbol_key IS NOT NULL AND target_symbol_key IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("resolved edge count");
+        assert_eq!(resolved_edges, 1);
     }
 
     #[tokio::test]
@@ -5441,30 +5449,79 @@ mod tests {
     }
 
     #[test]
+    fn code_intel_read_helpers_do_not_create_index() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+
+        assert!(
+            code_symbol_detail(&config, "missing")
+                .expect("detail read")
+                .is_none()
+        );
+        assert!(
+            code_symbols_containing_span(&config, "repo", "src/lib.rs", 1, 1, 10)
+                .expect("span read")
+                .is_empty()
+        );
+        assert!(
+            code_symbol_neighborhood(&config, "missing", 1, 10)
+                .expect("neighborhood read")
+                .is_none()
+        );
+        assert!(
+            compare_code_symbols(&config, "repo", "base", "head", 10)
+                .expect("compare read")
+                .diffs
+                .is_empty()
+        );
+        assert!(
+            !repo
+                .path()
+                .join(".opensymphony/memory/memory.duckdb")
+                .exists()
+        );
+    }
+
+    #[test]
     fn code_intel_impl_methods_link_to_owner_symbol_by_chain() {
         let repo = TempDir::new().expect("temp repo");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
         let mut document = sample_code_intel_document("hash-a", "pack-a");
         document.symbols = vec![
             CodeIntelSymbolInput {
-                kind: "struct".to_string(),
-                name: "Widget".to_string(),
+                kind: "module".to_string(),
+                name: "m".to_string(),
                 container_chain: Vec::new(),
                 signature: None,
                 start_line: 1,
                 start_col: 1,
-                end_line: 1,
-                end_col: 15,
+                end_line: 8,
+                end_col: 2,
                 start_byte: 0,
-                end_byte: 14,
+                end_byte: 120,
                 selection_start_line: 1,
-                selection_end_line: 1,
+                selection_end_line: 8,
+                snippet_sha256: "module".to_string(),
+            },
+            CodeIntelSymbolInput {
+                kind: "struct".to_string(),
+                name: "Widget".to_string(),
+                container_chain: vec!["m".to_string()],
+                signature: None,
+                start_line: 2,
+                start_col: 1,
+                end_line: 2,
+                end_col: 15,
+                start_byte: 16,
+                end_byte: 30,
+                selection_start_line: 2,
+                selection_end_line: 2,
                 snippet_sha256: "widget".to_string(),
             },
             CodeIntelSymbolInput {
                 kind: "method".to_string(),
                 name: "run".to_string(),
-                container_chain: vec!["Widget".to_string()],
+                container_chain: vec!["m".to_string(), "Widget".to_string()],
                 signature: None,
                 start_line: 3,
                 start_col: 5,
@@ -5479,7 +5536,7 @@ mod tests {
             CodeIntelSymbolInput {
                 kind: "method".to_string(),
                 name: "fmt".to_string(),
-                container_chain: vec!["Widget".to_string(), "Display".to_string()],
+                container_chain: vec!["m".to_string(), "Widget".to_string(), "Display".to_string()],
                 signature: None,
                 start_line: 5,
                 start_col: 5,
@@ -5509,15 +5566,23 @@ mod tests {
             .find(|symbol| symbol.name == "run")
             .expect("method symbol");
         assert!(method.container_symbol_id.is_some());
-        assert_eq!(method.container_chain, vec!["Widget"]);
+        assert_eq!(method.container_chain, vec!["m", "Widget"]);
 
+        let widget = code_symbols_containing_span(&config, "repo", "src/lib.rs", 2, 8, 10)
+            .expect("widget span containment")
+            .into_iter()
+            .find(|symbol| symbol.name == "Widget")
+            .expect("scoped widget symbol");
         let trait_method = code_symbols_containing_span(&config, "repo", "src/lib.rs", 5, 8, 10)
             .expect("trait impl span containment")
             .into_iter()
             .find(|symbol| symbol.name == "fmt")
             .expect("trait impl method symbol");
-        assert!(trait_method.container_symbol_id.is_some());
-        assert_eq!(trait_method.container_chain, vec!["Widget", "Display"]);
+        assert_eq!(
+            trait_method.container_symbol_id.as_deref(),
+            Some(widget.symbol_id.as_str())
+        );
+        assert_eq!(trait_method.container_chain, vec!["m", "Widget", "Display"]);
     }
 
     #[test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5483,6 +5483,71 @@ mod tests {
     }
 
     #[test]
+    fn code_intel_read_helpers_schema_gate_legacy_index() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        std::fs::create_dir_all(config.index_path.parent().expect("index parent"))
+            .expect("index dir");
+        let connection = Connection::open(&config.index_path).expect("legacy index opens");
+        connection
+            .execute_batch(
+                r#"
+CREATE TABLE code_symbols (
+  symbol_id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT,
+  path TEXT NOT NULL,
+  language TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  freshness TEXT NOT NULL
+);
+CREATE TABLE code_edges (
+  edge_id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  edge_kind TEXT NOT NULL,
+  freshness TEXT NOT NULL
+);
+"#,
+            )
+            .expect("legacy schema");
+        drop(connection);
+
+        assert!(
+            code_symbol_detail(&config, "missing")
+                .expect("legacy detail read")
+                .is_none()
+        );
+        assert!(
+            code_symbols_containing_span(&config, "repo", "src/lib.rs", 1, 1, 10)
+                .expect("legacy span read")
+                .is_empty()
+        );
+        assert!(
+            code_symbol_neighborhood(&config, "missing", 1, 10)
+                .expect("legacy neighborhood read")
+                .is_none()
+        );
+        assert!(
+            compare_code_symbols(&config, "repo", "base", "head", 10)
+                .expect("legacy compare read")
+                .diffs
+                .is_empty()
+        );
+
+        let connection = Connection::open(&config.index_path).expect("legacy index reopens");
+        let symbol_key_columns: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('code_symbols') WHERE name = 'symbol_key'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("symbol_key column count");
+        assert_eq!(symbol_key_columns, 0);
+    }
+
+    #[test]
     fn code_intel_impl_methods_link_to_owner_symbol_by_chain() {
         let repo = TempDir::new().expect("temp repo");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5441,6 +5441,63 @@ mod tests {
     }
 
     #[test]
+    fn code_intel_impl_methods_link_to_owner_symbol_by_chain() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let mut document = sample_code_intel_document("hash-a", "pack-a");
+        document.symbols = vec![
+            CodeIntelSymbolInput {
+                kind: "struct".to_string(),
+                name: "Widget".to_string(),
+                container_chain: Vec::new(),
+                signature: None,
+                start_line: 1,
+                start_col: 1,
+                end_line: 1,
+                end_col: 15,
+                start_byte: 0,
+                end_byte: 14,
+                selection_start_line: 1,
+                selection_end_line: 1,
+                snippet_sha256: "widget".to_string(),
+            },
+            CodeIntelSymbolInput {
+                kind: "method".to_string(),
+                name: "run".to_string(),
+                container_chain: vec!["Widget".to_string()],
+                signature: None,
+                start_line: 3,
+                start_col: 5,
+                end_line: 3,
+                end_col: 16,
+                start_byte: 32,
+                end_byte: 43,
+                selection_start_line: 3,
+                selection_end_line: 3,
+                snippet_sha256: "run".to_string(),
+            },
+        ];
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("base".to_string()),
+                worktree_dirty: false,
+                documents: vec![document],
+            },
+        )
+        .expect("persist impl symbols");
+
+        let method = code_symbols_containing_span(&config, "repo", "src/lib.rs", 3, 8, 10)
+            .expect("span containment")
+            .into_iter()
+            .find(|symbol| symbol.name == "run")
+            .expect("method symbol");
+        assert!(method.container_symbol_id.is_some());
+        assert_eq!(method.container_chain, vec!["Widget"]);
+    }
+
+    #[test]
     fn code_intel_read_model_resolves_containers_edges_bounds_and_diff() {
         let repo = TempDir::new().expect("temp repo");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5507,17 +5507,30 @@ mod tests {
                 snippet_sha256: "removed".to_string(),
             },
         ];
-        base.edges = vec![CodeIntelEdgeInput {
-            edge_kind: "reference.call".to_string(),
-            target_hint: Some("helper()".to_string()),
-            confidence: "query_pack:calls".to_string(),
-            start_line: 4,
-            start_col: 9,
-            end_line: 4,
-            end_col: 17,
-            start_byte: 40,
-            end_byte: 48,
-        }];
+        base.edges = vec![
+            CodeIntelEdgeInput {
+                edge_kind: "reference.call".to_string(),
+                target_hint: Some("helper()".to_string()),
+                confidence: "query_pack:calls".to_string(),
+                start_line: 4,
+                start_col: 9,
+                end_line: 4,
+                end_col: 17,
+                start_byte: 40,
+                end_byte: 48,
+            },
+            CodeIntelEdgeInput {
+                edge_kind: "reference.call".to_string(),
+                target_hint: Some("Widget::helper()".to_string()),
+                confidence: "query_pack:calls".to_string(),
+                start_line: 4,
+                start_col: 20,
+                end_line: 4,
+                end_col: 28,
+                start_byte: 50,
+                end_byte: 58,
+            },
+        ];
         persist_code_intel_documents(
             &config,
             CodeIntelPersistBatch {
@@ -5570,10 +5583,33 @@ mod tests {
                     && !edge.unresolved
                     && edge.target_symbol_key.is_some())
         );
+        assert!(
+            neighborhood
+                .edges
+                .iter()
+                .any(
+                    |edge| edge.target_hint.as_deref() == Some("Widget::helper()")
+                        && edge.unresolved
+                        && edge.target_symbol_key.is_none()
+                )
+        );
         let truncated = code_symbol_neighborhood(&config, &run_key, 1, 1)
             .expect("bounded neighborhood")
             .expect("center exists");
         assert!(truncated.truncated);
+        assert!(
+            truncated.edges.iter().all(|edge| [
+                edge.source_symbol_key.as_deref(),
+                edge.target_symbol_key.as_deref()
+            ]
+            .into_iter()
+            .flatten()
+            .all(|key| truncated
+                .symbols
+                .iter()
+                .any(|symbol| symbol.symbol_key == key))),
+            "bounded neighborhoods must not expose dangling edges"
+        );
 
         let mut head = base;
         head.content_sha256 = "hash-b".to_string();
@@ -5674,6 +5710,33 @@ mod tests {
         assert!(
             comparison.diffs.is_empty(),
             "unchanged symbols must not become added or removed"
+        );
+
+        let containing = code_symbols_containing_span(&config, "repo", "src/lib.rs", 1, 2, 10)
+            .expect("span containment");
+        assert_eq!(
+            containing.len(),
+            1,
+            "current span lookups should collapse unchanged revision duplicates"
+        );
+
+        let mut dirty = document.clone();
+        dirty.symbols[0].snippet_sha256 = "dirty-snippet".to_string();
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("head".to_string()),
+                worktree_dirty: true,
+                documents: vec![dirty],
+            },
+        )
+        .expect("dirty revision persist");
+        let comparison =
+            compare_code_symbols(&config, "repo", "base", "head", 10).expect("compare revisions");
+        assert!(
+            comparison.diffs.is_empty(),
+            "dirty worktree rows must not be compared as committed revisions"
         );
     }
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -2978,6 +2978,7 @@ fn code_intel_document_input(
                 CodeIntelSymbolInput {
                     kind: symbol_kind_id(&symbol.kind).to_string(),
                     name: symbol.name.clone(),
+                    container_chain: symbol.container_chain.clone(),
                     signature: None,
                     start_line: symbol.span.start_line,
                     start_col: symbol.span.start_column,
@@ -4694,8 +4695,9 @@ mod tests {
     };
     use crate::opensymphony_memory::{
         CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
-        CodeIntelPersistBatch, CodeIntelSymbolInput, MemoryConfig, MemoryError,
-        persist_code_intel_documents,
+        CodeIntelPersistBatch, CodeIntelSymbolInput, CodeSymbolDiffStatus, MemoryConfig,
+        MemoryError, code_symbol_detail, code_symbol_neighborhood, code_symbols_containing_span,
+        compare_code_symbols, persist_code_intel_documents,
     };
     use axum::http::{HeaderMap, HeaderValue, header};
     use duckdb::{Connection, params};
@@ -5302,6 +5304,280 @@ mod tests {
         assert_eq!(count_rows(&connection, "code_diagnostics", "current"), 2);
     }
 
+    #[test]
+    fn code_intel_symbol_key_is_stable_beside_revision_bound_symbol_id() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let base = sample_code_intel_document("hash-a", "pack-a");
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("base".to_string()),
+                worktree_dirty: false,
+                documents: vec![base],
+            },
+        )
+        .expect("base persist");
+
+        let mut shifted = sample_code_intel_document("hash-b", "pack-a");
+        shifted.symbols[0].start_line = 5;
+        shifted.symbols[0].end_line = 5;
+        shifted.symbols[0].start_byte = 40;
+        shifted.symbols[0].end_byte = 52;
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("head".to_string()),
+                worktree_dirty: false,
+                documents: vec![shifted],
+            },
+        )
+        .expect("head persist");
+
+        let connection = Connection::open(repo.path().join(".opensymphony/memory/memory.duckdb"))
+            .expect("index opens");
+        let rows = connection
+            .prepare("SELECT symbol_id, symbol_key FROM code_symbols ORDER BY commit_sha")
+            .expect("prepare symbols")
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("query symbols")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("symbol rows");
+        assert_eq!(rows.len(), 2);
+        assert_ne!(rows[0].0, rows[1].0);
+        assert_eq!(rows[0].1, rows[1].1);
+    }
+
+    #[test]
+    fn code_intel_duplicate_symbol_keys_get_deterministic_ordinals() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let mut document = sample_code_intel_document("hash-a", "pack-a");
+        document.symbols.push(CodeIntelSymbolInput {
+            kind: "function".to_string(),
+            name: "answer".to_string(),
+            container_chain: Vec::new(),
+            signature: None,
+            start_line: 2,
+            start_col: 1,
+            end_line: 2,
+            end_col: 12,
+            start_byte: 20,
+            end_byte: 32,
+            selection_start_line: 2,
+            selection_end_line: 2,
+            snippet_sha256: "snippet-2".to_string(),
+        });
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("same".to_string()),
+                worktree_dirty: false,
+                documents: vec![document],
+            },
+        )
+        .expect("persist duplicate symbols");
+
+        let connection = Connection::open(repo.path().join(".opensymphony/memory/memory.duckdb"))
+            .expect("index opens");
+        let keys = connection
+            .prepare("SELECT symbol_key FROM code_symbols ORDER BY start_byte")
+            .expect("prepare keys")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query keys")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("keys");
+        assert_eq!(keys.len(), 2);
+        assert!(!keys[0].ends_with("#2"));
+        assert_eq!(keys[1], format!("{}#2", keys[0]));
+    }
+
+    #[test]
+    fn code_intel_read_model_resolves_containers_edges_bounds_and_diff() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let mut base = sample_code_intel_document("hash-a", "pack-a");
+        base.symbols = vec![
+            CodeIntelSymbolInput {
+                kind: "struct".to_string(),
+                name: "Widget".to_string(),
+                container_chain: Vec::new(),
+                signature: None,
+                start_line: 1,
+                start_col: 1,
+                end_line: 8,
+                end_col: 1,
+                start_byte: 0,
+                end_byte: 120,
+                selection_start_line: 1,
+                selection_end_line: 8,
+                snippet_sha256: "widget".to_string(),
+            },
+            CodeIntelSymbolInput {
+                kind: "method".to_string(),
+                name: "run".to_string(),
+                container_chain: vec!["Widget".to_string()],
+                signature: None,
+                start_line: 3,
+                start_col: 5,
+                end_line: 5,
+                end_col: 6,
+                start_byte: 20,
+                end_byte: 80,
+                selection_start_line: 3,
+                selection_end_line: 5,
+                snippet_sha256: "run-v1".to_string(),
+            },
+            CodeIntelSymbolInput {
+                kind: "function".to_string(),
+                name: "helper".to_string(),
+                container_chain: Vec::new(),
+                signature: None,
+                start_line: 10,
+                start_col: 1,
+                end_line: 10,
+                end_col: 20,
+                start_byte: 140,
+                end_byte: 160,
+                selection_start_line: 10,
+                selection_end_line: 10,
+                snippet_sha256: "helper".to_string(),
+            },
+            CodeIntelSymbolInput {
+                kind: "function".to_string(),
+                name: "removed".to_string(),
+                container_chain: Vec::new(),
+                signature: None,
+                start_line: 12,
+                start_col: 1,
+                end_line: 12,
+                end_col: 20,
+                start_byte: 170,
+                end_byte: 190,
+                selection_start_line: 12,
+                selection_end_line: 12,
+                snippet_sha256: "removed".to_string(),
+            },
+        ];
+        base.edges = vec![CodeIntelEdgeInput {
+            edge_kind: "reference.call".to_string(),
+            target_hint: Some("helper()".to_string()),
+            confidence: "query_pack:calls".to_string(),
+            start_line: 4,
+            start_col: 9,
+            end_line: 4,
+            end_col: 17,
+            start_byte: 40,
+            end_byte: 48,
+        }];
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("base".to_string()),
+                worktree_dirty: false,
+                documents: vec![base.clone()],
+            },
+        )
+        .expect("base persist");
+
+        let containing = code_symbols_containing_span(&config, "repo", "src/lib.rs", 4, 10, 10)
+            .expect("span containment");
+        assert_eq!(
+            containing
+                .iter()
+                .map(|symbol| symbol.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Widget", "run"]
+        );
+        let run_key = containing
+            .iter()
+            .find(|symbol| symbol.name == "run")
+            .expect("run symbol")
+            .symbol_key
+            .clone();
+        let detail = code_symbol_detail(&config, &run_key)
+            .expect("detail query")
+            .expect("run detail");
+        assert_eq!(detail.container_chain, vec!["Widget"]);
+
+        let neighborhood = code_symbol_neighborhood(&config, &run_key, 1, 10)
+            .expect("neighborhood")
+            .expect("center exists");
+        assert!(!neighborhood.truncated);
+        assert!(
+            neighborhood
+                .edges
+                .iter()
+                .any(|edge| edge.confidence == "exact"
+                    && !edge.unresolved
+                    && edge.target_symbol_key.is_some())
+        );
+        let truncated = code_symbol_neighborhood(&config, &run_key, 1, 1)
+            .expect("bounded neighborhood")
+            .expect("center exists");
+        assert!(truncated.truncated);
+
+        let mut head = base;
+        head.content_sha256 = "hash-b".to_string();
+        head.symbols[1].snippet_sha256 = "run-v2".to_string();
+        head.symbols.retain(|symbol| symbol.name != "removed");
+        head.symbols.push(CodeIntelSymbolInput {
+            kind: "function".to_string(),
+            name: "added".to_string(),
+            container_chain: Vec::new(),
+            signature: None,
+            start_line: 12,
+            start_col: 1,
+            end_line: 12,
+            end_col: 20,
+            start_byte: 170,
+            end_byte: 190,
+            selection_start_line: 12,
+            selection_end_line: 12,
+            snippet_sha256: "added".to_string(),
+        });
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("head".to_string()),
+                worktree_dirty: false,
+                documents: vec![head],
+            },
+        )
+        .expect("head persist");
+
+        let comparison =
+            compare_code_symbols(&config, "repo", "base", "head", 10).expect("compare revisions");
+        assert!(
+            comparison
+                .diffs
+                .iter()
+                .any(|diff| matches!(diff.status, CodeSymbolDiffStatus::Added))
+        );
+        assert!(
+            comparison
+                .diffs
+                .iter()
+                .any(|diff| matches!(diff.status, CodeSymbolDiffStatus::Removed))
+        );
+        assert!(
+            comparison
+                .diffs
+                .iter()
+                .any(|diff| matches!(diff.status, CodeSymbolDiffStatus::Modified))
+        );
+        let capped =
+            compare_code_symbols(&config, "repo", "base", "head", 1).expect("capped compare");
+        assert!(capped.truncated);
+    }
+
     fn sample_code_intel_document(hash: &str, query_pack: &str) -> CodeIntelDocumentInput {
         CodeIntelDocumentInput {
             path: "src/lib.rs".into(),
@@ -5315,6 +5591,7 @@ mod tests {
             symbols: vec![CodeIntelSymbolInput {
                 kind: "function".to_string(),
                 name: "answer".to_string(),
+                container_chain: Vec::new(),
                 signature: None,
                 start_line: 1,
                 start_col: 1,

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5086,7 +5086,7 @@ mod tests {
         let connection = Connection::open(repo.path().join(".opensymphony/memory/memory.duckdb"))
             .expect("index opens");
         assert_eq!(count_rows(&connection, "code_documents", "current"), 1);
-        assert_eq!(count_rows(&connection, "code_symbols", "current"), 1);
+        assert_eq!(count_rows(&connection, "code_symbols", "current"), 2);
         assert_eq!(count_rows(&connection, "code_edges", "current"), 1);
         assert_eq!(count_rows(&connection, "code_diagnostics", "current"), 1);
         assert_eq!(count_rows(&connection, "code_symbols", "stale"), 0);
@@ -5122,7 +5122,7 @@ mod tests {
         let connection = Connection::open(repo.path().join(".opensymphony/memory/memory.duckdb"))
             .expect("index opens");
         assert_eq!(count_rows(&connection, "code_documents", "current"), 1);
-        assert_eq!(count_rows(&connection, "code_symbols", "current"), 1);
+        assert_eq!(count_rows(&connection, "code_symbols", "current"), 2);
         assert_eq!(count_rows(&connection, "code_edges", "current"), 1);
         assert_eq!(count_rows(&connection, "code_diagnostics", "current"), 1);
         assert_eq!(count_rows(&connection, "code_documents", "stale"), 0);
@@ -5398,6 +5398,49 @@ mod tests {
     }
 
     #[test]
+    fn code_intel_container_chain_survives_partial_symbol_indexes() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let mut document = sample_code_intel_document("hash-a", "pack-a");
+        document.symbols = vec![CodeIntelSymbolInput {
+            kind: "method".to_string(),
+            name: "run".to_string(),
+            container_chain: vec!["Widget".to_string()],
+            signature: None,
+            start_line: 3,
+            start_col: 5,
+            end_line: 5,
+            end_col: 6,
+            start_byte: 20,
+            end_byte: 80,
+            selection_start_line: 3,
+            selection_end_line: 5,
+            snippet_sha256: "run-v1".to_string(),
+        }];
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("base".to_string()),
+                worktree_dirty: false,
+                documents: vec![document],
+            },
+        )
+        .expect("persist partial symbols");
+
+        let containing = code_symbols_containing_span(&config, "repo", "src/lib.rs", 4, 10, 10)
+            .expect("span containment");
+        assert_eq!(containing.len(), 1);
+        assert_eq!(containing[0].container_symbol_id, None);
+        assert_eq!(containing[0].container_chain, vec!["Widget"]);
+
+        let detail = code_symbol_detail(&config, &containing[0].symbol_key)
+            .expect("detail query")
+            .expect("method detail");
+        assert_eq!(detail.container_chain, vec!["Widget"]);
+    }
+
+    #[test]
     fn code_intel_read_model_resolves_containers_edges_bounds_and_diff() {
         let repo = TempDir::new().expect("temp repo");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
@@ -5505,6 +5548,15 @@ mod tests {
             .expect("detail query")
             .expect("run detail");
         assert_eq!(detail.container_chain, vec!["Widget"]);
+        let endpoint = code_symbols_containing_span(&config, "repo", "src/lib.rs", 5, 6, 10)
+            .expect("exclusive end containment");
+        assert_eq!(
+            endpoint
+                .iter()
+                .map(|symbol| symbol.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Widget"]
+        );
 
         let neighborhood = code_symbol_neighborhood(&config, &run_key, 1, 10)
             .expect("neighborhood")
@@ -5514,7 +5566,7 @@ mod tests {
             neighborhood
                 .edges
                 .iter()
-                .any(|edge| edge.confidence == "exact"
+                .any(|edge| edge.confidence == "syntactic"
                     && !edge.unresolved
                     && edge.target_symbol_key.is_some())
         );
@@ -5576,6 +5628,53 @@ mod tests {
         let capped =
             compare_code_symbols(&config, "repo", "base", "head", 1).expect("capped compare");
         assert!(capped.truncated);
+    }
+
+    #[test]
+    fn code_intel_revision_comparison_preserves_unchanged_file_rows() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let document = sample_code_intel_document("hash-a", "pack-a");
+        for revision in ["base", "head"] {
+            persist_code_intel_documents(
+                &config,
+                CodeIntelPersistBatch {
+                    repo_id: "repo".to_string(),
+                    commit_sha: Some(revision.to_string()),
+                    worktree_dirty: false,
+                    documents: vec![document.clone()],
+                },
+            )
+            .expect("persist revision");
+        }
+
+        let connection = Connection::open(repo.path().join(".opensymphony/memory/memory.duckdb"))
+            .expect("index opens");
+        let rows = connection
+            .prepare(
+                "SELECT commit_sha, symbol_id, symbol_key FROM code_symbols ORDER BY commit_sha",
+            )
+            .expect("prepare symbols")
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .expect("query symbols")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("symbol rows");
+        assert_eq!(rows.len(), 2);
+        assert_ne!(rows[0].1, rows[1].1);
+        assert_eq!(rows[0].2, rows[1].2);
+
+        let comparison =
+            compare_code_symbols(&config, "repo", "base", "head", 10).expect("compare revisions");
+        assert!(
+            comparison.diffs.is_empty(),
+            "unchanged symbols must not become added or removed"
+        );
     }
 
     fn sample_code_intel_document(hash: &str, query_pack: &str) -> CodeIntelDocumentInput {

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5476,6 +5476,21 @@ mod tests {
                 selection_end_line: 3,
                 snippet_sha256: "run".to_string(),
             },
+            CodeIntelSymbolInput {
+                kind: "method".to_string(),
+                name: "fmt".to_string(),
+                container_chain: vec!["Widget".to_string(), "Display".to_string()],
+                signature: None,
+                start_line: 5,
+                start_col: 5,
+                end_line: 5,
+                end_col: 16,
+                start_byte: 64,
+                end_byte: 75,
+                selection_start_line: 5,
+                selection_end_line: 5,
+                snippet_sha256: "fmt".to_string(),
+            },
         ];
         persist_code_intel_documents(
             &config,
@@ -5495,6 +5510,14 @@ mod tests {
             .expect("method symbol");
         assert!(method.container_symbol_id.is_some());
         assert_eq!(method.container_chain, vec!["Widget"]);
+
+        let trait_method = code_symbols_containing_span(&config, "repo", "src/lib.rs", 5, 8, 10)
+            .expect("trait impl span containment")
+            .into_iter()
+            .find(|symbol| symbol.name == "fmt")
+            .expect("trait impl method symbol");
+        assert!(trait_method.container_symbol_id.is_some());
+        assert_eq!(trait_method.container_chain, vec!["Widget", "Display"]);
     }
 
     #[test]
@@ -5789,6 +5812,24 @@ mod tests {
             },
         )
         .expect("dirty revision persist");
+        for table in [
+            "code_documents",
+            "code_symbols",
+            "code_edges",
+            "code_diagnostics",
+        ] {
+            let dirty_key_rows: i64 = connection
+                .query_row(
+                    &format!("SELECT count(*) FROM {table} WHERE commit_sha LIKE '%+dirty'"),
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("dirty revision key count");
+            assert_eq!(
+                dirty_key_rows, 0,
+                "{table} must keep commit_sha as real HEAD"
+            );
+        }
         let comparison =
             compare_code_symbols(&config, "repo", "base", "head", 10).expect("compare revisions");
         assert!(

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5741,6 +5741,13 @@ mod tests {
                 .iter()
                 .any(|diff| matches!(diff.status, CodeSymbolDiffStatus::Modified))
         );
+        let exact_cap =
+            compare_code_symbols(&config, "repo", "base", "head", comparison.diffs.len())
+                .expect("exact capped compare");
+        assert!(
+            !exact_cap.truncated,
+            "exact-sized diff pages must not truncate on unchanged trailing keys"
+        );
         let capped =
             compare_code_symbols(&config, "repo", "base", "head", 1).expect("capped compare");
         assert!(capped.truncated);
@@ -5835,6 +5842,48 @@ mod tests {
         assert!(
             comparison.diffs.is_empty(),
             "dirty worktree rows must not be compared as committed revisions"
+        );
+    }
+
+    #[test]
+    fn code_intel_neighborhood_skips_edges_without_source_symbols() {
+        let repo = TempDir::new().expect("temp repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let mut document = sample_code_intel_document("hash-a", "pack-a");
+        document.edges = vec![CodeIntelEdgeInput {
+            edge_kind: "reference.call".to_string(),
+            target_hint: Some("answer".to_string()),
+            confidence: "query_pack:calls".to_string(),
+            start_line: 2,
+            start_col: 1,
+            end_line: 2,
+            end_col: 7,
+            start_byte: 20,
+            end_byte: 26,
+        }];
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "repo".to_string(),
+                commit_sha: Some("base".to_string()),
+                worktree_dirty: false,
+                documents: vec![document],
+            },
+        )
+        .expect("persist source-less edge");
+
+        let symbol = code_symbols_containing_span(&config, "repo", "src/lib.rs", 1, 2, 10)
+            .expect("span containment")
+            .into_iter()
+            .next()
+            .expect("answer symbol");
+        let neighborhood = code_symbol_neighborhood(&config, &symbol.symbol_key, 1, 10)
+            .expect("neighborhood")
+            .expect("center exists");
+        assert!(neighborhood.edges.is_empty());
+        assert!(
+            neighborhood.truncated,
+            "dropped edges with missing source endpoints must be explicit"
         );
     }
 

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1495,13 +1495,15 @@ fn run_query_pack(
                     && let Some(name) =
                         symbol_name_for_capture(&capture_name, capture.node, source)?
                 {
+                    let (container_name, container_chain) =
+                        rust_impl_container(language, &kind, capture.node, source)?;
                     symbols.push(SymbolRecord {
                         kind,
                         name,
                         span: span.clone(),
                         rendered_span: rendered_span.clone(),
-                        container_name: None,
-                        container_chain: Vec::new(),
+                        container_name,
+                        container_chain,
                         parser_version: TREE_SITTER_VERSION.to_string(),
                         query_pack_version: query_pack.version.clone(),
                     });
@@ -1525,6 +1527,9 @@ fn run_query_pack(
 
 fn assign_symbol_containers(symbols: &mut [SymbolRecord]) {
     for index in 0..symbols.len() {
+        if !symbols[index].container_chain.is_empty() {
+            continue;
+        }
         let parent_index = symbols
             .iter()
             .enumerate()
@@ -1550,6 +1555,37 @@ fn assign_symbol_containers(symbols: &mut [SymbolRecord]) {
             symbols[index].container_name = Some(parent.name);
             symbols[index].container_chain = chain;
         }
+    }
+}
+
+fn rust_impl_container(
+    language: SourceLanguage,
+    kind: &SymbolKind,
+    node: Node<'_>,
+    source: &[u8],
+) -> Result<(Option<String>, Vec<String>), CodeIntelError> {
+    if language != SourceLanguage::Rust || kind != &SymbolKind::Method {
+        return Ok((None, Vec::new()));
+    }
+    let Some(impl_item) = ancestor_node(node, "impl_item") else {
+        return Ok((None, Vec::new()));
+    };
+    let Some(owner) = impl_item
+        .child_by_field_name("type")
+        .or_else(|| first_named_child_kind(impl_item, &["type_identifier", "generic_type"]))
+    else {
+        return Ok((None, Vec::new()));
+    };
+    let name = owner
+        .utf8_text(source)?
+        .split('<')
+        .next()
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() {
+        Ok((None, Vec::new()))
+    } else {
+        Ok((Some(name.to_string()), vec![name.to_string()]))
     }
 }
 
@@ -1716,14 +1752,24 @@ fn is_test_function(language: SourceLanguage, node: Node<'_>, source: &[u8]) -> 
     }
 }
 
-fn has_ancestor(mut node: Node<'_>, kind: &str) -> bool {
+fn has_ancestor(node: Node<'_>, kind: &str) -> bool {
+    ancestor_node(node, kind).is_some()
+}
+
+fn ancestor_node<'tree>(mut node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
     while let Some(parent) = node.parent() {
         if parent.kind() == kind {
-            return true;
+            return Some(parent);
         }
         node = parent;
     }
-    false
+    None
+}
+
+fn first_named_child_kind<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| kinds.contains(&child.kind()))
 }
 
 fn has_test_attribute(node: Node<'_>, source: &[u8]) -> bool {
@@ -2303,6 +2349,18 @@ mod tests {
 
         assert_eq!(trait_method.container_name.as_deref(), Some("Runnable"));
         assert_eq!(trait_method.container_chain, vec!["Runnable"]);
+
+        let impl_method = summary
+            .symbols
+            .iter()
+            .find(|symbol| {
+                symbol.kind == SymbolKind::Method
+                    && symbol.name == "run"
+                    && symbol.rendered_span == "23:5-25:6"
+            })
+            .expect("impl method symbol");
+        assert_eq!(impl_method.container_name.as_deref(), Some("Widget"));
+        assert_eq!(impl_method.container_chain, vec!["Widget"]);
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1526,7 +1526,16 @@ fn run_query_pack(
 }
 
 fn assign_symbol_containers(symbols: &mut [SymbolRecord]) {
-    for index in 0..symbols.len() {
+    let mut indexes = (0..symbols.len()).collect::<Vec<_>>();
+    indexes.sort_by_key(|index| {
+        std::cmp::Reverse(
+            symbols[*index]
+                .span
+                .end_byte
+                .saturating_sub(symbols[*index].span.start_byte),
+        )
+    });
+    for index in indexes {
         if !symbols[index].container_chain.is_empty() {
             continue;
         }
@@ -1577,16 +1586,29 @@ fn rust_impl_container(
         return Ok((None, Vec::new()));
     };
     let name = owner
-        .utf8_text(source)?
-        .split('<')
-        .next()
-        .unwrap_or("")
-        .trim();
+        .utf8_text(source)
+        .map(rust_container_part)?
+        .unwrap_or_default();
     if name.is_empty() {
-        Ok((None, Vec::new()))
+        return Ok((None, Vec::new()));
+    }
+    let trait_name = impl_item
+        .child_by_field_name("trait")
+        .and_then(|node| node.utf8_text(source).ok())
+        .and_then(rust_container_part);
+    if let Some(trait_name) = trait_name {
+        Ok((
+            Some(trait_name.to_string()),
+            vec![name.to_string(), trait_name.to_string()],
+        ))
     } else {
         Ok((Some(name.to_string()), vec![name.to_string()]))
     }
+}
+
+fn rust_container_part(text: &str) -> Option<&str> {
+    let trimmed = text.split('<').next().unwrap_or(text).trim();
+    (!trimmed.is_empty()).then_some(trimmed)
 }
 
 fn span_strictly_contains(outer: &SourceSpan, inner: &SourceSpan) -> bool {
@@ -2361,6 +2383,40 @@ mod tests {
             .expect("impl method symbol");
         assert_eq!(impl_method.container_name.as_deref(), Some("Widget"));
         assert_eq!(impl_method.container_chain, vec!["Widget"]);
+    }
+
+    #[test]
+    fn rust_trait_impl_methods_include_trait_in_container_chain() {
+        let summary = parse_rust_source(
+            Some(PathBuf::from("fixtures/rust/trait_impl.rs")),
+            "struct Widget;\nimpl Display for Widget {\n    fn fmt(&self) {}\n}\n",
+        )
+        .expect("rust parses");
+
+        let method = summary
+            .symbols
+            .iter()
+            .find(|symbol| symbol.kind == SymbolKind::Method && symbol.name == "fmt")
+            .expect("trait impl method");
+        assert_eq!(method.container_name.as_deref(), Some("Display"));
+        assert_eq!(method.container_chain, vec!["Widget", "Display"]);
+    }
+
+    #[test]
+    fn nested_symbols_get_complete_parent_chains() {
+        let summary = parse_path(
+            "fixtures/python/nested.py",
+            "class Outer:\n    class Inner:\n        def run(self):\n            pass\n",
+        )
+        .expect("python parses");
+
+        let method = summary
+            .symbols
+            .iter()
+            .find(|symbol| symbol.kind == SymbolKind::Method && symbol.name == "run")
+            .expect("nested method");
+        assert_eq!(method.container_name.as_deref(), Some("Inner"));
+        assert_eq!(method.container_chain, vec!["Outer", "Inner"]);
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1588,30 +1588,39 @@ fn rust_impl_container(
     else {
         return Ok((None, Vec::new()));
     };
-    let name = owner
+    let owner_parts = owner
         .utf8_text(source)
-        .map(rust_container_part)?
+        .map(rust_container_parts)?
         .unwrap_or_default();
-    if name.is_empty() {
+    let Some(owner_name) = owner_parts.last() else {
         return Ok((None, Vec::new()));
-    }
+    };
     let trait_name = impl_item
         .child_by_field_name("trait")
         .and_then(|node| node.utf8_text(source).ok())
         .and_then(rust_container_part);
     if let Some(trait_name) = trait_name {
-        Ok((
-            Some(trait_name.to_string()),
-            vec![name.to_string(), trait_name.to_string()],
-        ))
+        let mut chain = owner_parts;
+        chain.push(trait_name.to_string());
+        Ok((Some(trait_name.to_string()), chain))
     } else {
-        Ok((Some(name.to_string()), vec![name.to_string()]))
+        Ok((Some(owner_name.to_string()), owner_parts))
     }
 }
 
 fn rust_container_part(text: &str) -> Option<&str> {
     let trimmed = text.split('<').next().unwrap_or(text).trim();
     (!trimmed.is_empty()).then_some(trimmed)
+}
+
+fn rust_container_parts(text: &str) -> Option<Vec<String>> {
+    let parts = rust_container_part(text)?
+        .split("::")
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    (!parts.is_empty()).then_some(parts)
 }
 
 fn span_strictly_contains(outer: &SourceSpan, inner: &SourceSpan) -> bool {
@@ -2420,6 +2429,23 @@ mod tests {
             .expect("nested impl method");
         assert_eq!(method.container_name.as_deref(), Some("Widget"));
         assert_eq!(method.container_chain, vec!["outer", "Widget"]);
+    }
+
+    #[test]
+    fn rust_qualified_impl_owners_split_into_container_chain_parts() {
+        let summary = parse_rust_source(
+            Some(PathBuf::from("fixtures/rust/qualified_impl.rs")),
+            "mod m {\n    struct Widget;\n}\nimpl m::Widget {\n    fn run(&self) {}\n}\n",
+        )
+        .expect("rust parses");
+
+        let method = summary
+            .symbols
+            .iter()
+            .find(|symbol| symbol.kind == SymbolKind::Method && symbol.name == "run")
+            .expect("qualified impl method");
+        assert_eq!(method.container_name.as_deref(), Some("Widget"));
+        assert_eq!(method.container_chain, vec!["m", "Widget"]);
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1536,9 +1536,7 @@ fn assign_symbol_containers(symbols: &mut [SymbolRecord]) {
         )
     });
     for index in indexes {
-        if !symbols[index].container_chain.is_empty() {
-            continue;
-        }
+        let existing_chain = symbols[index].container_chain.clone();
         let parent_index = symbols
             .iter()
             .enumerate()
@@ -1561,8 +1559,13 @@ fn assign_symbol_containers(symbols: &mut [SymbolRecord]) {
             let parent = symbols[parent_index].clone();
             let mut chain = parent.container_chain;
             chain.push(parent.name.clone());
-            symbols[index].container_name = Some(parent.name);
-            symbols[index].container_chain = chain;
+            if existing_chain.is_empty() {
+                symbols[index].container_name = Some(parent.name);
+                symbols[index].container_chain = chain;
+            } else if !existing_chain.starts_with(&chain) {
+                chain.extend(existing_chain);
+                symbols[index].container_chain = chain;
+            }
         }
     }
 }
@@ -2400,6 +2403,23 @@ mod tests {
             .expect("trait impl method");
         assert_eq!(method.container_name.as_deref(), Some("Display"));
         assert_eq!(method.container_chain, vec!["Widget", "Display"]);
+    }
+
+    #[test]
+    fn rust_impl_methods_keep_lexical_parent_chains() {
+        let summary = parse_rust_source(
+            Some(PathBuf::from("fixtures/rust/nested_impl.rs")),
+            "fn outer() {\n    struct Widget;\n    impl Widget {\n        fn run(&self) {}\n    }\n}\n",
+        )
+        .expect("rust parses");
+
+        let method = summary
+            .symbols
+            .iter()
+            .find(|symbol| symbol.kind == SymbolKind::Method && symbol.name == "run")
+            .expect("nested impl method");
+        assert_eq!(method.container_name.as_deref(), Some("Widget"));
+        assert_eq!(method.container_chain, vec!["outer", "Widget"]);
     }
 
     #[test]

--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -388,6 +388,10 @@ pub struct SymbolRecord {
     pub name: String,
     pub span: SourceSpan,
     pub rendered_span: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub container_chain: Vec<String>,
     pub parser_version: String,
     pub query_pack_version: String,
 }
@@ -1496,6 +1500,8 @@ fn run_query_pack(
                         name,
                         span: span.clone(),
                         rendered_span: rendered_span.clone(),
+                        container_name: None,
+                        container_chain: Vec::new(),
                         parser_version: TREE_SITTER_VERSION.to_string(),
                         query_pack_version: query_pack.version.clone(),
                     });
@@ -1512,7 +1518,45 @@ fn run_query_pack(
         }
     }
 
+    assign_symbol_containers(&mut symbols);
+
     Ok((symbols, captures))
+}
+
+fn assign_symbol_containers(symbols: &mut [SymbolRecord]) {
+    for index in 0..symbols.len() {
+        let parent_index = symbols
+            .iter()
+            .enumerate()
+            .filter(|(candidate_index, candidate)| {
+                *candidate_index != index
+                    && span_strictly_contains(&candidate.span, &symbols[index].span)
+            })
+            .min_by_key(|(_, candidate)| {
+                (
+                    candidate
+                        .span
+                        .end_byte
+                        .saturating_sub(candidate.span.start_byte),
+                    std::cmp::Reverse(candidate.span.start_byte),
+                )
+            })
+            .map(|(candidate_index, _)| candidate_index);
+
+        if let Some(parent_index) = parent_index {
+            let parent = symbols[parent_index].clone();
+            let mut chain = parent.container_chain;
+            chain.push(parent.name.clone());
+            symbols[index].container_name = Some(parent.name);
+            symbols[index].container_chain = chain;
+        }
+    }
+}
+
+fn span_strictly_contains(outer: &SourceSpan, inner: &SourceSpan) -> bool {
+    outer.start_byte <= inner.start_byte
+        && outer.end_byte >= inner.end_byte
+        && (outer.start_byte < inner.start_byte || outer.end_byte > inner.end_byte)
 }
 
 fn symbol_kind_for_capture(
@@ -1778,6 +1822,8 @@ fn parse_lightweight_source(
                 .to_string(),
             rendered_span: span.render(),
             span,
+            container_name: None,
+            container_chain: Vec::new(),
             parser_version: LIGHTWEIGHT_PARSER_VERSION.to_string(),
             query_pack_version: query_pack,
         }],
@@ -2235,6 +2281,28 @@ mod tests {
             symbols.contains(&(SymbolKind::Test, "exercises_widget", "30:1-33:2")),
             "{symbols:?}"
         );
+    }
+
+    #[test]
+    fn rust_fixture_extracts_container_chains() {
+        let summary = parse_rust_source(
+            Some(PathBuf::from("fixtures/rust/complete.rs")),
+            RUST_COMPLETE,
+        )
+        .expect("fixture parses");
+
+        let trait_method = summary
+            .symbols
+            .iter()
+            .find(|symbol| {
+                symbol.kind == SymbolKind::Method
+                    && symbol.name == "run"
+                    && symbol.rendered_span == "15:5-15:19"
+            })
+            .expect("trait method symbol");
+
+        assert_eq!(trait_method.container_name.as_deref(), Some("Runnable"));
+        assert_eq!(trait_method.container_chain, vec!["Runnable"]);
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -537,6 +537,8 @@ pub fn persist_code_intel_documents(
         skipped_files: Vec::new(),
         diagnostics: Vec::new(),
     };
+    let stored_commit_sha =
+        code_revision_key(batch.commit_sha.as_deref(), batch.worktree_dirty);
 
     for document in batch.documents {
         let path = document.path.to_string_lossy().to_string();
@@ -558,10 +560,10 @@ pub fn persist_code_intel_documents(
         transaction
             .execute(
                 "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                params![
-                    batch.repo_id,
-                    batch.commit_sha,
-                    batch.worktree_dirty,
+                    params![
+                        batch.repo_id,
+                    stored_commit_sha.clone(),
+                        batch.worktree_dirty,
                     path,
                     document.language,
                     document.content_sha256,
@@ -582,7 +584,7 @@ pub fn persist_code_intel_documents(
 
         let prepared_symbols = prepare_code_symbols(
             &batch.repo_id,
-            batch.commit_sha.as_deref(),
+            stored_commit_sha.as_deref(),
             batch.worktree_dirty,
             &path,
             &document,
@@ -597,7 +599,7 @@ pub fn persist_code_intel_documents(
                         prepared.symbol_id,
                         prepared.symbol_key,
                         batch.repo_id,
-                        batch.commit_sha,
+                        stored_commit_sha.clone(),
                         batch.worktree_dirty,
                         path,
                         document.language,
@@ -652,7 +654,7 @@ pub fn persist_code_intel_documents(
                     params![
                         edge_id,
                         batch.repo_id,
-                        batch.commit_sha,
+                        stored_commit_sha.clone(),
                         batch.worktree_dirty,
                         path,
                         document.language,
@@ -705,7 +707,7 @@ pub fn persist_code_intel_documents(
                     params![
                         diagnostic_id,
                         batch.repo_id,
-                        batch.commit_sha,
+                        stored_commit_sha.clone(),
                         batch.worktree_dirty,
                         path,
                         document.language,
@@ -872,12 +874,14 @@ fn symbol_contains_span(symbol: &CodeIntelSymbolInput, start_byte: usize, end_by
 }
 
 fn edge_target_name(target_hint: &str) -> Option<&str> {
-    let before_call = target_hint.split_once('(').map_or(target_hint, |(name, _)| name);
-    before_call
-        .split([':', '.'])
-        .rfind(|part| !part.is_empty())
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
+    let before_call = target_hint
+        .split_once('(')
+        .map_or(target_hint, |(name, _)| name)
+        .trim();
+    if before_call.contains("::") || before_call.contains('.') {
+        return None;
+    }
+    (!before_call.is_empty()).then_some(before_call)
 }
 
 fn single_symbol_named<'a>(
@@ -999,7 +1003,7 @@ pub fn code_symbols_containing_span(
     })?;
     let mut statement = connection
         .prepare(
-            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key",
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' AND symbol_key != '' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key, indexed_at DESC, symbol_id",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -1016,8 +1020,10 @@ pub fn code_symbols_containing_span(
             path: config.index_path.clone(),
             source,
         })?;
+    let mut seen_keys = BTreeSet::new();
     rows.into_iter()
         .filter(|symbol| symbol_contains_point(symbol, line, column))
+        .filter(|symbol| seen_keys.insert(symbol.symbol_key.clone()))
         .take(limit)
         .map(|mut symbol| {
             fill_container_chain(&connection, &mut symbol)?;
@@ -1071,6 +1077,10 @@ pub fn code_symbol_neighborhood(
                         }
                     }
                 }
+                if !edge_endpoints_present(&edge, &symbols) {
+                    truncated = true;
+                    continue;
+                }
                 edges.insert(edge.edge_id.clone(), edge);
             }
             if truncated {
@@ -1091,6 +1101,13 @@ pub fn code_symbol_neighborhood(
         max_records,
         truncated,
     }))
+}
+
+fn edge_endpoints_present(edge: &CodeEdgeRecord, symbols: &BTreeMap<String, CodeSymbolRecord>) -> bool {
+    [edge.source_symbol_key.as_deref(), edge.target_symbol_key.as_deref()]
+        .into_iter()
+        .flatten()
+        .all(|key| symbols.contains_key(key))
 }
 
 pub fn compare_code_symbols(
@@ -1197,7 +1214,7 @@ fn query_symbols_for_revision(
 ) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
     let mut statement = connection
         .prepare(
-            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND commit_sha = ? ORDER BY symbol_key, indexed_at DESC, symbol_id",
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' ORDER BY symbol_key, indexed_at DESC, symbol_id",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
@@ -1384,6 +1401,16 @@ fn stale_code_rows(
 
 fn code_row_id(parts: &[&str]) -> String {
     sha256_hex(&parts.join("\u{1f}"))
+}
+
+fn code_revision_key(commit_sha: Option<&str>, worktree_dirty: bool) -> Option<String> {
+    commit_sha.map(|sha| {
+        if worktree_dirty {
+            format!("{sha}+dirty")
+        } else {
+            sha.to_string()
+        }
+    })
 }
 
 fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, MemoryError> {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -391,6 +391,7 @@ CREATE TABLE IF NOT EXISTS code_documents (
 );
 CREATE TABLE IF NOT EXISTS code_symbols (
   symbol_id TEXT PRIMARY KEY,
+  symbol_key TEXT NOT NULL,
   repo_id TEXT NOT NULL,
   commit_sha TEXT,
   worktree_dirty BOOLEAN NOT NULL,
@@ -424,7 +425,9 @@ CREATE TABLE IF NOT EXISTS code_edges (
   language TEXT NOT NULL,
   edge_kind TEXT NOT NULL,
   source_symbol_id TEXT,
+  source_symbol_key TEXT,
   target_symbol_id TEXT,
+  target_symbol_key TEXT,
   target_hint TEXT,
   confidence TEXT NOT NULL,
   start_line BIGINT NOT NULL,
@@ -463,10 +466,13 @@ CREATE TABLE IF NOT EXISTS code_diagnostics (
 );
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
 UPDATE code_symbols SET worktree_dirty = false WHERE worktree_dirty IS NULL;
+ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS symbol_key TEXT DEFAULT '';
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS parser_version TEXT DEFAULT '';
 UPDATE code_symbols SET parser_version = '' WHERE parser_version IS NULL;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
 UPDATE code_edges SET worktree_dirty = false WHERE worktree_dirty IS NULL;
+ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS source_symbol_key TEXT;
+ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS target_symbol_key TEXT;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS start_col BIGINT DEFAULT 0;
 UPDATE code_edges SET start_col = 0 WHERE start_col IS NULL;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS end_col BIGINT DEFAULT 0;
@@ -490,10 +496,13 @@ UPDATE code_diagnostics SET end_byte = 0 WHERE end_byte IS NULL;
 ALTER TABLE code_diagnostics ADD COLUMN IF NOT EXISTS parser_version TEXT DEFAULT '';
 UPDATE code_diagnostics SET parser_version = '' WHERE parser_version IS NULL;
 CREATE INDEX IF NOT EXISTS idx_code_symbols_name ON code_symbols(name);
+CREATE INDEX IF NOT EXISTS idx_code_symbols_key ON code_symbols(symbol_key);
 CREATE INDEX IF NOT EXISTS idx_code_symbols_path ON code_symbols(path);
 CREATE INDEX IF NOT EXISTS idx_code_symbols_kind ON code_symbols(kind);
 CREATE INDEX IF NOT EXISTS idx_code_edges_source ON code_edges(source_symbol_id);
 CREATE INDEX IF NOT EXISTS idx_code_edges_target ON code_edges(target_symbol_id);
+CREATE INDEX IF NOT EXISTS idx_code_edges_source_key ON code_edges(source_symbol_key);
+CREATE INDEX IF NOT EXISTS idx_code_edges_target_key ON code_edges(target_symbol_key);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostics_path ON code_diagnostics(path);
 "#,
     ))
@@ -568,25 +577,16 @@ pub fn persist_code_intel_documents(
             })?;
         report.persisted_documents += 1;
 
-        for symbol in &document.symbols {
-            let symbol_id = code_row_id(&[
-                &batch.repo_id,
-                &path,
-                &document.content_sha256,
-                &document.parser_version,
-                &document.query_pack_version,
-                &symbol.kind,
-                &symbol.name,
-                &symbol.start_line.to_string(),
-                &symbol.start_col.to_string(),
-                &symbol.end_line.to_string(),
-                &symbol.end_col.to_string(),
-            ]);
+        let prepared_symbols = prepare_code_symbols(&batch.repo_id, &path, &document);
+
+        for prepared in &prepared_symbols {
+            let symbol = prepared.symbol;
             transaction
                 .execute(
-                    "INSERT OR REPLACE INTO code_symbols (symbol_id, repo_id, commit_sha, worktree_dirty, path, language, kind, name, container_symbol_id, signature, start_line, start_col, end_line, end_col, start_byte, end_byte, selection_start_line, selection_end_line, content_sha256, snippet_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT OR REPLACE INTO code_symbols (symbol_id, symbol_key, repo_id, commit_sha, worktree_dirty, path, language, kind, name, container_symbol_id, signature, start_line, start_col, end_line, end_col, start_byte, end_byte, selection_start_line, selection_end_line, content_sha256, snippet_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
-                        symbol_id,
+                        prepared.symbol_id,
+                        prepared.symbol_key,
                         batch.repo_id,
                         batch.commit_sha,
                         batch.worktree_dirty,
@@ -594,7 +594,7 @@ pub fn persist_code_intel_documents(
                         document.language,
                         symbol.kind,
                         symbol.name,
-                        Option::<String>::None,
+                        prepared.container_symbol_id,
                         symbol.signature,
                         symbol.start_line as i64,
                         symbol.start_col as i64,
@@ -620,6 +620,7 @@ pub fn persist_code_intel_documents(
         }
 
         for edge in &document.edges {
+            let resolved = resolve_code_edge(edge, &prepared_symbols);
             let edge_id = code_row_id(&[
                 &batch.repo_id,
                 &path,
@@ -637,7 +638,7 @@ pub fn persist_code_intel_documents(
             ]);
             transaction
                 .execute(
-                    "INSERT OR REPLACE INTO code_edges (edge_id, repo_id, commit_sha, worktree_dirty, path, language, edge_kind, source_symbol_id, target_symbol_id, target_hint, confidence, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT OR REPLACE INTO code_edges (edge_id, repo_id, commit_sha, worktree_dirty, path, language, edge_kind, source_symbol_id, source_symbol_key, target_symbol_id, target_symbol_key, target_hint, confidence, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
                         edge_id,
                         batch.repo_id,
@@ -646,10 +647,12 @@ pub fn persist_code_intel_documents(
                         path,
                         document.language,
                         edge.edge_kind,
-                        Option::<String>::None,
-                        Option::<String>::None,
+                        resolved.source_symbol_id,
+                        resolved.source_symbol_key,
+                        resolved.target_symbol_id,
+                        resolved.target_symbol_key,
                         edge.target_hint,
-                        edge.confidence,
+                        normalize_edge_confidence(&edge.confidence, resolved.target_resolved),
                         edge.start_line as i64,
                         edge.start_col as i64,
                         edge.end_line as i64,
@@ -727,6 +730,596 @@ pub fn persist_code_intel_documents(
             source,
         })?;
     Ok(report)
+}
+
+struct PreparedCodeSymbol<'a> {
+    symbol: &'a CodeIntelSymbolInput,
+    symbol_id: String,
+    symbol_key: String,
+    container_symbol_id: Option<String>,
+}
+
+struct ResolvedCodeEdge {
+    source_symbol_id: Option<String>,
+    source_symbol_key: Option<String>,
+    target_symbol_id: Option<String>,
+    target_symbol_key: Option<String>,
+    target_resolved: bool,
+}
+
+fn prepare_code_symbols<'a>(
+    repo_id: &str,
+    path: &str,
+    document: &'a CodeIntelDocumentInput,
+) -> Vec<PreparedCodeSymbol<'a>> {
+    let mut base_key_counts = BTreeMap::<String, usize>::new();
+    let mut prepared = document
+        .symbols
+        .iter()
+        .map(|symbol| {
+            let symbol_id = code_row_id(&[
+                repo_id,
+                path,
+                &document.content_sha256,
+                &document.parser_version,
+                &document.query_pack_version,
+                &symbol.kind,
+                &symbol.name,
+                &symbol.start_line.to_string(),
+                &symbol.start_col.to_string(),
+                &symbol.end_line.to_string(),
+                &symbol.end_col.to_string(),
+            ]);
+            let base_key = code_row_id(&[
+                repo_id,
+                path,
+                &document.language,
+                &symbol.kind,
+                &symbol.container_chain.join("\u{1f}"),
+                &symbol.name,
+            ]);
+            let ordinal = base_key_counts.entry(base_key.clone()).or_default();
+            *ordinal += 1;
+            let symbol_key = if *ordinal == 1 {
+                base_key
+            } else {
+                format!("{base_key}#{ordinal}")
+            };
+            PreparedCodeSymbol {
+                symbol,
+                symbol_id,
+                symbol_key,
+                container_symbol_id: None,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    for index in 0..prepared.len() {
+        if let Some(parent_index) = container_symbol_index(&prepared, index) {
+            prepared[index].container_symbol_id = Some(prepared[parent_index].symbol_id.clone());
+        }
+    }
+
+    prepared
+}
+
+fn container_symbol_index(symbols: &[PreparedCodeSymbol<'_>], child_index: usize) -> Option<usize> {
+    let child = symbols[child_index].symbol;
+    let parent_name = child.container_chain.last()?;
+    let parent_chain = &child.container_chain[..child.container_chain.len().saturating_sub(1)];
+    symbols
+        .iter()
+        .enumerate()
+        .filter(|(candidate_index, candidate)| {
+            *candidate_index != child_index
+                && candidate.symbol.name == *parent_name
+                && candidate.symbol.container_chain == parent_chain
+                && symbol_contains_span(candidate.symbol, child.start_byte, child.end_byte)
+        })
+        .min_by_key(|(_, candidate)| {
+            (
+                candidate.symbol.end_byte.saturating_sub(candidate.symbol.start_byte),
+                std::cmp::Reverse(candidate.symbol.start_byte),
+            )
+        })
+        .map(|(candidate_index, _)| candidate_index)
+}
+
+fn resolve_code_edge(
+    edge: &CodeIntelEdgeInput,
+    symbols: &[PreparedCodeSymbol<'_>],
+) -> ResolvedCodeEdge {
+    let source = symbols
+        .iter()
+        .filter(|symbol| symbol_contains_span(symbol.symbol, edge.start_byte, edge.end_byte))
+        .min_by_key(|symbol| {
+            (
+                symbol.symbol.end_byte.saturating_sub(symbol.symbol.start_byte),
+                std::cmp::Reverse(symbol.symbol.start_byte),
+            )
+        });
+    let target = edge
+        .target_hint
+        .as_deref()
+        .and_then(edge_target_name)
+        .and_then(|name| single_symbol_named(symbols, name));
+
+    ResolvedCodeEdge {
+        source_symbol_id: source.map(|symbol| symbol.symbol_id.clone()),
+        source_symbol_key: source.map(|symbol| symbol.symbol_key.clone()),
+        target_symbol_id: target.map(|symbol| symbol.symbol_id.clone()),
+        target_symbol_key: target.map(|symbol| symbol.symbol_key.clone()),
+        target_resolved: target.is_some(),
+    }
+}
+
+fn symbol_contains_span(symbol: &CodeIntelSymbolInput, start_byte: usize, end_byte: usize) -> bool {
+    symbol.start_byte <= start_byte && symbol.end_byte >= end_byte
+}
+
+fn edge_target_name(target_hint: &str) -> Option<&str> {
+    let before_call = target_hint.split_once('(').map_or(target_hint, |(name, _)| name);
+    before_call
+        .split([':', '.'])
+        .filter(|part| !part.is_empty())
+        .next_back()
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+}
+
+fn single_symbol_named<'a>(
+    symbols: &'a [PreparedCodeSymbol<'_>],
+    name: &str,
+) -> Option<&'a PreparedCodeSymbol<'a>> {
+    let mut matches = symbols.iter().filter(|symbol| symbol.symbol.name == name);
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+fn normalize_edge_confidence(input: &str, target_resolved: bool) -> &'static str {
+    if target_resolved {
+        return "exact";
+    }
+    let normalized = input.trim().to_ascii_lowercase();
+    if normalized.contains("heuristic") {
+        "heuristic"
+    } else {
+        "syntactic"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeSymbolRecord {
+    pub symbol_id: String,
+    pub symbol_key: String,
+    pub repo_id: String,
+    pub commit_sha: Option<String>,
+    pub path: String,
+    pub language: String,
+    pub kind: String,
+    pub name: String,
+    pub container_symbol_id: Option<String>,
+    pub container_chain: Vec<String>,
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub snippet_sha256: String,
+    pub freshness: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeEdgeRecord {
+    pub edge_id: String,
+    pub edge_kind: String,
+    pub source_symbol_key: Option<String>,
+    pub target_symbol_key: Option<String>,
+    pub target_hint: Option<String>,
+    pub confidence: String,
+    pub unresolved: bool,
+    pub path: String,
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeNeighborhood {
+    pub center: CodeSymbolRecord,
+    pub symbols: Vec<CodeSymbolRecord>,
+    pub edges: Vec<CodeEdgeRecord>,
+    pub max_depth: usize,
+    pub max_records: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodeSymbolDiffStatus {
+    Added,
+    Removed,
+    Modified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeSymbolDiff {
+    pub symbol_key: String,
+    pub status: CodeSymbolDiffStatus,
+    pub base: Option<CodeSymbolRecord>,
+    pub head: Option<CodeSymbolRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeSymbolComparison {
+    pub base_revision: String,
+    pub head_revision: String,
+    pub diffs: Vec<CodeSymbolDiff>,
+    pub max_records: usize,
+    pub truncated: bool,
+}
+
+pub fn code_symbol_detail(
+    config: &MemoryConfig,
+    symbol_key: &str,
+) -> Result<Option<CodeSymbolRecord>, MemoryError> {
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    query_code_symbol_by_key(&connection, symbol_key, true)
+}
+
+pub fn code_symbols_containing_span(
+    config: &MemoryConfig,
+    repo_id: &str,
+    path: &str,
+    line: usize,
+    column: usize,
+    limit: usize,
+) -> Result<Vec<CodeSymbolRecord>, MemoryError> {
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let mut statement = connection
+        .prepare(
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key",
+        )
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let rows = statement
+        .query_map(params![repo_id, path], |row| code_symbol_from_row(row))
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    rows.into_iter()
+        .filter(|symbol| symbol_contains_point(symbol, line, column))
+        .take(limit)
+        .map(|mut symbol| {
+            symbol.container_chain = load_container_chain(&connection, symbol.container_symbol_id.as_deref())?;
+            Ok(symbol)
+        })
+        .collect()
+}
+
+pub fn code_symbol_neighborhood(
+    config: &MemoryConfig,
+    symbol_key: &str,
+    max_depth: usize,
+    max_records: usize,
+) -> Result<Option<CodeNeighborhood>, MemoryError> {
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let Some(center) = query_code_symbol_by_key(&connection, symbol_key, true)? else {
+        return Ok(None);
+    };
+    let mut symbols = BTreeMap::from([(center.symbol_key.clone(), center.clone())]);
+    let mut edges = BTreeMap::<String, CodeEdgeRecord>::new();
+    let mut frontier = BTreeSet::from([center.symbol_key.clone()]);
+    let mut truncated = false;
+
+    for _ in 0..max_depth {
+        let mut next_frontier = BTreeSet::new();
+        for key in &frontier {
+            for edge in query_edges_for_symbol_key(&connection, key)? {
+                if edges.len() >= max_records {
+                    truncated = true;
+                    break;
+                }
+                for adjacent in [
+                    edge.source_symbol_key.as_deref(),
+                    edge.target_symbol_key.as_deref(),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    if !symbols.contains_key(adjacent) {
+                        if symbols.len() >= max_records {
+                            truncated = true;
+                            continue;
+                        }
+                        if let Some(symbol) = query_code_symbol_by_key(&connection, adjacent, true)? {
+                            next_frontier.insert(adjacent.to_string());
+                            symbols.insert(adjacent.to_string(), symbol);
+                        }
+                    }
+                }
+                edges.insert(edge.edge_id.clone(), edge);
+            }
+            if truncated {
+                break;
+            }
+        }
+        if truncated || next_frontier.is_empty() {
+            break;
+        }
+        frontier = next_frontier;
+    }
+
+    Ok(Some(CodeNeighborhood {
+        center,
+        symbols: symbols.into_values().collect(),
+        edges: edges.into_values().collect(),
+        max_depth,
+        max_records,
+        truncated,
+    }))
+}
+
+pub fn compare_code_symbols(
+    config: &MemoryConfig,
+    repo_id: &str,
+    base_revision: &str,
+    head_revision: &str,
+    max_records: usize,
+) -> Result<CodeSymbolComparison, MemoryError> {
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let base = query_symbols_for_revision(&connection, repo_id, base_revision)?;
+    let head = query_symbols_for_revision(&connection, repo_id, head_revision)?;
+    let mut keys = base.keys().cloned().collect::<BTreeSet<_>>();
+    keys.extend(head.keys().cloned());
+    let mut diffs = Vec::new();
+    let mut truncated = false;
+
+    for key in keys {
+        if diffs.len() >= max_records {
+            truncated = true;
+            break;
+        }
+        match (base.get(&key), head.get(&key)) {
+            (None, Some(head_symbol)) => diffs.push(CodeSymbolDiff {
+                symbol_key: key,
+                status: CodeSymbolDiffStatus::Added,
+                base: None,
+                head: Some(head_symbol.clone()),
+            }),
+            (Some(base_symbol), None) => diffs.push(CodeSymbolDiff {
+                symbol_key: key,
+                status: CodeSymbolDiffStatus::Removed,
+                base: Some(base_symbol.clone()),
+                head: None,
+            }),
+            (Some(base_symbol), Some(head_symbol))
+                if base_symbol.snippet_sha256 != head_symbol.snippet_sha256 =>
+            {
+                diffs.push(CodeSymbolDiff {
+                    symbol_key: key,
+                    status: CodeSymbolDiffStatus::Modified,
+                    base: Some(base_symbol.clone()),
+                    head: Some(head_symbol.clone()),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(CodeSymbolComparison {
+        base_revision: base_revision.to_string(),
+        head_revision: head_revision.to_string(),
+        diffs,
+        max_records,
+        truncated,
+    })
+}
+
+fn query_code_symbol_by_key(
+    connection: &Connection,
+    symbol_key: &str,
+    current_only: bool,
+) -> Result<Option<CodeSymbolRecord>, MemoryError> {
+    let sql = if current_only {
+        "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE symbol_key = ? AND freshness = 'current' ORDER BY indexed_at DESC, symbol_id LIMIT 1"
+    } else {
+        "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE symbol_key = ? ORDER BY indexed_at DESC, symbol_id LIMIT 1"
+    };
+    let mut statement = connection
+        .prepare(sql)
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    let mut rows = statement
+        .query(params![symbol_key])
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    let Some(row) = rows.next().map_err(|source| MemoryError::DuckDb {
+        path: PathBuf::from("<memory-index>"),
+        source,
+    })?
+    else {
+        return Ok(None);
+    };
+    let mut symbol = code_symbol_from_row(row).map_err(|source| MemoryError::DuckDb {
+        path: PathBuf::from("<memory-index>"),
+        source,
+    })?;
+    symbol.container_chain = load_container_chain(connection, symbol.container_symbol_id.as_deref())?;
+    Ok(Some(symbol))
+}
+
+fn query_symbols_for_revision(
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND commit_sha = ? ORDER BY symbol_key, indexed_at DESC, symbol_id",
+        )
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    let rows = statement
+        .query_map(params![repo_id, revision], |row| code_symbol_from_row(row))
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    let mut symbols = BTreeMap::new();
+    for mut symbol in rows {
+        if !symbols.contains_key(&symbol.symbol_key) {
+            symbol.container_chain = load_container_chain(connection, symbol.container_symbol_id.as_deref())?;
+            symbols.insert(symbol.symbol_key.clone(), symbol);
+        }
+    }
+    Ok(symbols)
+}
+
+fn query_edges_for_symbol_key(
+    connection: &Connection,
+    symbol_key: &str,
+) -> Result<Vec<CodeEdgeRecord>, MemoryError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, start_line, start_col, end_line, end_col FROM code_edges WHERE freshness = 'current' AND (source_symbol_key = ? OR target_symbol_key = ?) ORDER BY edge_kind, path, start_line, start_col, edge_id",
+        )
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    statement
+        .query_map(params![symbol_key, symbol_key], |row| code_edge_from_row(row))
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })
+}
+
+fn load_container_chain(
+    connection: &Connection,
+    container_symbol_id: Option<&str>,
+) -> Result<Vec<String>, MemoryError> {
+    let mut chain = Vec::new();
+    let mut next = container_symbol_id.map(str::to_string);
+    while let Some(symbol_id) = next {
+        let mut statement = connection
+            .prepare("SELECT name, container_symbol_id FROM code_symbols WHERE symbol_id = ? LIMIT 1")
+            .map_err(|source| MemoryError::DuckDb {
+                path: PathBuf::from("<memory-index>"),
+                source,
+            })?;
+        let mut rows = statement
+            .query(params![symbol_id])
+            .map_err(|source| MemoryError::DuckDb {
+                path: PathBuf::from("<memory-index>"),
+                source,
+            })?;
+        let Some(row) = rows.next().map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?
+        else {
+            break;
+        };
+        chain.push(row.get::<_, String>(0).map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?);
+        next = row.get::<_, Option<String>>(1).map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    }
+    chain.reverse();
+    Ok(chain)
+}
+
+fn code_symbol_from_row(row: &duckdb::Row<'_>) -> Result<CodeSymbolRecord, duckdb::Error> {
+    Ok(CodeSymbolRecord {
+        symbol_id: row.get(0)?,
+        symbol_key: row.get(1)?,
+        repo_id: row.get(2)?,
+        commit_sha: row.get(3)?,
+        path: row.get(4)?,
+        language: row.get(5)?,
+        kind: row.get(6)?,
+        name: row.get(7)?,
+        container_symbol_id: row.get(8)?,
+        container_chain: Vec::new(),
+        start_line: row.get::<_, i64>(9)? as usize,
+        start_col: row.get::<_, i64>(10)? as usize,
+        end_line: row.get::<_, i64>(11)? as usize,
+        end_col: row.get::<_, i64>(12)? as usize,
+        start_byte: row.get::<_, i64>(13)? as usize,
+        end_byte: row.get::<_, i64>(14)? as usize,
+        snippet_sha256: row.get(15)?,
+        freshness: row.get(16)?,
+    })
+}
+
+fn code_edge_from_row(row: &duckdb::Row<'_>) -> Result<CodeEdgeRecord, duckdb::Error> {
+    let target_symbol_key = row.get::<_, Option<String>>(3)?;
+    Ok(CodeEdgeRecord {
+        edge_id: row.get(0)?,
+        edge_kind: row.get(1)?,
+        source_symbol_key: row.get(2)?,
+        unresolved: target_symbol_key.is_none(),
+        target_symbol_key,
+        target_hint: row.get(4)?,
+        confidence: row.get(5)?,
+        path: row.get(6)?,
+        start_line: row.get::<_, i64>(7)? as usize,
+        start_col: row.get::<_, i64>(8)? as usize,
+        end_line: row.get::<_, i64>(9)? as usize,
+        end_col: row.get::<_, i64>(10)? as usize,
+    })
+}
+
+fn symbol_contains_point(symbol: &CodeSymbolRecord, line: usize, column: usize) -> bool {
+    (symbol.start_line < line || (symbol.start_line == line && symbol.start_col <= column))
+        && (symbol.end_line > line || (symbol.end_line == line && symbol.end_col >= column))
 }
 
 struct CodeFreshnessKey<'a> {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -861,8 +861,7 @@ fn edge_target_name(target_hint: &str) -> Option<&str> {
     let before_call = target_hint.split_once('(').map_or(target_hint, |(name, _)| name);
     before_call
         .split([':', '.'])
-        .filter(|part| !part.is_empty())
-        .next_back()
+        .rfind(|part| !part.is_empty())
         .map(str::trim)
         .filter(|part| !part.is_empty())
 }
@@ -994,7 +993,7 @@ pub fn code_symbols_containing_span(
             source,
         })?;
     let rows = statement
-        .query_map(params![repo_id, path], |row| code_symbol_from_row(row))
+        .query_map(params![repo_id, path], code_symbol_from_row)
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
             source,
@@ -1192,7 +1191,7 @@ fn query_symbols_for_revision(
             source,
         })?;
     let rows = statement
-        .query_map(params![repo_id, revision], |row| code_symbol_from_row(row))
+        .query_map(params![repo_id, revision], code_symbol_from_row)
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
             source,
@@ -1225,7 +1224,7 @@ fn query_edges_for_symbol_key(
             source,
         })?;
     statement
-        .query_map(params![symbol_key, symbol_key], |row| code_edge_from_row(row))
+        .query_map(params![symbol_key, symbol_key], code_edge_from_row)
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
             source,

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -823,15 +823,19 @@ fn container_symbol_index(symbols: &[PreparedCodeSymbol<'_>], child_index: usize
     let child = symbols[child_index].symbol;
     let parent_name = child.container_chain.last()?;
     let parent_chain = &child.container_chain[..child.container_chain.len().saturating_sub(1)];
-    symbols
+    let matches = symbols
         .iter()
         .enumerate()
         .filter(|(candidate_index, candidate)| {
             *candidate_index != child_index
                 && candidate.symbol.name == *parent_name
                 && candidate.symbol.container_chain == parent_chain
-                && symbol_contains_span(candidate.symbol, child.start_byte, child.end_byte)
         })
+        .collect::<Vec<_>>();
+    matches
+        .iter()
+        .copied()
+        .filter(|(_, candidate)| symbol_contains_span(candidate.symbol, child.start_byte, child.end_byte))
         .min_by_key(|(_, candidate)| {
             (
                 candidate.symbol.end_byte.saturating_sub(candidate.symbol.start_byte),
@@ -839,6 +843,7 @@ fn container_symbol_index(symbols: &[PreparedCodeSymbol<'_>], child_index: usize
             )
         })
         .map(|(candidate_index, _)| candidate_index)
+        .or_else(|| (matches.len() == 1).then(|| matches[0].0))
 }
 
 fn resolve_code_edge(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -255,6 +255,50 @@ fn open_existing_index_read_only(config: &MemoryConfig) -> Result<Option<Connect
     open_index_read_only(config).map(Some)
 }
 
+fn table_has_columns(
+    connection: &Connection,
+    path: &Path,
+    table: &str,
+    columns: &[&str],
+) -> Result<bool, MemoryError> {
+    let mut statement = connection
+        .prepare(&format!("SELECT name FROM pragma_table_info('{table}')"))
+        .map_err(|source| MemoryError::DuckDb {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let existing = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|source| MemoryError::DuckDb {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(|source| MemoryError::DuckDb {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(columns.iter().all(|column| existing.contains(*column)))
+}
+
+fn code_symbols_read_model_ready(connection: &Connection, path: &Path) -> Result<bool, MemoryError> {
+    table_has_columns(
+        connection,
+        path,
+        "code_symbols",
+        &["symbol_key", "container_chain", "worktree_dirty"],
+    )
+}
+
+fn code_edges_read_model_ready(connection: &Connection, path: &Path) -> Result<bool, MemoryError> {
+    table_has_columns(
+        connection,
+        path,
+        "code_edges",
+        &["source_symbol_key", "target_symbol_key", "worktree_dirty"],
+    )
+}
+
 fn migrate_index(connection: &Connection) -> Result<(), duckdb::Error> {
     connection.execute_batch(&format!(
         r#"
@@ -1038,6 +1082,9 @@ pub fn code_symbol_detail(
     let Some(connection) = open_existing_index_read_only(config)? else {
         return Ok(None);
     };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Ok(None);
+    }
     query_code_symbol_by_key(&connection, symbol_key, true)
 }
 
@@ -1052,6 +1099,9 @@ pub fn code_symbols_containing_span(
     let Some(connection) = open_existing_index_read_only(config)? else {
         return Ok(Vec::new());
     };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Ok(Vec::new());
+    }
     let mut statement = connection
         .prepare(
             "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' AND symbol_key != '' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key, indexed_at DESC, symbol_id",
@@ -1092,6 +1142,11 @@ pub fn code_symbol_neighborhood(
     let Some(connection) = open_existing_index_read_only(config)? else {
         return Ok(None);
     };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)?
+        || !code_edges_read_model_ready(&connection, &config.index_path)?
+    {
+        return Ok(None);
+    }
     let Some(center) = query_code_symbol_by_key(&connection, symbol_key, true)? else {
         return Ok(None);
     };
@@ -1181,6 +1236,15 @@ pub fn compare_code_symbols(
             truncated: false,
         });
     };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Ok(CodeSymbolComparison {
+            base_revision: base_revision.to_string(),
+            head_revision: head_revision.to_string(),
+            diffs: Vec::new(),
+            max_records,
+            truncated: false,
+        });
+    }
     let base = query_symbols_for_revision(&connection, repo_id, base_revision)?;
     let head = query_symbols_for_revision(&connection, repo_id, head_revision)?;
     let mut keys = base.keys().cloned().collect::<BTreeSet<_>>();

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -248,6 +248,13 @@ fn open_index_read_only(config: &MemoryConfig) -> Result<Connection, MemoryError
     })
 }
 
+fn open_existing_index_read_only(config: &MemoryConfig) -> Result<Option<Connection>, MemoryError> {
+    if !config.index_path.exists() {
+        return Ok(None);
+    }
+    open_index_read_only(config).map(Some)
+}
+
 fn migrate_index(connection: &Connection) -> Result<(), duckdb::Error> {
     connection.execute_batch(&format!(
         r#"
@@ -609,7 +616,6 @@ pub fn persist_code_intel_documents(
             &path,
             &document,
         );
-
         for prepared in &prepared_symbols {
             let symbol = prepared.symbol;
             transaction
@@ -875,14 +881,16 @@ fn trait_impl_owner_symbol_index(
     if child.container_chain.len() < 2 {
         return None;
     }
-    let owner_name = child.container_chain.first()?;
+    let owner_index = child.container_chain.len().saturating_sub(2);
+    let owner_name = child.container_chain.get(owner_index)?;
+    let owner_chain = &child.container_chain[..owner_index];
     let matches = symbols
         .iter()
         .enumerate()
         .filter(|(candidate_index, candidate)| {
             *candidate_index != child_index
                 && candidate.symbol.name == *owner_name
-                && candidate.symbol.container_chain.is_empty()
+                && candidate.symbol.container_chain == owner_chain
         })
         .collect::<Vec<_>>();
     (matches.len() == 1).then(|| matches[0].0)
@@ -1027,11 +1035,9 @@ pub fn code_symbol_detail(
     config: &MemoryConfig,
     symbol_key: &str,
 ) -> Result<Option<CodeSymbolRecord>, MemoryError> {
-    let connection = open_index(config)?;
-    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
-        path: config.index_path.clone(),
-        source,
-    })?;
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Ok(None);
+    };
     query_code_symbol_by_key(&connection, symbol_key, true)
 }
 
@@ -1043,11 +1049,9 @@ pub fn code_symbols_containing_span(
     column: usize,
     limit: usize,
 ) -> Result<Vec<CodeSymbolRecord>, MemoryError> {
-    let connection = open_index(config)?;
-    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
-        path: config.index_path.clone(),
-        source,
-    })?;
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Ok(Vec::new());
+    };
     let mut statement = connection
         .prepare(
             "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' AND symbol_key != '' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key, indexed_at DESC, symbol_id",
@@ -1085,11 +1089,9 @@ pub fn code_symbol_neighborhood(
     max_depth: usize,
     max_records: usize,
 ) -> Result<Option<CodeNeighborhood>, MemoryError> {
-    let connection = open_index(config)?;
-    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
-        path: config.index_path.clone(),
-        source,
-    })?;
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Ok(None);
+    };
     let Some(center) = query_code_symbol_by_key(&connection, symbol_key, true)? else {
         return Ok(None);
     };
@@ -1170,11 +1172,15 @@ pub fn compare_code_symbols(
     head_revision: &str,
     max_records: usize,
 ) -> Result<CodeSymbolComparison, MemoryError> {
-    let connection = open_index(config)?;
-    migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
-        path: config.index_path.clone(),
-        source,
-    })?;
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Ok(CodeSymbolComparison {
+            base_revision: base_revision.to_string(),
+            head_revision: head_revision.to_string(),
+            diffs: Vec::new(),
+            max_records,
+            truncated: false,
+        });
+    };
     let base = query_symbols_for_revision(&connection, repo_id, base_revision)?;
     let head = query_symbols_for_revision(&connection, repo_id, head_revision)?;
     let mut keys = base.keys().cloned().collect::<BTreeSet<_>>();

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -400,6 +400,7 @@ CREATE TABLE IF NOT EXISTS code_symbols (
   kind TEXT NOT NULL,
   name TEXT NOT NULL,
   container_symbol_id TEXT,
+  container_chain TEXT NOT NULL DEFAULT '',
   signature TEXT,
   start_line BIGINT NOT NULL,
   start_col BIGINT NOT NULL,
@@ -467,6 +468,8 @@ CREATE TABLE IF NOT EXISTS code_diagnostics (
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
 UPDATE code_symbols SET worktree_dirty = false WHERE worktree_dirty IS NULL;
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS symbol_key TEXT DEFAULT '';
+ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS container_chain TEXT DEFAULT '';
+UPDATE code_symbols SET container_chain = '' WHERE container_chain IS NULL;
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS parser_version TEXT DEFAULT '';
 UPDATE code_symbols SET parser_version = '' WHERE parser_version IS NULL;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
@@ -577,13 +580,19 @@ pub fn persist_code_intel_documents(
             })?;
         report.persisted_documents += 1;
 
-        let prepared_symbols = prepare_code_symbols(&batch.repo_id, &path, &document);
+        let prepared_symbols = prepare_code_symbols(
+            &batch.repo_id,
+            batch.commit_sha.as_deref(),
+            batch.worktree_dirty,
+            &path,
+            &document,
+        );
 
         for prepared in &prepared_symbols {
             let symbol = prepared.symbol;
             transaction
                 .execute(
-                    "INSERT OR REPLACE INTO code_symbols (symbol_id, symbol_key, repo_id, commit_sha, worktree_dirty, path, language, kind, name, container_symbol_id, signature, start_line, start_col, end_line, end_col, start_byte, end_byte, selection_start_line, selection_end_line, content_sha256, snippet_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT OR REPLACE INTO code_symbols (symbol_id, symbol_key, repo_id, commit_sha, worktree_dirty, path, language, kind, name, container_symbol_id, container_chain, signature, start_line, start_col, end_line, end_col, start_byte, end_byte, selection_start_line, selection_end_line, content_sha256, snippet_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
                         prepared.symbol_id,
                         prepared.symbol_key,
@@ -595,6 +604,7 @@ pub fn persist_code_intel_documents(
                         symbol.kind,
                         symbol.name,
                         prepared.container_symbol_id,
+                        symbol.container_chain.join("\u{1f}"),
                         symbol.signature,
                         symbol.start_line as i64,
                         symbol.start_col as i64,
@@ -749,6 +759,8 @@ struct ResolvedCodeEdge {
 
 fn prepare_code_symbols<'a>(
     repo_id: &str,
+    commit_sha: Option<&str>,
+    worktree_dirty: bool,
     path: &str,
     document: &'a CodeIntelDocumentInput,
 ) -> Vec<PreparedCodeSymbol<'a>> {
@@ -759,6 +771,8 @@ fn prepare_code_symbols<'a>(
         .map(|symbol| {
             let symbol_id = code_row_id(&[
                 repo_id,
+                commit_sha.unwrap_or(""),
+                if worktree_dirty { "dirty" } else { "clean" },
                 path,
                 &document.content_sha256,
                 &document.parser_version,
@@ -876,11 +890,10 @@ fn single_symbol_named<'a>(
 }
 
 fn normalize_edge_confidence(input: &str, target_resolved: bool) -> &'static str {
-    if target_resolved {
-        return "exact";
-    }
     let normalized = input.trim().to_ascii_lowercase();
-    if normalized.contains("heuristic") {
+    if target_resolved && normalized.contains("exact") {
+        "exact"
+    } else if normalized.contains("heuristic") {
         "heuristic"
     } else {
         "syntactic"
@@ -986,7 +999,7 @@ pub fn code_symbols_containing_span(
     })?;
     let mut statement = connection
         .prepare(
-            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key",
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current' ORDER BY start_line, start_col, end_line DESC, end_col DESC, symbol_key",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -1007,7 +1020,7 @@ pub fn code_symbols_containing_span(
         .filter(|symbol| symbol_contains_point(symbol, line, column))
         .take(limit)
         .map(|mut symbol| {
-            symbol.container_chain = load_container_chain(&connection, symbol.container_symbol_id.as_deref())?;
+            fill_container_chain(&connection, &mut symbol)?;
             Ok(symbol)
         })
         .collect()
@@ -1146,9 +1159,9 @@ fn query_code_symbol_by_key(
     current_only: bool,
 ) -> Result<Option<CodeSymbolRecord>, MemoryError> {
     let sql = if current_only {
-        "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE symbol_key = ? AND freshness = 'current' ORDER BY indexed_at DESC, symbol_id LIMIT 1"
+        "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE symbol_key = ? AND freshness = 'current' ORDER BY indexed_at DESC, symbol_id LIMIT 1"
     } else {
-        "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE symbol_key = ? ORDER BY indexed_at DESC, symbol_id LIMIT 1"
+        "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE symbol_key = ? ORDER BY indexed_at DESC, symbol_id LIMIT 1"
     };
     let mut statement = connection
         .prepare(sql)
@@ -1173,7 +1186,7 @@ fn query_code_symbol_by_key(
         path: PathBuf::from("<memory-index>"),
         source,
     })?;
-    symbol.container_chain = load_container_chain(connection, symbol.container_symbol_id.as_deref())?;
+    fill_container_chain(connection, &mut symbol)?;
     Ok(Some(symbol))
 }
 
@@ -1184,7 +1197,7 @@ fn query_symbols_for_revision(
 ) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
     let mut statement = connection
         .prepare(
-            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND commit_sha = ? ORDER BY symbol_key, indexed_at DESC, symbol_id",
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND commit_sha = ? ORDER BY symbol_key, indexed_at DESC, symbol_id",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
@@ -1204,7 +1217,7 @@ fn query_symbols_for_revision(
     let mut symbols = BTreeMap::new();
     for mut symbol in rows {
         if !symbols.contains_key(&symbol.symbol_key) {
-            symbol.container_chain = load_container_chain(connection, symbol.container_symbol_id.as_deref())?;
+            fill_container_chain(connection, &mut symbol)?;
             symbols.insert(symbol.symbol_key.clone(), symbol);
         }
     }
@@ -1275,6 +1288,17 @@ fn load_container_chain(
     Ok(chain)
 }
 
+fn fill_container_chain(
+    connection: &Connection,
+    symbol: &mut CodeSymbolRecord,
+) -> Result<(), MemoryError> {
+    if symbol.container_chain.is_empty() {
+        symbol.container_chain =
+            load_container_chain(connection, symbol.container_symbol_id.as_deref())?;
+    }
+    Ok(())
+}
+
 fn code_symbol_from_row(row: &duckdb::Row<'_>) -> Result<CodeSymbolRecord, duckdb::Error> {
     Ok(CodeSymbolRecord {
         symbol_id: row.get(0)?,
@@ -1286,15 +1310,20 @@ fn code_symbol_from_row(row: &duckdb::Row<'_>) -> Result<CodeSymbolRecord, duckd
         kind: row.get(6)?,
         name: row.get(7)?,
         container_symbol_id: row.get(8)?,
-        container_chain: Vec::new(),
-        start_line: row.get::<_, i64>(9)? as usize,
-        start_col: row.get::<_, i64>(10)? as usize,
-        end_line: row.get::<_, i64>(11)? as usize,
-        end_col: row.get::<_, i64>(12)? as usize,
-        start_byte: row.get::<_, i64>(13)? as usize,
-        end_byte: row.get::<_, i64>(14)? as usize,
-        snippet_sha256: row.get(15)?,
-        freshness: row.get(16)?,
+        container_chain: row
+            .get::<_, String>(9)?
+            .split('\u{1f}')
+            .filter(|part| !part.is_empty())
+            .map(str::to_string)
+            .collect(),
+        start_line: row.get::<_, i64>(10)? as usize,
+        start_col: row.get::<_, i64>(11)? as usize,
+        end_line: row.get::<_, i64>(12)? as usize,
+        end_col: row.get::<_, i64>(13)? as usize,
+        start_byte: row.get::<_, i64>(14)? as usize,
+        end_byte: row.get::<_, i64>(15)? as usize,
+        snippet_sha256: row.get(16)?,
+        freshness: row.get(17)?,
     })
 }
 
@@ -1318,7 +1347,7 @@ fn code_edge_from_row(row: &duckdb::Row<'_>) -> Result<CodeEdgeRecord, duckdb::E
 
 fn symbol_contains_point(symbol: &CodeSymbolRecord, line: usize, column: usize) -> bool {
     (symbol.start_line < line || (symbol.start_line == line && symbol.start_col <= column))
-        && (symbol.end_line > line || (symbol.end_line == line && symbol.end_col >= column))
+        && (symbol.end_line > line || (symbol.end_line == line && column < symbol.end_col))
 }
 
 struct CodeFreshnessKey<'a> {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -465,15 +465,11 @@ CREATE TABLE IF NOT EXISTS code_diagnostics (
   indexed_at TEXT NOT NULL,
   freshness TEXT NOT NULL
 );
-ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
-UPDATE code_symbols SET worktree_dirty = false WHERE worktree_dirty IS NULL;
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS symbol_key TEXT DEFAULT '';
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS container_chain TEXT DEFAULT '';
 UPDATE code_symbols SET container_chain = '' WHERE container_chain IS NULL;
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS parser_version TEXT DEFAULT '';
 UPDATE code_symbols SET parser_version = '' WHERE parser_version IS NULL;
-ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
-UPDATE code_edges SET worktree_dirty = false WHERE worktree_dirty IS NULL;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS source_symbol_key TEXT;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS target_symbol_key TEXT;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS start_col BIGINT DEFAULT 0;
@@ -486,8 +482,6 @@ ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS end_byte BIGINT DEFAULT 0;
 UPDATE code_edges SET end_byte = 0 WHERE end_byte IS NULL;
 ALTER TABLE code_edges ADD COLUMN IF NOT EXISTS parser_version TEXT DEFAULT '';
 UPDATE code_edges SET parser_version = '' WHERE parser_version IS NULL;
-ALTER TABLE code_diagnostics ADD COLUMN IF NOT EXISTS worktree_dirty BOOLEAN DEFAULT false;
-UPDATE code_diagnostics SET worktree_dirty = false WHERE worktree_dirty IS NULL;
 ALTER TABLE code_diagnostics ADD COLUMN IF NOT EXISTS start_col BIGINT DEFAULT 0;
 UPDATE code_diagnostics SET start_col = 0 WHERE start_col IS NULL;
 ALTER TABLE code_diagnostics ADD COLUMN IF NOT EXISTS end_col BIGINT DEFAULT 0;
@@ -508,7 +502,35 @@ CREATE INDEX IF NOT EXISTS idx_code_edges_source_key ON code_edges(source_symbol
 CREATE INDEX IF NOT EXISTS idx_code_edges_target_key ON code_edges(target_symbol_key);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostics_path ON code_diagnostics(path);
 "#,
-    ))
+    ))?;
+    for table in [
+        "code_documents",
+        "code_symbols",
+        "code_edges",
+        "code_diagnostics",
+    ] {
+        ensure_worktree_dirty_column(connection, table)?;
+    }
+    Ok(())
+}
+
+fn ensure_worktree_dirty_column(connection: &Connection, table: &str) -> Result<(), duckdb::Error> {
+    let column_count: i64 = connection.query_row(
+        &format!("SELECT count(*) FROM pragma_table_info('{table}') WHERE name = 'worktree_dirty'"),
+        [],
+        |row| row.get(0),
+    )?;
+    if column_count == 0 {
+        connection.execute(
+            &format!("ALTER TABLE {table} ADD COLUMN worktree_dirty BOOLEAN DEFAULT false"),
+            [],
+        )?;
+    }
+    connection.execute(
+        &format!("UPDATE {table} SET worktree_dirty = false WHERE worktree_dirty IS NULL"),
+        [],
+    )?;
+    Ok(())
 }
 
 pub fn persist_code_intel_documents(
@@ -537,9 +559,7 @@ pub fn persist_code_intel_documents(
         skipped_files: Vec::new(),
         diagnostics: Vec::new(),
     };
-    let stored_commit_sha =
-        code_revision_key(batch.commit_sha.as_deref(), batch.worktree_dirty);
-
+    let worktree_dirty = if batch.worktree_dirty { 1_i64 } else { 0_i64 };
     for document in batch.documents {
         let path = document.path.to_string_lossy().to_string();
         report.stale_rows += stale_code_rows(
@@ -562,8 +582,8 @@ pub fn persist_code_intel_documents(
                 "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
                         batch.repo_id,
-                    stored_commit_sha.clone(),
-                        batch.worktree_dirty,
+                    batch.commit_sha.clone(),
+                        worktree_dirty,
                     path,
                     document.language,
                     document.content_sha256,
@@ -584,7 +604,7 @@ pub fn persist_code_intel_documents(
 
         let prepared_symbols = prepare_code_symbols(
             &batch.repo_id,
-            stored_commit_sha.as_deref(),
+            batch.commit_sha.as_deref(),
             batch.worktree_dirty,
             &path,
             &document,
@@ -599,8 +619,8 @@ pub fn persist_code_intel_documents(
                         prepared.symbol_id,
                         prepared.symbol_key,
                         batch.repo_id,
-                        stored_commit_sha.clone(),
-                        batch.worktree_dirty,
+                        batch.commit_sha.clone(),
+                        worktree_dirty,
                         path,
                         document.language,
                         symbol.kind,
@@ -654,8 +674,8 @@ pub fn persist_code_intel_documents(
                     params![
                         edge_id,
                         batch.repo_id,
-                        stored_commit_sha.clone(),
-                        batch.worktree_dirty,
+                        batch.commit_sha.clone(),
+                        worktree_dirty,
                         path,
                         document.language,
                         edge.edge_kind,
@@ -707,8 +727,8 @@ pub fn persist_code_intel_documents(
                     params![
                         diagnostic_id,
                         batch.repo_id,
-                        stored_commit_sha.clone(),
-                        batch.worktree_dirty,
+                        batch.commit_sha.clone(),
+                        worktree_dirty,
                         path,
                         document.language,
                         diagnostic.kind,
@@ -844,6 +864,28 @@ fn container_symbol_index(symbols: &[PreparedCodeSymbol<'_>], child_index: usize
         })
         .map(|(candidate_index, _)| candidate_index)
         .or_else(|| (matches.len() == 1).then(|| matches[0].0))
+        .or_else(|| trait_impl_owner_symbol_index(symbols, child_index))
+}
+
+fn trait_impl_owner_symbol_index(
+    symbols: &[PreparedCodeSymbol<'_>],
+    child_index: usize,
+) -> Option<usize> {
+    let child = symbols[child_index].symbol;
+    if child.container_chain.len() < 2 {
+        return None;
+    }
+    let owner_name = child.container_chain.first()?;
+    let matches = symbols
+        .iter()
+        .enumerate()
+        .filter(|(candidate_index, candidate)| {
+            *candidate_index != child_index
+                && candidate.symbol.name == *owner_name
+                && candidate.symbol.container_chain.is_empty()
+        })
+        .collect::<Vec<_>>();
+    (matches.len() == 1).then(|| matches[0].0)
 }
 
 fn resolve_code_edge(
@@ -1219,14 +1261,21 @@ fn query_symbols_for_revision(
 ) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
     let mut statement = connection
         .prepare(
-            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' ORDER BY symbol_key, indexed_at DESC, symbol_id",
+            "SELECT symbol_id, symbol_key, repo_id, commit_sha, path, language, kind, name, container_symbol_id, container_chain, start_line, start_col, end_line, end_col, start_byte, end_byte, snippet_sha256, freshness, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' ORDER BY symbol_key, indexed_at DESC, symbol_id",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
             source,
         })?;
     let rows = statement
-        .query_map(params![repo_id, revision], code_symbol_from_row)
+        .query_map(params![repo_id, revision], |row| {
+            let dirty = row.get::<_, i64>(18)?;
+            if dirty != 0 {
+                Ok(None)
+            } else {
+                code_symbol_from_row(row).map(Some)
+            }
+        })
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
             source,
@@ -1237,7 +1286,10 @@ fn query_symbols_for_revision(
             source,
         })?;
     let mut symbols = BTreeMap::new();
-    for mut symbol in rows {
+    for row in rows {
+        let Some(mut symbol) = row else {
+            continue;
+        };
         if !symbols.contains_key(&symbol.symbol_key) {
             fill_container_chain(connection, &mut symbol)?;
             symbols.insert(symbol.symbol_key.clone(), symbol);
@@ -1406,16 +1458,6 @@ fn stale_code_rows(
 
 fn code_row_id(parts: &[&str]) -> String {
     sha256_hex(&parts.join("\u{1f}"))
-}
-
-fn code_revision_key(commit_sha: Option<&str>, worktree_dirty: bool) -> Option<String> {
-    commit_sha.map(|sha| {
-        if worktree_dirty {
-            format!("{sha}+dirty")
-        } else {
-            sha.to_string()
-        }
-    })
 }
 
 fn load_indexed_issues(config: &MemoryConfig) -> Result<Vec<IndexedIssue>, MemoryError> {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -1151,10 +1151,16 @@ pub fn code_symbol_neighborhood(
 }
 
 fn edge_endpoints_present(edge: &CodeEdgeRecord, symbols: &BTreeMap<String, CodeSymbolRecord>) -> bool {
-    [edge.source_symbol_key.as_deref(), edge.target_symbol_key.as_deref()]
-        .into_iter()
-        .flatten()
-        .all(|key| symbols.contains_key(key))
+    let Some(source) = edge.source_symbol_key.as_deref() else {
+        return false;
+    };
+    if !symbols.contains_key(source) {
+        return false;
+    }
+    match edge.target_symbol_key.as_deref() {
+        Some(target) => symbols.contains_key(target),
+        None => edge.unresolved,
+    }
 }
 
 pub fn compare_code_symbols(
@@ -1177,18 +1183,14 @@ pub fn compare_code_symbols(
     let mut truncated = false;
 
     for key in keys {
-        if diffs.len() >= max_records {
-            truncated = true;
-            break;
-        }
-        match (base.get(&key), head.get(&key)) {
-            (None, Some(head_symbol)) => diffs.push(CodeSymbolDiff {
+        let diff = match (base.get(&key), head.get(&key)) {
+            (None, Some(head_symbol)) => Some(CodeSymbolDiff {
                 symbol_key: key,
                 status: CodeSymbolDiffStatus::Added,
                 base: None,
                 head: Some(head_symbol.clone()),
             }),
-            (Some(base_symbol), None) => diffs.push(CodeSymbolDiff {
+            (Some(base_symbol), None) => Some(CodeSymbolDiff {
                 symbol_key: key,
                 status: CodeSymbolDiffStatus::Removed,
                 base: Some(base_symbol.clone()),
@@ -1197,14 +1199,21 @@ pub fn compare_code_symbols(
             (Some(base_symbol), Some(head_symbol))
                 if base_symbol.snippet_sha256 != head_symbol.snippet_sha256 =>
             {
-                diffs.push(CodeSymbolDiff {
+                Some(CodeSymbolDiff {
                     symbol_key: key,
                     status: CodeSymbolDiffStatus::Modified,
                     base: Some(base_symbol.clone()),
                     head: Some(head_symbol.clone()),
-                });
+                })
             }
-            _ => {}
+            _ => None,
+        };
+        if let Some(diff) = diff {
+            if diffs.len() >= max_records {
+                truncated = true;
+                break;
+            }
+            diffs.push(diff);
         }
     }
 

--- a/crates/opensymphony-memory/src/lib.rs
+++ b/crates/opensymphony-memory/src/lib.rs
@@ -431,6 +431,7 @@ pub struct CodeIntelDocumentInput {
 pub struct CodeIntelSymbolInput {
     pub kind: String,
     pub name: String,
+    pub container_chain: Vec<String>,
     pub signature: Option<String>,
     pub start_line: usize,
     pub start_col: usize,


### PR DESCRIPTION
## Summary

Adds stable logical symbol identity and read-model primitives for the Code Graph while preserving revision-bound `symbol_id` provenance and real checked-out `commit_sha` values.

## Changes

- Add AST container-chain extraction on symbol records, including Rust `impl` owner chains, lexical parent chains, and trait-impl qualifiers, and pass container chains into memory persistence.
- Persist `symbol_key`, duplicate ordinal suffixes, container symbol IDs, source/target symbol-key edge endpoints, and normalized edge confidence.
- Add memory read-model helpers for symbol detail, deduplicated span containment, bounded self-contained neighborhoods, and revision-pair comparison by `symbol_key`.
- Keep qualified syntactic call hints unresolved instead of resolving by basename, drop source-less neighborhood edges explicitly, and isolate dirty worktree code-intel rows with `worktree_dirty` while keeping `commit_sha` as the real HEAD.
- Keep code graph read helpers read-only: symbol detail, span containment, neighborhoods, and revision comparisons no longer create or migrate the DuckDB index while serving lookups.
- Schema-gate code graph reads on legacy indexes that predate `symbol_key`/container/edge-key columns, returning empty read results instead of mutating or failing on missing columns.
- Split qualified Rust impl owners such as `m::Widget` into container-chain components so impl methods align with the indexed owner hierarchy.
- Persist the full parsed symbol set for persistent code-intel ingest so edge endpoint resolution is not capped by the artifact display limit.
- Add focused tests for stable identity, duplicates, containers, nested chains, impl parent linking, trait-impl owner links, edge resolution, traversal bounds, read-only lookups, legacy-index schema gating, dirty revision isolation, and revision diff classification/truncation.

## Evidence

### Test output

```text
cargo test-system-duckdb rust_qualified_impl_owners_split_into_container_chain_parts -- --nocapture
result: 1 passed; 0 failed

cargo test-system-duckdb opensymphony_code_intel::tests -- --nocapture
result: 34 passed; 0 failed

cargo fmt --check
result: passed

git diff --check
result: passed

cargo clippy --workspace --all-targets -- -D warnings
result: passed

cargo test-system-duckdb code_intel_read_helpers_schema_gate_legacy_index -- --nocapture
result: 1 passed; 0 failed

cargo test-system-duckdb memory_ingest_code_intel_limit_does_not_cap_persisted_symbols -- --nocapture
result: 1 passed; 0 failed

cargo test-system-duckdb code_intel_read_helpers_do_not_create_index -- --nocapture
result: 1 passed; 0 failed

cargo test-system-duckdb code_intel_impl_methods_link_to_owner_symbol_by_chain -- --nocapture
result: 1 passed; 0 failed

cargo test-system-duckdb code_intel_ -- --nocapture
result: 22 passed; 0 failed

cargo test-system-duckdb opensymphony_code_intel::tests -- --nocapture
result: 33 passed; 0 failed

cargo test-system-duckdb --test memory
result: 46 passed; 0 failed

cargo fmt --check
result: passed

git diff --check
result: passed

cargo clippy --workspace --all-targets -- -D warnings
result: passed
```

### Verification

Reproduced the initial gap before editing: `SymbolRecord` had no container fields, `code_symbols` had no `symbol_key`, and persistence inserted `container_symbol_id` as `NULL`. The tests now verify `symbol_id` changes across content/span changes while `symbol_key` remains stable, duplicate logical symbols receive `#2` suffixes, nested and Rust impl container chains are returned, qualified Rust impl owners split into container-chain parts before method key generation, trait impl methods include the trait qualifier in stable keys, nested Rust impl methods preserve lexical parents, trait impl methods link to owner symbols even inside lexical containers, persistent ingest keeps all parsed symbols available for edge resolution despite a low artifact limit, code graph read helpers do not create or migrate the index, legacy pre-code-graph indexes return empty read results without adding columns, syntactic/qualified edge targets stay honest, neighborhoods omit source-less edges and report truncation, dirty worktree rows keep real `commit_sha` values without polluting clean revision comparisons, and revision comparison returns added/removed/modified symbols without false truncation on exact-sized pages.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other:

## Breaking changes

None. The existing revision-bound `symbol_id` remains revision-scoped; `symbol_key` is added beside it as stable logical identity, and persisted `commit_sha` values remain the checked-out revision.

## Related issues

COE-532

## Additional notes

The requested `cargo test-system-duckdb --test code_intel` target does not exist in this repo; code-intel coverage is under `opensymphony_code_intel::tests`, which passed.

