### PR TITLE
fix(orchestrator): stop reporting parked recovered issues as completed

### DIFF
--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -289,7 +289,16 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
     let server =
         GatewayServer::with_journal(store.clone(), gateway_journal.clone(), gateway_broker)
             .with_linear_task_graph(build_optional_task_graph_client(&runtime.workflow))
-            .with_memory_config(server_memory_config);
+            .with_memory_config(server_memory_config)
+            .with_active_states(
+                runtime
+                    .workflow
+                    .config
+                    .tracker
+                    .active_states
+                    .iter()
+                    .cloned(),
+            );
     let mut server_task = tokio::spawn(async move { server.serve(listener).await });
     let mut gateway_action_cursor = 0;
 

--- a/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
@@ -11,8 +11,8 @@ use crate::opensymphony_control::{
     RecentEventKind, WorkerOutcome,
 };
 use crate::opensymphony_domain::{
-    HarnessInterruptStatus, HealthStatus, IssueIdentifier, OrchestratorSnapshot, ReleaseReason,
-    SchedulerStatus, WorkerOutcomeKind,
+    HarnessInterruptStatus, HealthStatus, IssueIdentifier, IssueStateCategory,
+    OrchestratorSnapshot, SchedulerStatus, WorkerOutcomeKind,
 };
 use crate::opensymphony_openhands::LocalServerSupervisor;
 use crate::opensymphony_workflow::ResolvedWorkflow;
@@ -106,11 +106,15 @@ fn map_issue(
                 | WorkerOutcomeKind::TimedOut
                 | WorkerOutcomeKind::Stalled,
             ) => IssueRuntimeState::Failed,
-            // A tracker-inactive release with no recorded run is a parked
-            // issue (e.g. a recovered workspace whose issue sits in Backlog),
-            // not a completion — reporting it Completed would surface phantom
-            // rows in every completed-work view.
-            None if issue.runtime.release_reason == Some(ReleaseReason::TrackerInactive) => {
+            // A released execution with no recorded run never dispatched a
+            // worker (e.g. a recovered workspace parked while its issue sits
+            // in a non-active tracker state). Key on the *current* tracker
+            // state, not the release reason: `release_issue` refreshes the
+            // issue state but leaves a stale `TrackerInactive` reason when the
+            // execution is already released, so a parked issue later moved
+            // straight to a terminal state (Backlog → Done) must still surface
+            // as a completion rather than a phantom idle row.
+            None if issue.issue.state.category != IssueStateCategory::Terminal => {
                 IssueRuntimeState::Idle
             }
             _ => IssueRuntimeState::Completed,
@@ -745,6 +749,24 @@ tracker:
             "Done",
             IssueStateCategory::Terminal,
             crate::opensymphony_domain::ReleaseReason::TrackerTerminal,
+        ));
+        assert_eq!(
+            state,
+            crate::opensymphony_control::IssueRuntimeState::Completed
+        );
+    }
+
+    #[test]
+    fn stale_tracker_inactive_reason_with_terminal_state_still_maps_to_completed() {
+        // A parked issue (released `TrackerInactive`) moved straight to Done
+        // keeps its stale release reason because `release_issue` does not
+        // re-release an already-released execution. The current terminal
+        // tracker state must still win so the completion reaches the
+        // Completed pane and dashboard instead of vanishing as idle.
+        let state = map_single_issue_runtime_state(released_issue_snapshot(
+            "Done",
+            IssueStateCategory::Terminal,
+            crate::opensymphony_domain::ReleaseReason::TrackerInactive,
         ));
         assert_eq!(
             state,

--- a/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/snapshot.rs
@@ -11,8 +11,8 @@ use crate::opensymphony_control::{
     RecentEventKind, WorkerOutcome,
 };
 use crate::opensymphony_domain::{
-    HarnessInterruptStatus, HealthStatus, IssueIdentifier, OrchestratorSnapshot, SchedulerStatus,
-    WorkerOutcomeKind,
+    HarnessInterruptStatus, HealthStatus, IssueIdentifier, OrchestratorSnapshot, ReleaseReason,
+    SchedulerStatus, WorkerOutcomeKind,
 };
 use crate::opensymphony_openhands::LocalServerSupervisor;
 use crate::opensymphony_workflow::ResolvedWorkflow;
@@ -106,6 +106,13 @@ fn map_issue(
                 | WorkerOutcomeKind::TimedOut
                 | WorkerOutcomeKind::Stalled,
             ) => IssueRuntimeState::Failed,
+            // A tracker-inactive release with no recorded run is a parked
+            // issue (e.g. a recovered workspace whose issue sits in Backlog),
+            // not a completion — reporting it Completed would surface phantom
+            // rows in every completed-work view.
+            None if issue.runtime.release_reason == Some(ReleaseReason::TrackerInactive) => {
+                IssueRuntimeState::Idle
+            }
             _ => IssueRuntimeState::Completed,
         },
         SchedulerStatus::Unclaimed => IssueRuntimeState::Idle,
@@ -634,5 +641,114 @@ tracker:
             Some("OpenSymphony")
         );
         assert_eq!(mapped.issues[0].workspace_label.as_deref(), Some("COE-352"));
+    }
+
+    fn released_issue_snapshot(
+        state_name: &str,
+        category: IssueStateCategory,
+        release_reason: crate::opensymphony_domain::ReleaseReason,
+    ) -> DomainIssueSnapshot {
+        DomainIssueSnapshot {
+            issue: NormalizedIssue {
+                id: must(IssueId::new("lin_532")),
+                identifier: must(IssueIdentifier::new("COE-532")),
+                title: "Symbol identity container chain".to_owned(),
+                description: None,
+                priority: None,
+                state: IssueState {
+                    id: None,
+                    name: state_name.to_owned(),
+                    category,
+                },
+                branch_name: None,
+                pr_url: None,
+                url: None,
+                labels: Vec::new(),
+                project_id: None,
+                project_slug: None,
+                project_name: None,
+                parent_id: None,
+                blocked_by: Vec::<BlockerRef>::new(),
+                sub_issues: Vec::<IssueRef>::new(),
+                created_at: None,
+                updated_at: None,
+            },
+            runtime: RuntimeStateSnapshot {
+                state: SchedulerStatus::Released,
+                claimed_at: None,
+                started_at: None,
+                released_at: Some(ts(1_500)),
+                release_reason: Some(release_reason),
+                worker: None,
+                last_event_at: None,
+                stalled_at: None,
+                interrupt: None,
+            },
+            workspace: None,
+            conversation: None,
+            retry: None,
+            last_worker_outcome: None,
+            recent_worker_outcomes: Vec::new(),
+        }
+    }
+
+    fn map_single_issue_runtime_state(
+        issue: DomainIssueSnapshot,
+    ) -> crate::opensymphony_control::IssueRuntimeState {
+        let snapshot = OrchestratorSnapshot::new(
+            ts(2_000),
+            DaemonSnapshot::new(
+                HealthStatus::Healthy,
+                1_000,
+                4,
+                Some(ts(2_000)),
+                ComponentHealthSnapshot::default(),
+                RuntimeUsageTotals::default(),
+            ),
+            vec![issue],
+        );
+        let mapped = map_snapshot(
+            &snapshot,
+            PathBuf::from("/tmp/workspaces").as_path(),
+            &terminal_state_set(&resolved_workflow_for_tests()),
+            crate::opensymphony_control::AgentServerStatus {
+                reachable: true,
+                base_url: "http://127.0.0.1:3000".to_owned(),
+                conversation_count: 0,
+                status_line: "healthy".to_owned(),
+            },
+            crate::opensymphony_control::MemoryServerStatus::default(),
+            &std::collections::VecDeque::new(),
+        );
+        mapped.issues[0].runtime_state
+    }
+
+    #[test]
+    fn tracker_inactive_release_without_a_run_maps_to_idle_not_completed() {
+        // A recovered workspace whose issue sits in Backlog is parked, not
+        // completed — Completed here surfaced phantom rows in the desktop
+        // Completed pane and blocked the Current pane from showing the issue
+        // after it moved back to an active state.
+        let state = map_single_issue_runtime_state(released_issue_snapshot(
+            "Backlog",
+            IssueStateCategory::NonActive,
+            crate::opensymphony_domain::ReleaseReason::TrackerInactive,
+        ));
+        assert_eq!(state, crate::opensymphony_control::IssueRuntimeState::Idle);
+    }
+
+    #[test]
+    fn tracker_terminal_release_without_a_run_still_maps_to_completed() {
+        // An issue moved straight to Done in the tracker was completed
+        // externally; the tracker state is authoritative.
+        let state = map_single_issue_runtime_state(released_issue_snapshot(
+            "Done",
+            IssueStateCategory::Terminal,
+            crate::opensymphony_domain::ReleaseReason::TrackerTerminal,
+        ));
+        assert_eq!(
+            state,
+            crate::opensymphony_control::IssueRuntimeState::Completed
+        );
     }
 }

--- a/crates/opensymphony-gateway-schema/src/run.rs
+++ b/crates/opensymphony-gateway-schema/src/run.rs
@@ -18,6 +18,11 @@ pub enum RunLifecycleState {
     Failed,
     Canceled,
     RetryExhausted,
+    /// The issue is idle in the control plane but its tracker state is not a
+    /// configured active state (e.g. a recovered workspace parked in Backlog
+    /// or Triage). It is not dispatchable until the tracker state becomes
+    /// active, so it is reported as backlog rather than eligible.
+    Backlog,
 }
 
 /// Run detail exposed by `/api/v1/runs/{run_id}`.

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -282,6 +282,13 @@ pub struct GatewayState {
     pub linear_mutations: Option<Arc<dyn LinearMutationClient>>,
     pub linear_task_graph: Option<Arc<dyn LinearTaskGraphClient>>,
     pub memory_config: Option<MemoryConfig>,
+    /// Normalized (trimmed, lowercased) workflow active-state names. The task
+    /// graph consults these to decide whether an Idle issue is actually
+    /// dispatchable — the authoritative signal the scheduler itself uses —
+    /// rather than inferring it from the coarse graph category. Empty when no
+    /// workflow config is wired in (bare test servers), in which case the
+    /// category is used as a fallback.
+    pub active_states: Arc<HashSet<String>>,
     pub codex_readiness_cache: Arc<CodexReadinessCache>,
     pub workspace_scans: WorkspaceScans,
     pub pr_urls: PrUrls,
@@ -299,6 +306,7 @@ impl Clone for GatewayState {
             linear_mutations: self.linear_mutations.clone(),
             linear_task_graph: self.linear_task_graph.clone(),
             memory_config: self.memory_config.clone(),
+            active_states: self.active_states.clone(),
             codex_readiness_cache: self.codex_readiness_cache.clone(),
             workspace_scans: self.workspace_scans.clone(),
             pr_urls: self.pr_urls.clone(),
@@ -500,6 +508,7 @@ pub struct GatewayServer {
     linear_mutations: Option<Arc<dyn LinearMutationClient>>,
     linear_task_graph: Option<Arc<dyn LinearTaskGraphClient>>,
     memory_config: Option<MemoryConfig>,
+    active_states: Arc<HashSet<String>>,
     terminal_ingest_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -513,6 +522,7 @@ impl Clone for GatewayServer {
             linear_mutations: self.linear_mutations.clone(),
             linear_task_graph: self.linear_task_graph.clone(),
             memory_config: self.memory_config.clone(),
+            active_states: self.active_states.clone(),
             // Each cloned server owns its own ingest handle. The task is tied
             // to the specific server instance that spawned it, so Drop aborts
             // reliably without depending on Arc uniqueness.
@@ -537,6 +547,7 @@ impl std::fmt::Debug for GatewayServer {
                 &self.linear_task_graph.as_ref().map(|_| "..."),
             )
             .field("memory_config", &self.memory_config.as_ref().map(|_| "..."))
+            .field("active_states", &self.active_states.len())
             .field("terminal_ingest_handle", &"<handle>")
             .finish()
     }
@@ -567,6 +578,7 @@ impl GatewayServer {
             linear_mutations: None,
             linear_task_graph: None,
             memory_config: None,
+            active_states: Arc::new(HashSet::new()),
             terminal_ingest_handle: Mutex::new(None),
         }
     }
@@ -585,6 +597,7 @@ impl GatewayServer {
             linear_mutations: None,
             linear_task_graph: None,
             memory_config: None,
+            active_states: Arc::new(HashSet::new()),
             terminal_ingest_handle: Mutex::new(None),
         }
     }
@@ -624,6 +637,20 @@ impl GatewayServer {
         self
     }
 
+    /// Install the workflow's active-state names so the task graph can decide
+    /// whether an Idle issue is genuinely dispatchable (matching the
+    /// scheduler's own active-state test) instead of inferring it from the
+    /// coarse graph category. Names are normalized (trimmed, lowercased).
+    pub fn with_active_states(mut self, states: impl IntoIterator<Item = String>) -> Self {
+        self.active_states = Arc::new(
+            states
+                .into_iter()
+                .map(|state| state.trim().to_ascii_lowercase())
+                .collect(),
+        );
+        self
+    }
+
     /// Extract clones of the journal and broker so the caller can keep them for testing.
     pub fn journal_and_broker(self) -> (InMemoryEventJournal, StreamBroker) {
         (self.journal.clone(), self.broker.clone())
@@ -641,6 +668,7 @@ impl GatewayServer {
             linear_mutations: self.linear_mutations.clone(),
             linear_task_graph: self.linear_task_graph.clone(),
             memory_config: self.memory_config.clone(),
+            active_states: self.active_states.clone(),
             codex_readiness_cache: Arc::new(CodexReadinessCache::default()),
             workspace_scans: WorkspaceScans::default(),
             pr_urls: PrUrls::default(),
@@ -3109,15 +3137,26 @@ async fn get_task_graph(
                 }
                 Some(runtime_state) => map_runtime_state_to_graph_category(runtime_state),
             };
-            let runtime_overlay = snapshot_issue.map(|snapshot_issue| {
-                build_runtime_overlay(
-                    snapshot_issue,
-                    matches!(
-                        state_category,
-                        TaskGraphStateCategory::Todo | TaskGraphStateCategory::InProgress
-                    ),
+            // Dispatchability drives the queued/eligible overlay. Use the
+            // workflow's active-state names — the same authority the scheduler
+            // uses — so a parked Idle issue in a non-active state (Backlog,
+            // Triage, or a custom state absent from `active_states`) is never
+            // shown as queued/eligible, and a genuinely active state that maps
+            // to the coarse `todo` category (e.g. "Rework") still is. Fall back
+            // to the graph category only when no active states are configured
+            // (bare test servers).
+            let dispatchable = if state.active_states.is_empty() {
+                matches!(
+                    state_category,
+                    TaskGraphStateCategory::Todo | TaskGraphStateCategory::InProgress
                 )
-            });
+            } else {
+                state
+                    .active_states
+                    .contains(&issue.state.trim().to_ascii_lowercase())
+            };
+            let runtime_overlay = snapshot_issue
+                .map(|snapshot_issue| build_runtime_overlay(snapshot_issue, dispatchable));
             let parent_id = issue
                 .parent
                 .as_ref()

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3354,10 +3354,11 @@ fn build_runtime_overlay(
 // ── Run endpoints ─────────────────────────────────────────────────────────────
 
 async fn get_run_detail(
-    State(store): State<SnapshotStore>,
-    State(pr_urls): State<PrUrls>,
+    State(state): State<GatewayState>,
     AxumPath(run_id): AxumPath<String>,
 ) -> impl IntoResponse {
+    let store = &state.store;
+    let pr_urls = &state.pr_urls;
     let envelope = store.current().await;
     let issue = match find_issue_snapshot(&envelope, &run_id) {
         Some(issue) => issue,
@@ -3407,7 +3408,20 @@ async fn get_run_detail(
         }
     };
 
+    // A parked recovered issue maps to Idle (it never ran) but is only
+    // dispatchable once its tracker state is a configured active state. Use
+    // the workflow's active states — the scheduler's own authority — so run
+    // detail does not advertise a parked Backlog/Triage issue as an eligible,
+    // retryable run. Fall back to treating Idle as eligible only when no
+    // active states are configured (bare test servers).
+    let dispatchable = state.active_states.is_empty()
+        || state
+            .active_states
+            .contains(&issue.tracker_state.trim().to_ascii_lowercase());
     let (status, lifecycle_state) = match issue.runtime_state {
+        ControlPlaneIssueRuntimeState::Idle if !dispatchable => {
+            (RunStatus::Unclaimed, RunLifecycleState::Backlog)
+        }
         ControlPlaneIssueRuntimeState::Idle => (RunStatus::Unclaimed, RunLifecycleState::Eligible),
         ControlPlaneIssueRuntimeState::Running => (RunStatus::Running, RunLifecycleState::Running),
         ControlPlaneIssueRuntimeState::Paused => (RunStatus::Paused, RunLifecycleState::Paused),
@@ -3484,7 +3498,7 @@ async fn get_run_detail(
             summary: None,
             blocker: issue.blocked.then(|| "Blocked by dependency".into()),
             error: None,
-            allowed_actions: allowed_actions_for_issue(issue),
+            allowed_actions: allowed_actions_for_issue(issue, dispatchable),
             liveness: Some(build_liveness(issue)),
             diagnostics: Some(RunDiagnostics {
                 harness_scheduler_disagreement: None,
@@ -4070,7 +4084,10 @@ fn default_terminal_limit() -> usize {
     1000
 }
 
-fn allowed_actions_for_issue(issue: &ControlPlaneIssueSnapshot) -> Vec<RunAction> {
+fn allowed_actions_for_issue(
+    issue: &ControlPlaneIssueSnapshot,
+    dispatchable: bool,
+) -> Vec<RunAction> {
     let mut allowed = Vec::new();
     use ControlPlaneIssueRuntimeState as State;
     match issue.runtime_state {
@@ -4086,7 +4103,10 @@ fn allowed_actions_for_issue(issue: &ControlPlaneIssueSnapshot) -> Vec<RunAction
             allowed.push(RunAction::Retry);
             allowed.push(RunAction::Rehydrate);
         }
-        State::Idle => {
+        // Retry re-queues the issue for dispatch, which only makes sense when
+        // the scheduler will actually pick it up. A parked issue (Idle but in
+        // a non-active tracker state) is not dispatchable, so it gets no retry.
+        State::Idle if dispatchable => {
             allowed.push(RunAction::Retry);
         }
         _ => {}
@@ -4706,7 +4726,7 @@ exit 2
                 detached: false,
             },
         );
-        let actions = allowed_actions_for_issue(&issue);
+        let actions = allowed_actions_for_issue(&issue, true);
         assert!(actions.contains(&RunAction::Cancel));
         assert!(actions.contains(&RunAction::Pause));
         assert!(actions.contains(&RunAction::Comment));
@@ -4728,7 +4748,7 @@ exit 2
                 detached: false,
             },
         );
-        let actions = allowed_actions_for_issue(&issue);
+        let actions = allowed_actions_for_issue(&issue, true);
         assert!(actions.contains(&RunAction::Comment));
         assert!(actions.contains(&RunAction::CreateFollowup));
         assert!(!actions.contains(&RunAction::OpenWorkspace));
@@ -4745,7 +4765,7 @@ exit 2
                 detached: false,
             },
         );
-        let actions = allowed_actions_for_issue(&issue);
+        let actions = allowed_actions_for_issue(&issue, true);
         assert!(actions.contains(&RunAction::Retry));
         assert!(actions.contains(&RunAction::Rehydrate));
         assert!(actions.contains(&RunAction::OpenWorkspace));
@@ -4767,7 +4787,7 @@ exit 2
                 detached: false,
             },
         );
-        assert!(allowed_actions_for_issue(&stalled).contains(&RunAction::Detach));
+        assert!(allowed_actions_for_issue(&stalled, true).contains(&RunAction::Detach));
 
         let healthy = test_issue(
             ControlPlaneIssueRuntimeState::Running,
@@ -4777,7 +4797,7 @@ exit 2
                 detached: false,
             },
         );
-        assert!(!allowed_actions_for_issue(&healthy).contains(&RunAction::Detach));
+        assert!(!allowed_actions_for_issue(&healthy, true).contains(&RunAction::Detach));
 
         let already_detached = test_issue(
             ControlPlaneIssueRuntimeState::Running,
@@ -4787,7 +4807,7 @@ exit 2
                 detached: true,
             },
         );
-        assert!(!allowed_actions_for_issue(&already_detached).contains(&RunAction::Detach));
+        assert!(!allowed_actions_for_issue(&already_detached, true).contains(&RunAction::Detach));
     }
 
     #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3099,9 +3099,16 @@ async fn get_task_graph(
             let snapshot_issue = snapshot_by_identifier
                 .get(issue.identifier.as_str())
                 .copied();
-            let state_category = snapshot_issue
-                .map(|issue| map_runtime_state_to_graph_category(&issue.runtime_state))
-                .unwrap_or_else(|| map_tracker_state_kind_to_graph_category(&issue.state_kind));
+            // Idle carries no run information (queued work, or a parked
+            // issue whose recovered workspace waits for reactivation), so
+            // the tracker state decides the category — otherwise an Idle
+            // Backlog issue would surface as Todo in the Current pane.
+            let state_category = match snapshot_issue.map(|issue| &issue.runtime_state) {
+                None | Some(ControlPlaneIssueRuntimeState::Idle) => {
+                    map_tracker_state_kind_to_graph_category(&issue.state_kind)
+                }
+                Some(runtime_state) => map_runtime_state_to_graph_category(runtime_state),
+            };
             let runtime_overlay = snapshot_issue.map(build_runtime_overlay);
             let parent_id = issue
                 .parent

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3109,7 +3109,15 @@ async fn get_task_graph(
                 }
                 Some(runtime_state) => map_runtime_state_to_graph_category(runtime_state),
             };
-            let runtime_overlay = snapshot_issue.map(build_runtime_overlay);
+            let runtime_overlay = snapshot_issue.map(|snapshot_issue| {
+                build_runtime_overlay(
+                    snapshot_issue,
+                    matches!(
+                        state_category,
+                        TaskGraphStateCategory::Todo | TaskGraphStateCategory::InProgress
+                    ),
+                )
+            });
             let parent_id = issue
                 .parent
                 .as_ref()
@@ -3215,7 +3223,10 @@ fn map_tracker_state_kind_to_graph_category(
     }
 }
 
-fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeOverlay {
+fn build_runtime_overlay(
+    issue: &ControlPlaneIssueSnapshot,
+    dispatchable: bool,
+) -> TaskGraphRuntimeOverlay {
     let diff_summary = if issue.modified_files.is_empty() {
         None
     } else {
@@ -3256,15 +3267,21 @@ fn build_runtime_overlay(issue: &ControlPlaneIssueSnapshot) -> TaskGraphRuntimeO
     };
 
     let is_running = matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Running);
-    // An issue is eligible only when it is idle (not yet started) and not
-    // blocked.  Completed and failed issues must not appear eligible.
-    let is_eligible =
-        !issue.blocked && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle);
+    // An issue is eligible only when it is idle (not yet started), not
+    // blocked, and in a dispatchable graph category. Completed and failed
+    // issues must not appear eligible, and neither must a parked Idle issue
+    // whose tracker state is non-active (e.g. a recovered Backlog
+    // workspace) — the scheduler will not dispatch it until the tracker
+    // state turns active.
+    let is_eligible = dispatchable
+        && !issue.blocked
+        && matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle);
     // Queued means the issue is actively waiting to be picked up by a worker.
     // Blocked issues must never appear queued, regardless of state:
     // a blocked Idle issue is not schedulable, and a blocked RetryQueued
     // issue is waiting on its blocker to clear before retry.
-    let is_queued = !issue.blocked
+    let is_queued = dispatchable
+        && !issue.blocked
         && (matches!(issue.runtime_state, ControlPlaneIssueRuntimeState::Idle)
             || matches!(
                 issue.runtime_state,

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2269,6 +2269,14 @@ async fn gateway_task_graph_categorizes_idle_issues_by_tracker_state() {
         response.nodes[0].state_category,
         opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphStateCategory::Backlog,
     );
+    // A parked issue is not schedulable until its tracker state turns
+    // active, so its overlay must not advertise it as queued or eligible.
+    let overlay = response.nodes[0]
+        .runtime_overlay
+        .as_ref()
+        .expect("tracked issue should carry a runtime overlay");
+    assert!(!overlay.eligible);
+    assert!(!overlay.queued);
 
     server_task.abort();
 }

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2224,6 +2224,56 @@ async fn gateway_task_graph_keeps_failed_issues_visible_as_todo() {
 }
 
 #[tokio::test]
+async fn gateway_task_graph_categorizes_idle_issues_by_tracker_state() {
+    // An Idle control-plane entry carries no run information — e.g. a
+    // recovered workspace parked while its issue sits in Backlog. The
+    // tracker state must decide the category, or the issue would surface
+    // as Todo in the Current pane instead of staying in Backlog.
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].runtime_state = IssueRuntimeState::Idle;
+    snapshot.issues[0].tracker_state = "Backlog".to_owned();
+    let issues = snapshot
+        .issues
+        .iter()
+        .map(|issue| tracker_issue_from_snapshot(issue, &[]))
+        .collect::<Vec<_>>();
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store).with_linear_task_graph(Some(std::sync::Arc::new(
+        FakeLinearTaskGraphClient { issues },
+    )));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    assert_eq!(response.nodes.len(), 1);
+    assert_eq!(response.nodes[0].identifier, "COE-255");
+    assert_eq!(
+        response.nodes[0].state_category,
+        opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphStateCategory::Backlog,
+    );
+
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn gateway_serves_memory_completed_tasks() {
     let repo = tempfile::tempdir().expect("memory repo");
     let config = write_completed_tasks_fixture(repo.path());

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2765,6 +2765,89 @@ async fn gateway_serves_run_detail() {
 }
 
 #[tokio::test]
+async fn gateway_run_detail_parked_non_active_issue_is_not_eligible_or_retryable() {
+    use opensymphony::opensymphony_gateway_schema::run::{RunAction, RunLifecycleState, RunStatus};
+
+    // A recovered issue parked in Backlog maps to Idle in the control plane
+    // but is not dispatchable until its tracker state becomes active. Run
+    // detail must not advertise it as an eligible, retryable run.
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].runtime_state = IssueRuntimeState::Idle;
+    snapshot.issues[0].tracker_state = "Backlog".to_owned();
+    let store = SnapshotStore::new(snapshot);
+    let server =
+        GatewayServer::new(store).with_active_states(["Todo".to_owned(), "In Progress".to_owned()]);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{address}/api/v1/runs/COE-255"))
+        .send()
+        .await
+        .expect("fetch run detail")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunDetail>()
+        .await
+        .expect("decode run detail");
+
+    assert_eq!(response.status, RunStatus::Unclaimed);
+    assert_eq!(response.lifecycle_state, RunLifecycleState::Backlog);
+    assert!(
+        !response.allowed_actions.contains(&RunAction::Retry),
+        "a parked non-active issue must not offer a retry action"
+    );
+    assert!(!response.safe_actions.retry);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_run_detail_dispatchable_idle_issue_is_eligible_and_retryable() {
+    use opensymphony::opensymphony_gateway_schema::run::{RunAction, RunLifecycleState, RunStatus};
+
+    // An Idle issue whose tracker state IS a configured active state is a
+    // genuine queued run: eligible and retryable.
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].runtime_state = IssueRuntimeState::Idle;
+    snapshot.issues[0].tracker_state = "Todo".to_owned();
+    let store = SnapshotStore::new(snapshot);
+    let server =
+        GatewayServer::new(store).with_active_states(["Todo".to_owned(), "In Progress".to_owned()]);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{address}/api/v1/runs/COE-255"))
+        .send()
+        .await
+        .expect("fetch run detail")
+        .json::<opensymphony::opensymphony_gateway_schema::run::RunDetail>()
+        .await
+        .expect("decode run detail");
+
+    assert_eq!(response.status, RunStatus::Unclaimed);
+    assert_eq!(response.lifecycle_state, RunLifecycleState::Eligible);
+    assert!(response.allowed_actions.contains(&RunAction::Retry));
+
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn gateway_serves_run_detail_cancel_diagnostics() {
     let mut snapshot = fixture_snapshot(0);
     snapshot.issues[0].cancel_requested = true;

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2282,6 +2282,118 @@ async fn gateway_task_graph_categorizes_idle_issues_by_tracker_state() {
 }
 
 #[tokio::test]
+async fn gateway_task_graph_suppresses_overlay_for_parked_non_active_state() {
+    // A parked recovered issue whose tracker state maps to the coarse `todo`
+    // graph category but is NOT a configured active state (e.g. Triage, or a
+    // custom state) must not be advertised as queued/eligible: the scheduler
+    // released it as tracker-inactive and will not dispatch it until it
+    // enters a configured active state.
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].runtime_state = IssueRuntimeState::Idle;
+    snapshot.issues[0].tracker_state = "Triage".to_owned();
+    let issues = snapshot
+        .issues
+        .iter()
+        .map(|issue| tracker_issue_from_snapshot(issue, &[]))
+        .collect::<Vec<_>>();
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store)
+        .with_linear_task_graph(Some(std::sync::Arc::new(FakeLinearTaskGraphClient {
+            issues,
+        })))
+        .with_active_states(["Todo".to_owned(), "In Progress".to_owned()]);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    // Triage still lands in the coarse `todo` category ...
+    assert_eq!(
+        response.nodes[0].state_category,
+        opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphStateCategory::Todo,
+    );
+    // ... but it is not a configured active state, so the overlay is clean.
+    let overlay = response.nodes[0]
+        .runtime_overlay
+        .as_ref()
+        .expect("tracked issue should carry a runtime overlay");
+    assert!(!overlay.eligible);
+    assert!(!overlay.queued);
+
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_task_graph_marks_configured_active_state_eligible() {
+    // A custom active state that maps to the coarse `todo` category (e.g.
+    // "Rework") is genuinely dispatchable when listed in active_states, so
+    // its overlay must be queued/eligible even though the category alone is
+    // ambiguous. This is why dispatchability keys on active_states, not the
+    // category or the semantic tracker-state kind.
+    let mut snapshot = fixture_snapshot(0);
+    snapshot.issues[0].runtime_state = IssueRuntimeState::Idle;
+    snapshot.issues[0].tracker_state = "Rework".to_owned();
+    let issues = snapshot
+        .issues
+        .iter()
+        .map(|issue| tracker_issue_from_snapshot(issue, &[]))
+        .collect::<Vec<_>>();
+    let store = SnapshotStore::new(snapshot);
+    let server = GatewayServer::new(store)
+        .with_linear_task_graph(Some(std::sync::Arc::new(FakeLinearTaskGraphClient {
+            issues,
+        })))
+        .with_active_states(["Todo".to_owned(), "Rework".to_owned()]);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("test listener address");
+    let server_task = tokio::spawn(async move {
+        server
+            .serve(listener)
+            .await
+            .expect("test gateway server should serve")
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/projects/default/taskgraph"
+        ))
+        .send()
+        .await
+        .expect("fetch task graph")
+        .json::<opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphSnapshot>()
+        .await
+        .expect("decode task graph");
+
+    let overlay = response.nodes[0]
+        .runtime_overlay
+        .as_ref()
+        .expect("tracked issue should carry a runtime overlay");
+    assert!(overlay.eligible);
+    assert!(overlay.queued);
+
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn gateway_serves_memory_completed_tasks() {
     let repo = tempfile::tempdir().expect("memory repo");
     let config = write_completed_tasks_fixture(repo.path());

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -1390,6 +1390,27 @@ where
                 );
                 continue;
             }
+            // A released execution blocks dispatch until the hourly full
+            // refresh reconciles it. When the tracker reactivates such an
+            // issue (e.g. Backlog back to Todo after its workspace was
+            // recovered and parked), reopen it here so the 60s discovery
+            // cadence picks it up instead.
+            let needs_reopen = self
+                .executions
+                .get(&normalized.id)
+                .is_some_and(|execution| {
+                    execution.status() == SchedulerStatus::Released
+                        && !terminal_worker_outcome_prevents_reopen(execution)
+                });
+            if needs_reopen {
+                if self
+                    .interrupt_human_review_polling_for_merging(&normalized, observed_at)
+                    .await?
+                {
+                    continue;
+                }
+                self.upsert_active_execution(normalized, observed_at, None)?;
+            }
             detailed.push(detailed_issue);
         }
 

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -1661,6 +1661,74 @@ async fn recovery_reuses_manifest_workspace_for_active_issue_dispatch() {
 }
 
 #[tokio::test]
+async fn parked_recovered_issue_redispatches_when_tracker_reactivates() {
+    // A leftover workspace for a non-active (Backlog) issue is recovered and
+    // parked at startup. When the issue later moves back into an active
+    // state, the 60s dispatch discovery must reopen the released execution
+    // and dispatch it instead of waiting for the hourly full detail refresh.
+    let recovered_workspace = workspace_record("COE-532", "/tmp/recovered/COE-532");
+    let tracker = FakeTracker {
+        states: HashMap::from([(
+            "lin-532".to_string(),
+            tracker_state_snapshot("lin-532", "COE-532", "Backlog", "backlog", 0),
+        )]),
+        ..Default::default()
+    };
+    let workspace = FakeWorkspace {
+        recoveries: vec![RecoveryRecord {
+            issue: normalized_issue("lin-532", "COE-532", "Backlog"),
+            workspace: recovered_workspace.clone(),
+            had_in_flight_run: false,
+            harness_kind: None,
+            recovered_run: None,
+        }],
+        records: HashMap::from([("lin-532".to_string(), recovered_workspace.clone())]),
+        ..Default::default()
+    };
+    let worker = FakeWorker::default();
+    let mut scheduler = Scheduler::new(tracker, workspace, worker, scheduler_config());
+
+    scheduler
+        .tick(ts(100))
+        .await
+        .expect("recovery tick should succeed");
+
+    let issue_id = IssueId::new("lin-532").expect("issue id should be valid");
+    let parked = scheduler
+        .execution(&issue_id)
+        .expect("recovered issue should be parked");
+    assert_eq!(parked.status(), SchedulerStatus::Released);
+    match parked.state() {
+        crate::opensymphony_orchestrator::SchedulerState::Released { reason, .. } => {
+            assert_eq!(*reason, ReleaseReason::TrackerInactive);
+        }
+        other => panic!("expected released state, got {other:?}"),
+    }
+    assert!(scheduler.worker().launches.is_empty());
+
+    scheduler.tracker_mut().active = vec![tracker_issue("lin-532", "COE-532", "In Progress", 0)];
+
+    scheduler
+        .tick(ts(60_200))
+        .await
+        .expect("dispatch discovery should reopen and dispatch the issue");
+
+    assert_eq!(scheduler.worker().launches.len(), 1);
+    assert_eq!(
+        scheduler.worker().launches[0].issue.identifier.as_str(),
+        "COE-532"
+    );
+    assert_eq!(
+        scheduler.worker().launches[0].workspace.path,
+        recovered_workspace.path
+    );
+    let running = scheduler
+        .execution(&issue_id)
+        .expect("dispatched issue should have an execution");
+    assert_eq!(running.status(), SchedulerStatus::Running);
+}
+
+#[tokio::test]
 async fn tracker_inactive_release_frees_the_per_state_slot() {
     let tracker = FakeTracker {
         active: vec![

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -138,6 +138,11 @@ both the task graph's done nodes and the dashboard snapshot's control-plane
 completed count, so completions surface even when the finished issue is
 absent from the task graph (e.g. no project metadata). `memory_graph_updated`
 events reload it too, for capsule/PR evidence captured after completion.
+Only real completions count: a workspace recovered at daemon startup whose
+issue sits in a non-active tracker state is *parked* (runtime `idle`, and
+the tracker state decides its pane), never reported as `completed`, and the
+scheduler's 60-second dispatch discovery reopens a parked issue as soon as
+its tracker state turns active again — no orchestrator restart required.
 
 ### Drill-down navigation
 

--- a/packages/gateway-schema/src/run.ts
+++ b/packages/gateway-schema/src/run.ts
@@ -97,7 +97,11 @@ export type RunLifecycleState =
   | "completed"
   | "failed"
   | "canceled"
-  | "retry_exhausted";
+  | "retry_exhausted"
+  // Idle in the control plane but parked in a non-active tracker state
+  // (e.g. a recovered workspace waiting in Backlog/Triage): not dispatchable
+  // until its tracker state becomes active.
+  | "backlog";
 
 /** Action a client may dispatch on a run. */
 export type RunAction =


### PR DESCRIPTION
## Problem

Reported against the three-pane task graph (#199): starting the orchestrator with no dispatchable tasks and then moving `COE-532` from Backlog to Todo made the issue appear in the **Completed** pane instead of **Current** — the TUI showed it as `completed / Backlog` with zero tokens and no run. Only an orchestrator restart healed it.

## Root cause (three compounding defects)

1. **Phantom completions.** At daemon startup, `bootstrap_recovery` parks every recovered workspace whose issue is in a non-active tracker state: it creates an execution and immediately releases it with `ReleaseReason::TrackerInactive`. The snapshot mapper then reported *any* non-failed `Released` execution as `Completed` — despite `release_reason` saying otherwise and no run ever existing. Every leftover workspace for a Backlog issue became a phantom `completed` row (the `COE-370/371/418/420/436/450/532` rows dated Jul 06 with no PR and no capsule).
2. **Wrong pane for parked issues.** The task-graph endpoint let the control-plane runtime state override the tracker state unconditionally, so a parked issue could never land back in the pane its tracker state calls for.
3. **Stuck until restart.** `dispatch_ready_issues` never dispatches a `Released` execution, and the reconcile pass that reopens released executions runs on the **hourly** full detail refresh. So after Backlog→Todo, the 60-second dispatch discovery saw the issue, found its parked execution, and skipped it — for up to an hour. Restarting the daemon forced an immediate full refresh, which is why that "fixed" it.

## Fix

- `orchestrator_run/snapshot.rs`: a `TrackerInactive` release with **no recorded run** maps to `idle`, not `completed`. Tracker-terminal releases (issue moved to Done externally) still map to `completed`.
- `gateway/get_task_graph`: when the control-plane runtime is `Idle` (no run information), the tracker state decides the graph category — a parked Backlog issue stays in the Backlog pane.
- `scheduler/dispatch_summary_candidates`: when the tracker reactivates an issue whose execution is `Released` and reopenable, reopen it during the 60s discovery pass (same guards as the hourly reconcile, including the human-review-merging interrupt check) so it dispatches without a restart.

## Tests

- `scheduler::parked_recovered_issue_redispatches_when_tracker_reactivates` — reproduces the exact report: recovered Backlog workspace parked at startup, tracker flips the issue active, next discovery tick reopens and dispatches on the recovered workspace. **Verified to fail without the scheduler fix.**
- `snapshot::tracker_inactive_release_without_a_run_maps_to_idle_not_completed` and `snapshot::tracker_terminal_release_without_a_run_still_maps_to_completed` — pin the release-reason mapping both ways.
- `gateway::gateway_task_graph_categorizes_idle_issues_by_tracker_state` — Idle + Backlog categorizes as `backlog`, not `todo`.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the full workspace suite (1309 passed, 0 failed) are green.