### PR TITLE
fix(task-graph): keep untracked active issues visible in the Current pane

### DIFF
--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -65,11 +65,12 @@ impl LinearTaskGraphClient for FakeLinearTaskGraphClient {
 }
 
 /// Fake that mirrors the real client's task-graph contract: requested
-/// identifiers plus every backlog-state issue from the project scan.
+/// identifiers plus every unrequested backlog- or active-state issue from
+/// the project scan.
 #[derive(Clone)]
 struct BacklogLinearTaskGraphClient {
     issues: Vec<TrackerIssue>,
-    backlog: Vec<TrackerIssue>,
+    unrequested: Vec<TrackerIssue>,
 }
 
 #[async_trait]
@@ -91,7 +92,7 @@ impl LinearTaskGraphClient for BacklogLinearTaskGraphClient {
 
     async fn task_graph_issues(&self, identifiers: &[String]) -> Result<Vec<TrackerIssue>, String> {
         let mut issues = self.issues_by_identifiers(identifiers).await?;
-        issues.extend(self.backlog.iter().cloned());
+        issues.extend(self.unrequested.iter().cloned());
         Ok(issues)
     }
 }
@@ -2133,11 +2134,36 @@ async fn gateway_task_graph_includes_backlog_issues_with_cross_edges() {
         created_at: now,
         updated_at: now,
     };
+    // An issue just promoted Backlog→Todo: active in Linear but untracked by
+    // the control plane, so it arrives only via the unrequested scan bucket.
+    let promoted_issue = TrackerIssue {
+        id: "COE-901".to_owned(),
+        identifier: "COE-901".to_owned(),
+        url: "https://linear.app/kumanday/issue/COE-901".to_owned(),
+        title: "Freshly promoted todo".to_owned(),
+        description: None,
+        priority: None,
+        state: "Todo".to_owned(),
+        state_kind: TrackerIssueStateKind::Unstarted,
+        branch_name: None,
+        pr_url: None,
+        labels: Vec::new(),
+        project_id: Some("proj-open".to_owned()),
+        project_slug: Some("opensymphony-bootstrap".to_owned()),
+        project_name: Some("OpenSymphony".to_owned()),
+        parent_id: None,
+        parent: None,
+        project_milestone: None,
+        blocked_by: Vec::new(),
+        sub_issues: Vec::new(),
+        created_at: now,
+        updated_at: now,
+    };
     let store = SnapshotStore::new(snapshot);
     let server = GatewayServer::new(store).with_linear_task_graph(Some(std::sync::Arc::new(
         BacklogLinearTaskGraphClient {
             issues,
-            backlog: vec![backlog_issue],
+            unrequested: vec![backlog_issue, promoted_issue],
         },
     )));
     let listener = TcpListener::bind("127.0.0.1:0")
@@ -2162,7 +2188,19 @@ async fn gateway_task_graph_includes_backlog_issues_with_cross_edges() {
         .await
         .expect("decode task graph");
 
-    assert_eq!(response.nodes.len(), 2);
+    assert_eq!(response.nodes.len(), 3);
+    // The untracked-but-active issue lands in the Current pane as Todo
+    // instead of vanishing until the orchestrator picks it up.
+    let promoted_node = response
+        .nodes
+        .iter()
+        .find(|node| node.identifier == "COE-901")
+        .expect("promoted todo issue should be present in the task graph");
+    assert_eq!(
+        promoted_node.state_category,
+        opensymphony::opensymphony_gateway_schema::task_graph::TaskGraphStateCategory::Todo,
+    );
+    assert!(promoted_node.runtime_overlay.is_none());
     let backlog_node = response
         .nodes
         .iter()

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -398,12 +398,12 @@ impl LinearClient {
     }
 
     /// Task-graph issue set from a single project scan: every requested
-    /// identifier plus all backlog- and active-state issues. Backlog issues
-    /// never enter the control plane (they are not in `active_states`), and
-    /// active (unstarted/started) issues only enter it once the orchestrator
-    /// picks them up — until then a freshly promoted Backlog→Todo issue is
-    /// tracked nowhere, so the scan carries both without a second Linear
-    /// pass.
+    /// identifier plus unrequested backlog, dispatchable (`active_states`),
+    /// and started-kind issues. Backlog issues never enter the control
+    /// plane, and active issues only enter it once the orchestrator picks
+    /// them up — until then a freshly promoted Backlog→Todo issue is
+    /// tracked nowhere, so the scan carries all of them without a second
+    /// Linear pass.
     pub async fn project_task_graph_issues<S>(
         &self,
         identifiers: &[S],
@@ -417,18 +417,34 @@ impl LinearClient {
             .map(|identifier| identifier.to_ascii_uppercase())
             .collect::<HashSet<_>>();
 
+        let active_state_names = self
+            .config
+            .active_states
+            .iter()
+            .map(|state| state.trim().to_ascii_lowercase())
+            .collect::<HashSet<_>>();
+        // Unrequested issues worth carrying: backlog (Backlog pane), states
+        // the scheduler dispatches from (`active_states` — a freshly promoted
+        // Todo issue the control plane does not track yet), and started-kind
+        // states (in-flight work like Human Review / Rework belongs in the
+        // Current pane even when not dispatchable). Parked unstarted states
+        // outside `active_states` stay out: the orchestrator will never pick
+        // them up, so showing them as queued work would mislead.
+        let carry_unrequested = |issue: &TrackerIssue| {
+            matches!(
+                issue.state_kind,
+                crate::opensymphony_domain::TrackerIssueStateKind::Backlog
+                    | crate::opensymphony_domain::TrackerIssueStateKind::Started
+            ) || active_state_names.contains(&issue.state.trim().to_ascii_lowercase())
+        };
+
         let mut issues_by_identifier = HashMap::new();
         let mut unrequested = Vec::new();
         for issue in self.project_issues(false).await? {
             let key = issue.identifier.to_ascii_uppercase();
             if requested_keys.contains(&key) {
                 issues_by_identifier.insert(key, issue);
-            } else if matches!(
-                issue.state_kind,
-                crate::opensymphony_domain::TrackerIssueStateKind::Backlog
-                    | crate::opensymphony_domain::TrackerIssueStateKind::Unstarted
-                    | crate::opensymphony_domain::TrackerIssueStateKind::Started
-            ) {
+            } else if carry_unrequested(&issue) {
                 unrequested.push(issue);
             }
         }

--- a/crates/opensymphony-linear/src/client.rs
+++ b/crates/opensymphony-linear/src/client.rs
@@ -398,9 +398,12 @@ impl LinearClient {
     }
 
     /// Task-graph issue set from a single project scan: every requested
-    /// identifier plus all backlog-state issues. Backlog issues never enter
-    /// the control plane (they are not in `active_states`), so the task
-    /// graph endpoint asks for them here without a second Linear pass.
+    /// identifier plus all backlog- and active-state issues. Backlog issues
+    /// never enter the control plane (they are not in `active_states`), and
+    /// active (unstarted/started) issues only enter it once the orchestrator
+    /// picks them up — until then a freshly promoted Backlog→Todo issue is
+    /// tracked nowhere, so the scan carries both without a second Linear
+    /// pass.
     pub async fn project_task_graph_issues<S>(
         &self,
         identifiers: &[S],
@@ -415,7 +418,7 @@ impl LinearClient {
             .collect::<HashSet<_>>();
 
         let mut issues_by_identifier = HashMap::new();
-        let mut backlog = Vec::new();
+        let mut unrequested = Vec::new();
         for issue in self.project_issues(false).await? {
             let key = issue.identifier.to_ascii_uppercase();
             if requested_keys.contains(&key) {
@@ -423,8 +426,10 @@ impl LinearClient {
             } else if matches!(
                 issue.state_kind,
                 crate::opensymphony_domain::TrackerIssueStateKind::Backlog
+                    | crate::opensymphony_domain::TrackerIssueStateKind::Unstarted
+                    | crate::opensymphony_domain::TrackerIssueStateKind::Started
             ) {
-                backlog.push(issue);
+                unrequested.push(issue);
             }
         }
 
@@ -459,8 +464,8 @@ impl LinearClient {
             }
         }
 
-        backlog.sort_by(|left, right| left.identifier.cmp(&right.identifier));
-        issues.extend(backlog);
+        unrequested.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+        issues.extend(unrequested);
         Ok(issues)
     }
 

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -346,27 +346,46 @@ async fn project_task_graph_issues_return_requested_backlog_and_active_from_one_
                 "Todo",
                 "unstarted",
             ),
+            (
+                "issue-320",
+                "COE-320",
+                "Unrequested human review issue",
+                "Human Review",
+                "started",
+            ),
+            (
+                "issue-330",
+                "COE-330",
+                "Parked unstarted issue",
+                "Ready for Spec",
+                "unstarted",
+            ),
         ]),
     )])
     .await;
-    let client = LinearClient::new(test_config(server.base_url()))
-        .expect("client configuration should work");
+    let mut config = test_config(server.base_url());
+    config.active_states = vec!["Todo".to_string(), "In Progress".to_string()];
+    let client = LinearClient::new(config).expect("client configuration should work");
 
     let issues = client
         .project_task_graph_issues(&["COE-260"])
         .await
         .expect("task graph lookup should succeed");
 
-    // Requested identifiers first, then unrequested backlog AND active
-    // issues. COE-310 is Todo but untracked by the control plane (e.g. just
-    // promoted from Backlog, not yet dispatched) — dropping it would make the
-    // issue vanish from every pane until the orchestrator picks it up.
+    // Requested identifiers first, then unrequested backlog, dispatchable,
+    // and started-kind issues. COE-310 is Todo but untracked by the control
+    // plane (e.g. just promoted from Backlog, not yet dispatched) — dropping
+    // it would make the issue vanish from every pane until the orchestrator
+    // picks it up. COE-320 is in-flight (started kind) so it belongs in the
+    // Current pane even though "Human Review" is not dispatchable. COE-330
+    // sits in a parked unstarted state outside `active_states`, which the
+    // scheduler will never dispatch, so it stays out of the task graph.
     assert_eq!(
         issues
             .iter()
             .map(|issue| issue.identifier.as_str())
             .collect::<Vec<_>>(),
-        vec!["COE-260", "COE-300", "COE-310"],
+        vec!["COE-260", "COE-300", "COE-310", "COE-320"],
     );
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 1, "one project scan serves both buckets");

--- a/crates/opensymphony-linear/tests/linear_client.rs
+++ b/crates/opensymphony-linear/tests/linear_client.rs
@@ -322,7 +322,7 @@ async fn project_issues_by_identifiers_fetches_project_issue_details_in_one_quer
 }
 
 #[tokio::test]
-async fn project_task_graph_issues_return_requested_and_backlog_from_one_scan() {
+async fn project_task_graph_issues_return_requested_backlog_and_active_from_one_scan() {
     let server = MockGraphqlServer::start(vec![QueuedResponse::json(
         project_issues_response_with_states(&[
             (
@@ -357,14 +357,16 @@ async fn project_task_graph_issues_return_requested_and_backlog_from_one_scan() 
         .await
         .expect("task graph lookup should succeed");
 
-    // Requested identifiers first, then backlog issues; issues that are
-    // neither requested nor backlog-state stay out of the task graph set.
+    // Requested identifiers first, then unrequested backlog AND active
+    // issues. COE-310 is Todo but untracked by the control plane (e.g. just
+    // promoted from Backlog, not yet dispatched) — dropping it would make the
+    // issue vanish from every pane until the orchestrator picks it up.
     assert_eq!(
         issues
             .iter()
             .map(|issue| issue.identifier.as_str())
             .collect::<Vec<_>>(),
-        vec!["COE-260", "COE-300"],
+        vec!["COE-260", "COE-300", "COE-310"],
     );
     let requests = server.recorded_requests().await;
     assert_eq!(requests.len(), 1, "one project scan serves both buckets");

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -116,7 +116,9 @@ The desktop task surface splits into three panes
 - **Backlog** (collapsible, right) — backlog-state Linear issues, now
   included in the task-graph snapshot (`LinearClient::project_task_graph_issues`
   returns them from the same single project scan that already served the
-  identifier lookup). Cards use the Current pane's grammar with faded
+  identifier lookup; the scan also carries unrequested *active*-state issues,
+  so a task promoted Backlog→Todo appears in Current even before the
+  orchestrator control plane tracks it). Cards use the Current pane's grammar with faded
   edges; hovering or selecting a backlog task boldens its full **ancestry
   critical path** — every unfinished upstream chain that must complete to
   unblock it — across both panes, and dims unrelated backlog cards.
@@ -215,7 +217,7 @@ testing, `?memory=<deep-link>` on the desktop dev server (composable with
   (`gateway_task_graph_includes_backlog_issues_with_cross_edges`,
   `gateway_serves_memory_completed_tasks`),
   `crates/opensymphony-linear/tests/linear_client.rs`
-  (`project_task_graph_issues_return_requested_and_backlog_from_one_scan`),
+  (`project_task_graph_issues_return_requested_backlog_and_active_from_one_scan`),
   and the memory crate's PR-evidence projection unit test.
 
 When iterating on visuals, extend these fixtures and tests rather than

--- a/packages/gateway-schema/src/index.ts
+++ b/packages/gateway-schema/src/index.ts
@@ -14,7 +14,7 @@ export type { EntityKind, EntityRef, GatewayEnvelope } from "./envelope.js";
 export type { GatewayHealth, GatewayMetrics, ProjectSummary, SnapshotEventKind, SnapshotEventSummary, DashboardSnapshot } from "./snapshot.js";
 
 // task_graph
-export type { TaskGraphNodeKind, TaskGraphStateCategory, TaskGraphNode, TaskGraphSnapshot } from "./task_graph.js";
+export type { TaskGraphNodeKind, TaskGraphStateCategory, TaskGraphNode, TaskGraphNodeRuntimeOverlay, TaskGraphSnapshot } from "./task_graph.js";
 export type {
   RuntimeBadgeKind,
   TaskGraphRuntimeOverlay,

--- a/packages/gateway-schema/src/task_graph.ts
+++ b/packages/gateway-schema/src/task_graph.ts
@@ -39,6 +39,32 @@ export interface TaskGraphNode {
   run_id?: string;
   /** Count of comments / evidence notes attached to this node. */
   comment_count?: number;
+  /**
+   * Runtime overlay, present exactly when the orchestrator control plane
+   * tracks this node (queued/eligible flags, run linkage). Absent for nodes
+   * known only from the tracker scan (backlog, freshly promoted issues).
+   */
+  runtime_overlay?: TaskGraphNodeRuntimeOverlay;
+}
+
+/**
+ * Runtime overlay embedded on a control-plane-tracked task graph node.
+ * Distinct from `TaskGraphRuntimeOverlay` (task_graph_runtime.ts), the
+ * separately fetched run-status overlay keyed by run id.
+ */
+export interface TaskGraphNodeRuntimeOverlay {
+  eligible: boolean;
+  queued: boolean;
+  active_run_id?: string;
+  last_outcome?: string;
+  retry_count: number;
+  workspace_id?: string;
+  harness_type?: string;
+  conversation_id?: string;
+  last_event_at?: string;
+  diff_summary?: unknown;
+  validation_status?: string;
+  blocker_summary?: string;
 }
 
 /** Flat list response for a project task graph. */

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -3678,6 +3678,48 @@ describe("three-pane task graph", () => {
     await handle.destroy();
   });
 
+  it("selects an untracked active task without a spurious run-unavailable banner", async () => {
+    // An issue promoted Backlog→Todo arrives from the tracker scan alone:
+    // no run_id and no runtime_overlay, and the gateway has no run detail
+    // for it. Clicking it must select the card graph-locally, not surface
+    // "Run unavailable" noise.
+    const promotedGraph: TaskGraphSnapshot = {
+      ...threePaneTaskGraph,
+      nodes: [
+        ...threePaneTaskGraph.nodes,
+        {
+          schema_version: schemaVersionV1(),
+          node_id: "promoted-todo",
+          kind: "issue",
+          identifier: "COE-533",
+          title: "Freshly promoted todo",
+          state: "Todo",
+          state_category: "todo",
+          children: [],
+          blocked_by: [],
+          labels: [],
+        },
+      ],
+    };
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "desktop",
+      transport: buildTransport({ taskGraph: promotedGraph }),
+      graphAdapter: createFixtureGraphAdapter({ completedTasks: completedRows }),
+    });
+    await flushUntil(() => root.querySelector("[data-node-id='promoted-todo']") !== null);
+
+    (root.querySelector("[data-node-id='promoted-todo']") as HTMLButtonElement).click();
+    await flushUntil(() =>
+      root.querySelector("[data-node-id='promoted-todo']")?.classList.contains("is-selected") ?? false,
+    );
+    expect(root.textContent).not.toContain("Run COE-533 unavailable");
+
+    await handle.destroy();
+  });
+
   it("refreshes the Completed pane when live updates complete a task or touch memory", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1235,7 +1235,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       ]);
       return { runDetail, bundle };
     } catch (error) {
-      this.state.connectionMessage = `Run ${runId} unavailable: ${errorMessage(error)}`;
+      // Same as openRun: an untracked active node has no run detail by
+      // design, so a background refresh miss is not worth a banner.
+      if (nodeHasRun(node)) {
+        this.state.connectionMessage = `Run ${runId} unavailable: ${errorMessage(error)}`;
+      }
       return null;
     }
   }
@@ -1297,7 +1301,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.runValidation = null;
       this.state.runApprovals = null;
       this.state.selectedDiffPath = null;
-      this.state.connectionMessage = `Run ${runId} unavailable: ${errorMessage(error)}`;
+      // An active issue the control plane does not track yet (e.g. just
+      // promoted from Backlog, no run dispatched) has no run detail to
+      // serve — the miss is expected, so the selection stays graph-local
+      // without a spurious "Run unavailable" banner. Real lookup failures
+      // on run-carrying nodes still surface.
+      if (nodeHasRun(node)) {
+        this.state.connectionMessage = `Run ${runId} unavailable: ${errorMessage(error)}`;
+      }
     }
     this.state.loading = false;
     this.render();
@@ -5703,6 +5714,17 @@ function nodeLabel(node: TaskGraphNode): string {
 
 function runIdForNode(node: TaskGraphNode): string {
   return node.run_id || node.identifier || node.node_id;
+}
+
+/**
+ * Whether the control plane is expected to serve a run detail for this
+ * node. Backlog nodes and active issues the orchestrator has not picked up
+ * yet arrive from the tracker scan alone (no run linkage, no runtime
+ * overlay) — a /runs/{id} miss on them is by design, so it should not
+ * raise a "Run unavailable" banner.
+ */
+function nodeHasRun(node: TaskGraphNode): boolean {
+  return Boolean(node.run_id || node.runtime_overlay);
 }
 
 function findNodeByRef(nodes: TaskGraphNode[], ref: string): TaskGraphNode | undefined {


### PR DESCRIPTION
## Problem
Promoting a story from Backlog to Todo made it vanish from the Task Graph entirely (e.g. COE-533 and the rest of its milestone): it left the Backlog pane but never appeared in Current.

## Cause
`LinearClient::project_task_graph_issues` kept only (a) identifiers tracked by the control plane and (b) backlog-state issues from the project scan. A freshly promoted Todo issue is neither — the orchestrator hasn't dispatched it yet — so it was silently dropped from the snapshot.

## Fix
The single project scan now also carries unrequested **active-state** (unstarted/started) issues. The gateway already maps untracked issues by tracker state (`Unstarted`→Todo, `Started`→InProgress), so they land in the Current pane immediately; once the control plane picks them up, its runtime state takes over as before.

## Tests
- `project_task_graph_issues_return_requested_backlog_and_active_from_one_scan` — updated to assert the unrequested Todo issue is included (previously asserted the buggy exclusion).
- `gateway_task_graph_includes_backlog_issues_with_cross_edges` — extended with an untracked Todo issue asserting it surfaces with `state_category: todo` and no runtime overlay.
- `cargo fmt --check`, `clippy -D warnings`, and full workspace tests green locally.