### PR TITLE
feat(graph): declutter task cards, redirect arrows, resizable lower row

### DIFF
--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -87,11 +87,22 @@ The knowledge-graph surface is a 3D command center:
   node's neighborhood or an area hull. Camera and drag overrides persist in
   `KnowledgeGraphViewState` across live refreshes.
 
-Task-graph dependency arrows route skip-level edges through a left gutter
-with one lane and one hue per blocker (rounded corners, colored arrowheads);
-hovering a task spotlights its incident arrows. See
+Task-graph dependency arrows distinguish depth by where and how they meet the
+target's connector circle: next-level edges arrive vertically at the **top** of
+the circle (arrowhead pointing down), while skip-level edges route through a
+left gutter — one lane and one hue per blocker, rounded corners, colored
+arrowheads — and arrive horizontally at the **left** edge of the circle
+(arrowhead pointing right). Hovering a task spotlights its incident arrows. See
 `renderTaskGraphLink`/`buildTaskGraphLinks` in
 `packages/ui-core/src/app-shell.ts`.
+
+Read-only task cards are a single row: the connector circle, the identifier and
+title, then the run **Status** pill and a **BLOCKER** badge (when the task is
+actively blocking others) pinned to the right. Dependencies read from the
+arrows and the connector glyph (`<`, `>`, `<>`), not a text line; the full
+`blocked by … | blocks …` breakdown lives in the Run Detail panel. The task
+filters are **Status** and **Search** only — every node is a task, so there is
+no kind or runtime filter.
 
 ### Three-pane task graph
 
@@ -109,7 +120,7 @@ The desktop task surface splits into three panes
   the task's capsule through `openMemoryDeepLink`.
 - **Current** (center, never collapses) — the dispatchable dependency graph
   as before (Todo / In Progress / Human Review / Rework). Canceled nodes
-  also stay here (they have no other pane, and the Canceled state filter
+  also stay here (they have no other pane, and the Canceled status filter
   must still surface them). Selecting or hovering a task boldens its
   incoming and outgoing edges, including outgoing edges that leave the
   pane's right side toward blocked Backlog tasks.

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -758,9 +758,12 @@ describe("OpenSymphonyApp mount", () => {
     expect(shellStyleText).toMatch(/\.os-tg-hue-0 \{[^}]*marker-end: url\(#os-task-arrow-0\)/);
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-lane")).toBe("1");
     expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-indent")).toBe("34px");
-    expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-height")).toBe("78px");
-    expect(root.querySelector("[data-node-id='desktop-alpha'] [data-testid='dependency-suffix']")?.textContent).toContain("blocks COE-450, COE-452");
-    expect(root.querySelector("[data-node-id='app-shell'] [data-testid='dependency-suffix']")?.textContent).toContain("blocked by COE-449");
+    expect((root.querySelector("[data-node-id='app-shell']") as HTMLElement).style.getPropertyValue("--os-node-height")).toBe("44px");
+    // Dependencies are read from the connector glyph + arrows now, not a text
+    // line on the card: a downstream-only blocker shows ">", a blocked task "<".
+    expect(root.querySelector("[data-node-id='desktop-alpha'] .os-node-gutter")?.textContent).toContain(">");
+    expect(root.querySelector("[data-node-id='app-shell'] .os-node-gutter")?.textContent).toContain("<");
+    expect(root.querySelector("[data-node-id='desktop-alpha'] [data-testid='dependency-suffix']")).toBeNull();
     expect(root.querySelector("[data-node-id='app-shell'] .os-badge-blocker")).toBeNull();
     expect(root.querySelector("[data-node-id='desktop-alpha'] .os-badge-blocker")).not.toBeNull();
     expect(root.textContent).not.toContain("blocked by COE-448");
@@ -2150,10 +2153,14 @@ describe("OpenSymphonyApp mount", () => {
     expect(headings[1]).toContain("issues=2 running=0 todo=2 blocked=1");
     expect(headings[2]).toContain("issues=1 running=0 todo=1 blocked=0");
     expect(root.querySelector("[data-project-group='__opensymphony_unassigned__'] [data-node-id='COE-705']")).not.toBeNull();
-    expect(root.querySelector("[data-node-id='COE-700'] [data-testid='dependency-suffix']")?.textContent).toContain("blocks COE-701");
-    expect(root.querySelector("[data-node-id='COE-701'] [data-testid='dependency-suffix']")?.textContent).toContain("blocked by COE-700");
-    expect(root.querySelector("[data-node-id='COE-702'] [data-testid='dependency-suffix']")?.textContent).toContain("blocked by 1 hidden");
-    expect(root.querySelector("[data-node-id='COE-703'] [data-testid='dependency-suffix']")?.textContent ?? "").not.toContain("blocked by COE-704");
+    // Dependencies now surface as connector glyphs + arrows instead of a text
+    // line: ">" downstream (blocks), "<" upstream (blocked, visible or hidden).
+    expect(root.querySelector("[data-testid='task-graph-link'][data-link-from='COE-700'][data-link-to='COE-701']")).not.toBeNull();
+    expect(root.querySelector("[data-node-id='COE-700'] .os-node-gutter")?.textContent).toContain(">");
+    expect(root.querySelector("[data-node-id='COE-701'] .os-node-gutter")?.textContent).toContain("<");
+    expect(root.querySelector("[data-node-id='COE-702'] .os-node-gutter")?.textContent).toContain("<");
+    // COE-704 is terminal, so it is not an active blocker of COE-703 (no "<").
+    expect(root.querySelector("[data-node-id='COE-703'] .os-node-gutter")?.textContent ?? "").not.toContain("<");
 
     (root.querySelector("[data-project-group-toggle='beta-project']") as HTMLButtonElement).click();
     await flushUntil(
@@ -3501,11 +3508,10 @@ describe("three-pane task graph", () => {
     // the Canceled state filter can still surface them.
     expect(root.querySelector("[data-tg-pane='current'] [data-node-id='canceled-node']")).not.toBeNull();
 
-    // Backlog dependency suffix names the Current blocker instead of
-    // calling it hidden: both graph panes count as visible.
-    expect(
-      root.querySelector("[data-node-id='backlog-a'] [data-testid='dependency-suffix']")?.textContent,
-    ).toContain("blocked by COE-449");
+    // The backlog task's upstream blocker lives in the Current pane (both
+    // graph panes count as visible), so its connector glyph shows "<" and the
+    // specific blocker is named by the cross-pane edge below.
+    expect(root.querySelector("[data-node-id='backlog-a'] .os-node-gutter")?.textContent).toContain("<");
 
     // The cross-pane edge from the Current blocker into the Backlog exists
     // with the shared link data contract (geometry is measured in-browser).

--- a/packages/ui-core/__tests__/task-graph-editor.test.ts
+++ b/packages/ui-core/__tests__/task-graph-editor.test.ts
@@ -229,60 +229,6 @@ describe("TaskGraphEditor", () => {
     await handle.destroy();
   });
 
-  it("filters task nodes by runtime badge", async () => {
-    const root = document.createElement("div");
-    document.body.appendChild(root);
-    const handle = renderOpenSymphonyApp({
-      root,
-      mode: "web",
-      transport: buildTransport(),
-    });
-
-    await flushUntil(() => root.querySelector("[data-tg-filter='runtime']") !== null);
-
-    let runtimeSelect = root.querySelector("[data-tg-filter='runtime']") as HTMLSelectElement;
-    runtimeSelect.value = "running";
-    runtimeSelect.dispatchEvent(new Event("change"));
-    await flushAsync();
-
-    expect(root.querySelector("[data-node-id='editor-1']")).not.toBeNull();
-    expect(root.querySelector("[data-node-id='editor-2']")).toBeNull();
-    expect(root.querySelector("[data-node-id='editor-3']")).toBeNull();
-
-    runtimeSelect = root.querySelector("[data-tg-filter='runtime']") as HTMLSelectElement;
-    runtimeSelect.value = "complete";
-    runtimeSelect.dispatchEvent(new Event("change"));
-    await flushAsync();
-
-    expect(root.querySelector("[data-node-id='editor-1']")).toBeNull();
-    expect(root.querySelector("[data-node-id='editor-2']")).not.toBeNull();
-
-    await handle.destroy();
-  });
-
-  it("filters the runtime badge option to match the emitted badge", async () => {
-    const root = document.createElement("div");
-    document.body.appendChild(root);
-    const handle = renderOpenSymphonyApp({
-      root,
-      mode: "web",
-      transport: buildTransport(),
-    });
-
-    await flushUntil(() => root.querySelector("[data-tg-filter='runtime']") !== null);
-    expect(root.querySelector("[data-node-id='editor-1']")?.querySelector(".os-badge-blocker")).not.toBeNull();
-
-    const runtimeSelect = root.querySelector("[data-tg-filter='runtime']") as HTMLSelectElement;
-    runtimeSelect.value = "blocker";
-    runtimeSelect.dispatchEvent(new Event("change"));
-    await flushAsync();
-
-    expect(root.querySelector("[data-node-id='editor-1']")).not.toBeNull();
-    expect(root.querySelector("[data-node-id='editor-2']")).toBeNull();
-
-    await handle.destroy();
-  });
-
   it("preserves search input focus and cursor position while typing", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
@@ -309,7 +255,7 @@ describe("TaskGraphEditor", () => {
     await handle.destroy();
   });
 
-  it("filters task nodes by kind and state", async () => {
+  it("filters task nodes by status", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);
     const handle = renderOpenSymphonyApp({
@@ -318,20 +264,7 @@ describe("TaskGraphEditor", () => {
       transport: buildTransport(),
     });
 
-    await flushUntil(() => root.querySelector("[data-tg-filter='kind']") !== null);
-
-    let kindSelect = root.querySelector("[data-tg-filter='kind']") as HTMLSelectElement;
-    kindSelect.value = "milestone";
-    kindSelect.dispatchEvent(new Event("change"));
-    await flushAsync();
-
-    expect(root.querySelector("[data-node-id='m1']")).not.toBeNull();
-    expect(root.querySelector("[data-node-id='editor-1']")).toBeNull();
-
-    kindSelect = root.querySelector("[data-tg-filter='kind']") as HTMLSelectElement;
-    kindSelect.value = "all";
-    kindSelect.dispatchEvent(new Event("change"));
-    await flushAsync();
+    await flushUntil(() => root.querySelector("[data-tg-filter='state']") !== null);
 
     const stateSelect = root.querySelector("[data-tg-filter='state']") as HTMLSelectElement;
     stateSelect.value = "done";
@@ -340,6 +273,7 @@ describe("TaskGraphEditor", () => {
 
     expect(root.querySelector("[data-node-id='editor-2']")).not.toBeNull();
     expect(root.querySelector("[data-node-id='editor-1']")).toBeNull();
+    expect(root.querySelector("[data-node-id='m1']")).toBeNull();
 
     await handle.destroy();
   });
@@ -375,11 +309,11 @@ describe("TaskGraphEditor", () => {
       transport: buildTransport(),
     });
 
-    await flushUntil(() => root.querySelector("[data-tg-filter='kind']") !== null);
+    await flushUntil(() => root.querySelector("[data-tg-filter='state']") !== null);
 
-    let kindSelect = root.querySelector("[data-tg-filter='kind']") as HTMLSelectElement;
-    kindSelect.value = "milestone";
-    kindSelect.dispatchEvent(new Event("change"));
+    const stateSelect = root.querySelector("[data-tg-filter='state']") as HTMLSelectElement;
+    stateSelect.value = "done";
+    stateSelect.dispatchEvent(new Event("change"));
     await flushAsync();
     expect(root.querySelector("[data-node-id='editor-1']")).toBeNull();
 

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1622,12 +1622,19 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const startY = event.clientY;
     const startHeight = this.state.lowerRowHeight;
     const shell = this.options.root.querySelector<HTMLElement>(".os-lower-columns");
+    // The graph pane above is fixed-height, so a growing row extends downward
+    // and the handle would drift away from the cursor. Scroll the page by the
+    // same amount the row actually grows so the handle tracks the cursor and
+    // the divider + panes visually move up as the row expands.
+    const scroller = scrollContainerFor(shell);
+    const startScrollTop = scroller.get();
     const move = (moveEvent: PointerEvent) => {
       // The divider sits above the row, so dragging up (clientY decreases)
       // grows the row below and dragging down shrinks it.
       const next = clamp(startHeight - (moveEvent.clientY - startY), lowerRowHeightBounds.min, lowerRowHeightBounds.max);
       this.state.lowerRowHeight = next;
       shell?.style.setProperty("--os-lower-row-height", `${next}px`);
+      scroller.set(startScrollTop + (next - startHeight));
     };
     const done = () => {
       window.removeEventListener("pointermove", move);
@@ -4522,6 +4529,27 @@ function renderPaneResizer(handle: WorkspacePaneResizeHandle, label: string, val
       <span aria-hidden="true"></span>
     </div>
   `;
+}
+
+/**
+ * Nearest scrollable ancestor of `el` (vertical), falling back to the
+ * document scrolling element. Used so the lower-row resizer can scroll the
+ * page as the row grows, keeping the divider under the cursor.
+ */
+function scrollContainerFor(el: HTMLElement | null): { get(): number; set(value: number): void } {
+  const doc = el?.ownerDocument ?? document;
+  const view = doc.defaultView;
+  let node: HTMLElement | null = el?.parentElement ?? null;
+  while (node) {
+    const overflowY = view?.getComputedStyle(node).overflowY;
+    if ((overflowY === "auto" || overflowY === "scroll") && node.scrollHeight > node.clientHeight) {
+      const target = node;
+      return { get: () => target.scrollTop, set: (value) => { target.scrollTop = value; } };
+    }
+    node = node.parentElement;
+  }
+  const root = doc.scrollingElement ?? doc.documentElement;
+  return { get: () => root.scrollTop, set: (value) => { root.scrollTop = value; } };
 }
 
 function renderLowerRowResizer(height: number): string {

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1623,7 +1623,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const startHeight = this.state.lowerRowHeight;
     const shell = this.options.root.querySelector<HTMLElement>(".os-lower-columns");
     const move = (moveEvent: PointerEvent) => {
-      const next = clamp(startHeight + (moveEvent.clientY - startY), lowerRowHeightBounds.min, lowerRowHeightBounds.max);
+      // The divider sits above the row, so dragging up (clientY decreases)
+      // grows the row below and dragging down shrinks it.
+      const next = clamp(startHeight - (moveEvent.clientY - startY), lowerRowHeightBounds.min, lowerRowHeightBounds.max);
       this.state.lowerRowHeight = next;
       shell?.style.setProperty("--os-lower-row-height", `${next}px`);
     };
@@ -1645,8 +1647,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       return;
     }
     event.preventDefault();
-    // The divider sits above the row: ArrowDown grows it, ArrowUp shrinks it.
-    const delta = event.key === "ArrowDown" ? lowerRowResizeStep : -lowerRowResizeStep;
+    // The divider sits above the row: ArrowUp grows it, ArrowDown shrinks it,
+    // matching the pointer drag direction.
+    const delta = event.key === "ArrowUp" ? lowerRowResizeStep : -lowerRowResizeStep;
     this.state.lowerRowHeight = clamp(this.state.lowerRowHeight + delta, lowerRowHeightBounds.min, lowerRowHeightBounds.max);
     this.render();
   }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -234,6 +234,9 @@ interface AppState {
   // Widths (px) of the collapsible task-graph side panes; the Current pane
   // between them flexes to absorb the remainder.
   taskPaneSizes: { done: number; backlog: number };
+  // Height (px) of the lower Run Detail / Inspector row; drag the divider
+  // between the graph pane and this row to resize it vertically.
+  lowerRowHeight: number;
   eventLogModalOpen: boolean;
   runValidation: RunValidationSummary | null;
   runApprovals: ApprovalRequest[] | null;
@@ -315,6 +318,11 @@ const taskPaneSizeBounds: Record<TaskSidePane, { min: number; max: number }> = {
   backlog: { min: 240, max: 620 },
 };
 const taskPaneResizeStep = 24;
+// Lower Run Detail / Inspector row: taller by default than the old fixed
+// clamp, and drag-resizable vertically between these bounds.
+const defaultLowerRowHeight = 520;
+const lowerRowHeightBounds = { min: 240, max: 1000 };
+const lowerRowResizeStep = 24;
 const completedTasksPageSize = 25;
 const defaultCompletedTasksParams = { query: "", sort: "completed_desc", page: 1 } as const;
 
@@ -409,6 +417,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       collapsedActivityEvents: new Set(),
       workspacePaneSizes: createDefaultWorkspacePaneSizes(),
       taskPaneSizes: { ...defaultTaskPaneSizes },
+      lowerRowHeight: defaultLowerRowHeight,
       eventLogModalOpen: false,
       runValidation: null,
       runApprovals: null,
@@ -1604,6 +1613,44 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.render();
   }
 
+  /** Drag the divider between the graph pane and the lower row to a new px height. */
+  private startLowerRowResize(handle: string | undefined, event: PointerEvent): void {
+    if (handle !== "lower") {
+      return;
+    }
+    event.preventDefault();
+    const startY = event.clientY;
+    const startHeight = this.state.lowerRowHeight;
+    const shell = this.options.root.querySelector<HTMLElement>(".os-lower-columns");
+    const move = (moveEvent: PointerEvent) => {
+      const next = clamp(startHeight + (moveEvent.clientY - startY), lowerRowHeightBounds.min, lowerRowHeightBounds.max);
+      this.state.lowerRowHeight = next;
+      shell?.style.setProperty("--os-lower-row-height", `${next}px`);
+    };
+    const done = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", done);
+      this.render();
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", done, { once: true });
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+  }
+
+  private onLowerRowResizeKey(handle: string | undefined, event: KeyboardEvent): void {
+    if (handle !== "lower") {
+      return;
+    }
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {
+      return;
+    }
+    event.preventDefault();
+    // The divider sits above the row: ArrowDown grows it, ArrowUp shrinks it.
+    const delta = event.key === "ArrowDown" ? lowerRowResizeStep : -lowerRowResizeStep;
+    this.state.lowerRowHeight = clamp(this.state.lowerRowHeight + delta, lowerRowHeightBounds.min, lowerRowHeightBounds.max);
+    this.render();
+  }
+
   private async dispatchRunAction(action: RunAction): Promise<void> {
     const runId = this.state.runDetail?.run_id;
     if (!runId) return;
@@ -2168,7 +2215,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     return `
       <section class="os-workspace-shell" data-testid="workspace-pane-shell" data-graph-surface="${escapeAttr(this.state.graphPaneView)}">
         ${this.renderGraphPane()}
-        <section class="os-lower-columns" data-testid="workspace-lower-columns" style="--os-left-column: ${panePercent(sizes.left)}; --os-right-column: ${panePercent(sizes.right)};">
+        ${renderLowerRowResizer(this.state.lowerRowHeight)}
+        <section class="os-lower-columns" data-testid="workspace-lower-columns" style="--os-left-column: ${panePercent(sizes.left)}; --os-right-column: ${panePercent(sizes.right)}; --os-lower-row-height: ${this.state.lowerRowHeight}px;">
           ${this.renderLowerColumn("left")}
           ${renderPaneResizer("lower-columns", "Resize lower workspace columns", sizes.left)}
           ${this.renderLowerColumn("right")}
@@ -2554,7 +2602,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         buildRuntimeOverlay(node, run),
       );
     };
-    const filtered = filterTaskGraphNodes(taskGraph.nodes, this.state.taskGraphFilter, getOverlay);
+    const filtered = filterTaskGraphNodes(taskGraph.nodes, this.state.taskGraphFilter);
     if (this.options.mode === "web") {
       return this.renderEditableTaskGraph(taskGraph, filtered, getOverlay);
     }
@@ -3564,6 +3612,14 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         this.onTaskPaneResizeKey(handle.dataset.tgResizer, event as KeyboardEvent);
       });
     });
+    this.options.root.querySelectorAll<HTMLElement>("[data-row-resizer]").forEach((handle) => {
+      this.listen(handle, "row-resizer", "pointerdown", (event) => {
+        this.startLowerRowResize(handle.dataset.rowResizer, event as PointerEvent);
+      });
+      this.listen(handle, "row-resizer", "keydown", (event) => {
+        this.onLowerRowResizeKey(handle.dataset.rowResizer, event as KeyboardEvent);
+      });
+    });
     this.options.root.querySelectorAll<HTMLElement>("[data-activity-toggle]").forEach((button) => {
       this.listen(button, "activity-toggle", "click", () => {
         const eventKey = button.dataset.activityToggle;
@@ -3993,11 +4049,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   private onFilterChange(): void {
     const root = this.options.root;
-    const kind = (root.querySelector<HTMLSelectElement>("[data-tg-filter='kind']")?.value ?? "all") as TaskGraphFilter["kind"];
-    const runtime = (root.querySelector<HTMLSelectElement>("[data-tg-filter='runtime']")?.value ?? "all") as TaskGraphFilter["runtime"];
     const state = (root.querySelector<HTMLSelectElement>("[data-tg-filter='state']")?.value ?? "all") as TaskGraphFilter["stateCategory"];
     const search = root.querySelector<HTMLInputElement>("[data-tg-filter='search']")?.value ?? "";
-    this.state.taskGraphFilter = { kind, runtime, stateCategory: state, search };
+    this.state.taskGraphFilter = { stateCategory: state, search };
     this.renderPreservingFocus();
   }
 
@@ -4462,6 +4516,14 @@ function restoreShellScrollPositions(
 function renderPaneResizer(handle: WorkspacePaneResizeHandle, label: string, value: number): string {
   return `
     <div class="os-pane-resizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="${escapeAttr(label)}" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(value)}" data-pane-resizer="${handle}">
+      <span aria-hidden="true"></span>
+    </div>
+  `;
+}
+
+function renderLowerRowResizer(height: number): string {
+  return `
+    <div class="os-pane-resizer os-row-resizer" role="separator" tabindex="0" aria-orientation="horizontal" aria-label="Resize lower workspace row" aria-valuemin="${lowerRowHeightBounds.min}" aria-valuemax="${lowerRowHeightBounds.max}" aria-valuenow="${Math.round(height)}" data-row-resizer="lower">
       <span aria-hidden="true"></span>
     </div>
   `;
@@ -5017,8 +5079,10 @@ interface TaskGraphLink {
   hue: number;
 }
 
-const taskGraphRowHeight = 78;
+const taskGraphRowHeight = 44;
 const taskGraphRowGap = 8;
+/** Radius of the connector circle (.os-node-gutter, 22px) centred on each row. */
+const taskGraphNodeRadius = 11;
 /**
  * Skip-level dependency arrows route through a dedicated left gutter, one
  * lane and one hue per blocker, so several long-range dependencies stay
@@ -5570,25 +5634,36 @@ function renderTaskGraphLink(
   const y1 = link.from.index * (taskGraphRowHeight + taskGraphRowGap) + taskGraphRowHeight / 2;
   const y2 = link.to.index * (taskGraphRowHeight + taskGraphRowGap) + taskGraphRowHeight / 2;
   const linkAttrs = `data-testid="task-graph-link" data-link-from="${escapeAttr(link.from.node.node_id)}" data-link-to="${escapeAttr(link.to.node.node_id)}"`;
+  const r = taskGraphNodeRadius;
   if (link.span > 1) {
+    // Skip-level arrows sweep out through the left gutter and arrive
+    // horizontally at the LEFT edge of the target circle (pointing right), so
+    // several long-range blockers on one task stay individually legible.
     const routeX = Math.max(4, railX - 16 - link.routeLane * taskGraphSkipLaneGap);
     const turn = Math.min(14, Math.abs(y2 - y1) / 2, Math.max(4, x1 - routeX));
     const direction = y2 > y1 ? 1 : -1;
+    const endX = x2 - r;
     const d = [
       `M ${x1} ${y1}`,
       `H ${routeX + turn}`,
       `Q ${routeX} ${y1} ${routeX} ${y1 + turn * direction}`,
       `V ${y2 - turn * direction}`,
       `Q ${routeX} ${y2} ${routeX + turn} ${y2}`,
-      `H ${x2}`,
+      `H ${endX}`,
     ].join(" ");
     // The hue-specific marker is applied via CSS (see .os-tg-hue-* rules):
     // a `marker-end` presentation attribute here would lose to the base
     // `.os-task-graph-link` CSS rule, leaving every skip arrowhead default.
     return `<path class="os-task-graph-link os-task-graph-link-skip os-tg-hue-${link.hue}" ${linkAttrs} d="${escapeAttr(d)}"></path>`;
   }
-  const bend = Math.max(34, Math.abs(y2 - y1) * 0.24);
-  const d = `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${Math.max(x2 - bend, x1 + 18)} ${y2}, ${x2} ${y2}`;
+  // Next-level arrows arrive vertically at the TOP of the target circle
+  // (pointing down, orient=auto follows the tangent). Same lane → a straight
+  // drop; one lane deeper → an S-curve that shifts right while still landing
+  // vertically, which distinguishes it from the sideways skip-level arrows.
+  const dir = y2 >= y1 ? 1 : -1;
+  const endY = y2 - r * dir;
+  const bend = Math.min(20, Math.max(8, Math.abs(endY - y1) * 0.5));
+  const d = `M ${x1} ${y1} C ${x1} ${y1 + bend * dir}, ${x2} ${endY - bend * dir}, ${x2} ${endY}`;
   return `<path class="os-task-graph-link" ${linkAttrs} d="${escapeAttr(d)}"></path>`;
 }
 
@@ -5627,16 +5702,13 @@ function renderReadOnlyTaskGraphNode(
 ): string {
   const { node, signal } = model;
   const isSelected = node.node_id === selectedNodeId;
-  const overlayBadges = overlay.badges.length ? overlay.badges.map(renderBadge).join("") : "";
-  const runMeta = overlay.run_id
-    ? `<span class="os-run-meta">run ${escapeHtml(overlay.run_id)}</span>`
-    : "";
   const stateTone = stateToneForTaskNode(node);
   const hasUpstream = signal.upstreamVisible.length > 0 || signal.upstreamHiddenCount > 0;
   const hasDownstream = signal.downstreamVisible.length > 0 || signal.downstreamHiddenCount > 0;
-  const dependencyMeta = signal.suffix
-    ? `<span class="os-node-dependency" data-testid="dependency-suffix">${escapeHtml(signal.suffix)}</span>`
-    : "";
+  // Dependencies read from the connector arrows now, so the card only keeps
+  // the two badges that can't be inferred from position: the run status and
+  // whether this task is actively blocking others.
+  const blockerBadge = overlay.badges.includes("blocker") ? renderBadge("blocker") : "";
   const dependencyGlyph = hasUpstream && hasDownstream
     ? "<>"
     : hasUpstream
@@ -5648,18 +5720,13 @@ function renderReadOnlyTaskGraphNode(
   return `
     <button type="button" class="os-node os-node-readonly ${isSelected ? "is-selected" : ""} ${hasUpstream ? "os-node-has-upstream" : ""} ${hasDownstream ? "os-node-has-downstream" : ""}" data-node-id="${escapeAttr(node.node_id)}" style="--os-lane: ${model.lane}; --os-node-indent: ${model.lane * taskGraphLaneWidth}px; --os-node-height: ${taskGraphRowHeight}px;">
       <span class="os-node-gutter" aria-hidden="true">${escapeHtml(dependencyGlyph)}</span>
-      <span class="os-node-main">
-        <span class="os-node-line">
-          <strong>${escapeHtml(node.identifier)}</strong>
-          <span>${escapeHtml(node.title)}</span>
-        </span>
-        ${dependencyMeta}
-        <span class="os-node-subline">
-          <span class="os-node-kind">${escapeHtml(node.kind.replace(/_/g, " "))}</span>
-          <em class="os-node-state os-node-state-${escapeAttr(stateTone)}">${escapeHtml(node.state)}</em>
-          <span class="os-node-badges">${overlayBadges}</span>
-          ${runMeta}
-        </span>
+      <span class="os-node-line">
+        <strong>${escapeHtml(node.identifier)}</strong>
+        <span>${escapeHtml(node.title)}</span>
+      </span>
+      <span class="os-node-tags">
+        <em class="os-node-state os-node-state-${escapeAttr(stateTone)}">${escapeHtml(node.state)}</em>
+        ${blockerBadge}
       </span>
     </button>
   `;
@@ -5886,13 +5953,16 @@ function appShellStyles(): string {
     .os-graph-hero-toolbar h2 { margin: 0; font-size: 15px; letter-spacing: 0; }
     .os-graph-hero-toolbar span { display: block; color: #667788; font-size: 12px; margin-top: 2px; }
     .os-graph-hero-body { min-width: 0; }
-    .os-lower-columns { display: flex; align-items: stretch; gap: 0; min-height: 360px; }
-    .os-lower-columns > .os-panel { box-sizing: border-box; max-height: clamp(320px, calc(100vh - 560px), 560px); min-height: 320px; overflow: auto; }
+    .os-lower-columns { display: flex; align-items: stretch; gap: 0; height: var(--os-lower-row-height, 520px); min-height: 0; }
+    .os-lower-columns > .os-panel { box-sizing: border-box; height: 100%; min-height: 0; overflow: auto; }
     .os-lower-columns > .os-panel:first-child { flex: 0 0 calc(var(--os-left-column, 50%) - 5px); }
     .os-lower-columns > .os-panel:last-child { flex: 0 0 calc(var(--os-right-column, 50%) - 5px); }
     .os-pane-resizer { flex: 0 0 10px; min-width: 10px; display: grid; place-items: center; cursor: col-resize; touch-action: none; outline: none; }
     .os-pane-resizer span { width: 2px; height: 100%; min-height: 44px; border-radius: 999px; background: #cad3dd; transition-property: background-color, width; transition-duration: 150ms; transition-timing-function: cubic-bezier(0.2, 0, 0, 1); }
     .os-pane-resizer:hover span, .os-pane-resizer:focus-visible span { width: 3px; background: #39708f; }
+    .os-row-resizer { flex: none; width: 100%; height: 12px; cursor: row-resize; }
+    .os-row-resizer span { width: 100%; min-width: 44px; height: 2px; min-height: 0; }
+    .os-row-resizer:hover span, .os-row-resizer:focus-visible span { width: 100%; height: 3px; background: #39708f; }
     .os-panel-collapsed { padding-bottom: 12px; }
     .os-section-head > div { min-width: 0; }
     .os-section-head > div span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -6081,7 +6151,7 @@ function appShellStyles(): string {
     .os-project-group-header strong, .os-project-group-header em { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .os-project-group-header strong { color: #17202a; font-size: 12px; }
     .os-project-group-header em { color: #667788; font-size: 11px; font-style: normal; }
-    .os-node-readonly { box-sizing: border-box; grid-template-columns: 28px minmax(0, 1fr); align-items: center; height: var(--os-node-height, 78px); width: calc(100% - var(--os-node-indent, 0px) - 8px); margin-left: var(--os-node-indent, 0px); margin-right: 8px; padding: 8px 10px; border-radius: 8px; font-size: 12px; overflow: hidden; transition-property: background-color, border-color, box-shadow, transform; transition-duration: 150ms; transition-timing-function: ease-out; }
+    .os-node-readonly { box-sizing: border-box; grid-template-columns: 28px minmax(0, 1fr) auto; column-gap: 10px; align-items: center; height: var(--os-node-height, 44px); width: calc(100% - var(--os-node-indent, 0px) - 8px); margin-left: var(--os-node-indent, 0px); margin-right: 8px; padding: 6px 10px; border-radius: 8px; font-size: 12px; overflow: hidden; transition-property: background-color, border-color, box-shadow, transform; transition-duration: 150ms; transition-timing-function: ease-out; }
     .os-node-readonly:active { transform: scale(0.996); }
     .os-node-gutter { width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; color: #39708f; font-size: 11px; font-weight: 800; white-space: pre; background: #e7f1f5; box-shadow: 0 0 0 1px rgba(57, 112, 143, 0.28); }
     .os-node-gutter:empty { background: transparent; box-shadow: 0 0 0 1px rgba(57, 112, 143, 0.18); }
@@ -6089,6 +6159,7 @@ function appShellStyles(): string {
     .os-node-has-downstream .os-node-gutter { background: #e7f1f5; color: #23566f; box-shadow: 0 0 0 1px rgba(57, 112, 143, 0.34); }
     .os-node-has-upstream.os-node-has-downstream .os-node-gutter { background: #fef3c7; color: #78350f; box-shadow: 0 0 0 1px rgba(146, 64, 14, 0.38); }
     .os-node-main, .os-node-line, .os-node-subline { min-width: 0; }
+    .os-node-tags { display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; margin-left: auto; }
     .os-node-line { display: flex; gap: 8px; align-items: baseline; flex-wrap: nowrap; }
     .os-node-line > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .os-node-line strong { flex: 0 0 auto; font-size: 12px; font-variant-numeric: tabular-nums; }
@@ -6321,7 +6392,8 @@ function appShellStyles(): string {
       .os-grid { grid-template-columns: 1fr; }
       .os-profile-panel, .os-model-panel, .os-task-graph-panel, .os-graph-hero-panel, .os-run-detail-panel, .os-run-evidence-panel, .os-planning-panel { grid-column: 1 / -1; }
       .os-workspace-shell, .os-lower-columns { display: grid; grid-template-columns: 1fr; gap: 14px; min-height: 0; }
-      .os-lower-columns > .os-panel { max-height: none; min-height: 0; overflow: visible; }
+      .os-lower-columns { height: auto; }
+      .os-lower-columns > .os-panel { height: auto; max-height: none; min-height: 0; overflow: visible; }
       .os-pane-resizer { display: none; }
       .os-inline-fields, .os-model-layout, .os-advanced-grid, .os-run-grid { grid-template-columns: 1fr; }
       .os-topbar, .os-status-strip { grid-template-columns: 1fr; align-items: stretch; }

--- a/packages/ui-core/src/task-graph-editor.ts
+++ b/packages/ui-core/src/task-graph-editor.ts
@@ -1,6 +1,5 @@
 import type {
   TaskGraphNode,
-  TaskGraphNodeKind,
   TaskGraphSnapshot,
   RunDetail,
   TaskGraphRuntimeOverlay,
@@ -8,19 +7,12 @@ import type {
   TaskGraphStateCategory,
 } from "@opensymphony/gateway-schema";
 
-export type TaskGraphFilterKind = TaskGraphNodeKind | "all";
-export type TaskGraphFilterRuntime = RuntimeBadgeKind | "all";
-
 export interface TaskGraphFilter {
-  kind: TaskGraphFilterKind;
-  runtime: TaskGraphFilterRuntime;
   stateCategory: TaskGraphStateCategory | "all";
   search: string;
 }
 
 export const defaultTaskGraphFilter: TaskGraphFilter = {
-  kind: "all",
-  runtime: "all",
   stateCategory: "all",
   search: "",
 };
@@ -86,19 +78,13 @@ export function buildRuntimeOverlay(
   };
 }
 
-/** Apply kind, runtime badge, state category, and text filters to task graph nodes. */
+/** Apply status (state category) and text filters to task graph nodes. */
 export function filterTaskGraphNodes(
   nodes: TaskGraphNode[],
   filter: TaskGraphFilter,
-  getOverlay: (node: TaskGraphNode) => TaskGraphRuntimeOverlay,
 ): TaskGraphNode[] {
   return nodes.filter((node) => {
-    if (filter.kind !== "all" && node.kind !== filter.kind) return false;
     if (filter.stateCategory !== "all" && node.state_category !== filter.stateCategory) return false;
-    if (filter.runtime !== "all") {
-      const overlay = getOverlay(node);
-      if (!overlay.badges.includes(filter.runtime)) return false;
-    }
     if (filter.search) {
       const term = filter.search.toLowerCase();
       const haystack = `${node.identifier} ${node.title} ${node.state} ${node.labels.join(" ")}`.toLowerCase();
@@ -115,33 +101,8 @@ export function renderBadge(kind: RuntimeBadgeKind): string {
 
 /** Render the filter bar for the task graph editor. */
 export function renderTaskGraphFilters(filter: TaskGraphFilter): string {
-  const kindOptions = [
-    { value: "all", label: "All kinds" },
-    { value: "milestone", label: "Milestone" },
-    { value: "issue", label: "Issue" },
-    { value: "sub_issue", label: "Sub-issue" },
-  ]
-    .map((opt) => `<option value="${opt.value}" ${filter.kind === opt.value ? "selected" : ""}>${opt.label}</option>`)
-    .join("");
-
-  const runtimeOptions = [
-    { value: "all", label: "All runtime" },
-    { value: "running", label: "Running" },
-    { value: "queued", label: "Queued" },
-    { value: "complete", label: "Complete" },
-    { value: "failed", label: "Failed" },
-    { value: "stale", label: "Stale" },
-    { value: "blocker", label: "Blocker" },
-    { value: "retry", label: "Retry" },
-    { value: "workspace", label: "Workspace" },
-    { value: "harness", label: "Harness" },
-    { value: "validation", label: "Validation" },
-  ]
-    .map((opt) => `<option value="${opt.value}" ${filter.runtime === opt.value ? "selected" : ""}>${opt.label}</option>`)
-    .join("");
-
   const stateOptions = [
-    { value: "all", label: "All states" },
+    { value: "all", label: "All statuses" },
     { value: "backlog", label: "Backlog" },
     { value: "todo", label: "Todo" },
     { value: "in_progress", label: "In Progress" },
@@ -154,15 +115,7 @@ export function renderTaskGraphFilters(filter: TaskGraphFilter): string {
   return `
     <div class="os-filter-bar">
       <label class="os-field">
-        <span>Kind</span>
-        <select data-tg-filter="kind">${kindOptions}</select>
-      </label>
-      <label class="os-field">
-        <span>Runtime</span>
-        <select data-tg-filter="runtime">${runtimeOptions}</select>
-      </label>
-      <label class="os-field">
-        <span>State</span>
+        <span>Status</span>
         <select data-tg-filter="state">${stateOptions}</select>
       </label>
       <label class="os-field">


### PR DESCRIPTION
Hotfix polish for the desktop **Task Graph**, targeting `main` so it can ship independently of the orchestrator's ongoing merges into `develop`.

## What changed

### 1. Single-row task cards
Cards collapse from three rows to one (row height **78px → 44px**), so the Backlog and Current panes fit far more tasks:
- **Connector circle** (left, vertically centred) · **identifier + title** · **Status pill** and **BLOCKER** badge pinned to the right.
- Removed the `blocked by … | blocks …` text line — that information now reads from the arrows and the connector glyph (`<`, `>`, `<>`), and the full breakdown still lives in the Run Detail panel (`dependency-detail`).
- Removed the `ISSUE` kind label — every node is a task.

### 2. Filters trimmed to Status + Search
- **Kind** filter removed (there is only one kind: tasks).
- **Runtime** filter removed — of its options only *Blocker* ever matched a real state; the rest were never populated.
- **State** renamed to **Status**.
- `kind` / `runtime` dropped from `TaskGraphFilter`.

### 3. Directional dependency arrows
Arrows now encode dependency depth by where they meet the target's connector circle:
- **Next-level** edges arrive **vertically at the top** of the circle (arrowhead points **down**).
- **Skip-level** edges route through the left gutter and arrive **horizontally at the left edge** (arrowhead points **right**).

Previously both landed in the centre pointing right, which made stacked next-level and skip-level blockers hard to tell apart.

### 4. Taller, resizable lower row
The **Run Detail / Inspector** row gets a **520px** default (up from the old clamped max) and a horizontal drag + keyboard (↑/↓) resizer between it and the graph pane, mirroring the existing column resizers. Falls back to auto-height stacking on narrow (≤980px) viewports.

## Verification
- `type-check` ✅, `build --workspace @opensymphony/gateway-schema` ✅, `build --workspace @opensymphony/web` ✅
- `npx jest --testPathIgnorePatterns="apps"` → **642 passed** ✅ (the CI jest command)
- Verified live in the `?fixtures` workbench: filter bar shows only Status + Search; cards render as one 44px row with Status + BLOCKER right; next-level arrow path ends at the top of the target circle arriving vertically, skip-level ends at the left edge; lower row is 520px and resizes via keyboard/drag (520↔544); no console errors.

Tests and `docs/graph-view.md` updated to match.