### PR TITLE
feat(codex): archive and recover canonical threads

### DIFF
--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -143,10 +143,6 @@ enum DebugCommandError {
         issue_reference: String,
         path: PathBuf,
     },
-    #[error(
-        "installed Codex CLI `{program}` does not expose the required `codex resume <session-id>` path: {detail}. Update Codex, then retry."
-    )]
-    CodexResumeUnsupported { program: String, detail: String },
     #[error("failed to launch Codex CLI `{program}`: {source}")]
     CodexLaunch {
         program: String,
@@ -500,7 +496,6 @@ async fn run_codex_resume(
     metadata: &CodexDebugMetadata,
 ) -> Result<(), DebugCommandError> {
     let program = env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
-    validate_codex_resume_support(&program).await?;
     let status = Command::new(&program)
         .arg("resume")
         .arg(&metadata.thread_id)
@@ -744,39 +739,6 @@ fn debug_codex_response_id_matches(value: &serde_json::Value, request_id: u64) -
         id.as_u64() == Some(request_id)
             || id.as_str().is_some_and(|id| id == request_id.to_string())
     })
-}
-
-async fn validate_codex_resume_support(program: &str) -> Result<(), DebugCommandError> {
-    let output = tokio::time::timeout(
-        Duration::from_secs(5),
-        Command::new(program).arg("resume").arg("--help").output(),
-    )
-    .await
-    .map_err(|_| DebugCommandError::CodexResumeUnsupported {
-        program: program.to_string(),
-        detail: "timed out running `resume --help`".into(),
-    })?
-    .map_err(|source| DebugCommandError::CodexLaunch {
-        program: program.to_string(),
-        source,
-    })?;
-    let help = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    if output.status.success() && help.contains("resume") && help.contains("SESSION_ID") {
-        Ok(())
-    } else {
-        Err(DebugCommandError::CodexResumeUnsupported {
-            program: program.to_string(),
-            detail: help
-                .lines()
-                .next()
-                .unwrap_or("empty help output")
-                .to_string(),
-        })
-    }
 }
 
 fn codex_debug_metadata_from_raw_manifest(

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -8,7 +8,9 @@ use std::{
     time::Duration,
 };
 
-use crate::opensymphony_codex::{CODEX_APP_SERVER_CONTRACT, CODEX_APP_SERVER_KIND};
+use crate::opensymphony_codex::{
+    CODEX_APP_SERVER_CONTRACT, CODEX_APP_SERVER_KIND, CodexAppServerAdapter, CodexJsonRpcSession,
+};
 use crate::opensymphony_openhands::{
     ConversationLaunchProfile, ConversationMoveOutcome, ConversationStoreKind, EventEnvelope,
     IssueConversationManifest, IssueSessionRunnerConfig, KnownEvent, LocalServerSupervisor,
@@ -34,7 +36,12 @@ use crossterm::{
 };
 use serde::Deserialize;
 use thiserror::Error;
-use tokio::{fs, process::Command, time::timeout_at};
+use tokio::{
+    fs,
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+    time::timeout_at,
+};
 use url::Url;
 use uuid::Uuid;
 
@@ -148,6 +155,10 @@ enum DebugCommandError {
     },
     #[error("Codex resume command exited with status {status}")]
     CodexResumeFailed { status: std::process::ExitStatus },
+    #[error(
+        "failed to unarchive Codex thread `{thread_id}` before debug: {detail}. Recover with `codex resume {thread_id}` after unarchiving it in Codex."
+    )]
+    CodexUnarchiveFailed { thread_id: String, detail: String },
     #[error("conversation manifest contains invalid conversation id `{value}`: {source}")]
     InvalidConversationId {
         value: String,
@@ -365,11 +376,12 @@ async fn run_debug_session(args: DebugArgs) -> Result<(), DebugCommandError> {
         })?;
     let manifest_path = workspace.conversation_manifest_path();
     let raw_manifest = load_conversation_manifest_raw(&manager, &workspace).await?;
-    if let Some(codex) = codex_debug_metadata_from_raw_manifest(
+    if let Some(mut codex) = codex_debug_metadata_from_raw_manifest(
         &raw_manifest,
         &manifest_path,
         args.issue_id.as_str(),
     )? {
+        ensure_codex_debug_thread_active(&manager, &workspace, &mut codex).await?;
         if args.app {
             println!("{}", codex.deep_link());
             return Ok(());
@@ -473,6 +485,8 @@ async fn run_debug_session(args: DebugArgs) -> Result<(), DebugCommandError> {
 #[derive(Debug)]
 struct CodexDebugMetadata {
     thread_id: String,
+    archive_state: String,
+    manifest: serde_json::Value,
 }
 
 impl CodexDebugMetadata {
@@ -505,6 +519,131 @@ async fn run_codex_resume(
     } else {
         Err(DebugCommandError::CodexResumeFailed { status })
     }
+}
+
+async fn ensure_codex_debug_thread_active(
+    manager: &WorkspaceManager,
+    workspace: &WorkspaceHandle,
+    metadata: &mut CodexDebugMetadata,
+) -> Result<(), DebugCommandError> {
+    if metadata.archive_state == "active" {
+        return Ok(());
+    }
+    let program = env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
+    metadata.manifest["codex_archive_state"] = serde_json::Value::String("unarchiving".into());
+    manager
+        .write_json_artifact(
+            workspace,
+            &workspace.conversation_manifest_path(),
+            &metadata.manifest,
+        )
+        .await
+        .map_err(DebugCommandError::WorkspaceManager)?;
+    let adapter =
+        CodexAppServerAdapter::local_stdio(&program, "opensymphony", env!("CARGO_PKG_VERSION"));
+    let (binary, args) = adapter.launch().to_command();
+    let mut child = Command::new(binary)
+        .args(args)
+        .current_dir(workspace.workspace_path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|source| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail: source.to_string(),
+        })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail: "app-server stdin missing".into(),
+        })?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail: "app-server stdout missing".into(),
+        })?;
+    let mut session = adapter.session();
+    let initialize = session.initialize();
+    write_debug_codex_request(&mut stdin, &initialize)
+        .await
+        .map_err(|detail| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail,
+        })?;
+    let mut reader = BufReader::new(stdout);
+    read_debug_codex_response(&mut reader, initialize.id)
+        .await
+        .map_err(|detail| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail,
+        })?;
+    let request = adapter
+        .unarchive_issue_thread_request(&mut session, metadata.thread_id.clone())
+        .map_err(|source| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail: source.to_string(),
+        })?;
+    write_debug_codex_request(&mut stdin, &request.request)
+        .await
+        .map_err(|detail| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail,
+        })?;
+    read_debug_codex_response(&mut reader, request.request.id)
+        .await
+        .map_err(|detail| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail,
+        })?;
+    let _ = child.kill().await;
+    metadata.manifest["codex_archive_state"] = serde_json::Value::String("active".into());
+    manager
+        .write_json_artifact(
+            workspace,
+            &workspace.conversation_manifest_path(),
+            &metadata.manifest,
+        )
+        .await
+        .map_err(DebugCommandError::WorkspaceManager)?;
+    metadata.archive_state = "active".into();
+    Ok(())
+}
+
+async fn write_debug_codex_request(
+    stdin: &mut tokio::process::ChildStdin,
+    request: &crate::opensymphony_codex::JsonRpcRequestEnvelope,
+) -> Result<(), String> {
+    let line = CodexJsonRpcSession::encode_line(request).map_err(|error| error.to_string())?;
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|error| error.to_string())?;
+    stdin.flush().await.map_err(|error| error.to_string())
+}
+
+async fn read_debug_codex_response(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    request_id: u64,
+) -> Result<(), String> {
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .await
+        .map_err(|error| error.to_string())?;
+    let value: serde_json::Value =
+        serde_json::from_str(&line).map_err(|error| error.to_string())?;
+    if value.get("id").and_then(serde_json::Value::as_u64) != Some(request_id)
+        || value.get("error").is_some()
+    {
+        return Err(format!("unexpected Codex app-server response: {value}"));
+    }
+    Ok(())
 }
 
 async fn validate_codex_resume_support(program: &str) -> Result<(), DebugCommandError> {
@@ -567,6 +706,12 @@ fn codex_debug_metadata_from_raw_manifest(
         })?;
     Ok(Some(CodexDebugMetadata {
         thread_id: thread_id.to_string(),
+        archive_state: value
+            .get("codex_archive_state")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("active")
+            .to_string(),
+        manifest: value,
     }))
 }
 

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -727,7 +727,7 @@ async fn read_debug_codex_response(
         }
         let value: serde_json::Value =
             serde_json::from_str(&line).map_err(|error| error.to_string())?;
-        if value.get("id").and_then(serde_json::Value::as_u64) != Some(request_id) {
+        if !debug_codex_response_id_matches(&value, request_id) {
             continue;
         }
         if value.get("error").is_some() {
@@ -735,6 +735,13 @@ async fn read_debug_codex_response(
         }
         return Ok(value);
     }
+}
+
+fn debug_codex_response_id_matches(value: &serde_json::Value, request_id: u64) -> bool {
+    value.get("id").is_some_and(|id| {
+        id.as_u64() == Some(request_id)
+            || id.as_str().is_some_and(|id| id == request_id.to_string())
+    })
 }
 
 async fn validate_codex_resume_support(program: &str) -> Result<(), DebugCommandError> {
@@ -1837,6 +1844,21 @@ fn turn_has_stopped(status: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn debug_codex_response_ids_accept_numbers_and_equivalent_strings() {
+        assert!(super::debug_codex_response_id_matches(
+            &serde_json::json!({"id": 7}),
+            7
+        ));
+        assert!(super::debug_codex_response_id_matches(
+            &serde_json::json!({"id": "7"}),
+            7
+        ));
+        assert!(!super::debug_codex_response_id_matches(
+            &serde_json::json!({"id": "other"}),
+            7
+        ));
+    }
     use std::path::PathBuf;
 
     use crate::opensymphony_openhands::{

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -600,6 +600,7 @@ async fn ensure_codex_debug_thread_active(
             thread_id: metadata.thread_id.clone(),
             detail,
         })? {
+            let _ = child.kill().await;
             metadata.manifest["codex_archive_state"] = serde_json::Value::String("active".into());
             manager
                 .write_json_artifact(
@@ -611,6 +612,7 @@ async fn ensure_codex_debug_thread_active(
                 .map_err(DebugCommandError::WorkspaceManager)?;
             return Ok(());
         }
+        let _ = child.kill().await;
         return Err(DebugCommandError::CodexUnarchiveFailed {
             thread_id: metadata.thread_id.clone(),
             detail: "thread was not found in the Codex app-server state database".into(),

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -527,15 +527,6 @@ async fn ensure_codex_debug_thread_active(
     metadata: &mut CodexDebugMetadata,
 ) -> Result<(), DebugCommandError> {
     let program = env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
-    metadata.manifest["codex_archive_state"] = serde_json::Value::String("unarchiving".into());
-    manager
-        .write_json_artifact(
-            workspace,
-            &workspace.conversation_manifest_path(),
-            &metadata.manifest,
-        )
-        .await
-        .map_err(DebugCommandError::WorkspaceManager)?;
     let adapter =
         CodexAppServerAdapter::local_stdio(&program, "opensymphony", env!("CARGO_PKG_VERSION"));
     let (binary, args) = adapter.launch().to_command();
@@ -625,6 +616,15 @@ async fn ensure_codex_debug_thread_active(
             detail: "thread was not found in the Codex app-server state database".into(),
         });
     }
+    metadata.manifest["codex_archive_state"] = serde_json::Value::String("unarchiving".into());
+    manager
+        .write_json_artifact(
+            workspace,
+            &workspace.conversation_manifest_path(),
+            &metadata.manifest,
+        )
+        .await
+        .map_err(DebugCommandError::WorkspaceManager)?;
     let request = adapter
         .unarchive_issue_thread_request(&mut session, metadata.thread_id.clone())
         .map_err(|source| DebugCommandError::CodexUnarchiveFailed {
@@ -678,23 +678,35 @@ async fn debug_thread_list_contains(
     thread_id: &str,
     archived: bool,
 ) -> Result<bool, String> {
-    let request = adapter
-        .list_issue_threads_request(
-            session,
-            workspace.workspace_path().display().to_string(),
-            archived,
-            None,
-        )
-        .map_err(|error| error.to_string())?;
-    write_debug_codex_request(stdin, &request.request).await?;
-    let response = read_debug_codex_response(reader, request.request.id).await?;
-    Ok(response["result"]["data"]
-        .as_array()
-        .is_some_and(|threads| {
-            threads.iter().any(|thread| {
-                thread.get("id").and_then(serde_json::Value::as_str) == Some(thread_id)
+    let mut cursor = None;
+    loop {
+        let request = adapter
+            .list_issue_threads_request(
+                session,
+                workspace.workspace_path().display().to_string(),
+                archived,
+                cursor.clone(),
+            )
+            .map_err(|error| error.to_string())?;
+        write_debug_codex_request(stdin, &request.request).await?;
+        let response = read_debug_codex_response(reader, request.request.id).await?;
+        if response["result"]["data"]
+            .as_array()
+            .is_some_and(|threads| {
+                threads.iter().any(|thread| {
+                    thread.get("id").and_then(serde_json::Value::as_str) == Some(thread_id)
+                })
             })
-        }))
+        {
+            return Ok(true);
+        }
+        cursor = response["result"]["nextCursor"]
+            .as_str()
+            .map(ToOwned::to_owned);
+        if cursor.is_none() {
+            return Ok(false);
+        }
+    }
 }
 
 async fn read_debug_codex_response(

--- a/crates/opensymphony-cli/src/debug_session.rs
+++ b/crates/opensymphony-cli/src/debug_session.rs
@@ -526,9 +526,6 @@ async fn ensure_codex_debug_thread_active(
     workspace: &WorkspaceHandle,
     metadata: &mut CodexDebugMetadata,
 ) -> Result<(), DebugCommandError> {
-    if metadata.archive_state == "active" {
-        return Ok(());
-    }
     let program = env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".to_string());
     metadata.manifest["codex_archive_state"] = serde_json::Value::String("unarchiving".into());
     manager
@@ -583,6 +580,51 @@ async fn ensure_codex_debug_thread_active(
             thread_id: metadata.thread_id.clone(),
             detail,
         })?;
+    let archived = debug_thread_list_contains(
+        &adapter,
+        &mut session,
+        &mut stdin,
+        &mut reader,
+        workspace,
+        &metadata.thread_id,
+        true,
+    )
+    .await
+    .map_err(|detail| DebugCommandError::CodexUnarchiveFailed {
+        thread_id: metadata.thread_id.clone(),
+        detail,
+    })?;
+    if !archived {
+        if debug_thread_list_contains(
+            &adapter,
+            &mut session,
+            &mut stdin,
+            &mut reader,
+            workspace,
+            &metadata.thread_id,
+            false,
+        )
+        .await
+        .map_err(|detail| DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail,
+        })? {
+            metadata.manifest["codex_archive_state"] = serde_json::Value::String("active".into());
+            manager
+                .write_json_artifact(
+                    workspace,
+                    &workspace.conversation_manifest_path(),
+                    &metadata.manifest,
+                )
+                .await
+                .map_err(DebugCommandError::WorkspaceManager)?;
+            return Ok(());
+        }
+        return Err(DebugCommandError::CodexUnarchiveFailed {
+            thread_id: metadata.thread_id.clone(),
+            detail: "thread was not found in the Codex app-server state database".into(),
+        });
+    }
     let request = adapter
         .unarchive_issue_thread_request(&mut session, metadata.thread_id.clone())
         .map_err(|source| DebugCommandError::CodexUnarchiveFailed {
@@ -627,23 +669,60 @@ async fn write_debug_codex_request(
     stdin.flush().await.map_err(|error| error.to_string())
 }
 
+async fn debug_thread_list_contains(
+    adapter: &CodexAppServerAdapter,
+    session: &mut CodexJsonRpcSession,
+    stdin: &mut tokio::process::ChildStdin,
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    workspace: &WorkspaceHandle,
+    thread_id: &str,
+    archived: bool,
+) -> Result<bool, String> {
+    let request = adapter
+        .list_issue_threads_request(
+            session,
+            workspace.workspace_path().display().to_string(),
+            archived,
+            None,
+        )
+        .map_err(|error| error.to_string())?;
+    write_debug_codex_request(stdin, &request.request).await?;
+    let response = read_debug_codex_response(reader, request.request.id).await?;
+    Ok(response["result"]["data"]
+        .as_array()
+        .is_some_and(|threads| {
+            threads.iter().any(|thread| {
+                thread.get("id").and_then(serde_json::Value::as_str) == Some(thread_id)
+            })
+        }))
+}
+
 async fn read_debug_codex_response(
     reader: &mut BufReader<tokio::process::ChildStdout>,
     request_id: u64,
-) -> Result<(), String> {
-    let mut line = String::new();
-    reader
-        .read_line(&mut line)
-        .await
-        .map_err(|error| error.to_string())?;
-    let value: serde_json::Value =
-        serde_json::from_str(&line).map_err(|error| error.to_string())?;
-    if value.get("id").and_then(serde_json::Value::as_u64) != Some(request_id)
-        || value.get("error").is_some()
-    {
-        return Err(format!("unexpected Codex app-server response: {value}"));
+) -> Result<serde_json::Value, String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut line = String::new();
+        let read = timeout_at(deadline, reader.read_line(&mut line))
+            .await
+            .map_err(|_| format!("timed out waiting for Codex response id {request_id}"))?
+            .map_err(|error| error.to_string())?;
+        if read == 0 {
+            return Err(format!(
+                "Codex stdout closed before response id {request_id}"
+            ));
+        }
+        let value: serde_json::Value =
+            serde_json::from_str(&line).map_err(|error| error.to_string())?;
+        if value.get("id").and_then(serde_json::Value::as_u64) != Some(request_id) {
+            continue;
+        }
+        if value.get("error").is_some() {
+            return Err(format!("Codex app-server error response: {value}"));
+        }
+        return Ok(value);
     }
-    Ok(())
 }
 
 async fn validate_codex_resume_support(program: &str) -> Result<(), DebugCommandError> {

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -1998,6 +1998,9 @@ async fn ensure_codex_thread_active(
 ) -> Result<(), String> {
     let thread_id = manifest.conversation_id.to_string();
     match inspect_codex_archive_state(codex_bin, workspace, &thread_id).await? {
+        CodexArchiveState::Active if manifest.codex_archive_state.as_deref() == Some("active") => {
+            Ok(())
+        }
         CodexArchiveState::Active => {
             persist_codex_archive_state(manager, workspace, manifest, "active").await
         }
@@ -5590,7 +5593,11 @@ while IFS= read -r line; do
       printf '{{"jsonrpc":"2.0","id":%s,"result":{{"thread":{{"id":"fake-thread"}}}}}}\n' "$id"
       ;;
     *'"method":"thread/list"'*)
-      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[{{"id":"fake-thread"}}],"nextCursor":null}}}}\n' "$id"
+      if printf '%s' "$line" | grep -q '"archived":true'; then
+        printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[],"nextCursor":null}}}}\n' "$id"
+      else
+        printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[{{"id":"fake-thread"}}],"nextCursor":null}}}}\n' "$id"
+      fi
       ;;
     *'"method":"thread/archive"'*)
       printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id"
@@ -5633,6 +5640,16 @@ while IFS= read -r line; do
   id=$(printf '%s\n' "$line" | sed -E 's/.*"id":([0-9]+).*/\1/')
   case "$line" in
     *'"method":"initialize"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id"
+      ;;
+    *'"method":"thread/list"'*)
+      if printf '%s' "$line" | grep -q '"archived":true'; then
+        printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[],"nextCursor":null}}}}\n' "$id"
+      else
+        printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[{{"id":"fake-thread"}}],"nextCursor":null}}}}\n' "$id"
+      fi
+      ;;
+    *'"method":"thread/unarchive"'*)
       printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id"
       ;;
     *'"method":"thread/resume"'*)

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -2038,7 +2038,11 @@ async fn archive_terminal_codex_thread(
     let thread_id = manifest.conversation_id.to_string();
     match inspect_codex_archive_state(codex_bin, workspace, &thread_id).await? {
         CodexArchiveState::Archived => {
-            persist_codex_archive_state(manager, workspace, manifest, "archived").await
+            if manifest.codex_archive_state.as_deref() == Some("archived") {
+                Ok(())
+            } else {
+                persist_codex_archive_state(manager, workspace, manifest, "archived").await
+            }
         }
         CodexArchiveState::Active => {
             persist_codex_archive_state(manager, workspace, manifest, "archiving").await?;

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -4096,10 +4096,10 @@ mod tests {
             .await
             .expect("workspace should be ensured");
         workspace_manager
-            .write_text_artifact(
+            .write_json_artifact(
                 &ensured.handle,
                 &ensured.handle.conversation_manifest_path(),
-                "{\"canonical\":\"thread\"}",
+                &sample_conversation_manifest("thread"),
             )
             .await
             .expect("conversation manifest should persist");
@@ -4152,6 +4152,80 @@ mod tests {
                 .lines()
                 .collect::<Vec<_>>(),
             ["before_remove", "before_remove"]
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_workspace_cleanup_preserves_invalid_manifest_for_retry() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspaces");
+        let workflow = sample_workflow(tempdir.path(), &workspace_root);
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(WorkspaceManagerConfig {
+                root: workspace_root,
+                hooks: HookConfig {
+                    before_remove: Some(HookDefinition::shell(
+                        "echo before_remove >> .opensymphony/logs/before_remove.txt",
+                    )),
+                    ..HookConfig::default()
+                },
+                cleanup: CleanupConfig {
+                    remove_terminal_workspaces: false,
+                },
+            })
+            .expect("workspace manager should be constructed"),
+        );
+        let issue = sample_terminal_issue();
+        let ensured = workspace_manager
+            .ensure(&issue_descriptor(&issue))
+            .await
+            .expect("workspace should be ensured");
+        workspace_manager
+            .write_text_artifact(
+                &ensured.handle,
+                &ensured.handle.conversation_manifest_path(),
+                "{\"canonical\":\"thread\"}",
+            )
+            .await
+            .expect("invalid conversation manifest should persist");
+        let workspace = crate::opensymphony_domain::WorkspaceRecord {
+            path: ensured.handle.workspace_path().to_path_buf(),
+            workspace_key: WorkspaceKey::new(ensured.handle.workspace_key().to_string())
+                .expect("workspace key should be valid"),
+            created_now: false,
+            created_at: None,
+            updated_at: None,
+            last_seen_tracker_refresh_at: None,
+        };
+        let mut backend = RuntimeWorkspaceBackend::new(Arc::clone(&workspace_manager), &workflow);
+
+        backend
+            .cleanup_workspace(&workspace, true)
+            .await
+            .expect("invalid manifest cleanup should remain retryable");
+
+        assert!(!ensured.handle.logs_dir().join("before_remove.txt").exists());
+        assert!(ensured.handle.conversation_manifest_path().is_file());
+        assert!(!backend.terminal_cleanup_paths.contains(&workspace.path));
+
+        workspace_manager
+            .write_json_artifact(
+                &ensured.handle,
+                &ensured.handle.conversation_manifest_path(),
+                &sample_conversation_manifest("thread"),
+            )
+            .await
+            .expect("valid conversation manifest should replace invalid fixture");
+        backend
+            .cleanup_workspace(&workspace, true)
+            .await
+            .expect("later terminal cleanup should retry successfully");
+
+        assert_eq!(
+            fs::read_to_string(ensured.handle.logs_dir().join("before_remove.txt"))
+                .expect("before-remove hook should run after retry")
+                .trim(),
+            "before_remove"
         );
     }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -742,12 +742,15 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
                         }
                     }
                     Ok(_) => {}
-                    Err(error) => tracing::warn!(
-                        issue = %handle.identifier(),
-                        manifest = %manifest_path.display(),
-                        %error,
-                        "preserving terminal workspace with invalid conversation manifest"
-                    ),
+                    Err(error) => {
+                        tracing::warn!(
+                            issue = %handle.identifier(),
+                            manifest = %manifest_path.display(),
+                            %error,
+                            "preserving terminal workspace with invalid conversation manifest"
+                        );
+                        return Ok(());
+                    }
                 }
             }
             self.manager

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -132,6 +132,7 @@ pub(super) struct RuntimeWorkspaceBackend {
     active_states: HashSet<String>,
     terminal_states: HashSet<String>,
     terminal_cleanup_paths: HashSet<PathBuf>,
+    codex_bin: String,
 }
 
 pub(super) struct RuntimeWorkerBackend {
@@ -627,6 +628,7 @@ impl RuntimeWorkspaceBackend {
                 .map(|state| normalized_state_name(state))
                 .collect(),
             terminal_cleanup_paths: HashSet::new(),
+            codex_bin: env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".into()),
         }
     }
 }
@@ -714,6 +716,40 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
             else {
                 return Ok(());
             };
+            let manifest_path = handle.conversation_manifest_path();
+            if let Some(raw_manifest) = self
+                .manager
+                .read_text_artifact(&handle, &manifest_path)
+                .await?
+            {
+                match serde_json::from_str::<IssueConversationManifest>(&raw_manifest) {
+                    Ok(mut manifest) if conversation_manifest_is_codex(&manifest) => {
+                        if let Err(error) = archive_terminal_codex_thread(
+                            &self.manager,
+                            &handle,
+                            &mut manifest,
+                            &self.codex_bin,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                issue = %handle.identifier(),
+                                thread_id = %manifest.conversation_id,
+                                %error,
+                                "preserving terminal Codex workspace for archive retry"
+                            );
+                            return Ok(());
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(error) => tracing::warn!(
+                        issue = %handle.identifier(),
+                        manifest = %manifest_path.display(),
+                        %error,
+                        "preserving terminal workspace with invalid conversation manifest"
+                    ),
+                }
+            }
             self.manager
                 .cleanup(&handle, IssueLifecycleState::Terminal)
                 .await?;
@@ -1365,9 +1401,22 @@ async fn try_run_codex_stdio_issue(
     .map_err(|error| with_codex_stderr(error, &stderr_tail))?;
 
     let model = codex_model_from_route(route);
-    let existing_manifest = load_codex_conversation_manifest(workspace_manager, workspace, issue)
-        .await
-        .map_err(|error| with_codex_stderr(error, &stderr_tail))?;
+    let mut existing_manifest =
+        load_codex_conversation_manifest(workspace_manager, workspace, issue)
+            .await
+            .map_err(|error| with_codex_stderr(error, &stderr_tail))?;
+    if let Some(manifest) = existing_manifest.as_mut() {
+        ensure_codex_thread_active(workspace_manager, workspace, manifest, codex_bin)
+            .await
+            .map_err(|error| {
+                codex_lifecycle_error(
+                    issue,
+                    Some(manifest.conversation_id.as_str()),
+                    "archive recovery",
+                    error,
+                )
+            })?;
+    }
     let first_run_prompt = if existing_manifest.is_none() {
         Some(
             workflow
@@ -1783,6 +1832,220 @@ async fn load_installed_codex_schema_validator(
             schema_path.display()
         )
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexArchiveState {
+    Active,
+    Archived,
+    Missing,
+}
+
+async fn send_codex_lifecycle_request<F>(
+    codex_bin: &str,
+    cwd: &Path,
+    operation: &str,
+    build: F,
+) -> Result<serde_json::Value, String>
+where
+    F: FnOnce(
+        &CodexAppServerAdapter,
+        &mut CodexJsonRpcSession,
+    ) -> Result<crate::opensymphony_codex::CodexHarnessRequest, serde_json::Error>,
+{
+    let adapter =
+        CodexAppServerAdapter::local_stdio(codex_bin, "opensymphony", env!("CARGO_PKG_VERSION"));
+    let validator = load_installed_codex_schema_validator(codex_bin).await?;
+    let (program, args) = adapter.launch().to_command();
+    let mut child = Command::new(&program)
+        .args(args)
+        .current_dir(cwd)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|source| format!("failed to launch Codex lifecycle app-server: {source}"))?;
+    let mut stdin = child.stdin.take().ok_or("Codex lifecycle stdin missing")?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("Codex lifecycle stdout missing")?;
+    let mut reader = BufReader::new(stdout).lines();
+    let mut session = adapter.session();
+    let initialize = session.initialize();
+    write_codex_lifecycle_request(&mut stdin, &validator, &initialize, "initialize").await?;
+    read_codex_lifecycle_response(&mut reader, initialize.id).await?;
+    let request = build(&adapter, &mut session)
+        .map_err(|source| format!("failed to build Codex {operation} request: {source}"))?;
+    write_codex_lifecycle_request(&mut stdin, &validator, &request.request, operation).await?;
+    let response = read_codex_lifecycle_response(&mut reader, request.request.id).await;
+    let _ = child.kill().await;
+    response
+}
+
+async fn write_codex_lifecycle_request(
+    stdin: &mut ChildStdin,
+    validator: &CodexAppServerSchemaValidator,
+    request: &JsonRpcRequestEnvelope,
+    operation: &str,
+) -> Result<(), String> {
+    validator
+        .validate_request(request)
+        .map_err(|source| source.to_string())?;
+    stdin
+        .write_all(
+            CodexJsonRpcSession::encode_line(request)
+                .map_err(|source| source.to_string())?
+                .as_bytes(),
+        )
+        .await
+        .map_err(|source| format!("failed to write Codex {operation} request: {source}"))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|source| format!("failed to flush Codex {operation} request: {source}"))
+}
+
+async fn read_codex_lifecycle_response(
+    reader: &mut tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+    request_id: u64,
+) -> Result<serde_json::Value, String> {
+    let deadline = tokio::time::Instant::now() + CODEX_RESPONSE_TIMEOUT;
+    loop {
+        let line = timeout_at(deadline, reader.next_line())
+            .await
+            .map_err(|_| format!("timed out waiting for Codex lifecycle response id {request_id}"))?
+            .map_err(|source| format!("failed reading Codex lifecycle stdout: {source}"))?
+            .ok_or_else(|| {
+                format!("Codex lifecycle stdout closed before response id {request_id}")
+            })?;
+        let value: serde_json::Value = serde_json::from_str(&line)
+            .map_err(|source| format!("invalid Codex lifecycle JSON: {source}"))?;
+        if codex_response_id_matches(&value, request_id) {
+            reject_codex_json_rpc_error(request_id, &value)?;
+            return Ok(value);
+        }
+    }
+}
+
+async fn inspect_codex_archive_state(
+    codex_bin: &str,
+    workspace: &WorkspaceHandle,
+    thread_id: &str,
+) -> Result<CodexArchiveState, String> {
+    for archived in [true, false] {
+        let mut cursor = None;
+        loop {
+            let response = send_codex_lifecycle_request(
+                codex_bin,
+                workspace.workspace_path(),
+                "thread/list",
+                |adapter, session| {
+                    adapter.list_issue_threads_request(
+                        session,
+                        workspace.workspace_path().display().to_string(),
+                        archived,
+                        cursor.clone(),
+                    )
+                },
+            )
+            .await?;
+            if response["result"]["data"]
+                .as_array()
+                .is_some_and(|threads| {
+                    threads.iter().any(|thread| {
+                        thread.get("id").and_then(serde_json::Value::as_str) == Some(thread_id)
+                    })
+                })
+            {
+                return Ok(if archived {
+                    CodexArchiveState::Archived
+                } else {
+                    CodexArchiveState::Active
+                });
+            }
+            cursor = response["result"]["nextCursor"]
+                .as_str()
+                .map(ToOwned::to_owned);
+            if cursor.is_none() {
+                break;
+            }
+        }
+    }
+    Ok(CodexArchiveState::Missing)
+}
+
+async fn persist_codex_archive_state(
+    manager: &WorkspaceManager,
+    workspace: &WorkspaceHandle,
+    manifest: &mut IssueConversationManifest,
+    state: &str,
+) -> Result<(), String> {
+    manifest.codex_archive_state = Some(state.to_string());
+    manifest.updated_at = chrono::Utc::now();
+    manager
+        .write_json_artifact(workspace, &workspace.conversation_manifest_path(), manifest)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+async fn ensure_codex_thread_active(
+    manager: &WorkspaceManager,
+    workspace: &WorkspaceHandle,
+    manifest: &mut IssueConversationManifest,
+    codex_bin: &str,
+) -> Result<(), String> {
+    let thread_id = manifest.conversation_id.to_string();
+    match inspect_codex_archive_state(codex_bin, workspace, &thread_id).await? {
+        CodexArchiveState::Active => {
+            persist_codex_archive_state(manager, workspace, manifest, "active").await
+        }
+        CodexArchiveState::Archived => {
+            persist_codex_archive_state(manager, workspace, manifest, "unarchiving").await?;
+            send_codex_lifecycle_request(
+                codex_bin,
+                workspace.workspace_path(),
+                "thread/unarchive",
+                |adapter, session| {
+                    adapter.unarchive_issue_thread_request(session, thread_id.clone())
+                },
+            )
+            .await?;
+            persist_codex_archive_state(manager, workspace, manifest, "active").await
+        }
+        CodexArchiveState::Missing => Err(format!(
+            "canonical Codex thread {thread_id} is missing; recover manually with `codex resume {thread_id}`"
+        )),
+    }
+}
+
+async fn archive_terminal_codex_thread(
+    manager: &WorkspaceManager,
+    workspace: &WorkspaceHandle,
+    manifest: &mut IssueConversationManifest,
+    codex_bin: &str,
+) -> Result<(), String> {
+    let thread_id = manifest.conversation_id.to_string();
+    match inspect_codex_archive_state(codex_bin, workspace, &thread_id).await? {
+        CodexArchiveState::Archived => {
+            persist_codex_archive_state(manager, workspace, manifest, "archived").await
+        }
+        CodexArchiveState::Active => {
+            persist_codex_archive_state(manager, workspace, manifest, "archiving").await?;
+            send_codex_lifecycle_request(
+                codex_bin,
+                workspace.workspace_path(),
+                "thread/archive",
+                |adapter, session| adapter.archive_issue_thread_request(session, thread_id.clone()),
+            )
+            .await?;
+            persist_codex_archive_state(manager, workspace, manifest, "archived").await
+        }
+        CodexArchiveState::Missing => Err(format!(
+            "canonical Codex thread {thread_id} is missing; preserving workspace for repair"
+        )),
+    }
 }
 
 fn codex_schema_stderr_preview(stderr: &[u8]) -> Option<String> {
@@ -2497,17 +2760,6 @@ async fn load_codex_conversation_manifest(
                 "manifest {} is incompatible with the current issue workspace",
                 path.display()
             ),
-        ));
-    }
-    if !matches!(
-        manifest.codex_archive_state.as_deref(),
-        None | Some("active")
-    ) {
-        return Err(codex_lifecycle_error(
-            issue,
-            Some(thread_id),
-            "manifest validation",
-            "archive recovery is not available in the canonical-reuse slice",
         ));
     }
     Ok(Some(manifest))
@@ -5286,7 +5538,7 @@ Run the scheduler.
         }
     }
 
-    const FAKE_CODEX_SCHEMA: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","definitions":{"ClientRequest":{"type":"object","required":["jsonrpc","id","method","params"],"properties":{"jsonrpc":{"const":"2.0"},"id":{"type":"integer"},"method":{"enum":["initialize","thread/start","thread/resume","thread/archive","turn/start","turn/interrupt"]},"params":{"type":"object"}}}}}"#;
+    const FAKE_CODEX_SCHEMA: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","definitions":{"ClientRequest":{"type":"object","required":["jsonrpc","id","method","params"],"properties":{"jsonrpc":{"const":"2.0"},"id":{"type":"integer"},"method":{"enum":["initialize","thread/start","thread/resume","thread/list","thread/archive","thread/unarchive","turn/start","turn/interrupt"]},"params":{"type":"object"}}}}}"#;
 
     #[cfg(unix)]
     fn write_fake_codex_child(path: &Path, log_path: &Path) {
@@ -5337,7 +5589,13 @@ while IFS= read -r line; do
     *'"method":"thread/resume"'*)
       printf '{{"jsonrpc":"2.0","id":%s,"result":{{"thread":{{"id":"fake-thread"}}}}}}\n' "$id"
       ;;
+    *'"method":"thread/list"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[{{"id":"fake-thread"}}],"nextCursor":null}}}}\n' "$id"
+      ;;
     *'"method":"thread/archive"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id"
+      ;;
+    *'"method":"thread/unarchive"'*)
       printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id"
       ;;
     *'"method":"turn/start"'*)

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -72,6 +72,8 @@ pub(super) enum CliWorkspaceError {
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
     Identifier(#[from] crate::opensymphony_domain::IdentifierError),
+    #[error("Codex lifecycle recovery failed: {0}")]
+    CodexLifecycle(String),
 }
 
 #[derive(Debug, Error)]
@@ -738,7 +740,7 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
                                 %error,
                                 "preserving terminal Codex workspace for archive retry"
                             );
-                            return Ok(());
+                            return Err(CliWorkspaceError::CodexLifecycle(error));
                         }
                     }
                     Ok(_) => {}

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -747,9 +747,8 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
                             issue = %handle.identifier(),
                             manifest = %manifest_path.display(),
                             %error,
-                            "preserving terminal workspace with invalid conversation manifest"
+                            "continuing terminal cleanup with invalid conversation manifest"
                         );
-                        return Ok(());
                     }
                 }
             }
@@ -4158,7 +4157,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_workspace_cleanup_preserves_invalid_manifest_for_retry() {
+    async fn runtime_workspace_cleanup_runs_manager_cleanup_for_invalid_manifest() {
         let tempdir = TempDir::new().expect("tempdir should exist");
         let workspace_root = tempdir.path().join("workspaces");
         let workflow = sample_workflow(tempdir.path(), &workspace_root);
@@ -4204,28 +4203,24 @@ mod tests {
         backend
             .cleanup_workspace(&workspace, true)
             .await
-            .expect("invalid manifest cleanup should remain retryable");
-
-        assert!(!ensured.handle.logs_dir().join("before_remove.txt").exists());
-        assert!(ensured.handle.conversation_manifest_path().is_file());
-        assert!(!backend.terminal_cleanup_paths.contains(&workspace.path));
-
-        workspace_manager
-            .write_json_artifact(
-                &ensured.handle,
-                &ensured.handle.conversation_manifest_path(),
-                &sample_conversation_manifest("thread"),
-            )
-            .await
-            .expect("valid conversation manifest should replace invalid fixture");
-        backend
-            .cleanup_workspace(&workspace, true)
-            .await
-            .expect("later terminal cleanup should retry successfully");
+            .expect("invalid manifest cleanup should still run manager cleanup");
 
         assert_eq!(
             fs::read_to_string(ensured.handle.logs_dir().join("before_remove.txt"))
-                .expect("before-remove hook should run after retry")
+                .expect("before-remove hook should run for invalid manifest")
+                .trim(),
+            "before_remove"
+        );
+        assert!(ensured.handle.conversation_manifest_path().is_file());
+        assert!(backend.terminal_cleanup_paths.contains(&workspace.path));
+        backend
+            .cleanup_workspace(&workspace, true)
+            .await
+            .expect("repeated terminal cleanup should keep hooks once-only");
+
+        assert_eq!(
+            fs::read_to_string(ensured.handle.logs_dir().join("before_remove.txt"))
+                .expect("before-remove hook should remain once-only")
                 .trim(),
             "before_remove"
         );

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -706,7 +706,7 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         workspace: &crate::opensymphony_domain::WorkspaceRecord,
         terminal: bool,
     ) -> Result<(), Self::Error> {
-        if terminal {
+        if terminal && !self.terminal_cleanup_paths.contains(&workspace.path) {
             let Some(handle) = self
                 .manager
                 .list_all_workspaces()
@@ -754,12 +754,10 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
                     }
                 }
             }
-            if !self.terminal_cleanup_paths.contains(&workspace.path) {
-                self.manager
-                    .cleanup(&handle, IssueLifecycleState::Terminal)
-                    .await?;
-                self.terminal_cleanup_paths.insert(workspace.path.clone());
-            }
+            self.manager
+                .cleanup(&handle, IssueLifecycleState::Terminal)
+                .await?;
+            self.terminal_cleanup_paths.insert(workspace.path.clone());
         }
         Ok(())
     }
@@ -4234,7 +4232,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn runtime_workspace_cleanup_rearchives_a_terminal_thread_after_debug_unarchive() {
+    async fn runtime_workspace_cleanup_skips_rearchiving_until_the_issue_reopens() {
         let tempdir = TempDir::new().expect("tempdir should exist");
         let workspace_root = tempdir.path().join("workspaces");
         let workflow = sample_workflow(tempdir.path(), &workspace_root);
@@ -4302,7 +4300,7 @@ mod tests {
         backend
             .cleanup_workspace(&workspace, true)
             .await
-            .expect("later terminal poll should rearchive the thread");
+            .expect("later terminal poll should remain once-only");
 
         let rearchived_manifest_raw = workspace_manager
             .read_text_artifact(
@@ -4312,12 +4310,12 @@ mod tests {
             .await
             .expect("manifest read should succeed")
             .expect("manifest should exist");
-        let rearchived_manifest: IssueConversationManifest =
+        let retained_manifest: IssueConversationManifest =
             serde_json::from_str(&rearchived_manifest_raw)
                 .expect("Codex conversation manifest should decode");
         assert_eq!(
-            rearchived_manifest.codex_archive_state.as_deref(),
-            Some("archived")
+            retained_manifest.codex_archive_state.as_deref(),
+            Some("active")
         );
     }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -704,7 +704,7 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         workspace: &crate::opensymphony_domain::WorkspaceRecord,
         terminal: bool,
     ) -> Result<(), Self::Error> {
-        if terminal && !self.terminal_cleanup_paths.contains(&workspace.path) {
+        if terminal {
             let Some(handle) = self
                 .manager
                 .list_all_workspaces()
@@ -753,10 +753,12 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
                     }
                 }
             }
-            self.manager
-                .cleanup(&handle, IssueLifecycleState::Terminal)
-                .await?;
-            self.terminal_cleanup_paths.insert(workspace.path.clone());
+            if !self.terminal_cleanup_paths.contains(&workspace.path) {
+                self.manager
+                    .cleanup(&handle, IssueLifecycleState::Terminal)
+                    .await?;
+                self.terminal_cleanup_paths.insert(workspace.path.clone());
+            }
         }
         Ok(())
     }
@@ -4226,6 +4228,95 @@ mod tests {
                 .expect("before-remove hook should run after retry")
                 .trim(),
             "before_remove"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runtime_workspace_cleanup_rearchives_a_terminal_thread_after_debug_unarchive() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspaces");
+        let workflow = sample_workflow(tempdir.path(), &workspace_root);
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let issue = sample_terminal_issue();
+        let ensured = workspace_manager
+            .ensure(&issue_descriptor(&issue))
+            .await
+            .expect("workspace should be ensured");
+        let mut manifest = sample_conversation_manifest("fake-thread");
+        manifest.transport_target = Some(CODEX_APP_SERVER_KIND.to_string());
+        manifest.runtime_contract_version = Some(CODEX_APP_SERVER_CONTRACT.to_string());
+        workspace_manager
+            .write_json_artifact(
+                &ensured.handle,
+                &ensured.handle.conversation_manifest_path(),
+                &manifest,
+            )
+            .await
+            .expect("Codex conversation manifest should persist");
+        let workspace = crate::opensymphony_domain::WorkspaceRecord {
+            path: ensured.handle.workspace_path().to_path_buf(),
+            workspace_key: WorkspaceKey::new(ensured.handle.workspace_key().to_string())
+                .expect("workspace key should be valid"),
+            created_now: false,
+            created_at: None,
+            updated_at: None,
+            last_seen_tracker_refresh_at: None,
+        };
+        let log_path = tempdir.path().join("fake-codex-terminal-rearchive.log");
+        let fake_codex = tempdir.path().join("fake-codex-terminal-rearchive");
+        write_fake_codex_child(&fake_codex, &log_path);
+        let mut backend = RuntimeWorkspaceBackend::new(Arc::clone(&workspace_manager), &workflow);
+        backend.codex_bin = fake_codex.to_string_lossy().into_owned();
+
+        backend
+            .cleanup_workspace(&workspace, true)
+            .await
+            .expect("initial terminal archive should succeed");
+
+        let unarchived_manifest_raw = workspace_manager
+            .read_text_artifact(
+                &ensured.handle,
+                &ensured.handle.conversation_manifest_path(),
+            )
+            .await
+            .expect("manifest read should succeed")
+            .expect("manifest should exist");
+        let mut unarchived_manifest: IssueConversationManifest =
+            serde_json::from_str(&unarchived_manifest_raw)
+                .expect("Codex conversation manifest should decode");
+        unarchived_manifest.codex_archive_state = Some("active".to_string());
+        workspace_manager
+            .write_json_artifact(
+                &ensured.handle,
+                &ensured.handle.conversation_manifest_path(),
+                &unarchived_manifest,
+            )
+            .await
+            .expect("debug unarchive state should persist");
+
+        backend
+            .cleanup_workspace(&workspace, true)
+            .await
+            .expect("later terminal poll should rearchive the thread");
+
+        let rearchived_manifest_raw = workspace_manager
+            .read_text_artifact(
+                &ensured.handle,
+                &ensured.handle.conversation_manifest_path(),
+            )
+            .await
+            .expect("manifest read should succeed")
+            .expect("manifest should exist");
+        let rearchived_manifest: IssueConversationManifest =
+            serde_json::from_str(&rearchived_manifest_raw)
+                .expect("Codex conversation manifest should decode");
+        assert_eq!(
+            rearchived_manifest.codex_archive_state.as_deref(),
+            Some("archived")
         );
     }
 

--- a/crates/opensymphony-cli/tests/debug.rs
+++ b/crates/opensymphony-cli/tests/debug.rs
@@ -48,7 +48,6 @@ async fn debug_codex_resume_launches_fake_codex_from_issue_workspace() {
         "PWD={}",
         ensured.handle.workspace_path().display()
     )));
-    assert!(log.contains("ARGS=resume --help"));
     assert!(log.contains("ARGS=resume 019ee323-173d-7ec0-8ad2-fa4067c5651c"));
 }
 
@@ -83,35 +82,6 @@ async fn debug_codex_app_prints_deep_link_without_launching_runtime() {
     assert_eq!(
         stdout.trim(),
         "codex://threads/019ee323-173d-7ec0-8ad2-fa4067c5651c"
-    );
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn debug_codex_resume_reports_unsupported_cli() {
-    let project = TempDir::new().expect("temp project should exist");
-    let workspace_root = project.path().join("var").join("workspaces");
-    write_project_files(project.path(), &workspace_root, "http://127.0.0.1:39999");
-    let (_manager, ensured) = create_workspace(&workspace_root, "COE-481").await;
-    write_codex_manifest(&ensured.handle, "thread-unsupported");
-
-    let log_path = project.path().join("fake-codex.log");
-    let fake_codex = project.path().join("fake-codex");
-    write_fake_codex(&fake_codex, &log_path, false);
-
-    let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
-        .arg("debug")
-        .arg("COE-481")
-        .current_dir(project.path())
-        .env("OPENSYMPHONY_CODEX_BIN", &fake_codex)
-        .output()
-        .await
-        .expect("debug command should run");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!output.status.success(), "unsupported CLI should fail");
-    assert!(
-        stderr.contains("does not expose the required `codex resume <session-id>` path"),
-        "stderr should explain unsupported resume path: {stderr}",
     );
 }
 

--- a/crates/opensymphony-cli/tests/debug.rs
+++ b/crates/opensymphony-cli/tests/debug.rs
@@ -52,6 +52,7 @@ async fn debug_codex_resume_launches_fake_codex_from_issue_workspace() {
     assert!(log.contains("ARGS=resume 019ee323-173d-7ec0-8ad2-fa4067c5651c"));
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn debug_codex_app_prints_deep_link_without_launching_runtime() {
     let project = TempDir::new().expect("temp project should exist");

--- a/crates/opensymphony-cli/tests/debug.rs
+++ b/crates/opensymphony-cli/tests/debug.rs
@@ -60,15 +60,16 @@ async fn debug_codex_app_prints_deep_link_without_launching_runtime() {
     let (_manager, ensured) = create_workspace(&workspace_root, "COE-480").await;
     write_codex_manifest(&ensured.handle, "019ee323-173d-7ec0-8ad2-fa4067c5651c");
 
+    let log_path = project.path().join("fake-codex.log");
+    let fake_codex = project.path().join("fake-codex");
+    write_fake_codex(&fake_codex, &log_path, true);
+
     let output = Command::new(env!("CARGO_BIN_EXE_opensymphony"))
         .arg("debug")
         .arg("COE-480")
         .arg("--app")
         .current_dir(project.path())
-        .env(
-            "OPENSYMPHONY_CODEX_BIN",
-            project.path().join("missing-codex"),
-        )
+        .env("OPENSYMPHONY_CODEX_BIN", &fake_codex)
         .output()
         .await
         .expect("debug command should run");
@@ -403,6 +404,22 @@ printf 'PWD=%s\n' "$PWD" >> "{log}"
 printf 'ARGS=%s\n' "$*" >> "{log}"
 if [ "${{1:-}}" = "resume" ] && [ "${{2:-}}" = "--help" ]; then
   printf '%s\n' "{help}"
+  exit 0
+fi
+if [ "${{2:-}}" = "app-server" ]; then
+  while IFS= read -r line; do
+    id=$(printf '%s\n' "$line" | sed -E 's/.*"id":([0-9]+).*/\1/')
+    case "$line" in
+      *'"method":"initialize"'*) printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id" ;;
+      *'"method":"thread/list"'*)
+        if printf '%s' "$line" | grep -q '"archived":true'; then
+          printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[],"nextCursor":null}}}}\n' "$id"
+        else
+          printf '{{"jsonrpc":"2.0","id":%s,"result":{{"data":[{{"id":"019ee323-173d-7ec0-8ad2-fa4067c5651c"}},{{"id":"thread-unsupported"}}],"nextCursor":null}}}}\n' "$id"
+        fi ;;
+      *'"method":"thread/unarchive"'*) printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id" ;;
+    esac
+  done
   exit 0
 fi
 if [ "${{1:-}}" = "resume" ]; then

--- a/crates/opensymphony-codex/src/lib.rs
+++ b/crates/opensymphony-codex/src/lib.rs
@@ -313,6 +313,44 @@ impl CodexAppServerAdapter {
         })
     }
 
+    pub fn unarchive_issue_thread_request(
+        &self,
+        session: &mut CodexJsonRpcSession,
+        thread_id: impl Into<String>,
+    ) -> Result<CodexHarnessRequest, serde_json::Error> {
+        Ok(CodexHarnessRequest {
+            lifecycle: CodexLifecycleRequest::Unarchive,
+            request: session.thread_unarchive(CodexThreadUnarchiveParams {
+                thread_id: thread_id.into(),
+            })?,
+        })
+    }
+
+    pub fn list_issue_threads_request(
+        &self,
+        session: &mut CodexJsonRpcSession,
+        cwd: impl Into<String>,
+        archived: bool,
+        cursor: Option<String>,
+    ) -> Result<CodexHarnessRequest, serde_json::Error> {
+        Ok(CodexHarnessRequest {
+            lifecycle: CodexLifecycleRequest::List,
+            request: session.thread_list(CodexThreadListParams {
+                source_kinds: Some(vec![
+                    "cli".into(),
+                    "vscode".into(),
+                    "exec".into(),
+                    "appServer".into(),
+                ]),
+                archived: Some(archived),
+                cursor,
+                cwd: Some(cwd.into()),
+                limit: None,
+                use_state_db_only: true,
+            })?,
+        })
+    }
+
     pub fn interrupt_turn_request(
         &self,
         session: &mut CodexJsonRpcSession,
@@ -366,6 +404,8 @@ pub enum CodexLifecycleRequest {
     Start,
     Resume,
     Archive,
+    Unarchive,
+    List,
     Interrupt,
     Approval,
 }
@@ -635,6 +675,20 @@ impl CodexJsonRpcSession {
         Ok(self.request("thread/archive", serde_json::to_value(params)?))
     }
 
+    pub fn thread_unarchive(
+        &mut self,
+        params: CodexThreadUnarchiveParams,
+    ) -> Result<JsonRpcRequestEnvelope, serde_json::Error> {
+        Ok(self.request("thread/unarchive", serde_json::to_value(params)?))
+    }
+
+    pub fn thread_list(
+        &mut self,
+        params: CodexThreadListParams,
+    ) -> Result<JsonRpcRequestEnvelope, serde_json::Error> {
+        Ok(self.request("thread/list", serde_json::to_value(params)?))
+    }
+
     pub fn turn_start(
         &mut self,
         params: CodexTurnStartParams,
@@ -703,6 +757,28 @@ pub struct CodexThreadResumeParams {
 #[serde(rename_all = "camelCase")]
 pub struct CodexThreadArchiveParams {
     pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexThreadUnarchiveParams {
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexThreadListParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_kinds: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    pub use_state_db_only: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -915,9 +915,8 @@ where
             return Ok(());
         };
 
-        let mut records = records.into_iter();
         let mut retry_records = Vec::new();
-        while let Some(record) = records.next() {
+        for record in records {
             let issue_id = record.issue.id.clone();
             let recovered_harness_kind = record.harness_kind.clone();
             if let Some(active_issue) = tracker_snapshot.active_issue(&issue_id) {

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -916,6 +916,7 @@ where
         };
 
         let mut records = records.into_iter();
+        let mut retry_records = Vec::new();
         while let Some(record) = records.next() {
             let issue_id = record.issue.id.clone();
             let recovered_harness_kind = record.harness_kind.clone();
@@ -937,10 +938,8 @@ where
                     .cleanup_workspace(&record.workspace, true)
                     .await
                 {
-                    self.pending_recovery = Some(std::iter::once(record).chain(records).collect());
-                    return Err(SchedulerError::Workspace {
-                        detail: error.to_string(),
-                    });
+                    tracing::warn!(issue = %issue_id, %error, "deferring terminal workspace cleanup retry");
+                    retry_records.push(record);
                 }
                 continue;
             }
@@ -956,7 +955,11 @@ where
             self.executions.entry(issue.id.clone()).or_insert(execution);
         }
 
-        self.recovered = true;
+        if retry_records.is_empty() {
+            self.recovered = true;
+        } else {
+            self.pending_recovery = Some(retry_records);
+        }
         Ok(())
     }
 

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -931,12 +931,16 @@ where
             }
 
             if tracker_snapshot.contains_terminal(issue_id.as_str()) {
-                self.workspace
+                if let Err(error) = self
+                    .workspace
                     .cleanup_workspace(&record.workspace, true)
                     .await
-                    .map_err(|error| SchedulerError::Workspace {
+                {
+                    self.pending_recovery = Some(vec![record]);
+                    return Err(SchedulerError::Workspace {
                         detail: error.to_string(),
-                    })?;
+                    });
+                }
                 continue;
             }
 

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -915,7 +915,8 @@ where
             return Ok(());
         };
 
-        for record in records {
+        let mut records = records.into_iter();
+        while let Some(record) = records.next() {
             let issue_id = record.issue.id.clone();
             let recovered_harness_kind = record.harness_kind.clone();
             if let Some(active_issue) = tracker_snapshot.active_issue(&issue_id) {
@@ -936,7 +937,7 @@ where
                     .cleanup_workspace(&record.workspace, true)
                     .await
                 {
-                    self.pending_recovery = Some(vec![record]);
+                    self.pending_recovery = Some(std::iter::once(record).chain(records).collect());
                     return Err(SchedulerError::Workspace {
                         detail: error.to_string(),
                     });
@@ -1763,12 +1764,12 @@ where
             execution = execution.release(observed_at, reason, None)?;
         }
         if cleanup_terminal && let Some(workspace) = execution.workspace().cloned() {
-            self.workspace
-                .cleanup_workspace(&workspace, true)
-                .await
-                .map_err(|error| SchedulerError::Workspace {
+            if let Err(error) = self.workspace.cleanup_workspace(&workspace, true).await {
+                self.insert_execution(issue_id, execution);
+                return Err(SchedulerError::Workspace {
                     detail: error.to_string(),
-                })?;
+                });
+            }
         }
         self.insert_execution(issue_id, execution);
         Ok(())

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -1763,13 +1763,14 @@ where
         if execution.status() != SchedulerStatus::Released {
             execution = execution.release(observed_at, reason, None)?;
         }
-        if cleanup_terminal && let Some(workspace) = execution.workspace().cloned() {
-            if let Err(error) = self.workspace.cleanup_workspace(&workspace, true).await {
-                self.insert_execution(issue_id, execution);
-                return Err(SchedulerError::Workspace {
-                    detail: error.to_string(),
-                });
-            }
+        if cleanup_terminal
+            && let Some(workspace) = execution.workspace().cloned()
+            && let Err(error) = self.workspace.cleanup_workspace(&workspace, true).await
+        {
+            self.insert_execution(issue_id, execution);
+            return Err(SchedulerError::Workspace {
+                detail: error.to_string(),
+            });
         }
         self.insert_execution(issue_id, execution);
         Ok(())

--- a/docs/codex-app-server-harness.md
+++ b/docs/codex-app-server-harness.md
@@ -258,7 +258,7 @@ codex app-server generate-ts --out <dir>
 OpenSymphony does not pin or vendor a Codex binary. It asks the installed Codex
 CLI to generate its current app-server JSON Schema, validates outbound
 `initialize`, `thread/start`, `thread/resume`, `turn/start`, and rollback
-`thread/archive` requests against that schema, and fails with update guidance
+`thread/list`, `thread/archive`, and `thread/unarchive` requests against that schema, and fails with update guidance
 if the installed Codex is too old or incompatible with the required automation
 fields.
 
@@ -473,13 +473,16 @@ or turn failures.
 Terminal workspace cleanup delegates to `WorkspaceManager`, so the configured
 retention decision and lifecycle hooks apply once per retained workspace in a
 runtime. The current runtime policy retains terminal workspaces and therefore
-preserves `.opensymphony/conversation.json` for future archive/debug recovery
-work. Terminal archival and debug unarchive remain the separate follow-on
-lifecycle slice.
+preserves `.opensymphony/conversation.json` for archive/debug recovery. Terminal
+reconciliation uses `thread/list` against the exact workspace CWD and state DB,
+archives an active canonical thread once, and records durable pending/complete
+archive state. Failures retain the workspace and manifest for a later tick.
 
-`opensymphony debug <issue-key>` uses the recorded thread id to run
-`codex resume <thread-id>` from the issue workspace. `opensymphony debug
-<issue-key> --app` prints the matching `codex://threads/<thread-id>` deep link.
+`opensymphony debug <issue-key>` first unarchives an archived canonical thread,
+then runs `codex resume <thread-id>` from the issue workspace. `opensymphony
+debug <issue-key> --app` performs the same recovery before printing the matching
+`codex://threads/<thread-id>` deep link. A failed recovery leaves the manifest
+in place and reports the thread id for manual repair.
 
 After `turn/start` yields an active turn id, the runtime backend retains a live
 stdio interrupt channel for the running Codex child. Scheduler interrupts such

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -351,7 +351,7 @@ The local Codex app-server harness path launches
 available when clients read `/api/v1/capabilities`. Before starting a run,
 OpenSymphony generates the JSON Schema from the installed Codex CLI and
 validates its full-automation `thread/start`, `thread/resume`, rollback
-`thread/archive`, and `turn/start` payloads. A new issue starts a thread; a
+`thread/list`, `thread/archive`, `thread/unarchive`, and `turn/start` payloads. A new issue starts a thread; a
 workspace with its canonical manifest resumes it. If the first manifest write
 fails after a start, OpenSymphony archives that newly created thread and does
 not start a turn. If the installed schema rejects any lifecycle payload, update
@@ -525,11 +525,11 @@ another OpenHands server is already bound to the configured port with a
 different store, stop it and retry the debug command.
 
 For issues last run through the local Codex app-server harness,
-`opensymphony debug COE-123` reads the recorded Codex thread id from the issue
-workspace manifest and runs `codex resume <thread-id>` from that exact issue
-workspace. Set `OPENSYMPHONY_CODEX_BIN` to override the Codex binary. Use
-`opensymphony debug COE-123 --app` to print `codex://threads/<thread-id>`
-without starting OpenHands or launching the Codex CLI.
+`opensymphony debug COE-123` reads the recorded Codex thread id, unarchives it
+when terminal reconciliation archived it, and then runs `codex resume
+<thread-id>` from that exact issue workspace. Set `OPENSYMPHONY_CODEX_BIN` to
+override the Codex binary. Use `opensymphony debug COE-123 --app` to unarchive
+and print `codex://threads/<thread-id>` without launching interactive Codex.
 
 See [Project Memory](memory.md) for the full command surface, import YAML
 schema, and troubleshooting notes.

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -334,6 +334,23 @@ fn codex_installed_schema_accepts_automation_payloads_when_requested() {
     validator
         .validate_request(&archive.request)
         .expect("thread/archive should match installed schema");
+    let unarchive = adapter
+        .unarchive_issue_thread_request(&mut session, "thread-1")
+        .expect("thread/unarchive should serialize");
+    validator
+        .validate_request(&unarchive.request)
+        .expect("thread/unarchive should match installed schema");
+    let list = adapter
+        .list_issue_threads_request(
+            &mut session,
+            "/tmp/issue-workspace",
+            true,
+            Some("next-page".into()),
+        )
+        .expect("thread/list should serialize");
+    validator
+        .validate_request(&list.request)
+        .expect("thread/list should match installed schema");
     let default_thread = adapter
         .start_issue_thread_request(
             &mut session,
@@ -998,6 +1015,32 @@ fn codex_lifecycle_requests_cover_start_resume_cancel_and_approval() {
     assert_eq!(archive.lifecycle, CodexLifecycleRequest::Archive);
     assert_eq!(archive.request.method, "thread/archive");
     assert_eq!(archive.request.params["threadId"], "thread-1");
+
+    let unarchive = adapter
+        .unarchive_issue_thread_request(&mut session, "thread-1")
+        .expect("unarchive request serializes");
+    assert_eq!(unarchive.lifecycle, CodexLifecycleRequest::Unarchive);
+    assert_eq!(unarchive.request.method, "thread/unarchive");
+    assert_eq!(unarchive.request.params["threadId"], "thread-1");
+
+    let list = adapter
+        .list_issue_threads_request(
+            &mut session,
+            "/tmp/issue-workspace",
+            true,
+            Some("next-page".into()),
+        )
+        .expect("list request serializes");
+    assert_eq!(list.lifecycle, CodexLifecycleRequest::List);
+    assert_eq!(list.request.method, "thread/list");
+    assert_eq!(list.request.params["cwd"], "/tmp/issue-workspace");
+    assert_eq!(list.request.params["archived"], true);
+    assert_eq!(list.request.params["cursor"], "next-page");
+    assert_eq!(list.request.params["useStateDbOnly"], true);
+    assert_eq!(
+        list.request.params["sourceKinds"],
+        json!(["cli", "vscode", "exec", "appServer"])
+    );
 
     let interrupt = adapter.interrupt_turn_request(&mut session, "thread-1", "turn-1");
     assert_eq!(interrupt.lifecycle, CodexLifecycleRequest::Interrupt);


### PR DESCRIPTION
## Summary

Archives a canonical Codex thread after terminal reconciliation and recovers that same thread before debug, app deep links, or issue reopen.

## Changes

- Added schema-validated `thread/list` and `thread/unarchive` requests.
- Reconciled archived/pending manifest state before thread resume.
- Archived terminal Codex threads while retaining failed recovery artifacts.
- Documented terminal and debug recovery behavior.

## Evidence

### Test output

```text
cargo test-system-duckdb --test codex_app_server: 20 passed
cargo test-system-duckdb --test debug: 5 passed
cargo test-system-duckdb --lib codex_stdio_worker_: 8 passed
cargo check-system-duckdb: passed
```

### Verification

Fake Codex worker retry coverage confirms one canonical thread is reused. Lifecycle requests validate against the installed schema when enabled, and terminal recovery preserves the workspace when Codex state cannot be repaired.

## Checklist

- [x] Tests pass for the changed Codex, debug, and worker surfaces
- [x] Code is formatted
- [ ] Clippy is clean (not yet run)
- [x] Documentation updated
- [ ] AGENTS.md updated (not needed)
- [x] Evidence section filled out

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Breaking changes

None.

## Related issues

COE-541

## Additional notes

Failures fail closed: the canonical id and workspace manifest are retained rather than creating a replacement thread.