### PR TITLE
feat(run-detail): add diff symbol navigation

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -175,6 +175,12 @@ function createDesktopNativeCodeGraphApi(invoke: TauriInvoke): NativeCodeGraphAp
         headRevision,
         limit: options?.limit ?? null,
       }),
+    getRunDiffOverlay: (runId, repoId, options?: CodeGraphDiffOptions) =>
+      invoke<CodeDiffOverlay>("run_code_diff_overlay", {
+        runId,
+        repoId: repoId ?? null,
+        limit: options?.limit ?? null,
+      }),
   };
 }
 

--- a/packages/graph/__tests__/code-graph.test.ts
+++ b/packages/graph/__tests__/code-graph.test.ts
@@ -190,11 +190,15 @@ describe("Code Graph adapters and state", () => {
       added_symbols: [],
       removed_symbols: [],
       modified_symbols: [],
-      blast_radius: [{ symbol_key: "unchangedCaller", inbound_count: 3 }],
+      blast_radius: [{ symbol_key: "unchangedCaller", inbound_count: 3, outbound_count: 4 }],
     };
     const rendered = codeGraphSnapshotForRendering(snapshot, overlay);
     expect(rendered.nodes).toEqual(expect.arrayContaining([
-      expect.objectContaining({ concept_id: "unchangedCaller", concept_type: "blast_radius" }),
+      expect.objectContaining({
+        concept_id: "unchangedCaller",
+        concept_type: "blast_radius",
+        metrics: expect.objectContaining({ indegree: 3, outdegree: 4 }),
+      }),
     ]));
   });
 

--- a/packages/graph/__tests__/code-graph.test.ts
+++ b/packages/graph/__tests__/code-graph.test.ts
@@ -183,6 +183,21 @@ describe("Code Graph adapters and state", () => {
     expect(state.selectedNodeIds).toEqual(["sym:newSymbol"]);
   });
 
+  it("materializes blast-radius-only symbols for graph styling", async () => {
+    const snapshot = await createFixtureCodeGraphAdapter().getGraphSnapshot("opensymphony", { mode: "atlas" });
+    const overlay = {
+      ...codeGraphFixtureDiffOverlays[0],
+      added_symbols: [],
+      removed_symbols: [],
+      modified_symbols: [],
+      blast_radius: [{ symbol_key: "unchangedCaller", inbound_count: 3 }],
+    };
+    const rendered = codeGraphSnapshotForRendering(snapshot, overlay);
+    expect(rendered.nodes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ concept_id: "unchangedCaller", concept_type: "blast_radius" }),
+    ]));
+  });
+
   it("uses community node membership without requiring a metrics community id", async () => {
     const adapter = createFixtureCodeGraphAdapter();
     const snapshot = await adapter.getGraphSnapshot("opensymphony", { mode: "file" });

--- a/packages/graph/src/code-graph.ts
+++ b/packages/graph/src/code-graph.ts
@@ -773,7 +773,7 @@ function withCodeDiffNodes(snapshot: CodeGraphSnapshot, overlay?: CodeDiffOverla
       freshness: "unknown" as const,
       diagnostic_count: 0,
       diagnostic_severity: null,
-      metrics: { in_degree: entry.inbound_count, out_degree: 0, community_id: null },
+      metrics: { in_degree: entry.inbound_count, out_degree: entry.outbound_count, community_id: null },
     }));
   if (syntheticNodes.length === 0 && radiusNodes.length === 0) return snapshot;
   return { ...snapshot, nodes: [...snapshot.nodes, ...syntheticNodes, ...radiusNodes] };

--- a/packages/graph/src/code-graph.ts
+++ b/packages/graph/src/code-graph.ts
@@ -737,7 +737,6 @@ function withCodeDiffNodes(snapshot: CodeGraphSnapshot, overlay?: CodeDiffOverla
     const side = symbol.status === "removed" ? symbol.before : symbol.after ?? symbol.before;
     if (side) syntheticSides.set(symbol.symbol_key, side);
   }
-  if (syntheticSides.size === 0) return snapshot;
   const syntheticNodes = [...syntheticSides].map(([symbolKey, side]) => ({
     id: `symbol:${symbolKey}`,
     kind: "symbol" as const,
@@ -756,7 +755,28 @@ function withCodeDiffNodes(snapshot: CodeGraphSnapshot, overlay?: CodeDiffOverla
     diagnostic_severity: null,
     metrics: { in_degree: 0, out_degree: 0, community_id: null },
   }));
-  return { ...snapshot, nodes: [...snapshot.nodes, ...syntheticNodes] };
+  const radiusNodes = overlay.blast_radius
+    .filter((entry) => !existingKeys.has(entry.symbol_key) && !syntheticSides.has(entry.symbol_key))
+    .map((entry) => ({
+      id: `symbol:${entry.symbol_key}`,
+      kind: "symbol" as const,
+      label: entry.symbol_key,
+      symbol_kind: "blast_radius",
+      symbol_key: entry.symbol_key,
+      symbol_id: null,
+      path_display: null,
+      language: null,
+      container_chain: [],
+      signature: null,
+      span: null,
+      selection_span: null,
+      freshness: "unknown" as const,
+      diagnostic_count: 0,
+      diagnostic_severity: null,
+      metrics: { in_degree: entry.inbound_count, out_degree: 0, community_id: null },
+    }));
+  if (syntheticNodes.length === 0 && radiusNodes.length === 0) return snapshot;
+  return { ...snapshot, nodes: [...snapshot.nodes, ...syntheticNodes, ...radiusNodes] };
 }
 
 function matchesCodeNode(

--- a/packages/graph/src/code-graph.ts
+++ b/packages/graph/src/code-graph.ts
@@ -64,6 +64,7 @@ export interface CodeGraphAdapter {
     headRevision: string,
     options?: CodeGraphDiffOptions,
   ): Promise<CodeDiffOverlay>;
+  getRunDiffOverlay?(runId: string, repoId?: string, options?: CodeGraphDiffOptions): Promise<CodeDiffOverlay>;
 }
 
 /** Tauri/native providers keep the same DTO contract without importing Tauri. */
@@ -554,8 +555,18 @@ export interface CodeEdgeVisualStyle {
   lineStyle: "solid" | "dashed" | "dotted";
 }
 
-export function codeNodeVisualStyle(node: Pick<CodeGraphNode, "kind" | "symbol_kind" | "freshness" | "diagnostic_count">): CodeNodeVisualStyle {
-  const color = node.kind === "directory"
+export function codeNodeVisualStyle(
+  node: Pick<CodeGraphNode, "kind" | "symbol_kind" | "freshness" | "diagnostic_count">,
+  deltaStatus: CodeGraphDeltaStatus = "unchanged",
+  blastRadius = false,
+): CodeNodeVisualStyle {
+  const color = deltaStatus === "added"
+    ? "#15803d"
+    : deltaStatus === "removed"
+      ? "#64748b"
+      : deltaStatus === "modified"
+        ? "#b45309"
+        : node.kind === "directory"
     ? "#475569"
     : node.kind === "file"
       ? "#2563eb"
@@ -571,9 +582,11 @@ export function codeNodeVisualStyle(node: Pick<CodeGraphNode, "kind" | "symbol_k
       : { opacity: 0.45, borderStyle: "dotted" as const, label: "unknown" };
   return {
     color,
-    opacity: node.diagnostic_count > 0 ? Math.max(0.5, freshness.opacity) : freshness.opacity,
-    borderStyle: freshness.borderStyle,
-    freshnessLabel: node.diagnostic_count > 0 ? `${freshness.label}, diagnostics` : freshness.label,
+    opacity: deltaStatus === "removed" ? 0.42 : node.diagnostic_count > 0 ? Math.max(0.5, freshness.opacity) : freshness.opacity,
+    borderStyle: deltaStatus === "removed" || blastRadius ? "dashed" : freshness.borderStyle,
+    freshnessLabel: deltaStatus !== "unchanged"
+      ? `${deltaStatus}${blastRadius ? ", blast radius" : ""}`
+      : blastRadius ? `${freshness.label}, blast radius` : node.diagnostic_count > 0 ? `${freshness.label}, diagnostics` : freshness.label,
   };
 }
 
@@ -633,6 +646,12 @@ export function createHttpCodeGraphAdapter(
       const params = new URLSearchParams({ base_revision: baseRevision, head_revision: headRevision });
       if (options?.limit !== undefined) params.set("limit", String(options.limit));
       return read<CodeDiffOverlay>(`/api/v1/code/repos/${encodeURIComponent(repoId)}/diff-overlay`, params);
+    },
+    getRunDiffOverlay: (runId, repoId, options) => {
+      const params = new URLSearchParams();
+      if (repoId) params.set("repo_id", repoId);
+      if (options?.limit !== undefined) params.set("limit", String(options.limit));
+      return read<CodeDiffOverlay>(`/api/v1/runs/${encodeURIComponent(runId)}/code/diff-overlay`, params);
     },
   };
 }

--- a/packages/ui-core/__tests__/diff.test.ts
+++ b/packages/ui-core/__tests__/diff.test.ts
@@ -88,6 +88,34 @@ describe("diff symbol navigation", () => {
     expect(html).toContain("No diff available");
   });
 
+  it("keeps old and new line coordinates distinct", () => {
+    const coordinateDiff: FileDiffPage = {
+      ...diff,
+      hunks: [{
+        ...diff.hunks[0],
+        header: "@@ -5,7 +10,7 @@",
+        start_line: 5,
+        lines: [
+          { type: "addition", line: "new symbol" },
+          ...Array.from({ length: 5 }, () => ({ type: "context" as const, line: "context" })),
+          { type: "deletion", line: "old symbol" },
+        ],
+      }],
+    };
+    const coordinateOutline: CodeFileOutline = {
+      ...outline,
+      symbols: [
+        { ...outline.symbols[0], symbol_key: "added", name: "added", span: { ...outline.symbols[0].span, start_line: 10, end_line: 10 } },
+        { ...outline.symbols[1], symbol_key: "removed", name: "removed", span: { ...outline.symbols[1].span, start_line: 16, end_line: 16 } },
+      ],
+    };
+    const root = document.createElement("div");
+    root.innerHTML = renderFileDiff(coordinateDiff, coordinateOutline, (symbolKey) => `opensymphony://code/${symbolKey}`);
+    expect(root.querySelectorAll("[data-diff-symbol-action]")).toHaveLength(2);
+    expect(root.querySelector("[data-line-type='addition']")?.getAttribute("data-diff-symbol-key")).toBe("added");
+    expect(root.querySelector("[data-line-type='deletion']")?.getAttribute("data-diff-symbol-key")).toBe("removed");
+  });
+
   it("lists blast-radius-only symbols in the accessible delta", () => {
     const overlay = {
       schema_version: { major: 1, minor: 0, patch: 0 },

--- a/packages/ui-core/__tests__/diff.test.ts
+++ b/packages/ui-core/__tests__/diff.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
-import type { CodeFileOutline, FileDiffPage } from "@opensymphony/gateway-schema";
-import { innermostSymbolAtLine, renderFileDiff, resolveDiffSymbolRegions } from "../src/diff.js";
+import type { CodeDiffOverlay, CodeFileOutline, FileDiffPage } from "@opensymphony/gateway-schema";
+import { innermostSymbolAtLine, renderCodeDiffDeltaList, renderCodeDiffSummary, renderFileDiff, resolveDiffSymbolRegions } from "../src/diff.js";
 
 const outline: CodeFileOutline = {
   schema_version: { major: 1, minor: 0, patch: 0 },
@@ -66,5 +66,35 @@ describe("diff symbol navigation", () => {
     expect(root.querySelectorAll("[data-diff-symbol-action]")).toHaveLength(1);
     expect(root.querySelector("[data-diff-symbol-action]")?.getAttribute("aria-label")).toContain("inner");
     expect(root.querySelector("[data-diff-symbol-copy]")?.getAttribute("data-diff-symbol-copy")).toContain("opensymphony://code/");
+  });
+
+  it("keeps deletion-only regions navigable and hides unavailable file actions", () => {
+    const deletion: FileDiffPage = {
+      ...diff,
+      hunks: [{ ...diff.hunks[0], header: "@@ -9,1 +9,0 @@", lines: [{ type: "deletion", line: "}" }] }],
+      total_lines_added: 0,
+      total_lines_removed: 1,
+    };
+    expect(resolveDiffSymbolRegions(deletion, outline).map((region) => region.symbol.symbol_key)).toEqual(["outer"]);
+    expect(renderFileDiff(diff, outline)).not.toContain("os-diff-file-graph");
+    expect(renderFileDiff(diff, outline, (_symbolKey, path) => `opensymphony://code/file/${path}`)).toContain("os-diff-file-graph");
+  });
+
+  it("lists blast-radius-only symbols in the accessible delta", () => {
+    const overlay = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      repo_id: "repo",
+      base_revision: "base",
+      head_revision: "head",
+      added_symbols: [],
+      removed_symbols: [],
+      modified_symbols: [],
+      blast_radius: [{ symbol_key: "caller", inbound_count: 2 }],
+      unanalyzed_files: [],
+      truncation: { truncated: false, reason: null },
+      generated_at: "2026-07-12T00:00:00Z",
+    } satisfies CodeDiffOverlay;
+    expect(renderCodeDiffSummary(overlay)).toContain("data-run-code-summary");
+    expect(renderCodeDiffDeltaList(overlay)).toContain("caller");
   });
 });

--- a/packages/ui-core/__tests__/diff.test.ts
+++ b/packages/ui-core/__tests__/diff.test.ts
@@ -80,6 +80,14 @@ describe("diff symbol navigation", () => {
     expect(renderFileDiff(diff, outline, (_symbolKey, path) => `opensymphony://code/file/${path}`)).toContain("os-diff-file-graph");
   });
 
+  it("keeps file navigation available for empty diffs", () => {
+    const emptyDiff: FileDiffPage = { ...diff, hunks: [], total_lines_added: 0, total_lines_removed: 0 };
+    const html = renderFileDiff(emptyDiff, null, (_symbolKey, path) => `opensymphony://code/file/${path}`);
+    expect(html).toContain("data-testid=\"diff-header\"");
+    expect(html).toContain("data-diff-file-graph=\"src/lib.ts\"");
+    expect(html).toContain("No diff available");
+  });
+
   it("lists blast-radius-only symbols in the accessible delta", () => {
     const overlay = {
       schema_version: { major: 1, minor: 0, patch: 0 },

--- a/packages/ui-core/__tests__/diff.test.ts
+++ b/packages/ui-core/__tests__/diff.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+
+import type { CodeFileOutline, FileDiffPage } from "@opensymphony/gateway-schema";
+import { innermostSymbolAtLine, renderFileDiff, resolveDiffSymbolRegions } from "../src/diff.js";
+
+const outline: CodeFileOutline = {
+  schema_version: { major: 1, minor: 0, patch: 0 },
+  run_id: "run-535",
+  repo_id: "opensymphony",
+  path: "src/lib.ts",
+  generated_at: "2026-07-12T00:00:00Z",
+  symbols: [
+    {
+      symbol_key: "outer",
+      name: "outer",
+      kind: "function",
+      path: "src/lib.ts",
+      span: { start_line: 1, start_col: 0, end_line: 8, end_col: 1 },
+      selection_span: { start_line: 1, start_col: 0, end_line: 1, end_col: 5 },
+      container_chain: [],
+    },
+    {
+      symbol_key: "inner",
+      name: "inner",
+      kind: "function",
+      path: "src/lib.ts",
+      span: { start_line: 3, start_col: 0, end_line: 5, end_col: 1 },
+      selection_span: { start_line: 3, start_col: 0, end_line: 3, end_col: 5 },
+      container_chain: ["outer"],
+    },
+  ],
+};
+
+const diff: FileDiffPage = {
+  schema_version: { major: 1, minor: 0, patch: 0 },
+  run_id: "run-535",
+  file_path: "src/lib.ts",
+  next_cursor: undefined,
+  hunks: [{
+    file_path: "src/lib.ts",
+    header: "@@ -1,5 +1,5 @@",
+    start_line: 1,
+    old_line_count: 5,
+    new_line_count: 5,
+    lines: [
+      { type: "context", line: "function outer() {" },
+      { type: "context", line: "  return inner();" },
+      { type: "addition", line: "  const changed = true;" },
+      { type: "addition", line: "  return changed;" },
+    ],
+  }],
+  total_lines_added: 2,
+  total_lines_removed: 0,
+};
+
+describe("diff symbol navigation", () => {
+  it("chooses the innermost containing symbol", () => {
+    expect(innermostSymbolAtLine(outline.symbols, 4)?.symbol_key).toBe("inner");
+  });
+
+  it("renders one glyph per changed symbol region", () => {
+    const regions = resolveDiffSymbolRegions(diff, outline);
+    expect(regions.map((region) => region.symbol.symbol_key)).toEqual(["inner"]);
+    const root = document.createElement("div");
+    root.innerHTML = renderFileDiff(diff, outline, (symbolKey) => `opensymphony://code/repo/diff/base/head/symbols/${symbolKey}`);
+    expect(root.querySelectorAll("[data-diff-symbol-action]")).toHaveLength(1);
+    expect(root.querySelector("[data-diff-symbol-action]")?.getAttribute("aria-label")).toContain("inner");
+    expect(root.querySelector("[data-diff-symbol-copy]")?.getAttribute("data-diff-symbol-copy")).toContain("opensymphony://code/");
+  });
+});

--- a/packages/ui-core/__tests__/run-detail-views.test.ts
+++ b/packages/ui-core/__tests__/run-detail-views.test.ts
@@ -261,9 +261,12 @@ describe("Run detail views", () => {
     };
     const handle = renderOpenSymphonyApp({ root, mode: "web", transport, codeGraphAdapter: codeAdapter });
     await openRun(root);
+    await flushUntil(() => root.querySelector("[data-testid='run-code-summary']") !== null);
 
     expect(root.querySelector("[data-testid='run-code-summary']")?.textContent).toContain("1 modified");
     expect(root.querySelector("[data-testid='run-code-delta-list']")).not.toBeNull();
+    (root.querySelector("[data-testid='run-code-summary']") as HTMLButtonElement).click();
+    await flushUntil(() => root.querySelector("[data-active-graph-surface='code']") !== null);
     expect(root.querySelector("[data-diff-symbol-action]")).not.toBeNull();
     (root.querySelector("[data-diff-symbol-action]") as HTMLButtonElement).click();
     await flushUntil(() => root.querySelector("[data-active-graph-surface='code']") !== null);

--- a/packages/ui-core/__tests__/run-detail-views.test.ts
+++ b/packages/ui-core/__tests__/run-detail-views.test.ts
@@ -275,6 +275,33 @@ describe("Run detail views", () => {
     handle.destroy();
   });
 
+  it("keeps a pending run overlay alive while selecting another file", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    let releaseOverlay!: (overlay: typeof codeGraphFixtureDiffOverlays[number]) => void;
+    const pendingOverlay = new Promise<typeof codeGraphFixtureDiffOverlays[number]>((resolve) => {
+      releaseOverlay = resolve;
+    });
+    const handle = renderOpenSymphonyApp({
+      root,
+      mode: "web",
+      transport: buildTransport(runDetail),
+      codeGraphAdapter: {
+        ...createFixtureCodeGraphAdapter(),
+        getRunDiffOverlay: async () => pendingOverlay,
+      },
+    });
+
+    await openRun(root);
+    root.querySelector<HTMLElement>("[data-path='src/new.ts']")!.click();
+    await flushAsync();
+    expect(root.querySelector("[data-testid='run-code-summary']")).toBeNull();
+
+    releaseOverlay(codeGraphFixtureDiffOverlays[0]);
+    await flushUntil(() => root.querySelector("[data-testid='run-code-summary']") !== null);
+    await handle.destroy();
+  });
+
   it("renders changed files, diff, validation, approvals, and TUI-parity metadata", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/__tests__/run-detail-views.test.ts
+++ b/packages/ui-core/__tests__/run-detail-views.test.ts
@@ -8,6 +8,7 @@
 
 import { renderOpenSymphonyApp } from "../src/app-shell.js";
 import { MockGatewayTransport } from "@opensymphony/api-client";
+import { codeGraphFixtureDiffOverlays, codeGraphFixtureOutlines, createFixtureCodeGraphAdapter } from "@opensymphony/graph";
 import { schemaVersionV1 } from "@opensymphony/gateway-schema";
 import type {
   ApprovalRequest,
@@ -239,6 +240,38 @@ async function openRun(root: HTMLElement): Promise<void> {
 }
 
 describe("Run detail views", () => {
+  it("loads the run overlay and keeps Run Detail mounted after symbol navigation", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const transport = buildTransport(runDetail);
+    const codePath = codeGraphFixtureOutlines[0].path;
+    const codeDiff: FileDiffPage = {
+      ...diff,
+      file_path: codePath,
+      hunks: [{ ...diff.hunks[0], file_path: codePath, header: "@@ -10,1 +10,1 @@", start_line: 10, lines: [{ type: "addition", line: "const changed = true;" }] }],
+    };
+    Object.assign(transport, {
+      runFiles: async () => [{ ...files[0], path: codePath }],
+      runDiffs: async () => codeDiff,
+    });
+    const codeAdapter = {
+      ...createFixtureCodeGraphAdapter(),
+      getFileOutline: async () => ({ ...codeGraphFixtureOutlines[0], run_id: runDetail.run_id }),
+      getRunDiffOverlay: async () => codeGraphFixtureDiffOverlays[0],
+    };
+    const handle = renderOpenSymphonyApp({ root, mode: "web", transport, codeGraphAdapter: codeAdapter });
+    await openRun(root);
+
+    expect(root.querySelector("[data-testid='run-code-summary']")?.textContent).toContain("1 modified");
+    expect(root.querySelector("[data-testid='run-code-delta-list']")).not.toBeNull();
+    expect(root.querySelector("[data-diff-symbol-action]")).not.toBeNull();
+    (root.querySelector("[data-diff-symbol-action]") as HTMLButtonElement).click();
+    await flushUntil(() => root.querySelector("[data-active-graph-surface='code']") !== null);
+    expect(root.querySelector(".os-run-detail-panel")).not.toBeNull();
+    expect(root.querySelector(".os-run-evidence-panel")).not.toBeNull();
+    handle.destroy();
+  });
+
   it("renders changed files, diff, validation, approvals, and TUI-parity metadata", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -325,6 +325,7 @@ interface AuditTrailEntry {
 
 /** Evidence for one run, fetched concurrently and applied atomically. */
 interface RunDetailBundle {
+  runId: string;
   runFiles: ChangedFileEntry[];
   selectedDiffPath: string | null;
   runDiff: FileDiffPage | null;
@@ -583,20 +584,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           warnings.push(`Diff unavailable: ${errorMessage(error)}`);
         }
       }
-      let runCodeOutline: CodeFileOutline | null = null;
-      if (selectedDiffPath && this.codeGraphAdapter?.getFileOutline) {
-        const cacheKey = runOutlineCacheKey(runId, selectedDiffPath, runDiff);
-        runCodeOutline = this.runOutlineCache.get(cacheKey) ?? null;
-        if (!runCodeOutline) {
-          try {
-            runCodeOutline = await this.codeGraphAdapter.getFileOutline(runId, selectedDiffPath);
-            this.runOutlineCache.set(cacheKey, runCodeOutline);
-          } catch {
-            runCodeOutline = null;
-          }
-        }
-      }
-      return { runFiles, selectedDiffPath, runDiff, runCodeOutline };
+      return { runFiles, selectedDiffPath, runDiff };
     })();
     const events = (async () => {
       try {
@@ -630,20 +618,25 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     })();
 
     const [
-      { runFiles, selectedDiffPath, runDiff, runCodeOutline },
+      { runFiles, selectedDiffPath, runDiff },
       runEvents,
       runValidation,
       runApprovals,
     ] = await Promise.all([filesAndDiff, events, validation, approvals]);
-    return { runFiles, selectedDiffPath, runDiff, runCodeOverlay: null, runCodeOutline, runEvents, runValidation, runApprovals, warnings };
+    return { runId, runFiles, selectedDiffPath, runDiff, runCodeOverlay: null, runCodeOutline: null, runEvents, runValidation, runApprovals, warnings };
   }
 
   private applyRunDetailBundle(bundle: RunDetailBundle): void {
+    const sameRun = this.state.runDetail?.run_id === bundle.runId;
+    const sameDiff = sameRun
+      && this.state.selectedDiffPath === bundle.selectedDiffPath
+      && runOutlineCacheKey(bundle.runId, bundle.selectedDiffPath ?? "", this.state.runDiff)
+        === runOutlineCacheKey(bundle.runId, bundle.selectedDiffPath ?? "", bundle.runDiff);
     this.state.runFiles = bundle.runFiles;
     this.state.selectedDiffPath = bundle.selectedDiffPath;
     this.state.runDiff = bundle.runDiff;
-    this.state.runCodeOverlay = bundle.runCodeOverlay;
-    this.state.runCodeOutline = bundle.runCodeOutline;
+    this.state.runCodeOverlay = bundle.runCodeOverlay ?? (sameRun ? this.state.runCodeOverlay : null);
+    this.state.runCodeOutline = bundle.runCodeOutline ?? (sameDiff ? this.state.runCodeOutline : null);
     this.state.runEvents = bundle.runEvents;
     this.state.runValidation = bundle.runValidation;
     this.state.runApprovals = bundle.runApprovals;
@@ -1213,7 +1206,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     navigationVersion: number,
   ): Promise<void> {
     if (!this.codeGraphAdapter) return;
-    const overlay = this.state.codeGraph.runId && this.codeGraphAdapter.getRunDiffOverlay
+    const overlay = this.state.codeGraph.runId
+      && !baseRevision
+      && this.codeGraphAdapter.getRunDiffOverlay
       ? await this.codeGraphAdapter.getRunDiffOverlay(this.state.codeGraph.runId, repoId)
       : await this.codeGraphAdapter.getDiffOverlay(repoId, baseRevision, headRevision);
     if (this.destroyed || navigationVersion !== this.codeGraphNavigationVersion || requestKey !== this.codeGraphRequestKey()) return;
@@ -1701,6 +1696,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.runDetail = selectedRun.runDetail;
       this.state.runOverlays.set(selectedRun.runDetail.run_id, selectedRun.runDetail);
       this.applyRunDetailBundle(selectedRun.bundle);
+      void this.loadRunCodeOutline(selectedRun.runDetail.run_id, selectedRun.bundle.selectedDiffPath, selectedRun.bundle.runDiff);
       void this.loadRunCodeOverlay(selectedRun.runDetail.run_id);
     }
     if (completedSetChanged) {
@@ -1774,12 +1770,15 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       if (this.destroyed || openSeq !== this.runOpenSeq) {
         return;
       }
+      this.state.runCodeOverlay = null;
+      this.state.runCodeOutline = null;
       this.state.runDetail = runDetail;
       this.state.runOverlays.set(runId, runDetail);
       this.state.evidenceView = "diff";
       this.state.expandedActivityEvents = new Set();
       this.state.collapsedActivityEvents = new Set();
       this.applyRunDetailBundle(bundle);
+      void this.loadRunCodeOutline(runId, bundle.selectedDiffPath, bundle.runDiff);
       void this.loadRunCodeOverlay(runId);
     } catch (error) {
       if (this.destroyed || openSeq !== this.runOpenSeq) {
@@ -1878,6 +1877,37 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.render();
     } catch {
       // Code Graph is optional; Run Detail remains usable without its overlay.
+    }
+  }
+
+  private async loadRunCodeOutline(
+    runId: string,
+    path: string | null,
+    diff: FileDiffPage | null,
+  ): Promise<void> {
+    const getOutline = this.codeGraphAdapter?.getFileOutline;
+    if (!path || !diff || !getOutline) return;
+    const cacheKey = runOutlineCacheKey(runId, path, diff);
+    const apply = (outline: CodeFileOutline): void => {
+      if (this.destroyed
+        || this.state.runDetail?.run_id !== runId
+        || this.state.selectedDiffPath !== path
+        || !this.state.runDiff
+        || runOutlineCacheKey(runId, path, this.state.runDiff) !== cacheKey) return;
+      this.state.runCodeOutline = outline;
+      this.render();
+    };
+    const cached = this.runOutlineCache.get(cacheKey);
+    if (cached) {
+      apply(cached);
+      return;
+    }
+    try {
+      const outline = await getOutline(runId, path);
+      this.runOutlineCache.set(cacheKey, outline);
+      apply(outline);
+    } catch {
+      // Code intelligence is optional; the plain diff remains available.
     }
   }
 

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -336,6 +336,10 @@ interface RunDetailBundle {
   warnings: string[];
 }
 
+function runOutlineCacheKey(runId: string, path: string, diff: FileDiffPage | null): string {
+  return `${runId}:${path}:${diff ? JSON.stringify(diff.hunks) : "none"}`;
+}
+
 type EvidenceView = "diff" | "activity";
 type GraphPaneView = "task" | "knowledge" | "code";
 type WorkspacePaneResizeHandle = "lower-columns";
@@ -436,6 +440,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
    * loading — only a newer open, project switch, or full refresh does.
    */
   private runOpenSeq = 0;
+  private runCodeOverlaySeq = 0;
   /** Guards in-flight selectDiffFile loads (superseded by newer diff clicks or opens). */
   private diffSelectSeq = 0;
   private readonly runOutlineCache = new Map<string, CodeFileOutline>();
@@ -580,7 +585,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       }
       let runCodeOutline: CodeFileOutline | null = null;
       if (selectedDiffPath && this.codeGraphAdapter?.getFileOutline) {
-        const cacheKey = `${runId}:${selectedDiffPath}`;
+        const cacheKey = runOutlineCacheKey(runId, selectedDiffPath, runDiff);
         runCodeOutline = this.runOutlineCache.get(cacheKey) ?? null;
         if (!runCodeOutline) {
           try {
@@ -592,14 +597,6 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         }
       }
       return { runFiles, selectedDiffPath, runDiff, runCodeOutline };
-    })();
-    const runCodeOverlayRequest = (async () => {
-      if (!this.codeGraphAdapter?.getRunDiffOverlay) return null;
-      try {
-        return await this.codeGraphAdapter.getRunDiffOverlay(runId);
-      } catch {
-        return null;
-      }
     })();
     const events = (async () => {
       try {
@@ -634,12 +631,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
     const [
       { runFiles, selectedDiffPath, runDiff, runCodeOutline },
-      runCodeOverlay,
       runEvents,
       runValidation,
       runApprovals,
-    ] = await Promise.all([filesAndDiff, runCodeOverlayRequest, events, validation, approvals]);
-    return { runFiles, selectedDiffPath, runDiff, runCodeOverlay, runCodeOutline, runEvents, runValidation, runApprovals, warnings };
+    ] = await Promise.all([filesAndDiff, events, validation, approvals]);
+    return { runFiles, selectedDiffPath, runDiff, runCodeOverlay: null, runCodeOutline, runEvents, runValidation, runApprovals, warnings };
   }
 
   private applyRunDetailBundle(bundle: RunDetailBundle): void {
@@ -667,6 +663,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.interactionEpoch += 1;
     this.runOpenSeq += 1;
     this.diffSelectSeq += 1;
+    this.runCodeOverlaySeq += 1;
     this.state.loading = true;
     this.render();
 
@@ -1704,6 +1701,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.runDetail = selectedRun.runDetail;
       this.state.runOverlays.set(selectedRun.runDetail.run_id, selectedRun.runDetail);
       this.applyRunDetailBundle(selectedRun.bundle);
+      void this.loadRunCodeOverlay(selectedRun.runDetail.run_id);
     }
     if (completedSetChanged) {
       void this.loadCompletedTasks();
@@ -1761,6 +1759,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const runId = runIdForNode(node);
     this.interactionEpoch += 1;
     this.diffSelectSeq += 1;
+    this.runCodeOverlaySeq += 1;
     const openSeq = ++this.runOpenSeq;
     this.state.selectedNodeId = node.node_id;
     this.state.loading = true;
@@ -1781,6 +1780,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.expandedActivityEvents = new Set();
       this.state.collapsedActivityEvents = new Set();
       this.applyRunDetailBundle(bundle);
+      void this.loadRunCodeOverlay(runId);
     } catch (error) {
       if (this.destroyed || openSeq !== this.runOpenSeq) {
         return;
@@ -1819,26 +1819,21 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.selectedDiffPath = path;
     this.state.evidenceView = "diff";
     const runId = this.state.runDetail?.run_id;
-    this.state.runCodeOutline = runId ? this.runOutlineCache.get(`${runId}:${path}`) ?? null : null;
+    this.state.runCodeOutline = null;
     this.render();
     if (runId && typeof this.transport.runDiffs === "function") {
-      let runDiff: FileDiffPage | null = null;
-      let runCodeOutline: CodeFileOutline | null = this.state.runCodeOutline;
-      let warning: string | null = null;
-      const [diffResult, outlineResult] = await Promise.all([
-        this.transport.runDiffs!(runId, path).catch((error) => {
-          warning = `Diff unavailable: ${errorMessage(error)}`;
-          return null;
-        }),
-        this.state.runCodeOutline
-          ? Promise.resolve(this.state.runCodeOutline)
-          : this.codeGraphAdapter?.getFileOutline(runId, path).then((outline) => {
-              this.runOutlineCache.set(`${runId}:${path}`, outline);
-              return outline;
-            }).catch(() => null) ?? Promise.resolve(null),
-      ]);
-      runDiff = diffResult;
-      runCodeOutline = outlineResult;
+      const runDiff = await this.transport.runDiffs!(runId, path).catch((error) => {
+        this.state.connectionMessage = `Diff unavailable: ${errorMessage(error)}`;
+        return null;
+      });
+      if (this.destroyed || seq !== this.diffSelectSeq || this.state.runDetail?.run_id !== runId) return;
+      let runCodeOutline = this.runOutlineCache.get(runOutlineCacheKey(runId, path, runDiff)) ?? null;
+      if (!runCodeOutline && this.codeGraphAdapter?.getFileOutline) {
+        runCodeOutline = await this.codeGraphAdapter.getFileOutline(runId, path).then((outline) => {
+          this.runOutlineCache.set(runOutlineCacheKey(runId, path, runDiff), outline);
+          return outline;
+        }).catch(() => null);
+      }
       // Drop the result if a newer diff click or task open superseded this
       // fetch, or if the shown run changed while it was in flight.
       if (this.destroyed || seq !== this.diffSelectSeq || this.state.runDetail?.run_id !== runId) {
@@ -1846,9 +1841,6 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       }
       this.state.runDiff = runDiff;
       this.state.runCodeOutline = runCodeOutline;
-      if (warning) {
-        this.state.connectionMessage = warning;
-      }
     } else if (runId) {
       this.state.runDiff = null;
       this.state.connectionMessage = "Diff endpoint unavailable for the active transport";
@@ -1875,16 +1867,25 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     }
   }
 
+  private async loadRunCodeOverlay(runId: string): Promise<void> {
+    const getOverlay = this.codeGraphAdapter?.getRunDiffOverlay;
+    if (!getOverlay) return;
+    const seq = ++this.runCodeOverlaySeq;
+    try {
+      const overlay = await getOverlay(runId);
+      if (this.destroyed || seq !== this.runCodeOverlaySeq || this.state.runDetail?.run_id !== runId) return;
+      this.state.runCodeOverlay = overlay;
+      this.render();
+    } catch {
+      // Code Graph is optional; Run Detail remains usable without its overlay.
+    }
+  }
+
   private async openRunCodeTarget(symbolKey?: string, path?: string): Promise<void> {
     const runId = this.state.runDetail?.run_id;
     if (!runId || (symbolKey && path)) return;
-    if (!this.state.runCodeOverlay && this.codeGraphAdapter?.getRunDiffOverlay) {
-      try {
-        this.state.runCodeOverlay = await this.codeGraphAdapter.getRunDiffOverlay(runId);
-      } catch {
-        return;
-      }
-    }
+    if (!this.state.runCodeOverlay) await this.loadRunCodeOverlay(runId);
+    if (this.state.runDetail?.run_id !== runId) return;
     const link = this.runCodeDeepLink(symbolKey, path);
     if (link) await this.openCodeDeepLink(link);
   }
@@ -2282,6 +2283,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.interactionEpoch += 1;
     this.runOpenSeq += 1;
     this.diffSelectSeq += 1;
+    this.runCodeOverlaySeq += 1;
     this.state.selectedProjectId = projectId;
     this.state.loading = true;
     this.render();
@@ -3539,7 +3541,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       return panel("Inspector", `<div class="os-empty">Select an issue to inspect a diff or activity</div>`, "os-run-evidence-panel");
     }
     const diff = this.state.runDiff
-      ? renderFileDiff(this.state.runDiff, this.state.runCodeOutline, (symbolKey) => this.runCodeDeepLink(symbolKey))
+      ? renderFileDiff(this.state.runDiff, this.state.runCodeOutline, (symbolKey, path) => this.runCodeDeepLink(symbolKey || undefined, path))
       : "";
     const activity = renderRunActivity(
       this.state.runEvents,
@@ -4316,6 +4318,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.listen(button, "diff-file-graph", "click", () => {
         const path = button.dataset.diffFileGraph;
         if (path) void this.openRunCodeTarget(undefined, path);
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-run-code-summary]").forEach((button) => {
+      this.listen(button, "run-code-summary", "click", () => {
+        void this.openRunCodeTarget();
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-diff-symbol-key]").forEach((line) => {

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1208,7 +1208,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   ): Promise<void> {
     if (!this.codeGraphAdapter) return;
     const dirtyRun = this.state.codeGraph.runId
-      && (!baseRevision || !headRevision || headRevision.startsWith("HEAD+"));
+      && (!baseRevision || !headRevision || headRevision.startsWith("HEAD+") || headRevision.endsWith("+worktree"));
     const overlay = dirtyRun
       && this.state.codeGraph.runId
       && this.codeGraphAdapter.getRunDiffOverlay
@@ -1274,10 +1274,18 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       onSelectArea: this.onCodeAggregateSelected,
       nodeStyle: (node) => {
         const codeNode = snapshot?.nodes.find((candidate) => candidate.id === node.nodeId);
-        if (!codeNode) return undefined;
-        const deltaStatus = codeGraphNodeDeltaStatus(codeNode.symbol_key, this.state.codeGraph.diffOverlay);
-        const blastRadius = Boolean(codeNode.symbol_key && this.state.codeGraph.diffOverlay?.blast_radius.some((entry) => entry.symbol_key === codeNode.symbol_key));
-        return codeNodeVisualStyle(codeNode, deltaStatus, blastRadius);
+        const renderedNode = renderSnapshot?.nodes.find((candidate) => candidate.id === node.nodeId);
+        const styleNode = codeNode ?? (renderedNode ? {
+          kind: renderedNode.kind as CodeGraphNode["kind"],
+          symbol_kind: renderedNode.concept_type ?? null,
+          freshness: renderedNode.freshness as CodeGraphNode["freshness"],
+          diagnostic_count: renderedNode.warning_count,
+          symbol_key: renderedNode.concept_id ?? null,
+        } : undefined);
+        if (!styleNode) return undefined;
+        const deltaStatus = codeGraphNodeDeltaStatus(styleNode.symbol_key, this.state.codeGraph.diffOverlay);
+        const blastRadius = Boolean(styleNode.symbol_key && this.state.codeGraph.diffOverlay?.blast_radius.some((entry) => entry.symbol_key === styleNode.symbol_key));
+        return codeNodeVisualStyle(styleNode, deltaStatus, blastRadius);
       },
       edgeStyle: (edge) => edge.confidence
         ? codeEdgeVisualStyle({ confidence: edge.confidence as "exact" | "syntactic" | "heuristic" })

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1207,10 +1207,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     navigationVersion: number,
   ): Promise<void> {
     if (!this.codeGraphAdapter) return;
-    const dirtyRun = this.state.codeGraph.runId
-      && (!baseRevision || !headRevision || headRevision.startsWith("HEAD+") || headRevision.endsWith("+worktree"));
-    const overlay = dirtyRun
-      && this.state.codeGraph.runId
+    const overlay = this.state.codeGraph.runId
       && this.codeGraphAdapter.getRunDiffOverlay
       ? await this.codeGraphAdapter.getRunDiffOverlay(this.state.codeGraph.runId, repoId)
       : await this.codeGraphAdapter.getDiffOverlay(repoId, baseRevision, headRevision);

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -25,6 +25,8 @@ import type {
   CodeGraphUpdatedEvent,
   CodeGraphNode,
   CodeGraphSnapshot,
+  CodeDiffOverlay,
+  CodeFileOutline,
   CodeSymbolDetail,
 } from "@opensymphony/gateway-schema";
 import {
@@ -35,6 +37,7 @@ import {
   codeGraphNeedsBroadFreshness,
   codeGraphReducer,
   codeGraphSnapshotForRendering,
+  codeGraphNodeDeltaStatus,
   codeNodeVisualStyle,
   isConceptDetailStale,
   createGraphLayoutAdapter,
@@ -42,6 +45,7 @@ import {
   createInitialGraphState,
   currentCodeGraphSnapshot,
   formatMemoryDeepLink,
+  formatCodeDeepLink,
   graphLayoutKindForMode,
   graphReducer,
   currentGraphSnapshot,
@@ -73,7 +77,12 @@ import {
   validateStoredCredentialRef,
   validateSubscriptionCredential,
 } from "@opensymphony/gateway-schema";
-import { renderChangedFileList, renderFileDiff } from "./diff.js";
+import {
+  renderChangedFileList,
+  renderCodeDiffDeltaList,
+  renderCodeDiffSummary,
+  renderFileDiff,
+} from "./diff.js";
 import { renderValidationSummary } from "./validation.js";
 import { renderApprovalList, type ApprovalDecision } from "./approval.js";
 import {
@@ -256,6 +265,8 @@ interface AppState {
   runFiles: ChangedFileEntry[] | null;
   selectedDiffPath: string | null;
   runDiff: FileDiffPage | null;
+  runCodeOverlay: CodeDiffOverlay | null;
+  runCodeOutline: CodeFileOutline | null;
   evidenceView: EvidenceView;
   runEvents: RunEvent[] | null;
   expandedActivityEvents: Set<string>;
@@ -317,6 +328,8 @@ interface RunDetailBundle {
   runFiles: ChangedFileEntry[];
   selectedDiffPath: string | null;
   runDiff: FileDiffPage | null;
+  runCodeOverlay: CodeDiffOverlay | null;
+  runCodeOutline: CodeFileOutline | null;
   runEvents: RunEvent[];
   runValidation: RunValidationSummary | null;
   runApprovals: ApprovalRequest[];
@@ -425,6 +438,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private runOpenSeq = 0;
   /** Guards in-flight selectDiffFile loads (superseded by newer diff clicks or opens). */
   private diffSelectSeq = 0;
+  private readonly runOutlineCache = new Map<string, CodeFileOutline>();
   /** Tracks bindEvents sites already attached per element (see listen()). */
   private boundListeners = new WeakMap<Element, Set<string>>();
 
@@ -455,6 +469,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       runFiles: null,
       selectedDiffPath: null,
       runDiff: null,
+      runCodeOverlay: null,
+      runCodeOutline: null,
       evidenceView: "diff",
       runEvents: null,
       expandedActivityEvents: new Set(),
@@ -562,7 +578,28 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
           warnings.push(`Diff unavailable: ${errorMessage(error)}`);
         }
       }
-      return { runFiles, selectedDiffPath, runDiff };
+      let runCodeOutline: CodeFileOutline | null = null;
+      if (selectedDiffPath && this.codeGraphAdapter?.getFileOutline) {
+        const cacheKey = `${runId}:${selectedDiffPath}`;
+        runCodeOutline = this.runOutlineCache.get(cacheKey) ?? null;
+        if (!runCodeOutline) {
+          try {
+            runCodeOutline = await this.codeGraphAdapter.getFileOutline(runId, selectedDiffPath);
+            this.runOutlineCache.set(cacheKey, runCodeOutline);
+          } catch {
+            runCodeOutline = null;
+          }
+        }
+      }
+      return { runFiles, selectedDiffPath, runDiff, runCodeOutline };
+    })();
+    const runCodeOverlayRequest = (async () => {
+      if (!this.codeGraphAdapter?.getRunDiffOverlay) return null;
+      try {
+        return await this.codeGraphAdapter.getRunDiffOverlay(runId);
+      } catch {
+        return null;
+      }
     })();
     const events = (async () => {
       try {
@@ -596,18 +633,21 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     })();
 
     const [
-      { runFiles, selectedDiffPath, runDiff },
+      { runFiles, selectedDiffPath, runDiff, runCodeOutline },
+      runCodeOverlay,
       runEvents,
       runValidation,
       runApprovals,
-    ] = await Promise.all([filesAndDiff, events, validation, approvals]);
-    return { runFiles, selectedDiffPath, runDiff, runEvents, runValidation, runApprovals, warnings };
+    ] = await Promise.all([filesAndDiff, runCodeOverlayRequest, events, validation, approvals]);
+    return { runFiles, selectedDiffPath, runDiff, runCodeOverlay, runCodeOutline, runEvents, runValidation, runApprovals, warnings };
   }
 
   private applyRunDetailBundle(bundle: RunDetailBundle): void {
     this.state.runFiles = bundle.runFiles;
     this.state.selectedDiffPath = bundle.selectedDiffPath;
     this.state.runDiff = bundle.runDiff;
+    this.state.runCodeOverlay = bundle.runCodeOverlay;
+    this.state.runCodeOutline = bundle.runCodeOutline;
     this.state.runEvents = bundle.runEvents;
     this.state.runValidation = bundle.runValidation;
     this.state.runApprovals = bundle.runApprovals;
@@ -775,6 +815,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runDetail = null;
     this.state.runFiles = null;
     this.state.runDiff = null;
+    this.state.runCodeOverlay = null;
+    this.state.runCodeOutline = null;
     this.state.evidenceView = "diff";
     this.state.runEvents = null;
     this.state.expandedActivityEvents = new Set();
@@ -885,6 +927,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.runDetail = null;
       this.state.runFiles = null;
       this.state.runDiff = null;
+      this.state.runCodeOverlay = null;
+      this.state.runCodeOutline = null;
       this.state.evidenceView = "diff";
       this.state.runEvents = null;
       this.state.expandedActivityEvents = new Set();
@@ -903,6 +947,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runDetail = null;
     this.state.runFiles = null;
     this.state.runDiff = null;
+    this.state.runCodeOverlay = null;
+    this.state.runCodeOutline = null;
     this.state.evidenceView = "diff";
     this.state.runEvents = null;
     this.state.expandedActivityEvents = new Set();
@@ -1170,7 +1216,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     navigationVersion: number,
   ): Promise<void> {
     if (!this.codeGraphAdapter) return;
-    const overlay = await this.codeGraphAdapter.getDiffOverlay(repoId, baseRevision, headRevision);
+    const overlay = this.state.codeGraph.runId && this.codeGraphAdapter.getRunDiffOverlay
+      ? await this.codeGraphAdapter.getRunDiffOverlay(this.state.codeGraph.runId, repoId)
+      : await this.codeGraphAdapter.getDiffOverlay(repoId, baseRevision, headRevision);
     if (this.destroyed || navigationVersion !== this.codeGraphNavigationVersion || requestKey !== this.codeGraphRequestKey()) return;
     this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "DIFF_LOADED", overlay });
     this.invalidateCodeGraphLayout();
@@ -1184,6 +1232,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       code.mode,
       code.path,
       code.symbolKey,
+      code.runId,
       code.depth,
       code.baseRevision,
       code.headRevision,
@@ -1230,7 +1279,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       onSelectArea: this.onCodeAggregateSelected,
       nodeStyle: (node) => {
         const codeNode = snapshot?.nodes.find((candidate) => candidate.id === node.nodeId);
-        return codeNode ? codeNodeVisualStyle(codeNode) : undefined;
+        if (!codeNode) return undefined;
+        const deltaStatus = codeGraphNodeDeltaStatus(codeNode.symbol_key, this.state.codeGraph.diffOverlay);
+        const blastRadius = Boolean(codeNode.symbol_key && this.state.codeGraph.diffOverlay?.blast_radius.some((entry) => entry.symbol_key === codeNode.symbol_key));
+        return codeNodeVisualStyle(codeNode, deltaStatus, blastRadius);
       },
       edgeStyle: (edge) => edge.confidence
         ? codeEdgeVisualStyle({ confidence: edge.confidence as "exact" | "syntactic" | "heuristic" })
@@ -1736,6 +1788,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.runDetail = null;
       this.state.runFiles = null;
       this.state.runDiff = null;
+      this.state.runCodeOverlay = null;
+      this.state.runCodeOutline = null;
       this.state.evidenceView = "diff";
       this.state.runEvents = null;
       this.state.expandedActivityEvents = new Set();
@@ -1764,22 +1818,34 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const seq = ++this.diffSelectSeq;
     this.state.selectedDiffPath = path;
     this.state.evidenceView = "diff";
-    this.render();
     const runId = this.state.runDetail?.run_id;
+    this.state.runCodeOutline = runId ? this.runOutlineCache.get(`${runId}:${path}`) ?? null : null;
+    this.render();
     if (runId && typeof this.transport.runDiffs === "function") {
       let runDiff: FileDiffPage | null = null;
+      let runCodeOutline: CodeFileOutline | null = this.state.runCodeOutline;
       let warning: string | null = null;
-      try {
-        runDiff = await this.transport.runDiffs!(runId, path);
-      } catch (error) {
-        warning = `Diff unavailable: ${errorMessage(error)}`;
-      }
+      const [diffResult, outlineResult] = await Promise.all([
+        this.transport.runDiffs!(runId, path).catch((error) => {
+          warning = `Diff unavailable: ${errorMessage(error)}`;
+          return null;
+        }),
+        this.state.runCodeOutline
+          ? Promise.resolve(this.state.runCodeOutline)
+          : this.codeGraphAdapter?.getFileOutline(runId, path).then((outline) => {
+              this.runOutlineCache.set(`${runId}:${path}`, outline);
+              return outline;
+            }).catch(() => null) ?? Promise.resolve(null),
+      ]);
+      runDiff = diffResult;
+      runCodeOutline = outlineResult;
       // Drop the result if a newer diff click or task open superseded this
       // fetch, or if the shown run changed while it was in flight.
       if (this.destroyed || seq !== this.diffSelectSeq || this.state.runDetail?.run_id !== runId) {
         return;
       }
       this.state.runDiff = runDiff;
+      this.state.runCodeOutline = runCodeOutline;
       if (warning) {
         this.state.connectionMessage = warning;
       }
@@ -1788,6 +1854,39 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       this.state.connectionMessage = "Diff endpoint unavailable for the active transport";
     }
     this.render();
+  }
+
+  private runCodeDeepLink(symbolKey?: string, path?: string): string | null {
+    const run = this.state.runDetail;
+    const overlay = this.state.runCodeOverlay;
+    if (!run || !overlay || (symbolKey && path)) return null;
+    try {
+      return formatCodeDeepLink({
+        repoId: overlay.repo_id,
+        mode: "diff",
+        symbolKey: symbolKey ?? null,
+        path: path ?? null,
+        runId: run.run_id,
+        baseRevision: overlay.base_revision,
+        headRevision: overlay.head_revision,
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  private async openRunCodeTarget(symbolKey?: string, path?: string): Promise<void> {
+    const runId = this.state.runDetail?.run_id;
+    if (!runId || (symbolKey && path)) return;
+    if (!this.state.runCodeOverlay && this.codeGraphAdapter?.getRunDiffOverlay) {
+      try {
+        this.state.runCodeOverlay = await this.codeGraphAdapter.getRunDiffOverlay(runId);
+      } catch {
+        return;
+      }
+    }
+    const link = this.runCodeDeepLink(symbolKey, path);
+    if (link) await this.openCodeDeepLink(link);
   }
 
   private selectEvidenceView(view: AppState["evidenceView"]): void {
@@ -3266,6 +3365,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private renderLowerColumn(column: "left" | "right"): string {
+    if (this.state.graphPaneView === "code" && this.state.codeGraph.runId === this.state.runDetail?.run_id) {
+      return column === "left" ? this.renderRunDetail() : this.renderRunEvidence();
+    }
     switch (this.state.graphPaneView) {
       case "task":
         return column === "left" ? this.renderRunDetail() : this.renderRunEvidence();
@@ -3344,6 +3446,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const actionItems = buildActionBarItems(run);
     const actionBar = renderActionBar(actionItems);
     const files = renderChangedFileList(this.state.runFiles ?? [], this.state.selectedDiffPath ?? undefined);
+    const codeSummary = renderCodeDiffSummary(this.state.runCodeOverlay);
+    const codeDeltaList = renderCodeDiffDeltaList(this.state.runCodeOverlay);
     const selectedNode = this.selectedTaskNode();
     const dependencyDetail = selectedNode
       ? renderDependencyDetail(selectedNode, this.state.taskGraph?.nodes ?? [])
@@ -3406,6 +3510,8 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         ${receipt}
         <div class="os-run-section">
           <h3>Changed Files</h3>
+          ${codeSummary}
+          ${codeDeltaList}
           ${files}
         </div>
         ${validation || approvals ? `<div class="os-run-panels">${validation ? `<div class="os-validation-panel">${validation}</div>` : ""}${approvals ? `<div class="os-approval-panel">${approvals}</div>` : ""}</div>` : ""}
@@ -3432,7 +3538,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     if (!run) {
       return panel("Inspector", `<div class="os-empty">Select an issue to inspect a diff or activity</div>`, "os-run-evidence-panel");
     }
-    const diff = this.state.runDiff ? renderFileDiff(this.state.runDiff) : "";
+    const diff = this.state.runDiff
+      ? renderFileDiff(this.state.runDiff, this.state.runCodeOutline, (symbolKey) => this.runCodeDeepLink(symbolKey))
+      : "";
     const activity = renderRunActivity(
       this.state.runEvents,
       this.state.expandedActivityEvents,
@@ -4187,6 +4295,34 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         if (path) {
           void this.selectDiffFile(path);
         }
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-diff-symbol-action]").forEach((button) => {
+      this.listen(button, "diff-symbol-action", "click", () => {
+        const symbolKey = button.dataset.diffSymbolAction;
+        if (symbolKey) void this.openRunCodeTarget(symbolKey);
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-diff-symbol-copy]").forEach((button) => {
+      this.listen(button, "diff-symbol-copy", "click", (event) => {
+        event.stopPropagation();
+        const link = button.dataset.diffSymbolCopy;
+        if (!link) return;
+        void navigator.clipboard?.writeText(link).catch(() => undefined);
+        button.textContent = "✓";
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-diff-file-graph]").forEach((button) => {
+      this.listen(button, "diff-file-graph", "click", () => {
+        const path = button.dataset.diffFileGraph;
+        if (path) void this.openRunCodeTarget(undefined, path);
+      });
+    });
+    this.options.root.querySelectorAll<HTMLElement>("[data-diff-symbol-key]").forEach((line) => {
+      this.listen(line, "diff-symbol-context", "contextmenu", (event) => {
+        event.preventDefault();
+        const symbolKey = line.dataset.diffSymbolKey;
+        if (symbolKey) void this.openRunCodeTarget(symbolKey);
       });
     });
     this.options.root.querySelectorAll<HTMLElement>("[data-evidence-view]").forEach((button) => {
@@ -6989,9 +7125,18 @@ function appShellStyles(): string {
     .os-change-kind-removed { background: #fee2e2; color: #991b1b; }
     .os-file-diff { border: 1px solid #d8dee4; border-radius: 6px; background: #f8fafc; }
     .os-diff-header { display: flex; justify-content: space-between; padding: 8px; border-bottom: 1px solid #d8dee4; background: #eef3f8; font-size: 12px; }
+    .os-diff-file-graph { min-height: 24px; padding: 2px 7px; font-size: 11px; }
     .os-diff-hunk { padding: 8px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 12px; }
     .os-diff-hunk-header { color: #667788; margin-bottom: 4px; }
     .os-diff-line { white-space: pre-wrap; }
+    .os-diff-line-number { display: inline-block; width: 34px; margin-right: 6px; color: #98a6b3; text-align: right; user-select: none; }
+    .os-diff-symbol-glyph, .os-diff-symbol-copy { min-height: 21px; min-width: 21px; padding: 0 3px; margin-right: 4px; border-radius: 4px; color: #23566f; font-weight: 700; vertical-align: baseline; }
+    .os-diff-symbol-copy { color: #536170; }
+    .os-diff-line[data-diff-symbol-key]:hover { outline: 1px solid #39708f; outline-offset: -1px; }
+    .os-run-code-summary { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; padding: 7px 9px; border: 1px solid #cbd5df; border-radius: 6px; background: #eef7f8; color: #23566f; font-size: 11px; font-weight: 600; }
+    .os-run-code-delta-list { font-size: 11px; }
+    .os-run-code-delta-list ul { margin: 6px 0 0; padding-left: 18px; }
+    .os-run-code-delta-list code { color: #536170; }
     .os-diff-line-addition { color: #1f9d55; background: #dcfce7; }
     .os-diff-line-deletion { color: #c2410c; background: #fee2e2; }
     .os-diff-line-context { color: #334155; }
@@ -7198,6 +7343,7 @@ function appShellStyles(): string {
       .os-run-section + .os-run-section { border-color: #2a3440; }
       .os-run-section h3 { color: #94a3b3; }
       .os-diff-header, .os-validation-header { background: #1f2a35; border-color: #2a3440; }
+      .os-run-code-summary { background: #18303a; border-color: #3b6574; color: #c6edf3; }
       .os-diff-line-addition { background: #14532d; color: #86efac; }
       .os-diff-line-deletion { background: #7f1d1d; color: #fecaca; }
       .os-diff-line-context { color: #94a3b3; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1159,8 +1159,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       requestKey = this.codeGraphRequestKey();
       await this.refreshCodeGraphSnapshot(repoId, requestKey, navigationVersion);
       if (this.destroyed || navigationVersion !== this.codeGraphNavigationVersion || requestKey !== this.codeGraphRequestKey()) return;
-      if (this.state.codeGraph.mode === "diff" && this.state.codeGraph.baseRevision && this.state.codeGraph.headRevision) {
-        await this.loadCodeDiffOverlay(repoId, this.state.codeGraph.baseRevision, this.state.codeGraph.headRevision, requestKey, navigationVersion);
+      if (this.state.codeGraph.mode === "diff"
+        && (this.state.codeGraph.runId || (this.state.codeGraph.baseRevision && this.state.codeGraph.headRevision))) {
+        await this.loadCodeDiffOverlay(repoId, this.state.codeGraph.baseRevision ?? "", this.state.codeGraph.headRevision ?? "", requestKey, navigationVersion);
       }
     } catch (error) {
       if (this.destroyed
@@ -1206,8 +1207,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     navigationVersion: number,
   ): Promise<void> {
     if (!this.codeGraphAdapter) return;
-    const overlay = this.state.codeGraph.runId
-      && !baseRevision
+    const dirtyRun = this.state.codeGraph.runId
+      && (!baseRevision || !headRevision || headRevision.startsWith("HEAD+"));
+    const overlay = dirtyRun
+      && this.state.codeGraph.runId
       && this.codeGraphAdapter.getRunDiffOverlay
       ? await this.codeGraphAdapter.getRunDiffOverlay(this.state.codeGraph.runId, repoId)
       : await this.codeGraphAdapter.getDiffOverlay(repoId, baseRevision, headRevision);
@@ -1693,6 +1696,11 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runOverlays = overlays;
     this.state.selectedNodeId = selectedNode?.node_id ?? null;
     if (selectedRun) {
+      const changedRun = this.state.runDetail?.run_id !== selectedRun.runDetail.run_id;
+      if (changedRun) {
+        this.state.runCodeOverlay = null;
+        this.state.runCodeOutline = null;
+      }
       this.state.runDetail = selectedRun.runDetail;
       this.state.runOverlays.set(selectedRun.runDetail.run_id, selectedRun.runDetail);
       this.applyRunDetailBundle(selectedRun.bundle);
@@ -1821,25 +1829,18 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     this.state.runCodeOutline = null;
     this.render();
     if (runId && typeof this.transport.runDiffs === "function") {
+      let diffError: unknown = null;
       const runDiff = await this.transport.runDiffs!(runId, path).catch((error) => {
-        this.state.connectionMessage = `Diff unavailable: ${errorMessage(error)}`;
+        diffError = error;
         return null;
       });
       if (this.destroyed || seq !== this.diffSelectSeq || this.state.runDetail?.run_id !== runId) return;
-      let runCodeOutline = this.runOutlineCache.get(runOutlineCacheKey(runId, path, runDiff)) ?? null;
-      if (!runCodeOutline && this.codeGraphAdapter?.getFileOutline) {
-        runCodeOutline = await this.codeGraphAdapter.getFileOutline(runId, path).then((outline) => {
-          this.runOutlineCache.set(runOutlineCacheKey(runId, path, runDiff), outline);
-          return outline;
-        }).catch(() => null);
-      }
-      // Drop the result if a newer diff click or task open superseded this
-      // fetch, or if the shown run changed while it was in flight.
-      if (this.destroyed || seq !== this.diffSelectSeq || this.state.runDetail?.run_id !== runId) {
-        return;
-      }
+      if (diffError) this.state.connectionMessage = `Diff unavailable: ${errorMessage(diffError)}`;
       this.state.runDiff = runDiff;
-      this.state.runCodeOutline = runCodeOutline;
+      this.state.runCodeOutline = null;
+      this.render();
+      void this.loadRunCodeOutline(runId, path, runDiff);
+      return;
     } else if (runId) {
       this.state.runDiff = null;
       this.state.connectionMessage = "Diff endpoint unavailable for the active transport";
@@ -1867,11 +1868,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   }
 
   private async loadRunCodeOverlay(runId: string): Promise<void> {
-    const getOverlay = this.codeGraphAdapter?.getRunDiffOverlay;
-    if (!getOverlay) return;
+    if (!this.codeGraphAdapter?.getRunDiffOverlay) return;
     const seq = ++this.runCodeOverlaySeq;
     try {
-      const overlay = await getOverlay(runId);
+      const overlay = await this.codeGraphAdapter.getRunDiffOverlay(runId);
       if (this.destroyed || seq !== this.runCodeOverlaySeq || this.state.runDetail?.run_id !== runId) return;
       this.state.runCodeOverlay = overlay;
       this.render();
@@ -1885,8 +1885,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     path: string | null,
     diff: FileDiffPage | null,
   ): Promise<void> {
-    const getOutline = this.codeGraphAdapter?.getFileOutline;
-    if (!path || !diff || !getOutline) return;
+    if (!path || !diff || !this.codeGraphAdapter?.getFileOutline) return;
     const cacheKey = runOutlineCacheKey(runId, path, diff);
     const apply = (outline: CodeFileOutline): void => {
       if (this.destroyed
@@ -1903,7 +1902,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       return;
     }
     try {
-      const outline = await getOutline(runId, path);
+      const outline = await this.codeGraphAdapter.getFileOutline(runId, path);
       this.runOutlineCache.set(cacheKey, outline);
       apply(outline);
     } catch {

--- a/packages/ui-core/src/diff.ts
+++ b/packages/ui-core/src/diff.ts
@@ -1,5 +1,17 @@
-import type { ChangedFileEntry, FileDiffPage } from "@opensymphony/gateway-schema";
+import type {
+  ChangedFileEntry,
+  CodeDiffOverlay,
+  CodeFileOutline,
+  CodeOutlineSymbol,
+  FileDiffPage,
+} from "@opensymphony/gateway-schema";
 import { escapeHtml, escapeAttr } from "./html.js";
+
+export interface DiffSymbolRegion {
+  symbol: CodeOutlineSymbol;
+  firstChangedLine: number;
+  changedLines: number[];
+}
 
 /** UI model for a single changed file in the diff viewer. */
 export interface DiffFileItem {
@@ -33,21 +45,45 @@ export function renderChangedFileList(
 }
 
 /** Render a single diff page as a lightweight HTML string. */
-export function renderFileDiff(diff: FileDiffPage): string {
+export function renderFileDiff(
+  diff: FileDiffPage,
+  outline?: CodeFileOutline | null,
+  codeDeepLink?: (symbolKey: string) => string | null,
+): string {
   if (diff.hunks.length === 0) {
     return `<div class="os-file-diff os-empty" data-testid="file-diff" data-file-path="${escapeAttr(diff.file_path)}">No diff available</div>`;
+  }
+  const regions = outline ? resolveDiffSymbolRegions(diff, outline) : [];
+  const regionByLine = new Map(regions.map((region) => [region.firstChangedLine, region]));
+  const symbolLines = new Map<number, DiffSymbolRegion>();
+  for (const region of regions) {
+    for (const line of region.changedLines) symbolLines.set(line, region);
   }
   const header = `<div class="os-diff-header" data-testid="diff-header">
     <span class="os-diff-path">${escapeHtml(diff.file_path)}</span>
     <span class="os-diff-stats">${renderLineStats(diff.total_lines_added, diff.total_lines_removed)}</span>
+    <button type="button" class="os-diff-file-graph" data-diff-file-graph="${escapeAttr(diff.file_path)}" aria-label="Open ${escapeAttr(diff.file_path)} in Code Graph">Open file in Code Graph</button>
   </div>`;
   const hunks = diff.hunks
     .map((hunk) => {
+      let [oldLine, newLine] = hunkLineStarts(hunk);
       const lines = hunk.lines
         .map((line) => {
+          const lineNumber = line.type === "deletion" ? oldLine : newLine;
+          const region = symbolLines.get(lineNumber);
+          const glyph = region && regionByLine.get(lineNumber) === region
+            ? renderDiffSymbolGlyph(region.symbol, codeDeepLink?.(region.symbol.symbol_key) ?? null)
+            : "";
           const typeClass = `os-diff-line-${escapeAttr(line.type)}`;
           const prefix = line.type === "addition" ? "+" : line.type === "deletion" ? "-" : " ";
-          return `<div class="os-diff-line ${typeClass}" data-line-type="${escapeAttr(line.type)}"><span class="os-diff-prefix">${prefix}</span>${escapeHtml(line.line)}</div>`;
+          const symbolAttrs = region
+            ? ` data-diff-symbol-key="${escapeAttr(region.symbol.symbol_key)}" data-diff-symbol-name="${escapeAttr(region.symbol.name)}"`
+            : "";
+          const rendered = `<div class="os-diff-line ${typeClass}" data-line-type="${escapeAttr(line.type)}" data-line-number="${lineNumber}"${symbolAttrs}><span class="os-diff-line-number">${lineNumber}</span><span class="os-diff-prefix">${prefix}</span>${glyph}${escapeHtml(line.line)}</div>`;
+          if (line.type === "deletion") oldLine += 1;
+          else if (line.type === "addition") newLine += 1;
+          else { oldLine += 1; newLine += 1; }
+          return rendered;
         })
         .join("");
       return `<div class="os-diff-hunk" data-testid="diff-hunk">
@@ -57,6 +93,80 @@ export function renderFileDiff(diff: FileDiffPage): string {
     })
     .join("");
   return `<div class="os-file-diff" data-testid="file-diff" data-file-path="${escapeAttr(diff.file_path)}">${header}${hunks}</div>`;
+}
+
+export function resolveDiffSymbolRegions(
+  diff: FileDiffPage,
+  outline: CodeFileOutline,
+): DiffSymbolRegion[] {
+  const regions = new Map<string, DiffSymbolRegion>();
+  for (const hunk of diff.hunks) {
+    let [oldLine, newLine] = hunkLineStarts(hunk);
+    for (const line of hunk.lines) {
+      const lineNumber = line.type === "deletion" ? Math.max(1, newLine) : newLine;
+      const renderedLine = line.type === "deletion" ? oldLine : newLine;
+      if (line.type !== "context") {
+        const symbol = innermostSymbolAtLine(outline.symbols, lineNumber);
+        if (symbol) {
+          const region = regions.get(symbol.symbol_key) ?? { symbol, firstChangedLine: renderedLine, changedLines: [] };
+          region.firstChangedLine = Math.min(region.firstChangedLine, renderedLine);
+          if (!region.changedLines.includes(renderedLine)) region.changedLines.push(renderedLine);
+          regions.set(symbol.symbol_key, region);
+        }
+      }
+      if (line.type === "deletion") oldLine += 1;
+      else if (line.type === "addition") newLine += 1;
+      else { oldLine += 1; newLine += 1; }
+    }
+  }
+  return [...regions.values()].sort((a, b) => a.firstChangedLine - b.firstChangedLine || a.symbol.symbol_key.localeCompare(b.symbol.symbol_key));
+}
+
+function hunkLineStarts(hunk: FileDiffPage["hunks"][number]): [number, number] {
+  const match = /^@@ -(\d+)(?:,\d+)? \+(\d+)/.exec(hunk.header);
+  return match ? [Number(match[1]), Number(match[2])] : [hunk.start_line, hunk.start_line];
+}
+
+export function innermostSymbolAtLine(
+  symbols: readonly CodeOutlineSymbol[],
+  line: number,
+): CodeOutlineSymbol | null {
+  return symbols
+    .filter((symbol) => symbol.span.start_line <= line && line <= symbol.span.end_line)
+    .sort((a, b) => (a.span.end_line - a.span.start_line) - (b.span.end_line - b.span.start_line)
+      || b.span.start_line - a.span.start_line
+      || a.symbol_key.localeCompare(b.symbol_key))[0] ?? null;
+}
+
+function renderDiffSymbolGlyph(symbol: CodeOutlineSymbol, deepLink: string | null): string {
+  const label = `Open ${symbol.name} in Code Graph`;
+  const copy = deepLink
+    ? `<button type="button" class="os-diff-symbol-copy" data-diff-symbol-copy="${escapeAttr(deepLink)}" aria-label="Copy code deep link for ${escapeAttr(symbol.name)}" title="Copy code deep link">⧉</button>`
+    : "";
+  return `<button type="button" class="os-diff-symbol-glyph" data-diff-symbol-action="${escapeAttr(symbol.symbol_key)}" aria-label="${escapeAttr(label)}" title="${escapeAttr(label)}">⌘</button>${copy}`;
+}
+
+export function renderCodeDiffSummary(overlay: CodeDiffOverlay | null | undefined): string {
+  if (!overlay) return "";
+  const counts = [
+    `${overlay.added_symbols.length} added`,
+    `${overlay.removed_symbols.length} removed`,
+    `${overlay.modified_symbols.length} modified`,
+    `${overlay.blast_radius.length} blast radius`,
+  ];
+  return `<div class="os-run-code-summary" data-testid="run-code-summary" aria-label="Code diff summary">${counts.map((value) => `<span>${escapeHtml(value)}</span>`).join(" · ")}</div>`;
+}
+
+export function renderCodeDiffDeltaList(overlay: CodeDiffOverlay | null | undefined): string {
+  if (!overlay) return "";
+  const symbols = [...overlay.added_symbols, ...overlay.removed_symbols, ...overlay.modified_symbols];
+  const rows = symbols.map((symbol) => {
+    const side = symbol.after ?? symbol.before;
+    const radius = overlay.blast_radius.find((entry) => entry.symbol_key === symbol.symbol_key);
+    return `<li><span data-code-delta-status="${escapeAttr(symbol.status)}">${escapeHtml(symbol.status)}</span> <strong>${escapeHtml(side?.name ?? symbol.symbol_key)}</strong> <code>${escapeHtml(side?.path_display ?? "unknown path")}</code>${radius ? ` <span>(${radius.inbound_count} inbound)</span>` : ""}</li>`;
+  }).join("");
+  const files = overlay.unanalyzed_files.map((path) => `<li><span>unanalyzed</span> <code>${escapeHtml(path)}</code></li>`).join("");
+  return `<details class="os-run-code-delta-list" data-testid="run-code-delta-list"><summary>Code delta details</summary><ul>${rows || "<li>No analyzed symbol changes</li>"}${files}</ul></details>`;
 }
 
 function renderLineStats(added: number, removed: number): string {

--- a/packages/ui-core/src/diff.ts
+++ b/packages/ui-core/src/diff.ts
@@ -48,7 +48,7 @@ export function renderChangedFileList(
 export function renderFileDiff(
   diff: FileDiffPage,
   outline?: CodeFileOutline | null,
-  codeDeepLink?: (symbolKey: string) => string | null,
+  codeDeepLink?: (symbolKey: string, path?: string) => string | null,
 ): string {
   if (diff.hunks.length === 0) {
     return `<div class="os-file-diff os-empty" data-testid="file-diff" data-file-path="${escapeAttr(diff.file_path)}">No diff available</div>`;
@@ -59,10 +59,11 @@ export function renderFileDiff(
   for (const region of regions) {
     for (const line of region.changedLines) symbolLines.set(line, region);
   }
+  const fileDeepLink = codeDeepLink?.("", diff.file_path) ?? null;
   const header = `<div class="os-diff-header" data-testid="diff-header">
     <span class="os-diff-path">${escapeHtml(diff.file_path)}</span>
     <span class="os-diff-stats">${renderLineStats(diff.total_lines_added, diff.total_lines_removed)}</span>
-    <button type="button" class="os-diff-file-graph" data-diff-file-graph="${escapeAttr(diff.file_path)}" aria-label="Open ${escapeAttr(diff.file_path)} in Code Graph">Open file in Code Graph</button>
+    ${fileDeepLink ? `<button type="button" class="os-diff-file-graph" data-diff-file-graph="${escapeAttr(diff.file_path)}" aria-label="Open ${escapeAttr(diff.file_path)} in Code Graph">Open file in Code Graph</button>` : ""}
   </div>`;
   const hunks = diff.hunks
     .map((hunk) => {
@@ -106,7 +107,8 @@ export function resolveDiffSymbolRegions(
       const lineNumber = line.type === "deletion" ? Math.max(1, newLine) : newLine;
       const renderedLine = line.type === "deletion" ? oldLine : newLine;
       if (line.type !== "context") {
-        const symbol = innermostSymbolAtLine(outline.symbols, lineNumber);
+        const symbol = innermostSymbolAtLine(outline.symbols, lineNumber)
+          ?? (line.type === "deletion" ? nearestSymbolAtLine(outline.symbols, lineNumber) : null);
         if (symbol) {
           const region = regions.get(symbol.symbol_key) ?? { symbol, firstChangedLine: renderedLine, changedLines: [] };
           region.firstChangedLine = Math.min(region.firstChangedLine, renderedLine);
@@ -138,6 +140,17 @@ export function innermostSymbolAtLine(
       || a.symbol_key.localeCompare(b.symbol_key))[0] ?? null;
 }
 
+function nearestSymbolAtLine(
+  symbols: readonly CodeOutlineSymbol[],
+  line: number,
+): CodeOutlineSymbol | null {
+  return [...symbols]
+    .sort((a, b) => Math.min(Math.abs(a.span.start_line - line), Math.abs(a.span.end_line - line))
+      - Math.min(Math.abs(b.span.start_line - line), Math.abs(b.span.end_line - line))
+      || a.span.start_line - b.span.start_line
+      || a.symbol_key.localeCompare(b.symbol_key))[0] ?? null;
+}
+
 function renderDiffSymbolGlyph(symbol: CodeOutlineSymbol, deepLink: string | null): string {
   const label = `Open ${symbol.name} in Code Graph`;
   const copy = deepLink
@@ -154,19 +167,24 @@ export function renderCodeDiffSummary(overlay: CodeDiffOverlay | null | undefine
     `${overlay.modified_symbols.length} modified`,
     `${overlay.blast_radius.length} blast radius`,
   ];
-  return `<div class="os-run-code-summary" data-testid="run-code-summary" aria-label="Code diff summary">${counts.map((value) => `<span>${escapeHtml(value)}</span>`).join(" · ")}</div>`;
+  return `<button type="button" class="os-run-code-summary" data-testid="run-code-summary" data-run-code-summary aria-label="Open code diff summary in Code Graph">${counts.map((value) => `<span>${escapeHtml(value)}</span>`).join(" · ")}</button>`;
 }
 
 export function renderCodeDiffDeltaList(overlay: CodeDiffOverlay | null | undefined): string {
   if (!overlay) return "";
   const symbols = [...overlay.added_symbols, ...overlay.removed_symbols, ...overlay.modified_symbols];
+  const changedKeys = new Set(symbols.map((symbol) => symbol.symbol_key));
   const rows = symbols.map((symbol) => {
     const side = symbol.after ?? symbol.before;
     const radius = overlay.blast_radius.find((entry) => entry.symbol_key === symbol.symbol_key);
     return `<li><span data-code-delta-status="${escapeAttr(symbol.status)}">${escapeHtml(symbol.status)}</span> <strong>${escapeHtml(side?.name ?? symbol.symbol_key)}</strong> <code>${escapeHtml(side?.path_display ?? "unknown path")}</code>${radius ? ` <span>(${radius.inbound_count} inbound)</span>` : ""}</li>`;
   }).join("");
+  const radiusOnlyRows = overlay.blast_radius
+    .filter((entry) => !changedKeys.has(entry.symbol_key))
+    .map((entry) => `<li><span data-code-delta-status="blast-radius">blast radius</span> <strong>${escapeHtml(entry.symbol_key)}</strong> <code>unknown path</code> <span>(${entry.inbound_count} inbound)</span></li>`)
+    .join("");
   const files = overlay.unanalyzed_files.map((path) => `<li><span>unanalyzed</span> <code>${escapeHtml(path)}</code></li>`).join("");
-  return `<details class="os-run-code-delta-list" data-testid="run-code-delta-list"><summary>Code delta details</summary><ul>${rows || "<li>No analyzed symbol changes</li>"}${files}</ul></details>`;
+  return `<details class="os-run-code-delta-list" data-testid="run-code-delta-list"><summary>Code delta details</summary><ul>${rows || radiusOnlyRows ? `${rows}${radiusOnlyRows}` : "<li>No analyzed symbol changes</li>"}${files}</ul></details>`;
 }
 
 function renderLineStats(added: number, removed: number): string {

--- a/packages/ui-core/src/diff.ts
+++ b/packages/ui-core/src/diff.ts
@@ -10,7 +10,9 @@ import { escapeHtml, escapeAttr } from "./html.js";
 export interface DiffSymbolRegion {
   symbol: CodeOutlineSymbol;
   firstChangedLine: number;
+  firstChangedLineKey: string;
   changedLines: number[];
+  changedLineKeys: string[];
 }
 
 /** UI model for a single changed file in the diff viewer. */
@@ -60,10 +62,9 @@ export function renderFileDiff(
     return `<div class="os-file-diff os-empty" data-testid="file-diff" data-file-path="${escapeAttr(diff.file_path)}">${header}<div>No diff available</div></div>`;
   }
   const regions = outline ? resolveDiffSymbolRegions(diff, outline) : [];
-  const regionByLine = new Map(regions.map((region) => [region.firstChangedLine, region]));
-  const symbolLines = new Map<number, DiffSymbolRegion>();
+  const symbolLines = new Map<string, DiffSymbolRegion>();
   for (const region of regions) {
-    for (const line of region.changedLines) symbolLines.set(line, region);
+    for (const lineKey of region.changedLineKeys) symbolLines.set(lineKey, region);
   }
   const hunks = diff.hunks
     .map((hunk) => {
@@ -71,8 +72,9 @@ export function renderFileDiff(
       const lines = hunk.lines
         .map((line) => {
           const lineNumber = line.type === "deletion" ? oldLine : newLine;
-          const region = symbolLines.get(lineNumber);
-          const glyph = region && regionByLine.get(lineNumber) === region
+          const lineKey = diffLineKey(line.type, lineNumber);
+          const region = symbolLines.get(lineKey);
+          const glyph = region && region.firstChangedLineKey === lineKey
             ? renderDiffSymbolGlyph(region.symbol, codeDeepLink?.(region.symbol.symbol_key) ?? null)
             : "";
           const typeClass = `os-diff-line-${escapeAttr(line.type)}`;
@@ -110,9 +112,21 @@ export function resolveDiffSymbolRegions(
         const symbol = innermostSymbolAtLine(outline.symbols, lineNumber)
           ?? (line.type === "deletion" ? nearestSymbolAtLine(outline.symbols, lineNumber) : null);
         if (symbol) {
-          const region = regions.get(symbol.symbol_key) ?? { symbol, firstChangedLine: renderedLine, changedLines: [] };
-          region.firstChangedLine = Math.min(region.firstChangedLine, renderedLine);
+          const lineKey = diffLineKey(line.type, renderedLine);
+          const region = regions.get(symbol.symbol_key) ?? {
+            symbol,
+            firstChangedLine: renderedLine,
+            firstChangedLineKey: lineKey,
+            changedLines: [],
+            changedLineKeys: [],
+          };
+          if (renderedLine < region.firstChangedLine
+            || (renderedLine === region.firstChangedLine && lineKey < region.firstChangedLineKey)) {
+            region.firstChangedLine = renderedLine;
+            region.firstChangedLineKey = lineKey;
+          }
           if (!region.changedLines.includes(renderedLine)) region.changedLines.push(renderedLine);
+          if (!region.changedLineKeys.includes(lineKey)) region.changedLineKeys.push(lineKey);
           regions.set(symbol.symbol_key, region);
         }
       }
@@ -122,6 +136,10 @@ export function resolveDiffSymbolRegions(
     }
   }
   return [...regions.values()].sort((a, b) => a.firstChangedLine - b.firstChangedLine || a.symbol.symbol_key.localeCompare(b.symbol.symbol_key));
+}
+
+function diffLineKey(type: FileDiffPage["hunks"][number]["lines"][number]["type"], line: number): string {
+  return `${type}:${line}`;
 }
 
 function hunkLineStarts(hunk: FileDiffPage["hunks"][number]): [number, number] {

--- a/packages/ui-core/src/diff.ts
+++ b/packages/ui-core/src/diff.ts
@@ -50,8 +50,14 @@ export function renderFileDiff(
   outline?: CodeFileOutline | null,
   codeDeepLink?: (symbolKey: string, path?: string) => string | null,
 ): string {
+  const fileDeepLink = codeDeepLink?.("", diff.file_path) ?? null;
+  const header = `<div class="os-diff-header" data-testid="diff-header">
+    <span class="os-diff-path">${escapeHtml(diff.file_path)}</span>
+    <span class="os-diff-stats">${renderLineStats(diff.total_lines_added, diff.total_lines_removed)}</span>
+    ${fileDeepLink ? `<button type="button" class="os-diff-file-graph" data-diff-file-graph="${escapeAttr(diff.file_path)}" aria-label="Open ${escapeAttr(diff.file_path)} in Code Graph">Open file in Code Graph</button>` : ""}
+  </div>`;
   if (diff.hunks.length === 0) {
-    return `<div class="os-file-diff os-empty" data-testid="file-diff" data-file-path="${escapeAttr(diff.file_path)}">No diff available</div>`;
+    return `<div class="os-file-diff os-empty" data-testid="file-diff" data-file-path="${escapeAttr(diff.file_path)}">${header}<div>No diff available</div></div>`;
   }
   const regions = outline ? resolveDiffSymbolRegions(diff, outline) : [];
   const regionByLine = new Map(regions.map((region) => [region.firstChangedLine, region]));
@@ -59,12 +65,6 @@ export function renderFileDiff(
   for (const region of regions) {
     for (const line of region.changedLines) symbolLines.set(line, region);
   }
-  const fileDeepLink = codeDeepLink?.("", diff.file_path) ?? null;
-  const header = `<div class="os-diff-header" data-testid="diff-header">
-    <span class="os-diff-path">${escapeHtml(diff.file_path)}</span>
-    <span class="os-diff-stats">${renderLineStats(diff.total_lines_added, diff.total_lines_removed)}</span>
-    ${fileDeepLink ? `<button type="button" class="os-diff-file-graph" data-diff-file-graph="${escapeAttr(diff.file_path)}" aria-label="Open ${escapeAttr(diff.file_path)} in Code Graph">Open file in Code Graph</button>` : ""}
-  </div>`;
   const hunks = diff.hunks
     .map((hunk) => {
       let [oldLine, newLine] = hunkLineStarts(hunk);

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -38,8 +38,12 @@ export {
 export {
   renderChangedFileList,
   renderFileDiff,
+  renderCodeDiffDeltaList,
+  renderCodeDiffSummary,
+  resolveDiffSymbolRegions,
+  innermostSymbolAtLine,
 } from "./diff.js";
-export type { DiffFileItem } from "./diff.js";
+export type { DiffFileItem, DiffSymbolRegion } from "./diff.js";
 export { renderValidationSummary } from "./validation.js";
 export {
   renderApprovalList,


### PR DESCRIPTION
## Summary

Run Detail now maps changed diff lines to code symbols and opens the matching Code Graph neighborhood with the run overlay active.

## Changes

- Cache run-scoped outlines and resolve changed lines to innermost symbols.
- Add accessible diff glyphs, file navigation, context-menu activation, and copyable code deep links.
- Load run diff overlays through HTTP/Tauri code-graph adapters and render summary/delta fallbacks.
- Style added, removed, modified, and blast-radius graph nodes while preserving Run Detail lower-column state.

## Evidence

### Test output

```text
npm run type-check: passed
Jest focused UI/graph suites: 47 passed
cargo test-system-duckdb --test gateway: 70 passed
cargo test-system-duckdb code_intel_: 23 passed
cargo fmt --check: passed
web and desktop Vite builds: passed
git diff --check: passed
```

### Verification

Reproduced the prior plain diff behavior, then verified outline containment, one glyph per symbol region, accessible labels, overlay summary rendering, and preservation of Run Detail and Inspector lower panels after activation.

## Checklist

- [x] Tests pass (focused gateway, code-intelligence, and UI/graph suites)
- [x] Code is formatted
- [ ] Clippy is clean (no Rust source changed in this slice)
- [x] Documentation updated if behavior changed (existing code-graph spec and gateway contracts already describe this flow)
- [x] Evidence section filled out

## Type of change

- [x] New feature

## Breaking changes

None.

## Related issues

Linear: COE-535

## Additional notes

Server-side run outline and overlay primitives were already present on origin/develop from predecessor work; this change wires them into Run Detail and the shared Code Graph adapters.