### PR TITLE
feat(code-graph): index target branch snapshots

### DIFF
--- a/crates/opensymphony-code-intel/src/lib.rs
+++ b/crates/opensymphony-code-intel/src/lib.rs
@@ -1163,6 +1163,30 @@ pub fn detect_language(path: impl AsRef<Path>) -> Option<SourceLanguage> {
     }
 }
 
+/// Return the versions that a fresh parse would record for a language.
+///
+/// Indexers use this before deciding whether a content-identical file can be
+/// reused, so parser or query-pack upgrades invalidate reuse without parsing
+/// the file just to discover its metadata.
+pub fn current_parser_versions(language: SourceLanguage) -> ParserVersions {
+    if language.is_lightweight() {
+        return ParserVersions {
+            provider: LIGHTWEIGHT_PROVIDER_NAME.to_string(),
+            tree_sitter: LIGHTWEIGHT_TREE_SITTER_VERSION.to_string(),
+            grammar: "lightweight-text".to_string(),
+            query_pack: format!("{}-lightweight-v1", language.id()),
+        };
+    }
+
+    let config = language_config(language);
+    ParserVersions {
+        provider: PROVIDER_NAME.to_string(),
+        tree_sitter: TREE_SITTER_VERSION.to_string(),
+        grammar: format!("{}-{}", config.grammar_crate, config.grammar_version),
+        query_pack: config.query_pack_version.to_string(),
+    }
+}
+
 pub fn parse_path(
     path: impl AsRef<Path>,
     source: &str,

--- a/crates/opensymphony-gateway-schema/src/code_graph.rs
+++ b/crates/opensymphony-gateway-schema/src/code_graph.rs
@@ -357,8 +357,10 @@ pub struct CodeIndexReport {
 #[serde(rename_all = "snake_case")]
 pub enum CodeIndexStatus {
     Accepted,
+    Progress,
     Completed,
     Unavailable,
+    Failed,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/opensymphony-gateway-schema/src/event_journal.rs
+++ b/crates/opensymphony-gateway-schema/src/event_journal.rs
@@ -181,6 +181,12 @@ pub enum EventKind {
     CodeGraphUpdated {
         repo_id: String,
     },
+    CodeIndexProgress {
+        repo_id: String,
+    },
+    CodeIndexFailed {
+        repo_id: String,
+    },
 
     // Catch-all for unknown future events
     Unknown {
@@ -233,6 +239,8 @@ impl EventKind {
             // clients even though older gateway event families use dotted tags.
             Self::MemoryGraphUpdated { .. } => "memory_graph_updated".into(),
             Self::CodeGraphUpdated { .. } => "code_graph_updated".into(),
+            Self::CodeIndexProgress { .. } => "code_index_progress".into(),
+            Self::CodeIndexFailed { .. } => "code_index_failed".into(),
             Self::Unknown { raw_kind } => raw_kind.clone(),
         }
     }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -48,8 +48,8 @@ use crate::opensymphony_memory::{
     MemoryGraphProjectionError, code_file_outline_from_source, code_graph_diff_overlay,
     code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_symbol_detail,
     code_graph_updated_event, code_index_repository_is_git, code_index_target,
-    index_code_repository, index_code_repository_at, memory_completed_task_rows,
-    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
+    index_code_repository_at, memory_completed_task_rows, memory_concept_detail,
+    memory_graph_bundles, memory_graph_communities_with_options,
     memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
 };
 
@@ -1682,11 +1682,50 @@ async fn index_code_repo(
     AxumPath(repo_id): AxumPath<String>,
 ) -> Result<Json<CodeIndexReport>, (StatusCode, Json<serde_json::Value>)> {
     let config = configured_code_memory(&state)?.clone();
-    let Some((target_branch, head_revision)) =
-        code_index_target(&config).map_err(code_graph_error)?
-    else {
-        if code_index_repository_is_git(&config) {
-            let report = index_code_repository(&config, &repo_id).map_err(code_graph_error)?;
+    if !config.enabled {
+        let report = index_code_repository_at(&config, &repo_id, None).map_err(code_graph_error)?;
+        append_code_index_status_event(&state.journal, &repo_id, &report)
+            .await
+            .map_err(|_| {
+                code_graph_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "event_journal_error",
+                    "failed to append code index unavailable event",
+                )
+            })?;
+        return Ok(Json(report));
+    }
+    let preflight_config = config.clone();
+    let (target, repository_is_git) = tokio::task::spawn_blocking(move || {
+        let target = code_index_target(&preflight_config)?;
+        let repository_is_git = code_index_repository_is_git(&preflight_config);
+        Ok::<_, CodeGraphProjectionError>((target, repository_is_git))
+    })
+    .await
+    .map_err(|error| {
+        code_graph_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "code_index_preflight_failed",
+            &format!("code index preflight task failed: {error}"),
+        )
+    })?
+    .map_err(code_graph_error)?;
+    let Some((target_branch, head_revision)) = target else {
+        if repository_is_git {
+            let report_config = config.clone();
+            let report_repo_id = repo_id.clone();
+            let report = tokio::task::spawn_blocking(move || {
+                index_code_repository_at(&report_config, &report_repo_id, None)
+            })
+            .await
+            .map_err(|error| {
+                code_graph_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "code_index_task_failed",
+                    &format!("code index task failed: {error}"),
+                )
+            })?
+            .map_err(code_graph_error)?;
             append_code_index_status_event(&state.journal, &repo_id, &report)
                 .await
                 .map_err(|_| {
@@ -1698,7 +1737,20 @@ async fn index_code_repo(
                 })?;
             return Ok(Json(report));
         }
-        let report = code_graph_index_report(&config, &repo_id).map_err(code_graph_error)?;
+        let report_config = config.clone();
+        let report_repo_id = repo_id.clone();
+        let report = tokio::task::spawn_blocking(move || {
+            code_graph_index_report(&report_config, &report_repo_id)
+        })
+        .await
+        .map_err(|error| {
+            code_graph_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "code_index_report_failed",
+                &format!("code index report task failed: {error}"),
+            )
+        })?
+        .map_err(code_graph_error)?;
         if matches!(
             report.status,
             crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Completed

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -48,9 +48,9 @@ use crate::opensymphony_memory::{
     MemoryGraphProjectionError, code_file_outline_from_source, code_graph_diff_overlay,
     code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_symbol_detail,
     code_graph_updated_event, code_index_repository_is_git, code_index_target,
-    index_code_repository, memory_completed_task_rows, memory_concept_detail, memory_graph_bundles,
-    memory_graph_communities_with_options, memory_graph_search as search_memory_graph,
-    memory_graph_snapshot_with_options,
+    index_code_repository, index_code_repository_at, memory_completed_task_rows,
+    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
+    memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
 };
 
 pub mod action_handler;
@@ -1762,7 +1762,11 @@ async fn index_code_repo(
     tokio::spawn(async move {
         let _ = append_code_index_status_event(&journal, &progress.repo_id, &progress).await;
         let result = tokio::task::spawn_blocking(move || {
-            index_code_repository(&job_config, &job_repo_id_for_index)
+            index_code_repository_at(
+                &job_config,
+                &job_repo_id_for_index,
+                Some((target_branch, head_revision)),
+            )
         })
         .await;
         match result {

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1684,6 +1684,19 @@ async fn index_code_repo(
     let Some((target_branch, head_revision)) =
         code_index_target(&config).map_err(code_graph_error)?
     else {
+        if config.repo_root.join(".git").exists() {
+            let report = index_code_repository(&config, &repo_id).map_err(code_graph_error)?;
+            append_code_index_status_event(&state.journal, &repo_id, &report)
+                .await
+                .map_err(|_| {
+                    code_graph_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "event_journal_error",
+                        "failed to append code index unavailable event",
+                    )
+                })?;
+            return Ok(Json(report));
+        }
         let report = code_graph_index_report(&config, &repo_id).map_err(code_graph_error)?;
         if matches!(
             report.status,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1759,6 +1759,7 @@ async fn index_code_repo(
     progress
         .diagnostics
         .push("indexing target branch".to_string());
+    let failure_cursor = accepted.cursor.clone();
     tokio::spawn(async move {
         let _ = append_code_index_status_event(&journal, &progress.repo_id, &progress).await;
         let result = tokio::task::spawn_blocking(move || {
@@ -1799,7 +1800,7 @@ async fn index_code_repo(
                     stale_rows: 0,
                     skipped_files: Vec::new(),
                     diagnostics: vec![error.to_string()],
-                    cursor: StreamCursor::new(0, "code-graph:unknown"),
+                    cursor: failure_cursor.clone(),
                     indexed_at: Utc::now(),
                 };
                 let _ = append_code_index_status_event(&journal, &failed.repo_id, &failed).await;
@@ -1818,7 +1819,7 @@ async fn index_code_repo(
                     stale_rows: 0,
                     skipped_files: Vec::new(),
                     diagnostics: vec![format!("code index task failed: {error}")],
-                    cursor: StreamCursor::new(0, "code-graph:failed"),
+                    cursor: failure_cursor,
                     indexed_at: Utc::now(),
                 };
                 let _ = append_code_index_status_event(&journal, &failed.repo_id, &failed).await;

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -47,9 +47,10 @@ use crate::opensymphony_memory::{
     MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphCommunityOptions,
     MemoryGraphProjectionError, code_file_outline_from_source, code_graph_diff_overlay,
     code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_symbol_detail,
-    code_graph_updated_event, code_index_target, index_code_repository, memory_completed_task_rows,
-    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
-    memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
+    code_graph_updated_event, code_index_repository_is_git, code_index_target,
+    index_code_repository, memory_completed_task_rows, memory_concept_detail, memory_graph_bundles,
+    memory_graph_communities_with_options, memory_graph_search as search_memory_graph,
+    memory_graph_snapshot_with_options,
 };
 
 pub mod action_handler;
@@ -1684,7 +1685,7 @@ async fn index_code_repo(
     let Some((target_branch, head_revision)) =
         code_index_target(&config).map_err(code_graph_error)?
     else {
-        if config.repo_root.join(".git").exists() {
+        if code_index_repository_is_git(&config) {
             let report = index_code_repository(&config, &repo_id).map_err(code_graph_error)?;
             append_code_index_status_event(&state.journal, &repo_id, &report)
                 .await

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -47,8 +47,8 @@ use crate::opensymphony_memory::{
     MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphCommunityOptions,
     MemoryGraphProjectionError, code_file_outline_from_source, code_graph_diff_overlay,
     code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_symbol_detail,
-    code_graph_updated_event, memory_completed_task_rows, memory_concept_detail,
-    memory_graph_bundles, memory_graph_communities_with_options,
+    code_graph_updated_event, code_index_target, index_code_repository, memory_completed_task_rows,
+    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
     memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
 };
 
@@ -1680,44 +1680,206 @@ async fn index_code_repo(
     State(state): State<GatewayState>,
     AxumPath(repo_id): AxumPath<String>,
 ) -> Result<Json<CodeIndexReport>, (StatusCode, Json<serde_json::Value>)> {
-    let config = configured_code_memory(&state)?;
-    let report = code_graph_index_report(config, &repo_id).map_err(code_graph_error)?;
-    if matches!(
-        report.status,
-        crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Completed
-    ) {
-        let update = code_graph_updated_event(config, &repo_id, report.head_revision.clone())
-            .map_err(code_graph_error)?;
-        let payload = serde_json::to_value(&update).map_err(|_| {
-            code_graph_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "code_graph_event_error",
-                "failed to serialize code graph update event",
+    let config = configured_code_memory(&state)?.clone();
+    let Some((target_branch, head_revision)) =
+        code_index_target(&config).map_err(code_graph_error)?
+    else {
+        let report = code_graph_index_report(&config, &repo_id).map_err(code_graph_error)?;
+        if matches!(
+            report.status,
+            crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Completed
+        ) {
+            append_code_graph_updated_event(
+                &state.journal,
+                &config,
+                &repo_id,
+                report.head_revision.clone(),
             )
-        })?;
-        let event = EventRecord::builder()
-            .actor(EventActor::system("gateway"))
-            .entity_ref(EntityRef {
-                kind: EntityKind::Repository,
-                id: repo_id.clone(),
-                identifier: None,
-            })
-            .kind(EventKind::CodeGraphUpdated {
-                repo_id: repo_id.clone(),
-            })
-            .summary(format!("code graph updated for {repo_id}"))
-            .payload(payload)
-            .happened_at(update.updated_at)
-            .build();
-        state.journal.append(event).await.map_err(|_| {
+            .await
+            .map_err(|_| {
+                code_graph_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "event_journal_error",
+                    "failed to append code graph update event",
+                )
+            })?;
+        }
+        return Ok(Json(report));
+    };
+
+    let accepted = CodeIndexReport {
+        schema_version: SchemaVersion::v1(),
+        repo_id: repo_id.clone(),
+        status: crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Accepted,
+        head_revision: Some(head_revision.clone()),
+        parsed_files: 0,
+        persisted_documents: 0,
+        persisted_symbols: 0,
+        persisted_edges: 0,
+        persisted_diagnostics: 0,
+        stale_rows: 0,
+        skipped_files: Vec::new(),
+        diagnostics: vec![format!("indexing target branch `{target_branch}`")],
+        cursor: code_graph_updated_event(&config, &repo_id, Some(head_revision.clone()))
+            .map_err(code_graph_error)?
+            .cursor,
+        indexed_at: Utc::now(),
+    };
+    append_code_index_status_event(&state.journal, &repo_id, &accepted)
+        .await
+        .map_err(|_| {
             code_graph_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "event_journal_error",
-                "failed to append code graph update event",
+                "failed to append code index accepted event",
             )
         })?;
-    }
-    Ok(Json(report))
+
+    let journal = state.journal.clone();
+    let job_config = config.clone();
+    let event_config = config.clone();
+    let job_repo_id = repo_id.clone();
+    let job_repo_id_for_index = job_repo_id.clone();
+    let mut progress = accepted.clone();
+    progress.status = crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Progress;
+    progress
+        .diagnostics
+        .push("indexing target branch".to_string());
+    tokio::spawn(async move {
+        let _ = append_code_index_status_event(&journal, &progress.repo_id, &progress).await;
+        let result = tokio::task::spawn_blocking(move || {
+            index_code_repository(&job_config, &job_repo_id_for_index)
+        })
+        .await;
+        match result {
+            Ok(Ok(report)) => {
+                let _ = append_code_index_status_event(&journal, &report.repo_id, &report).await;
+                if matches!(
+                    report.status,
+                    crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Completed
+                ) {
+                    let _ = append_code_graph_updated_event(
+                        &journal,
+                        &event_config,
+                        &report.repo_id,
+                        report.head_revision.clone(),
+                    )
+                    .await;
+                }
+            }
+            Ok(Err(error)) => {
+                let failed = CodeIndexReport {
+                    schema_version: SchemaVersion::v1(),
+                    repo_id: job_repo_id,
+                    status: crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Failed,
+                    head_revision: None,
+                    parsed_files: 0,
+                    persisted_documents: 0,
+                    persisted_symbols: 0,
+                    persisted_edges: 0,
+                    persisted_diagnostics: 0,
+                    stale_rows: 0,
+                    skipped_files: Vec::new(),
+                    diagnostics: vec![error.to_string()],
+                    cursor: StreamCursor::new(0, "code-graph:unknown"),
+                    indexed_at: Utc::now(),
+                };
+                let _ = append_code_index_status_event(&journal, &failed.repo_id, &failed).await;
+            }
+            Err(error) => {
+                let failed = CodeIndexReport {
+                    schema_version: SchemaVersion::v1(),
+                    repo_id: job_repo_id,
+                    status: crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Failed,
+                    head_revision: None,
+                    parsed_files: 0,
+                    persisted_documents: 0,
+                    persisted_symbols: 0,
+                    persisted_edges: 0,
+                    persisted_diagnostics: 0,
+                    stale_rows: 0,
+                    skipped_files: Vec::new(),
+                    diagnostics: vec![format!("code index task failed: {error}")],
+                    cursor: StreamCursor::new(0, "code-graph:failed"),
+                    indexed_at: Utc::now(),
+                };
+                let _ = append_code_index_status_event(&journal, &failed.repo_id, &failed).await;
+            }
+        }
+    });
+    Ok(Json(accepted))
+}
+
+async fn append_code_index_status_event(
+    journal: &InMemoryEventJournal,
+    repo_id: &str,
+    report: &CodeIndexReport,
+) -> Result<(), String> {
+    let payload = serde_json::to_value(report).map_err(|error| error.to_string())?;
+    let kind = if matches!(
+        report.status,
+        crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Failed
+    ) {
+        EventKind::CodeIndexFailed {
+            repo_id: repo_id.to_string(),
+        }
+    } else {
+        EventKind::CodeIndexProgress {
+            repo_id: repo_id.to_string(),
+        }
+    };
+    journal
+        .append(
+            EventRecord::builder()
+                .actor(EventActor::system("gateway"))
+                .entity_ref(EntityRef {
+                    kind: EntityKind::Repository,
+                    id: repo_id.to_string(),
+                    identifier: None,
+                })
+                .kind(kind)
+                .summary(format!(
+                    "code index {} for {repo_id}",
+                    format!("{:?}", report.status).to_ascii_lowercase()
+                ))
+                .payload(payload)
+                .happened_at(report.indexed_at)
+                .build(),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("{error:?}"))
+}
+
+async fn append_code_graph_updated_event(
+    journal: &InMemoryEventJournal,
+    config: &MemoryConfig,
+    repo_id: &str,
+    head_revision: Option<String>,
+) -> Result<(), String> {
+    let update = code_graph_updated_event(config, repo_id, head_revision)
+        .map_err(|error| error.to_string())?;
+    let payload = serde_json::to_value(&update).map_err(|error| error.to_string())?;
+    journal
+        .append(
+            EventRecord::builder()
+                .actor(EventActor::system("gateway"))
+                .entity_ref(EntityRef {
+                    kind: EntityKind::Repository,
+                    id: repo_id.to_string(),
+                    identifier: None,
+                })
+                .kind(EventKind::CodeGraphUpdated {
+                    repo_id: repo_id.to_string(),
+                })
+                .summary(format!("code graph updated for {repo_id}"))
+                .payload(payload)
+                .happened_at(update.updated_at)
+                .build(),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("{error:?}"))
 }
 
 async fn get_run_code_outline(

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -48,8 +48,8 @@ use crate::opensymphony_memory::{
     MemoryGraphProjectionError, code_file_outline_from_source, code_graph_diff_overlay,
     code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_symbol_detail,
     code_graph_updated_event, code_index_repository_is_git, code_index_target,
-    index_code_repository_at, memory_completed_task_rows, memory_concept_detail,
-    memory_graph_bundles, memory_graph_communities_with_options,
+    index_code_repository_at, index_code_repository_at_current_target, memory_completed_task_rows,
+    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
     memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
 };
 
@@ -1682,7 +1682,7 @@ async fn index_code_repo(
     AxumPath(repo_id): AxumPath<String>,
 ) -> Result<Json<CodeIndexReport>, (StatusCode, Json<serde_json::Value>)> {
     let config = configured_code_memory(&state)?.clone();
-    if !config.enabled {
+    if !config.enabled || !config.code_intel.enabled || !config.code_intel.ast.enabled {
         let report = index_code_repository_at(&config, &repo_id, None).map_err(code_graph_error)?;
         append_code_index_status_event(&state.journal, &repo_id, &report)
             .await
@@ -1815,7 +1815,7 @@ async fn index_code_repo(
     tokio::spawn(async move {
         let _ = append_code_index_status_event(&journal, &progress.repo_id, &progress).await;
         let result = tokio::task::spawn_blocking(move || {
-            index_code_repository_at(
+            index_code_repository_at_current_target(
                 &job_config,
                 &job_repo_id_for_index,
                 Some((target_branch, head_revision)),

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2340,7 +2340,7 @@ async fn gateway_index_starts_target_branch_job_and_journals_completion() {
     assert_eq!(report.status, CodeIndexStatus::Accepted);
 
     let mut completed = false;
-    for _ in 0..50 {
+    for _ in 0..200 {
         let events = journal.all_events().await;
         completed = events.iter().any(|event| {
             matches!(
@@ -2351,7 +2351,7 @@ async fn gateway_index_starts_target_branch_job_and_journals_completion() {
         if completed {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
     assert!(completed, "index completion should be journaled");
     assert!(journal.all_events().await.iter().any(|event| {

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2291,6 +2291,100 @@ async fn gateway_serves_memory_graph_contract_endpoints() {
 }
 
 #[tokio::test]
+async fn gateway_index_starts_target_branch_job_and_journals_completion() {
+    let repo = tempfile::tempdir().expect("target repository");
+    std::fs::create_dir_all(repo.path().join("src")).expect("source directory");
+    std::fs::write(
+        repo.path().join("WORKFLOW.md"),
+        "## Branch target\n\nTarget branch: `develop`\n",
+    )
+    .expect("workflow marker");
+    std::fs::write(repo.path().join("src/lib.rs"), "pub fn main_branch() {}\n")
+        .expect("main source");
+    run_git(repo.path(), &["init", "-b", "main"]);
+    run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+    run_git(repo.path(), &["config", "user.name", "Test User"]);
+    run_git(repo.path(), &["add", "."]);
+    run_git(repo.path(), &["commit", "-m", "main"]);
+    run_git(repo.path(), &["switch", "-c", "develop"]);
+    std::fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn develop_branch() { helper(); }\nfn helper() {}\n",
+    )
+    .expect("develop source");
+    run_git(repo.path(), &["add", "."]);
+    run_git(repo.path(), &["commit", "-m", "develop"]);
+
+    let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+    let server = GatewayServer::new(SnapshotStore::new(fixture_snapshot(0)))
+        .with_memory_config(Some(config));
+    let (journal, _) = server.clone().journal_and_broker();
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener");
+    let address = listener.local_addr().expect("listener address");
+    let server_task = tokio::spawn(async move {
+        server.serve(listener).await.expect("gateway should serve");
+    });
+
+    let report = reqwest::Client::new()
+        .post(format!(
+            "http://{address}/api/v1/code/repos/target-repo/index"
+        ))
+        .send()
+        .await
+        .expect("index request")
+        .json::<CodeIndexReport>()
+        .await
+        .expect("accepted report");
+    assert_eq!(report.status, CodeIndexStatus::Accepted);
+
+    let mut completed = false;
+    for _ in 0..50 {
+        let events = journal.all_events().await;
+        completed = events.iter().any(|event| {
+            matches!(
+                event.kind,
+                opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeGraphUpdated { .. }
+            )
+        });
+        if completed {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(completed, "index completion should be journaled");
+    assert!(journal.all_events().await.iter().any(|event| {
+        matches!(
+            event.kind,
+            opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeIndexProgress { .. }
+        )
+    }));
+    let events = journal.all_events().await;
+    assert!(events.iter().any(|event| {
+        matches!(
+            event.kind,
+            opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeIndexProgress { .. }
+        ) && event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("status"))
+            == Some(&serde_json::json!("progress"))
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event.kind,
+            opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeIndexProgress { .. }
+        ) && event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("status"))
+            == Some(&serde_json::json!("completed"))
+    }));
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn gateway_serves_code_graph_contract_endpoints() {
     let repo = tempfile::tempdir().expect("memory repo");
     let config = write_code_graph_fixture(repo.path());

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1355,8 +1355,9 @@ fn code_index_edge_input(
     let end = capture
         .text
         .char_indices()
-        .map(|(index, _)| index)
-        .take_while(|index| *index <= max_capture_bytes)
+        .map(|(index, character)| (index, index + character.len_utf8()))
+        .take_while(|(_, end)| *end <= max_capture_bytes)
+        .map(|(_, end)| end)
         .last()
         .unwrap_or(0);
     Some(CodeIntelEdgeInput {
@@ -3065,6 +3066,7 @@ fn code_graph_sequence(timestamp: DateTime<Utc>) -> u64 {
 
 #[cfg(test)]
 mod code_graph_tests {
+    use crate::opensymphony_code_intel::{CaptureRecord, SourceSpan};
     use crate::opensymphony_memory::{KnowledgeScope, KnowledgeScopeKind, MemoryConfig};
     use chrono::Utc;
     use std::{fs, process::Command, sync::Arc};
@@ -3191,6 +3193,29 @@ mod code_graph_tests {
                 });
             }
         });
+    }
+
+    #[test]
+    fn code_index_edge_input_keeps_the_final_hint_character() {
+        let capture = CaptureRecord {
+            query_name: "rust.references".to_string(),
+            capture_name: "reference.call".to_string(),
+            text: "helper".to_string(),
+            span: SourceSpan {
+                start_byte: 0,
+                end_byte: 6,
+                start_line: 1,
+                start_column: 1,
+                end_line: 1,
+                end_column: 7,
+            },
+            rendered_span: "1:1-1:7".to_string(),
+        };
+        assert_eq!(
+            super::code_index_edge_input(&capture, 6)
+                .and_then(|edge| edge.target_hint),
+            Some("helper".to_string())
+        );
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -597,6 +597,7 @@ struct CodeSnapshotState<'a> {
     parsed_files: usize,
     skipped_files: usize,
     deleted_files: usize,
+    config_fingerprint: &'a str,
     indexed_at: DateTime<Utc>,
 }
 
@@ -667,10 +668,14 @@ pub fn index_code_repository_at(
     discard_staged_code_index_rows(config, repo_id)?;
     let paths = git_tree_paths(&config.repo_root, &commit_sha)?;
     let repo_prefix = git_repo_prefix(&config.repo_root)?;
+    let config_fingerprint = code_index_config_fingerprint(config);
     let previous = latest_code_snapshot(config, repo_id, &target_branch)?;
     let same_revision = previous
         .as_ref()
-        .is_some_and(|(revision, _)| revision == &commit_sha);
+        .is_some_and(|(revision, _, _)| revision == &commit_sha);
+    let reuse_edge_limits = previous
+        .as_ref()
+        .is_some_and(|(_, _, fingerprint)| fingerprint == &config_fingerprint);
 
     persist_code_snapshot_state(
         config,
@@ -683,11 +688,14 @@ pub fn index_code_repository_at(
             parsed_files: 0,
             skipped_files: 0,
             deleted_files: 0,
+            config_fingerprint: &config_fingerprint,
             indexed_at,
         },
     )?;
 
-    let previous_files = previous.map(|(_, files)| files).unwrap_or_default();
+    let previous_files = previous
+        .map(|(_, files, _)| files)
+        .unwrap_or_default();
     let mut current_files = BTreeMap::new();
     let mut memberships = Vec::new();
     let mut skipped_inputs = Vec::new();
@@ -705,11 +713,11 @@ pub fn index_code_repository_at(
         let skipped_directory = path.components().any(|component| {
             skipped_directory_name(Path::new(component.as_os_str())).is_some()
         });
-        if mode == "120000" || skipped_directory {
-            let reason = if mode == "120000" {
-                "symlink not indexed"
-            } else {
-                "skipped directory"
+        if mode == "120000" || mode == "160000" || skipped_directory {
+            let reason = match mode.as_str() {
+                "120000" => "symlink not indexed",
+                "160000" => "gitlink not indexed",
+                _ => "skipped directory",
             };
             let relative_display = path.to_string_lossy().to_string();
             skipped_files.push(format!("{relative_display}: {reason}"));
@@ -814,6 +822,7 @@ pub fn index_code_repository_at(
             && previous_file.language == language_id
             && !same_revision
             && ((previous_file.analyzed
+                && reuse_edge_limits
                 && previous_file.parser_version == current_parser_version
                 && previous_file.query_pack_version == versions.query_pack)
                 || (!previous_file.analyzed
@@ -1028,6 +1037,7 @@ pub fn index_code_repository_at(
         parsed_files,
         skipped_files: skipped_files.len(),
         deleted_files,
+        config_fingerprint: &config_fingerprint,
         indexed_at,
     };
     stale_rows += promote_staged_code_snapshot(
@@ -1176,7 +1186,7 @@ fn git_tree_paths(
                 } else {
                     entries.push((PathBuf::from(path), mode, object_id));
                 }
-            } else if object_kind == "blob" {
+            } else if object_kind == "blob" || object_kind == "commit" {
                 entries.push((PathBuf::from(path), mode, object_id));
             }
         }
@@ -1274,13 +1284,13 @@ fn latest_code_snapshot(
     config: &MemoryConfig,
     repo_id: &str,
     target_branch: &str,
-) -> Result<Option<(String, CodeSnapshotFiles)>, CodeGraphProjectionError> {
+) -> Result<Option<(String, CodeSnapshotFiles, String)>, CodeGraphProjectionError> {
     if !config.index_path.exists() {
         return Ok(None);
     }
     let connection = open_index_read_only(config)?;
     let mut statement = connection
-        .prepare("SELECT commit_sha FROM code_index_snapshots WHERE repo_id = ? AND target_branch = ? AND status = 'completed' ORDER BY indexed_at DESC LIMIT 1")
+        .prepare("SELECT commit_sha, config_fingerprint FROM code_index_snapshots WHERE repo_id = ? AND target_branch = ? AND status = 'completed' ORDER BY indexed_at DESC LIMIT 1")
         .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
             path: config.index_path.clone(),
             source,
@@ -1300,6 +1310,12 @@ fn latest_code_snapshot(
         return Ok(None);
     };
     let revision = row.get::<_, String>(0).map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })?;
+    let config_fingerprint = row.get::<_, String>(1).map_err(|source| {
         CodeGraphProjectionError::Memory(MemoryError::DuckDb {
             path: config.index_path.clone(),
             source,
@@ -1334,7 +1350,15 @@ fn latest_code_snapshot(
             path: config.index_path.clone(),
             source,
         }))?;
-    Ok(Some((revision, files)))
+    Ok(Some((revision, files, config_fingerprint)))
+}
+
+fn code_index_config_fingerprint(config: &MemoryConfig) -> String {
+    format!(
+        "edge-limits:{}:{}",
+        config.code_intel.ast.max_matches_per_request,
+        config.code_intel.ast.max_capture_bytes
+    )
 }
 
 fn persist_code_snapshot_state(
@@ -1367,7 +1391,7 @@ fn persist_code_snapshot_state(
     }
     connection
         .execute(
-            "INSERT OR REPLACE INTO code_index_snapshots (repo_id, commit_sha, target_branch, status, total_files, parsed_files, skipped_files, deleted_files, indexed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO code_index_snapshots (repo_id, commit_sha, target_branch, status, total_files, parsed_files, skipped_files, deleted_files, config_fingerprint, indexed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 state.repo_id,
                 state.commit_sha,
@@ -1377,6 +1401,7 @@ fn persist_code_snapshot_state(
                 state.parsed_files as i64,
                 state.skipped_files as i64,
                 state.deleted_files as i64,
+                state.config_fingerprint,
                 state.indexed_at.to_rfc3339(),
             ],
         )
@@ -1568,7 +1593,7 @@ fn promote_staged_code_snapshot(
     }
     transaction
         .execute(
-            "UPDATE code_index_snapshots SET target_branch = ?, status = ?, total_files = ?, parsed_files = ?, skipped_files = ?, deleted_files = ?, indexed_at = ? WHERE repo_id = ? AND commit_sha = ?",
+            "UPDATE code_index_snapshots SET target_branch = ?, status = ?, total_files = ?, parsed_files = ?, skipped_files = ?, deleted_files = ?, config_fingerprint = ?, indexed_at = ? WHERE repo_id = ? AND commit_sha = ?",
             params![
                 completed_state.target_branch,
                 completed_state.status,
@@ -1576,6 +1601,7 @@ fn promote_staged_code_snapshot(
                 completed_state.parsed_files as i64,
                 completed_state.skipped_files as i64,
                 completed_state.deleted_files as i64,
+                completed_state.config_fingerprint,
                 completed_state.indexed_at.to_rfc3339(),
                 completed_state.repo_id,
                 completed_state.commit_sha,
@@ -1606,7 +1632,7 @@ fn current_code_snapshot_file_matches(
     let exists = if file.analyzed {
         connection
             .query_row(
-                "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' LIMIT 1",
+                "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
                 params![
                     repo_id,
                     path,
@@ -1625,7 +1651,7 @@ fn current_code_snapshot_file_matches(
     } else {
         connection
             .query_row(
-                "SELECT 1 FROM code_skipped_files WHERE repo_id = ? AND path = ? AND reason = ? AND content_sha256 = ? AND freshness = 'current' LIMIT 1",
+                "SELECT 1 FROM code_skipped_files WHERE repo_id = ? AND path = ? AND reason = ? AND content_sha256 = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
                 params![
                     repo_id,
                     path,
@@ -2602,10 +2628,10 @@ fn query_retained_inbound_impact_count(
         "code_edges"
     };
     let query = if membership_edges {
-        "SELECT DISTINCT e.edge_id, e.source_symbol_key FROM code_edge_revisions AS e WHERE e.repo_id = ? AND e.target_symbol_key = ? AND NOT e.worktree_dirty AND (lower(e.edge_kind) LIKE '%call%' OR lower(e.edge_kind) LIKE '%reference%') AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed))"
+        "SELECT DISTINCT e.edge_id, e.source_symbol_key FROM code_edge_revisions AS e WHERE e.repo_id = ? AND e.target_symbol_key = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (lower(e.edge_kind) LIKE '%call%' OR lower(e.edge_kind) LIKE '%reference%') AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed))"
     } else {
         &format!(
-            "SELECT DISTINCT edge_id, source_symbol_key FROM {edge_table} WHERE repo_id = ? AND target_symbol_key = ? AND NOT worktree_dirty AND (lower(edge_kind) LIKE '%call%' OR lower(edge_kind) LIKE '%reference%') AND (commit_sha = ? OR (? IS NULL AND commit_sha IS NULL))"
+            "SELECT DISTINCT edge_id, source_symbol_key FROM {edge_table} WHERE repo_id = ? AND target_symbol_key = ? AND freshness <> 'staged' AND NOT worktree_dirty AND (lower(edge_kind) LIKE '%call%' OR lower(edge_kind) LIKE '%reference%') AND (commit_sha = ? OR (? IS NULL AND commit_sha IS NULL))"
         )
     };
     let mut statement = connection
@@ -3652,6 +3678,39 @@ mod code_graph_tests {
         assert_eq!(current_edge_commit, baseline);
         drop(connection);
 
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "fixture-repo".to_string(),
+                commit_sha: Some("workspace-dirty".to_string()),
+                worktree_dirty: true,
+                documents: vec![legacy_document.clone()],
+            },
+        )
+        .expect("dirty workspace document should persist");
+        index_code_repository(&config, "fixture-repo")
+            .expect("clean target rows should replace dirty rows");
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let clean_documents: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current' AND NOT worktree_dirty",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("clean document count should be readable");
+        let dirty_documents: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current' AND worktree_dirty",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("dirty document count should be readable");
+        assert_eq!(clean_documents, 1);
+        assert_eq!(dirty_documents, 0);
+        drop(connection);
+
         let before_staged_symbols = open_existing_index_read_only(&config)
             .expect("index should open")
             .expect("index should exist")
@@ -3729,6 +3788,7 @@ mod code_graph_tests {
                 parsed_files: 0,
                 skipped_files: 0,
                 deleted_files: 0,
+                config_fingerprint: "",
                 indexed_at: Utc::now(),
             },
         )
@@ -3756,6 +3816,7 @@ mod code_graph_tests {
                 parsed_files: 0,
                 skipped_files: 0,
                 deleted_files: 0,
+                config_fingerprint: "",
                 indexed_at: Utc::now(),
             },
         )
@@ -3791,6 +3852,7 @@ mod code_graph_tests {
                 parsed_files: 0,
                 skipped_files: 0,
                 deleted_files: 0,
+                config_fingerprint: "",
                 indexed_at: Utc::now(),
             },
         )
@@ -3971,6 +4033,112 @@ mod code_graph_tests {
             .skipped_files
             .iter()
             .any(|path| path.contains("max file size")));
+    }
+
+    #[test]
+    fn target_index_records_gitlink_coverage() {
+        let repo = TempDir::new().expect("repository tempdir");
+        let submodule = TempDir::new().expect("submodule tempdir");
+        fs::write(submodule.path().join("README.md"), "submodule\n")
+            .expect("submodule file");
+        git(submodule.path(), &["init", "-b", "develop"]);
+        git(submodule.path(), &["config", "user.email", "test@example.com"]);
+        git(submodule.path(), &["config", "user.name", "Test User"]);
+        git(submodule.path(), &["add", "."]);
+        git(submodule.path(), &["commit", "-m", "submodule"]);
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::create_dir_all(repo.path().join("src")).expect("source directory");
+        fs::write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n")
+            .expect("source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "gitlink base"]);
+        git(
+            repo.path(),
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                submodule.path().to_string_lossy().as_ref(),
+                "deps/submodule",
+            ],
+        );
+        git(repo.path(), &["commit", "-m", "gitlink pointer"]);
+        let head = git(repo.path(), &["rev-parse", "HEAD"]);
+
+        let paths = super::git_tree_paths(repo.path(), &head).expect("tree should include gitlink");
+        assert!(paths.iter().any(|(path, mode, _)| {
+            path == Path::new("deps/submodule") && mode == "160000"
+        }));
+
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let report = index_code_repository(&config, "gitlink-repo").expect("index");
+        assert!(report
+            .skipped_files
+            .iter()
+            .any(|path| path.contains("deps/submodule: gitlink not indexed")));
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let reason: String = connection
+            .query_row(
+                "SELECT skip_reason FROM code_snapshot_membership WHERE repo_id = ? AND path = ?",
+                duckdb::params!["gitlink-repo", "deps/submodule"],
+                |row| row.get(0),
+            )
+            .expect("gitlink membership should persist");
+        assert_eq!(reason, "gitlink not indexed");
+    }
+
+    #[test]
+    fn target_index_reparses_unchanged_files_when_edge_limits_change() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(
+            repo.path().join("src.rs"),
+            "pub fn helper() {}\npub fn caller() { helper(); }\n",
+        )
+        .expect("source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "bounded edges"]);
+        let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        config.code_intel.ast.max_matches_per_request = 0;
+        let first = index_code_repository(&config, "edge-limit-repo").expect("limited index");
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "raise edge limit"]);
+        config.code_intel.ast.max_matches_per_request = 100;
+        let second = index_code_repository(&config, "edge-limit-repo").expect("expanded index");
+        assert!(
+            first.parsed_files > 0,
+            "first parsed {}",
+            first.parsed_files
+        );
+        assert!(second.parsed_files > 0);
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let current_edges: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_edges WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["edge-limit-repo", "src.rs"],
+                |row| row.get(0),
+            )
+            .expect("edge count should be readable");
+        assert!(current_edges > 0);
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -665,6 +665,7 @@ pub fn index_code_repository_at(
     drop(connection);
 
     let paths = git_tree_paths(&config.repo_root, &commit_sha)?;
+    let repo_prefix = git_repo_prefix(&config.repo_root)?;
     let previous = latest_code_snapshot(config, repo_id, &target_branch)?;
     let same_revision = previous
         .as_ref()
@@ -739,7 +740,7 @@ pub fn index_code_repository_at(
             continue;
         }
         let relative_display = path.to_string_lossy().to_string();
-        let blob_size = git_blob_size(&config.repo_root, &commit_sha, &path)?;
+        let blob_size = git_blob_size(&config.repo_root, &repo_prefix, &commit_sha, &path)?;
         let Some(language) = detect_language(&path) else {
             let content_sha256 = format!("git-blob:{blob_id}");
             skipped_files.push(format!("{relative_display}: unsupported language"));
@@ -803,7 +804,7 @@ pub fn index_code_repository_at(
             continue;
         }
 
-        let bytes = git_blob(&config.repo_root, &commit_sha, &path)?;
+        let bytes = git_blob(&config.repo_root, &repo_prefix, &commit_sha, &path)?;
         let content_sha256 = sha256_bytes_hex(&bytes);
         let versions = current_parser_versions(language);
         let current_parser_version = format!("{}:{}", versions.grammar, versions.tree_sitter);
@@ -816,7 +817,8 @@ pub fn index_code_repository_at(
                 && previous_file.query_pack_version == versions.query_pack)
                 || (!previous_file.analyzed
                     && previous_file.parser_version.is_empty()
-                    && previous_file.query_pack_version.is_empty()))
+                    && previous_file.query_pack_version.is_empty()
+                    && previous_file.skip_reason.as_deref() != Some("max files per request")))
         {
             current_files.insert(relative_display.clone(), previous_file.clone());
             memberships.push(CodeSnapshotMembershipInput {
@@ -1185,12 +1187,31 @@ fn git_tree_paths(
     Ok(entries)
 }
 
+fn git_repo_prefix(root: &Path) -> Result<PathBuf, CodeGraphProjectionError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(root)
+        .args(["rev-parse", "--show-prefix"])
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: root.to_path_buf(),
+            source,
+        }))?;
+    if !output.status.success() {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "failed to resolve configured repository path".to_string(),
+        ));
+    }
+    Ok(PathBuf::from(String::from_utf8_lossy(&output.stdout).trim()))
+}
+
 fn git_blob(
     root: &Path,
+    repo_prefix: &Path,
     commit: &str,
     path: &Path,
 ) -> Result<Vec<u8>, CodeGraphProjectionError> {
-    let object = format!("{}:{}", commit, path.to_string_lossy());
+    let object = format!("{}:{}", commit, repo_prefix.join(path).to_string_lossy());
     let output = Command::new("git")
         .args(["-C"])
         .arg(root)
@@ -1212,10 +1233,11 @@ fn git_blob(
 
 fn git_blob_size(
     root: &Path,
+    repo_prefix: &Path,
     commit: &str,
     path: &Path,
 ) -> Result<u64, CodeGraphProjectionError> {
-    let object = format!("{}:{}", commit, path.to_string_lossy());
+    let object = format!("{}:{}", commit, repo_prefix.join(path).to_string_lossy());
     let output = Command::new("git")
         .args(["-C"])
         .arg(root)
@@ -1432,6 +1454,15 @@ fn promote_staged_code_snapshot(
         })
     })?;
     let mut stale_rows = 0;
+    transaction
+        .execute(
+            "UPDATE code_edges AS current SET commit_sha = staged.commit_sha, worktree_dirty = staged.worktree_dirty, path = staged.path, language = staged.language, edge_kind = staged.edge_kind, source_symbol_id = staged.source_symbol_id, source_symbol_key = staged.source_symbol_key, target_symbol_id = staged.target_symbol_id, target_symbol_key = staged.target_symbol_key, target_hint = staged.target_hint, confidence = staged.confidence, start_line = staged.start_line, start_col = staged.start_col, end_line = staged.end_line, end_col = staged.end_col, start_byte = staged.start_byte, end_byte = staged.end_byte, content_sha256 = staged.content_sha256, parser_version = staged.parser_version, query_pack_version = staged.query_pack_version, indexed_at = staged.indexed_at FROM code_edge_revisions AS staged WHERE current.edge_id = staged.edge_id AND current.repo_id = staged.repo_id AND current.freshness = 'current' AND staged.repo_id = ? AND staged.commit_sha = ? AND staged.freshness = 'staged'",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     stale_rows += transaction
         .execute(
             "UPDATE code_symbols AS current SET freshness = 'stale' WHERE current.repo_id = ? AND current.freshness = 'current' AND EXISTS (SELECT 1 FROM code_symbols AS staged WHERE staged.repo_id = current.repo_id AND staged.path = current.path AND staged.symbol_key = current.symbol_key AND staged.commit_sha = ? AND staged.freshness = 'staged')",
@@ -2376,8 +2407,9 @@ fn code_revision_indexed(
     repo_id: &str,
     revision: &str,
 ) -> Result<bool, MemoryError> {
-    if let Some(status) = code_snapshot_status(connection, config, repo_id, revision)? {
-        return Ok(status == "completed");
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    if snapshot_status.as_deref() == Some("completed") {
+        return Ok(true);
     }
     for (table, ready) in [
         (
@@ -2405,7 +2437,9 @@ fn code_revision_indexed(
             return Ok(true);
         }
     }
-    if code_snapshot_membership_read_model_ready(connection, &config.index_path)? {
+    if matches!(snapshot_status.as_deref(), None | Some("completed"))
+        && code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+    {
         let mut statement = connection
             .prepare("SELECT 1 FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? LIMIT 1")
             .map_err(|source| MemoryError::DuckDb {
@@ -2473,7 +2507,7 @@ fn code_revision_exists_in_table(
 ) -> Result<bool, MemoryError> {
     let mut statement = connection
         .prepare(&format!(
-            "SELECT 1 FROM {table} WHERE repo_id = ? AND commit_sha = ? AND NOT worktree_dirty LIMIT 1"
+            "SELECT 1 FROM {table} WHERE repo_id = ? AND commit_sha = ? AND freshness <> 'staged' AND NOT worktree_dirty LIMIT 1"
         ))
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -2918,12 +2952,10 @@ fn query_revision_documents(
     repo_id: &str,
     revision: &str,
 ) -> Result<BTreeMap<String, RevisionDocumentKey>, MemoryError> {
-    if code_snapshot_membership_read_model_ready(connection, &config.index_path)? {
-        if let Some(status) = code_snapshot_status(connection, config, repo_id, revision)?
-            && status != "completed"
-        {
-            return Ok(BTreeMap::new());
-        }
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    if matches!(snapshot_status.as_deref(), None | Some("completed"))
+        && code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+    {
         let mut statement = connection
             .prepare("SELECT path, content_sha256, parser_version, query_pack_version, analyzed FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? ORDER BY path")
             .map_err(|source| MemoryError::DuckDb {
@@ -2951,7 +2983,7 @@ fn query_revision_documents(
                 path: config.index_path.clone(),
                 source,
             })?;
-        if code_snapshot_status(connection, config, repo_id, revision)?.is_some() {
+        if snapshot_status.is_some() {
             return Ok(rows);
         }
     }
@@ -2986,7 +3018,7 @@ fn query_revision_documents_from_table(
 ) -> Result<BTreeMap<String, RevisionDocumentKey>, MemoryError> {
     let mut statement = connection
         .prepare(&format!(
-            "SELECT path, content_sha256, parser_version, query_pack_version FROM {table} WHERE repo_id = ? AND commit_sha = ? AND NOT worktree_dirty ORDER BY path, CASE WHEN freshness = 'current' THEN 0 ELSE 1 END, indexed_at DESC"
+            "SELECT path, content_sha256, parser_version, query_pack_version FROM {table} WHERE repo_id = ? AND commit_sha = ? AND freshness <> 'staged' AND NOT worktree_dirty ORDER BY path, CASE WHEN freshness = 'current' THEN 0 ELSE 1 END, indexed_at DESC"
         ))
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -3035,7 +3067,7 @@ fn query_revision_skipped_files(
     }
     let mut statement = connection
         .prepare(
-            "SELECT path, content_sha256 FROM code_skipped_files WHERE repo_id = ? AND commit_sha = ? AND NOT worktree_dirty ORDER BY path, CASE WHEN freshness = 'current' THEN 0 ELSE 1 END, indexed_at DESC",
+            "SELECT path, content_sha256 FROM code_skipped_files WHERE repo_id = ? AND commit_sha = ? AND freshness <> 'staged' AND NOT worktree_dirty ORDER BY path, CASE WHEN freshness = 'current' THEN 0 ELSE 1 END, indexed_at DESC",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -3559,6 +3591,14 @@ mod code_graph_tests {
             )
             .expect("current symbols should remain unique");
         assert_eq!(symbol_count, unique_symbol_count);
+        let current_edge_commit: String = connection
+            .query_row(
+                "SELECT commit_sha FROM code_edges WHERE repo_id = ? AND path = ? AND freshness = 'current' LIMIT 1",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("target snapshot edge should be current");
+        assert_eq!(current_edge_commit, baseline);
         drop(connection);
 
         let refreshed = index_code_repository(&config, "fixture-repo")
@@ -3591,6 +3631,29 @@ mod code_graph_tests {
             .expect("snapshot should exist");
         assert_eq!(snapshot_status, "completed");
         drop(connection);
+        super::persist_code_snapshot_state(
+            &config,
+            super::CodeSnapshotState {
+                repo_id: "fixture-repo",
+                commit_sha: "legacy-code-intel",
+                target_branch: "develop",
+                status: "running",
+                total_files: 0,
+                parsed_files: 0,
+                skipped_files: 0,
+                deleted_files: 0,
+                indexed_at: Utc::now(),
+            },
+        )
+        .expect("record legacy interrupted index");
+        assert!(code_graph_diff_overlay(
+            &config,
+            "fixture-repo",
+            "legacy-code-intel",
+            &baseline,
+            500,
+        )
+        .is_ok());
 
         fs::write(
             repo.path().join("src/lib.rs"),
@@ -3706,6 +3769,11 @@ mod code_graph_tests {
             .expect("outside source");
         fs::write(repo.path().join("configured/src/lib.rs"), "pub fn inside() {}\n")
             .expect("inside source");
+        fs::write(
+            repo.path().join("configured/WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
         git(repo.path(), &["init", "-b", "develop"]);
         git(repo.path(), &["config", "user.email", "test@example.com"]);
         git(repo.path(), &["config", "user.name", "Test User"]);
@@ -3721,6 +3789,43 @@ mod code_graph_tests {
         assert!(!paths
             .iter()
             .any(|(path, _, _)| path == Path::new("outside.rs")));
+        let config = MemoryConfig::load(repo.path().join("configured"), None)
+            .expect("scoped memory config should load");
+        let report = index_code_repository(&config, "scoped-repo")
+            .expect("scoped target index should read configured blobs");
+        assert!(report.parsed_files >= 1);
+        assert!(super::code_graph_file_snapshot(&config, "scoped-repo", "src/lib.rs", false).is_ok());
+        assert!(super::code_graph_file_snapshot(&config, "scoped-repo", "outside.rs", false).is_err());
+    }
+
+    #[test]
+    fn target_index_reparses_files_previously_skipped_by_file_limit() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(repo.path().join("a.rs"), "pub fn first() {}\n").expect("first source");
+        fs::write(repo.path().join("b.rs"), "pub fn second() {}\n").expect("second source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "limited tree"]);
+        let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        config.code_intel.ast.max_files_per_request = 1;
+        let first = index_code_repository(&config, "limited-repo").expect("limited index");
+        assert_eq!(first.parsed_files, 1);
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "raise limit"]);
+        config.code_intel.ast.max_files_per_request = 2;
+        let second = index_code_repository(&config, "limited-repo").expect("expanded index");
+        assert!(second.parsed_files > first.parsed_files);
+        assert!(!second
+            .skipped_files
+            .iter()
+            .any(|path| path.contains("max files per request")));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -666,12 +666,9 @@ pub fn index_code_repository_at(
 
     let paths = git_tree_paths(&config.repo_root, &commit_sha)?;
     let previous = latest_code_snapshot(config, repo_id, &target_branch)?;
-    if previous.as_ref().is_some_and(|(revision, _)| revision == &commit_sha) {
-        let mut report = code_graph_index_report(config, repo_id)?;
-        report.head_revision = Some(commit_sha);
-        report.diagnostics.push("revision already indexed".to_string());
-        return Ok(report);
-    }
+    let same_revision = previous
+        .as_ref()
+        .is_some_and(|(revision, _)| revision == &commit_sha);
 
     persist_code_snapshot_state(
         config,
@@ -813,6 +810,7 @@ pub fn index_code_repository_at(
         if let Some(previous_file) = previous_files.get(&relative_display)
             && previous_file.content_sha256 == content_sha256
             && previous_file.language == language_id
+            && !same_revision
             && ((previous_file.analyzed
                 && previous_file.parser_version == current_parser_version
                 && previous_file.query_pack_version == versions.query_pack)
@@ -1168,6 +1166,8 @@ fn git_tree_paths(
             if object_kind == "tree" {
                 if skipped_directory_name(Path::new(path)).is_none() {
                     directories.push(path.to_string());
+                } else {
+                    entries.push((PathBuf::from(path), mode, object_id));
                 }
             } else if object_kind == "blob" {
                 entries.push((PathBuf::from(path), mode, object_id));
@@ -1415,6 +1415,15 @@ fn promote_staged_code_snapshot(
         })
     })?;
     let mut stale_rows = 0;
+    stale_rows += transaction
+        .execute(
+            "UPDATE code_symbols AS current SET freshness = 'stale' WHERE current.repo_id = ? AND current.freshness = 'current' AND EXISTS (SELECT 1 FROM code_symbols AS staged WHERE staged.repo_id = current.repo_id AND staged.path = current.path AND staged.symbol_key = current.symbol_key AND staged.commit_sha = ? AND staged.freshness = 'staged')",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     for path in changed_paths {
         for table in [
             "code_documents",
@@ -3524,6 +3533,19 @@ mod code_graph_tests {
             )
             .expect("legacy document should remain current");
         assert_eq!(freshness, "current");
+        let (symbol_count, unique_symbol_count): (i64, i64) = connection
+            .query_row(
+                "SELECT COUNT(*), COUNT(DISTINCT symbol_key) FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("current symbols should remain unique");
+        assert_eq!(symbol_count, unique_symbol_count);
+        drop(connection);
+
+        let refreshed = index_code_repository(&config, "fixture-repo")
+            .expect("same revision should be revalidated");
+        assert!(refreshed.parsed_files > 0);
 
         fs::write(
             repo.path().join("src/lib.rs"),
@@ -3622,9 +3644,13 @@ mod code_graph_tests {
 
         let paths = super::git_tree_paths(repo.path(), &commit).expect("tree should list");
         assert!(paths.iter().any(|(path, _, _)| path == Path::new("src/lib.rs")));
-        assert!(!paths
+        assert!(paths
             .iter()
-            .any(|(path, _, _)| path.starts_with(Path::new("node_modules"))));
+            .any(|(path, mode, _)| path == Path::new("node_modules") && mode == "040000"));
+        assert!(!paths.iter().any(|(path, _, _)| {
+            path != Path::new("node_modules")
+                && path.starts_with(Path::new("node_modules"))
+        }));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -624,7 +624,7 @@ pub fn index_code_repository(
     config: &MemoryConfig,
     repo_id: &str,
 ) -> Result<CodeIndexReport, CodeGraphProjectionError> {
-    if !config.enabled {
+    if !config.enabled || !config.code_intel.enabled || !config.code_intel.ast.enabled {
         return index_code_repository_at(config, repo_id, None);
     }
     let target = code_index_target(config)?;
@@ -636,7 +636,24 @@ pub fn index_code_repository_at(
     repo_id: &str,
     target: Option<(String, String)>,
 ) -> Result<CodeIndexReport, CodeGraphProjectionError> {
-    if !config.enabled {
+    index_code_repository_at_checked(config, repo_id, target, false)
+}
+
+pub fn index_code_repository_at_current_target(
+    config: &MemoryConfig,
+    repo_id: &str,
+    target: Option<(String, String)>,
+) -> Result<CodeIndexReport, CodeGraphProjectionError> {
+    index_code_repository_at_checked(config, repo_id, target, true)
+}
+
+fn index_code_repository_at_checked(
+    config: &MemoryConfig,
+    repo_id: &str,
+    target: Option<(String, String)>,
+    revalidate_target: bool,
+) -> Result<CodeIndexReport, CodeGraphProjectionError> {
+    if !config.enabled || !config.code_intel.enabled || !config.code_intel.ast.enabled {
         let indexed_at = Utc::now();
         return Ok(CodeIndexReport {
             schema_version: SchemaVersion::v1(),
@@ -650,7 +667,11 @@ pub fn index_code_repository_at(
             persisted_diagnostics: 0,
             stale_rows: 0,
             skipped_files: Vec::new(),
-            diagnostics: vec!["memory is disabled in configuration".to_string()],
+            diagnostics: vec![if !config.enabled {
+                "memory is disabled in configuration".to_string()
+            } else {
+                "code intelligence is disabled in configuration".to_string()
+            }],
             cursor: code_graph_cursor(repo_id, indexed_at),
             indexed_at,
         });
@@ -674,6 +695,19 @@ pub fn index_code_repository_at(
         ));
         return Ok(report);
     };
+    if revalidate_target {
+        let current_target = code_index_target(config)?;
+        if current_target.as_ref() != Some(&(target_branch.clone(), commit_sha.clone())) {
+            let mut report = code_graph_index_report(config, repo_id)?;
+            report.status = CodeIndexStatus::Unavailable;
+            report.head_revision = None;
+            report.diagnostics.push(
+                "configured target branch advanced before index promotion; retry the index"
+                    .to_string(),
+            );
+            return Ok(report);
+        }
+    }
 
     // Existing memory stores may predate the snapshot tables. Migrate once
     // before the read-only previous-snapshot lookup so a first index works on
@@ -1032,6 +1066,13 @@ pub fn index_code_repository_at(
             deleted_files += 1;
             deleted_paths.push(path.clone());
             diagnostics.push(format!("{path}: deleted from target branch"));
+        }
+    }
+    for path in current_code_snapshot_paths(config, repo_id)? {
+        if !current_files.contains_key(&path) && !deleted_paths.contains(&path) {
+            deleted_files += 1;
+            deleted_paths.push(path.clone());
+            diagnostics.push(format!("{path}: removed from configured target branch"));
         }
     }
 
@@ -1492,6 +1533,15 @@ fn discard_staged_code_index_rows(
     }
     transaction
         .execute(
+            "DELETE FROM code_documents_staging WHERE repo_id = ?",
+            params![repo_id],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
             "DELETE FROM code_snapshot_membership_staging WHERE repo_id = ?",
             params![repo_id],
         )
@@ -1623,20 +1673,43 @@ fn promote_staged_code_snapshot(
         }
     }
     for path in edge_refresh_paths {
-        for table in ["code_edges", "code_diagnostics"] {
-            stale_rows += transaction
-                .execute(
-                    &format!(
-                        "UPDATE {table} SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'"
-                    ),
-                    params![repo_id, path],
-                )
-                .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
-                    path: config.index_path.clone(),
-                    source,
-                }))?;
-        }
+        stale_rows += transaction
+            .execute(
+                "UPDATE code_edges AS current SET freshness = 'stale' WHERE current.repo_id = ? AND current.path = ? AND current.freshness = 'current' AND NOT EXISTS (SELECT 1 FROM code_edge_revisions AS staged WHERE staged.edge_id = current.edge_id AND staged.repo_id = ? AND staged.commit_sha = ? AND staged.freshness = 'staged')",
+                params![repo_id, path, repo_id, commit_sha],
+            )
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            }))?;
+        stale_rows += transaction
+            .execute(
+                "UPDATE code_diagnostics SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                params![repo_id, path],
+            )
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            }))?;
     }
+    transaction
+        .execute(
+            "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) SELECT repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, 'current' FROM code_documents_staging WHERE repo_id = ? AND commit_sha = ?",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
+            "DELETE FROM code_documents_staging WHERE repo_id = ? AND commit_sha = ?",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     for table in [
         "code_documents",
         "code_document_revisions",
@@ -1714,6 +1787,34 @@ fn promote_staged_code_snapshot(
         })
     })?;
     Ok(stale_rows)
+}
+
+fn current_code_snapshot_paths(
+    config: &MemoryConfig,
+    repo_id: &str,
+) -> Result<BTreeSet<String>, CodeGraphProjectionError> {
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Ok(BTreeSet::new());
+    };
+    let mut statement = connection
+        .prepare(
+            "SELECT path FROM code_documents WHERE repo_id = ? AND freshness = 'current' UNION SELECT path FROM code_skipped_files WHERE repo_id = ? AND freshness = 'current'",
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    statement
+        .query_map(params![repo_id, repo_id], |row| row.get::<_, String>(0))
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))
 }
 
 fn current_code_snapshot_file_matches(
@@ -3667,7 +3768,8 @@ mod code_graph_tests {
         code_citation_matches_symbol, code_graph_diff_overlay, code_graph_repos,
         code_index_document, code_symbol_span_matches, has_work_item_scope,
         CodeSnapshotMembershipInput,
-        index_code_repository, index_code_repository_at, open_existing_index_read_only,
+        index_code_repository, index_code_repository_at, index_code_repository_at_current_target,
+        open_existing_index_read_only,
         repository_scope_matches,
     };
 
@@ -4033,6 +4135,20 @@ mod code_graph_tests {
         )
         .expect("explicit accepted revision should index");
         assert_eq!(bound.head_revision.as_deref(), Some(baseline.as_str()));
+        let stale_bound = index_code_repository_at_current_target(
+            &config,
+            "stale-bound-repo",
+            Some(("develop".to_string(), baseline.clone())),
+        )
+        .expect("stale accepted revision should be rejected without indexing");
+        assert_eq!(
+            stale_bound.status,
+            crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Unavailable
+        );
+        assert!(stale_bound
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("advanced before index promotion")));
 
         fs::write(repo.path().join("src/new.rs"), "pub fn new_symbol() {}\n")
             .expect("new source");
@@ -4290,6 +4406,23 @@ mod code_graph_tests {
             )
             .expect("stale edge count should be readable");
         assert!(stale_edges > 0);
+        drop(connection);
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "raise edge limit"]);
+        config.code_intel.ast.max_matches_per_request = 100;
+        let third = index_code_repository(&config, "edge-limit-repo").expect("raised index");
+        assert!(third.parsed_files > 0);
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let current_edges_after_raise: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_edges WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["edge-limit-repo", "src.rs"],
+                |row| row.get(0),
+            )
+            .expect("raised edge count should be readable");
+        assert!(current_edges_after_raise > 0);
     }
 
     #[test]
@@ -4314,6 +4447,93 @@ mod code_graph_tests {
             .iter()
             .any(|diagnostic| diagnostic.contains("memory is disabled")));
         assert!(!config.index_path.exists());
+
+        config.enabled = true;
+        config.code_intel.enabled = false;
+        let report = index_code_repository_at(
+            &config,
+            "disabled-code-intel-repo",
+            Some(("develop".to_string(), "commit".to_string())),
+        )
+        .expect("disabled code intelligence should return unavailable");
+        assert_eq!(
+            report.status,
+            crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Unavailable
+        );
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("code intelligence is disabled")));
+        assert!(!config.index_path.exists());
+
+        config.code_intel.enabled = true;
+        config.code_intel.ast.enabled = false;
+        let report = index_code_repository_at(
+            &config,
+            "disabled-ast-repo",
+            Some(("develop".to_string(), "commit".to_string())),
+        )
+        .expect("disabled AST code intelligence should return unavailable");
+        assert_eq!(
+            report.status,
+            crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Unavailable
+        );
+        assert!(!config.index_path.exists());
+    }
+
+    #[test]
+    fn target_branch_switch_stales_rows_from_the_previous_branch() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `main`\n",
+        )
+        .expect("workflow marker");
+        fs::write(repo.path().join("old.rs"), "pub fn old() {}\n").expect("old source");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "main baseline"]);
+        git(repo.path(), &["switch", "-c", "develop"]);
+        fs::remove_file(repo.path().join("old.rs")).expect("remove old source");
+        fs::write(repo.path().join("new.rs"), "pub fn new() {}\n").expect("new source");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "develop baseline"]);
+
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("develop target marker");
+        index_code_repository(&config, "branch-switch-repo").expect("develop index");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `main`\n",
+        )
+        .expect("main target marker");
+        let report = index_code_repository(&config, "branch-switch-repo").expect("main index");
+        assert!(report.stale_rows > 0);
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let old_current: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["branch-switch-repo", "new.rs"],
+                |row| row.get(0),
+            )
+            .expect("old branch document count should be readable");
+        let new_current: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["branch-switch-repo", "old.rs"],
+                |row| row.get(0),
+            )
+            .expect("new branch document count should be readable");
+        assert_eq!(old_current, 0);
+        assert_eq!(new_current, 1);
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -179,7 +179,7 @@ pub fn code_graph_repos(
 
             let mut membership = connection
                 .prepare(
-                    "SELECT path, language FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? ORDER BY path",
+                    "SELECT path, language FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? AND analyzed ORDER BY path",
                 )
                 .map_err(|source| MemoryError::DuckDb {
                     path: config.index_path.clone(),
@@ -907,7 +907,11 @@ fn index_code_repository_at_checked(
                             && !previous_file
                                 .skip_reason
                                 .as_deref()
-                                .is_some_and(|reason| reason.starts_with("max file size ")))
+                                .is_some_and(|reason| reason.starts_with("max file size "))
+                            && !matches!(
+                                previous_file.skip_reason.as_deref(),
+                                Some("unsupported language") | Some("parse failed")
+                            ))
                 })
                 .map(|previous_file| {
                     current_code_snapshot_file_matches(
@@ -1154,6 +1158,20 @@ fn index_code_repository_at_checked(
         config_fingerprint: &config_fingerprint,
         indexed_at,
     };
+    if revalidate_target {
+        let current_target = code_index_target(config)?;
+        if current_target.as_ref() != Some(&(target_branch.clone(), commit_sha.clone())) {
+            discard_staged_code_index_rows(config, repo_id)?;
+            let mut report = code_graph_index_report(config, repo_id)?;
+            report.status = CodeIndexStatus::Unavailable;
+            report.head_revision = None;
+            report.diagnostics.push(
+                "configured target branch advanced before index promotion; retry the index"
+                    .to_string(),
+            );
+            return Ok(report);
+        }
+    }
     stale_rows += promote_staged_code_snapshot(
         config,
         repo_id,
@@ -4438,6 +4456,35 @@ mod code_graph_tests {
             .skipped_files
             .iter()
             .any(|path| path.contains("max file size")));
+    }
+
+    #[test]
+    fn code_repo_summary_excludes_skipped_only_snapshot_membership() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(repo.path().join("notes.txt"), "not indexed\n").expect("unsupported source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "skipped-only snapshot"]);
+        let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        config.code_intel.ast.max_file_bytes = 1;
+
+        let report = index_code_repository(&config, "skipped-only-repo").expect("index");
+        assert_eq!(report.parsed_files, 0);
+        let summary = code_graph_repos(&config, false)
+            .expect("repo summaries")
+            .repos
+            .into_iter()
+            .find(|repo| repo.repo_id == "skipped-only-repo")
+            .expect("skipped-only repo summary");
+        assert_eq!(summary.document_count, 0);
+        assert!(summary.languages.is_empty());
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1,6 +1,6 @@
 use crate::opensymphony_code_intel::{
-    AstDiagnosticKind, CaptureRecord, SymbolKind, detect_language, parse_path,
-    skipped_directory_name,
+    AstDiagnosticKind, CaptureRecord, SymbolKind, current_parser_versions, detect_language,
+    parse_path, skipped_directory_name,
 };
 use crate::opensymphony_gateway_schema::{
     code_graph::{
@@ -14,6 +14,7 @@ use crate::opensymphony_gateway_schema::{
         CodeSymbolProvenance,
     },
 };
+use duckdb::OptionalExt;
 use url::Url;
 use std::sync::{Mutex, OnceLock};
 
@@ -118,6 +119,91 @@ pub fn code_graph_repos(
         if is_newer {
             entry.indexed_at = parsed_indexed_at;
             entry.head_revision = commit_sha;
+        }
+    }
+
+    if table_has_columns(
+        &connection,
+        &config.index_path,
+        "code_index_snapshots",
+        &["repo_id", "commit_sha", "status", "indexed_at"],
+    )? && code_snapshot_membership_read_model_ready(&connection, &config.index_path)?
+    {
+        let mut snapshots = connection
+            .prepare(
+                r#"
+                    SELECT repo_id, commit_sha, indexed_at
+                    FROM (
+                        SELECT repo_id, commit_sha, indexed_at,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY repo_id
+                                ORDER BY indexed_at DESC, commit_sha DESC
+                            ) AS row_rank
+                        FROM code_index_snapshots
+                        WHERE status = 'completed'
+                    ) latest
+                    WHERE row_rank = 1
+                "#,
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        let snapshots = snapshots
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        for (repo_id, commit_sha, indexed_at) in snapshots {
+            let entry = repos.entry(repo_id.clone()).or_insert_with(|| {
+                CodeRepoAccumulator {
+                    repo_id: repo_id.clone(),
+                    ..CodeRepoAccumulator::default()
+                }
+            });
+            entry.has_current = true;
+            entry.head_revision = Some(commit_sha.clone());
+            entry.indexed_at = parse_code_datetime(&indexed_at);
+
+            let mut membership = connection
+                .prepare(
+                    "SELECT path, language FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? ORDER BY path",
+                )
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?;
+            let membership = membership
+                .query_map(params![&repo_id, &commit_sha], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?;
+            if let Some(entry) = repos.get_mut(&repo_id) {
+                for (path, language) in membership {
+                    entry.paths.insert(path);
+                    entry.languages.insert(language);
+                }
+            }
         }
     }
 
@@ -539,6 +625,8 @@ pub fn index_code_repository(
     let indexed_at = Utc::now();
     let Some((target_branch, commit_sha)) = code_index_target(config)? else {
         let mut report = code_graph_index_report(config, repo_id)?;
+        report.status = CodeIndexStatus::Unavailable;
+        report.head_revision = None;
         report.diagnostics.push(format!(
             "target branch is unavailable for configured repository {}",
             config.repo_root.display()
@@ -594,6 +682,7 @@ pub fn index_code_repository(
     let mut remaining_matches = config.code_intel.ast.max_matches_per_request;
     let mut stale_rows = 0;
     let mut deleted_files = 0;
+    let mut deleted_paths = Vec::new();
 
     for (path, mode, blob_id) in paths {
         let skipped_directory = path.components().any(|component| {
@@ -635,9 +724,9 @@ pub fn index_code_repository(
             continue;
         }
         let relative_display = path.to_string_lossy().to_string();
+        let blob_size = git_blob_size(&config.repo_root, &commit_sha, &path)?;
         let Some(language) = detect_language(&path) else {
-            let bytes = git_blob(&config.repo_root, &commit_sha, &path)?;
-            let content_sha256 = sha256_bytes_hex(&bytes);
+            let content_sha256 = format!("git-blob:{blob_id}");
             skipped_files.push(format!("{relative_display}: unsupported language"));
             memberships.push(CodeSnapshotMembershipInput {
                 path: path.clone(),
@@ -667,9 +756,10 @@ pub fn index_code_repository(
             continue;
         };
         let language_id = language.id().to_string();
-        if remaining_files == 0 {
+        if blob_size > config.code_intel.ast.max_file_bytes {
+            let reason = format!("max file size {} bytes", config.code_intel.ast.max_file_bytes);
             let content_sha256 = format!("git-blob:{blob_id}");
-            skipped_files.push(format!("{relative_display}: max files per request"));
+            skipped_files.push(format!("{relative_display}: {reason}"));
             memberships.push(CodeSnapshotMembershipInput {
                 path: path.clone(),
                 language: language_id.clone(),
@@ -677,33 +767,37 @@ pub fn index_code_repository(
                 parser_version: String::new(),
                 query_pack_version: String::new(),
                 analyzed: false,
-                skip_reason: Some("max files per request".to_string()),
+                skip_reason: Some(reason.clone()),
             });
             current_files.insert(
-                relative_display,
+                relative_display.clone(),
                 CodeSnapshotFile {
-                    language: language_id,
+                    language: language_id.clone(),
                     content_sha256: content_sha256.clone(),
                     parser_version: String::new(),
                     query_pack_version: String::new(),
                     analyzed: false,
-                    skip_reason: Some("max files per request".to_string()),
+                    skip_reason: Some(reason.clone()),
                 },
             );
             skipped_inputs.push(CodeIntelSkippedFileInput {
                 path,
-                reason: "max files per request".to_string(),
+                reason,
                 content_sha256,
             });
             continue;
         }
-        remaining_files -= 1;
 
         let bytes = git_blob(&config.repo_root, &commit_sha, &path)?;
         let content_sha256 = sha256_bytes_hex(&bytes);
+        let versions = current_parser_versions(language);
+        let current_parser_version = format!("{}:{}", versions.grammar, versions.tree_sitter);
         if let Some(previous_file) = previous_files.get(&relative_display)
             && previous_file.content_sha256 == content_sha256
             && previous_file.language == language_id
+            && previous_file.analyzed
+            && previous_file.parser_version == current_parser_version
+            && previous_file.query_pack_version == versions.query_pack
         {
             current_files.insert(relative_display.clone(), previous_file.clone());
             memberships.push(CodeSnapshotMembershipInput {
@@ -729,11 +823,8 @@ pub fn index_code_repository(
             }
             continue;
         }
-        if bytes.len() as u64 > config.code_intel.ast.max_file_bytes {
-            let reason = format!(
-                "max file size {} bytes",
-                config.code_intel.ast.max_file_bytes
-            );
+        if remaining_files == 0 {
+            let reason = "max files per request".to_string();
             skipped_files.push(format!("{relative_display}: {reason}"));
             let file = CodeSnapshotFile {
                 language: language_id.clone(),
@@ -760,6 +851,7 @@ pub fn index_code_repository(
             });
             continue;
         }
+        remaining_files -= 1;
         let source = match String::from_utf8(bytes) {
             Ok(source) => source,
             Err(error) => {
@@ -867,7 +959,7 @@ pub fn index_code_repository(
     for path in previous_files.keys() {
         if !current_files.contains_key(path) {
             deleted_files += 1;
-            stale_rows += stale_current_code_path(config, repo_id, path)?;
+            deleted_paths.push(path.clone());
             diagnostics.push(format!("{path}: deleted from target branch"));
         }
     }
@@ -877,28 +969,61 @@ pub fn index_code_repository(
         repo_id,
         &commit_sha,
         documents,
+        "staged",
+        false,
     )?;
     for batch in skipped_inputs.chunks(32) {
-        persist_code_intel_skipped_files(config, repo_id, Some(&commit_sha), false, batch)?;
+        persist_code_intel_skipped_files_with_freshness(
+            config,
+            repo_id,
+            Some(&commit_sha),
+            false,
+            batch,
+            "staged",
+            false,
+        )?;
     }
     persist_code_snapshot_membership(config, repo_id, &commit_sha, &memberships)?;
+    let mut promotion_paths = Vec::new();
+    for file in &memberships {
+        let reused = previous_files.get(&file.path.to_string_lossy().to_string()).is_some_and(
+            |previous| {
+                previous.language == file.language
+                    && previous.content_sha256 == file.content_sha256
+                    && previous.parser_version == file.parser_version
+                    && previous.query_pack_version == file.query_pack_version
+                    && previous.analyzed == file.analyzed
+                    && previous.skip_reason == file.skip_reason
+            },
+        );
+        if !reused {
+            promotion_paths.push(file.path.to_string_lossy().to_string());
+        }
+    }
+    for path in deleted_paths {
+        promotion_paths.push(path);
+    }
+    let completed_state = CodeSnapshotState {
+        repo_id,
+        commit_sha: &commit_sha,
+        target_branch: &target_branch,
+        status: "completed",
+        total_files: memberships.len(),
+        parsed_files,
+        skipped_files: skipped_files.len(),
+        deleted_files,
+        indexed_at,
+    };
+    stale_rows += promote_staged_code_snapshot(
+        config,
+        repo_id,
+        &commit_sha,
+        &promotion_paths,
+        completed_state,
+    )?;
     let analyzed_documents = memberships.iter().filter(|file| file.analyzed).count();
     let current_counts = code_index_counts(config, repo_id)?;
     stale_rows += persisted.stale_rows;
-    persist_code_snapshot_state(
-        config,
-        CodeSnapshotState {
-            repo_id,
-            commit_sha: &commit_sha,
-            target_branch: &target_branch,
-            status: "completed",
-            total_files: memberships.len(),
-            parsed_files,
-            skipped_files: skipped_files.len(),
-            deleted_files,
-            indexed_at,
-        },
-    )?;
     Ok(CodeIndexReport {
         schema_version: SchemaVersion::v1(),
         repo_id: repo_id.to_string(),
@@ -1040,6 +1165,39 @@ fn git_blob(
         )));
     }
     Ok(output.stdout)
+}
+
+fn git_blob_size(
+    root: &Path,
+    commit: &str,
+    path: &Path,
+) -> Result<u64, CodeGraphProjectionError> {
+    let object = format!("{}:{}", commit, path.to_string_lossy());
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(root)
+        .args(["cat-file", "-s"])
+        .arg(object)
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: root.to_path_buf(),
+            source,
+        }))?;
+    if !output.status.success() {
+        return Err(CodeGraphProjectionError::InvalidRequest(format!(
+            "failed to inspect target-branch file {}",
+            path.display()
+        )));
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| {
+            CodeGraphProjectionError::InvalidRequest(format!(
+                "invalid target-branch blob size for {}",
+                path.display()
+            ))
+        })
 }
 
 fn latest_code_snapshot(
@@ -1193,46 +1351,12 @@ fn persist_code_snapshot_membership(
     Ok(())
 }
 
-fn persist_code_index_documents_in_batches(
+fn promote_staged_code_snapshot(
     config: &MemoryConfig,
     repo_id: &str,
     commit_sha: &str,
-    documents: Vec<CodeIntelDocumentInput>,
-) -> Result<CodeIntelPersistReport, CodeGraphProjectionError> {
-    let mut total = CodeIntelPersistReport {
-        parsed_files: 0,
-        persisted_documents: 0,
-        persisted_symbols: 0,
-        persisted_edges: 0,
-        persisted_diagnostics: 0,
-        stale_rows: 0,
-        skipped_files: Vec::new(),
-        diagnostics: Vec::new(),
-    };
-    for batch in documents.chunks(32) {
-        let report = persist_code_intel_documents(
-            config,
-            CodeIntelPersistBatch {
-                repo_id: repo_id.to_string(),
-                commit_sha: Some(commit_sha.to_string()),
-                worktree_dirty: false,
-                documents: batch.to_vec(),
-            },
-        )?;
-        total.parsed_files += report.parsed_files;
-        total.persisted_documents += report.persisted_documents;
-        total.persisted_symbols += report.persisted_symbols;
-        total.persisted_edges += report.persisted_edges;
-        total.persisted_diagnostics += report.persisted_diagnostics;
-        total.stale_rows += report.stale_rows;
-    }
-    Ok(total)
-}
-
-fn stale_current_code_path(
-    config: &MemoryConfig,
-    repo_id: &str,
-    path: &str,
+    changed_paths: &[String],
+    completed_state: CodeSnapshotState<'_>,
 ) -> Result<usize, CodeGraphProjectionError> {
     let mut connection = open_index(config)?;
     migrate_index(&connection).map_err(|source| CodeGraphProjectionError::Memory(
@@ -1247,25 +1371,115 @@ fn stale_current_code_path(
             source,
         })
     })?;
-    let mut count = 0;
-    for table in ["code_documents", "code_symbols", "code_edges", "code_diagnostics"] {
-        count += transaction
+    let mut stale_rows = 0;
+    for path in changed_paths {
+        for table in [
+            "code_documents",
+            "code_symbols",
+            "code_edges",
+            "code_diagnostics",
+            "code_skipped_files",
+        ] {
+            stale_rows += transaction
+                .execute(
+                    &format!(
+                        "UPDATE {table} SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'"
+                    ),
+                    params![repo_id, path],
+                )
+                .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                }))?;
+        }
+    }
+    for table in [
+        "code_documents",
+        "code_document_revisions",
+        "code_symbols",
+        "code_edges",
+        "code_edge_revisions",
+        "code_diagnostics",
+        "code_diagnostic_revisions",
+        "code_skipped_files",
+    ] {
+        transaction
             .execute(
-                &format!("UPDATE {table} SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'"),
-                params![repo_id, path],
+                &format!(
+                    "UPDATE {table} SET freshness = 'current' WHERE repo_id = ? AND commit_sha = ? AND freshness = 'staged'"
+                ),
+                params![repo_id, commit_sha],
             )
             .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
                 path: config.index_path.clone(),
                 source,
             }))?;
     }
+    transaction
+        .execute(
+            "UPDATE code_index_snapshots SET status = ?, total_files = ?, parsed_files = ?, skipped_files = ?, deleted_files = ?, indexed_at = ? WHERE repo_id = ? AND commit_sha = ?",
+            params![
+                completed_state.status,
+                completed_state.total_files as i64,
+                completed_state.parsed_files as i64,
+                completed_state.skipped_files as i64,
+                completed_state.deleted_files as i64,
+                completed_state.indexed_at.to_rfc3339(),
+                completed_state.repo_id,
+                completed_state.commit_sha,
+            ],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     transaction.commit().map_err(|source| {
         CodeGraphProjectionError::Memory(MemoryError::DuckDb {
             path: config.index_path.clone(),
             source,
         })
     })?;
-    Ok(count)
+    Ok(stale_rows)
+}
+
+fn persist_code_index_documents_in_batches(
+    config: &MemoryConfig,
+    repo_id: &str,
+    commit_sha: &str,
+    documents: Vec<CodeIntelDocumentInput>,
+    freshness: &str,
+    stale_existing: bool,
+) -> Result<CodeIntelPersistReport, CodeGraphProjectionError> {
+    let mut total = CodeIntelPersistReport {
+        parsed_files: 0,
+        persisted_documents: 0,
+        persisted_symbols: 0,
+        persisted_edges: 0,
+        persisted_diagnostics: 0,
+        stale_rows: 0,
+        skipped_files: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    for batch in documents.chunks(32) {
+        let report = persist_code_intel_documents_with_freshness(
+            config,
+            CodeIntelPersistBatch {
+                repo_id: repo_id.to_string(),
+                commit_sha: Some(commit_sha.to_string()),
+                worktree_dirty: false,
+                documents: batch.to_vec(),
+            },
+            freshness,
+            stale_existing,
+        )?;
+        total.parsed_files += report.parsed_files;
+        total.persisted_documents += report.persisted_documents;
+        total.persisted_symbols += report.persisted_symbols;
+        total.persisted_edges += report.persisted_edges;
+        total.persisted_diagnostics += report.persisted_diagnostics;
+        total.stale_rows += report.stale_rows;
+    }
+    Ok(total)
 }
 
 fn code_index_document(
@@ -1303,8 +1517,8 @@ fn code_index_document(
     let edges = summary
         .captures
         .iter()
-        .take(*remaining_matches)
         .filter_map(|capture| code_index_edge_input(capture, max_capture_bytes))
+        .take(*remaining_matches)
         .collect::<Vec<_>>();
     *remaining_matches = remaining_matches.saturating_sub(edges.len());
     CodeIntelDocumentInput {
@@ -2042,6 +2256,9 @@ fn code_revision_indexed(
     repo_id: &str,
     revision: &str,
 ) -> Result<bool, MemoryError> {
+    if let Some(status) = code_snapshot_status(connection, config, repo_id, revision)? {
+        return Ok(status == "completed");
+    }
     for (table, ready) in [
         (
             "code_document_revisions",
@@ -2568,6 +2785,11 @@ fn query_revision_documents(
     revision: &str,
 ) -> Result<BTreeMap<String, RevisionDocumentKey>, MemoryError> {
     if code_snapshot_membership_read_model_ready(connection, &config.index_path)? {
+        if let Some(status) = code_snapshot_status(connection, config, repo_id, revision)?
+            && status != "completed"
+        {
+            return Ok(BTreeMap::new());
+        }
         let mut statement = connection
             .prepare("SELECT path, content_sha256, parser_version, query_pack_version, analyzed FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? ORDER BY path")
             .map_err(|source| MemoryError::DuckDb {
@@ -2595,7 +2817,7 @@ fn query_revision_documents(
                 path: config.index_path.clone(),
                 source,
             })?;
-        if !rows.is_empty() {
+        if code_snapshot_status(connection, config, repo_id, revision)?.is_some() {
             return Ok(rows);
         }
     }
@@ -2912,6 +3134,33 @@ fn code_snapshot_membership_read_model_ready(
     )
 }
 
+fn code_snapshot_status(
+    connection: &Connection,
+    config: &MemoryConfig,
+    repo_id: &str,
+    revision: &str,
+) -> Result<Option<String>, MemoryError> {
+    if !table_has_columns(
+        connection,
+        &config.index_path,
+        "code_index_snapshots",
+        &["repo_id", "commit_sha", "status"],
+    )? {
+        return Ok(None);
+    }
+    connection
+        .query_row(
+            "SELECT status FROM code_index_snapshots WHERE repo_id = ? AND commit_sha = ? LIMIT 1",
+            params![repo_id, revision],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+}
+
 fn code_diagnostics_read_model_ready(
     connection: &Connection,
     path: &Path,
@@ -3159,6 +3408,11 @@ mod code_graph_tests {
             },
         )
         .expect("record interrupted index");
+        let during_interrupted = code_graph_repos(&config, false).expect("current graph remains readable");
+        assert_eq!(
+            during_interrupted.repos[0].head_revision.as_deref(),
+            Some(baseline.as_str())
+        );
 
         let second = index_code_repository(&config, "fixture-repo").expect("incremental index");
         assert_eq!(second.head_revision.as_deref(), Some(changed.as_str()));
@@ -3178,6 +3432,7 @@ mod code_graph_tests {
         let repos = code_graph_repos(&config, false).expect("current repo list");
         assert_eq!(repos.repos.len(), 1);
         assert_eq!(repos.repos[0].repo_id, "fixture-repo");
+        assert_eq!(repos.repos[0].head_revision.as_deref(), Some(identical.as_str()));
 
         fs::write(repo.path().join("src/new.rs"), "pub fn new_symbol() {}\n")
             .expect("new source");

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -623,6 +623,15 @@ pub fn index_code_repository(
     config: &MemoryConfig,
     repo_id: &str,
 ) -> Result<CodeIndexReport, CodeGraphProjectionError> {
+    let target = code_index_target(config)?;
+    index_code_repository_at(config, repo_id, target)
+}
+
+pub fn index_code_repository_at(
+    config: &MemoryConfig,
+    repo_id: &str,
+    target: Option<(String, String)>,
+) -> Result<CodeIndexReport, CodeGraphProjectionError> {
     let _guard = CODE_INDEX_WRITE_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -632,7 +641,7 @@ pub fn index_code_repository(
             )
         })?;
     let indexed_at = Utc::now();
-    let Some((target_branch, commit_sha)) = code_index_target(config)? else {
+    let Some((target_branch, commit_sha)) = target else {
         let mut report = code_graph_index_report(config, repo_id)?;
         report.status = CodeIndexStatus::Unavailable;
         report.head_revision = None;
@@ -804,9 +813,12 @@ pub fn index_code_repository(
         if let Some(previous_file) = previous_files.get(&relative_display)
             && previous_file.content_sha256 == content_sha256
             && previous_file.language == language_id
-            && previous_file.analyzed
-            && previous_file.parser_version == current_parser_version
-            && previous_file.query_pack_version == versions.query_pack
+            && ((previous_file.analyzed
+                && previous_file.parser_version == current_parser_version
+                && previous_file.query_pack_version == versions.query_pack)
+                || (!previous_file.analyzed
+                    && previous_file.parser_version.is_empty()
+                    && previous_file.query_pack_version.is_empty()))
         {
             current_files.insert(relative_display.clone(), previous_file.clone());
             memberships.push(CodeSnapshotMembershipInput {
@@ -995,17 +1007,7 @@ pub fn index_code_repository(
     persist_code_snapshot_membership(config, repo_id, &commit_sha, &memberships)?;
     let mut promotion_paths = Vec::new();
     for file in &memberships {
-        let reused = previous_files.get(&file.path.to_string_lossy().to_string()).is_some_and(
-            |previous| {
-                previous.language == file.language
-                    && previous.content_sha256 == file.content_sha256
-                    && previous.parser_version == file.parser_version
-                    && previous.query_pack_version == file.query_pack_version
-                    && previous.analyzed == file.analyzed
-                    && previous.skip_reason == file.skip_reason
-            },
-        );
-        if !reused {
+        if !current_code_snapshot_file_matches(config, repo_id, file)? {
             promotion_paths.push(file.path.to_string_lossy().to_string());
         }
     }
@@ -1126,35 +1128,52 @@ fn git_tree_paths(
     root: &Path,
     commit: &str,
 ) -> Result<Vec<(PathBuf, String, String)>, CodeGraphProjectionError> {
-    let output = Command::new("git")
-        .args(["-C"])
-        .arg(root)
-        .args(["ls-tree", "-r", "-z", "--full-tree"])
-        .arg(commit)
-        .output()
-        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
-            path: root.to_path_buf(),
-            source,
-        }))?;
-    if !output.status.success() {
-        return Err(CodeGraphProjectionError::InvalidRequest(
-            "failed to list configured target branch files".to_string(),
-        ));
-    }
-    let entries = output
-        .stdout
-        .split(|byte| *byte == 0)
-        .filter(|record| !record.is_empty())
-        .filter_map(|record| {
+    let mut directories = vec![String::new()];
+    let mut entries = Vec::new();
+    while let Some(directory) = directories.pop() {
+        let pathspec = if directory.is_empty() {
+            ".".to_string()
+        } else {
+            format!("{directory}/")
+        };
+        let output = Command::new("git")
+            .args(["-C"])
+            .arg(root)
+            .args(["ls-tree", "-z", "--full-tree"])
+            .arg(commit)
+            .args(["--", &pathspec])
+            .output()
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+                path: root.to_path_buf(),
+                source,
+            }))?;
+        if !output.status.success() {
+            return Err(CodeGraphProjectionError::InvalidRequest(
+                "failed to list configured target branch files".to_string(),
+            ));
+        }
+        for record in output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|record| !record.is_empty())
+        {
             let record = String::from_utf8_lossy(record);
-            let (metadata, path) = record.split_once('\t')?;
+            let Some((metadata, path)) = record.split_once('\t') else {
+                continue;
+            };
             let mut parts = metadata.split_whitespace();
-            let mode = parts.next()?.to_string();
-            let object_kind = parts.next()?;
-            let blob_id = parts.next()?.to_string();
-            (object_kind == "blob").then(|| (PathBuf::from(path), mode, blob_id))
-        })
-        .collect::<Vec<_>>();
+            let mode = parts.next().unwrap_or_default().to_string();
+            let object_kind = parts.next().unwrap_or_default();
+            let object_id = parts.next().unwrap_or_default().to_string();
+            if object_kind == "tree" {
+                if skipped_directory_name(Path::new(path)).is_none() {
+                    directories.push(path.to_string());
+                }
+            } else if object_kind == "blob" {
+                entries.push((PathBuf::from(path), mode, object_id));
+            }
+        }
+    }
     for (path, _, _) in &entries {
         if normalize_code_path(&path.to_string_lossy()).is_err() {
             return Err(CodeGraphProjectionError::InvalidRequest(format!(
@@ -1464,6 +1483,56 @@ fn promote_staged_code_snapshot(
         })
     })?;
     Ok(stale_rows)
+}
+
+fn current_code_snapshot_file_matches(
+    config: &MemoryConfig,
+    repo_id: &str,
+    file: &CodeSnapshotMembershipInput,
+) -> Result<bool, CodeGraphProjectionError> {
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Ok(false);
+    };
+    let path = file.path.to_string_lossy().to_string();
+    let exists = if file.analyzed {
+        connection
+            .query_row(
+                "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' LIMIT 1",
+                params![
+                    repo_id,
+                    path,
+                    file.content_sha256,
+                    file.parser_version,
+                    file.query_pack_version,
+                ],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .is_some()
+    } else {
+        connection
+            .query_row(
+                "SELECT 1 FROM code_skipped_files WHERE repo_id = ? AND path = ? AND reason = ? AND content_sha256 = ? AND freshness = 'current' LIMIT 1",
+                params![
+                    repo_id,
+                    path,
+                    file.skip_reason.as_deref().unwrap_or(""),
+                    file.content_sha256,
+                ],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .is_some()
+    };
+    Ok(exists)
 }
 
 fn persist_code_index_documents_in_batches(
@@ -3353,19 +3422,23 @@ fn code_graph_sequence(timestamp: DateTime<Utc>) -> u64 {
 
 #[cfg(test)]
 mod code_graph_tests {
-    use crate::opensymphony_code_intel::{CaptureRecord, SourceSpan};
-    use crate::opensymphony_memory::{KnowledgeScope, KnowledgeScopeKind, MemoryConfig};
+    use crate::opensymphony_code_intel::{CaptureRecord, SourceSpan, parse_path};
+    use crate::opensymphony_memory::{
+        CodeIntelPersistBatch, KnowledgeScope, KnowledgeScopeKind, MemoryConfig,
+        persist_code_intel_documents,
+    };
     use chrono::Utc;
-    use std::{fs, process::Command, sync::Arc};
+    use std::{fs, path::{Path, PathBuf}, process::Command, sync::Arc};
     use tempfile::TempDir;
 
     use super::{
         code_citation_matches_symbol, code_graph_diff_overlay, code_graph_repos,
-        code_symbol_span_matches, has_work_item_scope, index_code_repository,
+        code_index_document, code_symbol_span_matches, has_work_item_scope,
+        index_code_repository, index_code_repository_at, open_existing_index_read_only,
         repository_scope_matches,
     };
 
-    fn git(root: &std::path::Path, args: &[&str]) -> String {
+    fn git(root: &Path, args: &[&str]) -> String {
         let output = Command::new("git")
             .args(["-C"])
             .arg(root)
@@ -3413,12 +3486,44 @@ mod code_graph_tests {
         let baseline = git(repo.path(), &["rev-parse", "HEAD"]);
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
 
+        let source = fs::read_to_string(repo.path().join("src/lib.rs")).expect("baseline source");
+        let summary = parse_path(Path::new("src/lib.rs"), &source).expect("baseline parse");
+        let mut remaining_matches = config.code_intel.ast.max_matches_per_request;
+        let legacy_document = code_index_document(
+            PathBuf::from("src/lib.rs"),
+            &source,
+            &summary,
+            &mut remaining_matches,
+            config.code_intel.ast.max_capture_bytes,
+        );
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "fixture-repo".to_string(),
+                commit_sha: Some("legacy-code-intel".to_string()),
+                worktree_dirty: false,
+                documents: vec![legacy_document],
+            },
+        )
+        .expect("legacy code-intel document should persist");
+
         let first = index_code_repository(&config, "fixture-repo").expect("baseline index");
         assert_eq!(first.status, crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Completed);
         assert_eq!(first.head_revision.as_deref(), Some(baseline.as_str()));
         assert!(first.persisted_documents > 0);
         assert!(first.persisted_symbols > 0);
         assert!(first.persisted_edges > 0);
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let freshness: String = connection
+            .query_row(
+                "SELECT freshness FROM code_documents WHERE repo_id = ? AND path = ?",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("legacy document should remain current");
+        assert_eq!(freshness, "current");
 
         fs::write(
             repo.path().join("src/lib.rs"),
@@ -3472,6 +3577,14 @@ mod code_graph_tests {
         assert_eq!(repos.repos[0].repo_id, "fixture-repo");
         assert_eq!(repos.repos[0].head_revision.as_deref(), Some(identical.as_str()));
 
+        let bound = index_code_repository_at(
+            &config,
+            "bound-repo",
+            Some(("develop".to_string(), baseline.clone())),
+        )
+        .expect("explicit accepted revision should index");
+        assert_eq!(bound.head_revision.as_deref(), Some(baseline.as_str()));
+
         fs::write(repo.path().join("src/new.rs"), "pub fn new_symbol() {}\n")
             .expect("new source");
         git(repo.path(), &["add", "."]);
@@ -3486,6 +3599,32 @@ mod code_graph_tests {
                 });
             }
         });
+    }
+
+    #[test]
+    fn target_tree_listing_prunes_skipped_directories_before_recursion() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::create_dir_all(repo.path().join("src")).expect("src directory");
+        fs::create_dir_all(repo.path().join("node_modules/dependency")).expect("node modules");
+        fs::write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n")
+            .expect("source file");
+        fs::write(
+            repo.path().join("node_modules/dependency/generated.js"),
+            "module.exports = {};\n",
+        )
+        .expect("skipped file");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "tree"]);
+        let commit = git(repo.path(), &["rev-parse", "HEAD"]);
+
+        let paths = super::git_tree_paths(repo.path(), &commit).expect("tree should list");
+        assert!(paths.iter().any(|(path, _, _)| path == Path::new("src/lib.rs")));
+        assert!(!paths
+            .iter()
+            .any(|(path, _, _)| path.starts_with(Path::new("node_modules"))));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1,4 +1,7 @@
-use crate::opensymphony_code_intel::{SymbolKind, parse_path};
+use crate::opensymphony_code_intel::{
+    AstDiagnosticKind, CaptureRecord, SymbolKind, detect_language, parse_path,
+    skipped_directory_name,
+};
 use crate::opensymphony_gateway_schema::{
     code_graph::{
         CodeDiagnostic, CodeDiffBlastRadius, CodeDiffOverlay, CodeDiffSymbol,
@@ -12,9 +15,12 @@ use crate::opensymphony_gateway_schema::{
     },
 };
 use url::Url;
+use std::sync::{Mutex, OnceLock};
 
 static CODE_GRAPH_SEQUENCE_FLOOR: AtomicU64 = AtomicU64::new(0);
+static CODE_INDEX_WRITE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 const CODE_GRAPH_MAX_RECORDS: usize = 500;
+const DEFAULT_CODE_INDEX_BRANCH: &str = "develop";
 
 #[derive(Debug, thiserror::Error)]
 pub enum CodeGraphProjectionError {
@@ -470,6 +476,899 @@ pub fn code_graph_index_report(
         diagnostics: Vec::new(),
         cursor: code_graph_cursor(repo_id, indexed_at),
         indexed_at,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct CodeSnapshotFile {
+    language: String,
+    content_sha256: String,
+    parser_version: String,
+    query_pack_version: String,
+    analyzed: bool,
+    skip_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CodeSnapshotMembershipInput {
+    path: PathBuf,
+    language: String,
+    content_sha256: String,
+    parser_version: String,
+    query_pack_version: String,
+    analyzed: bool,
+    skip_reason: Option<String>,
+}
+
+type CodeSnapshotFiles = BTreeMap<String, CodeSnapshotFile>;
+
+struct CodeSnapshotState<'a> {
+    repo_id: &'a str,
+    commit_sha: &'a str,
+    target_branch: &'a str,
+    status: &'a str,
+    total_files: usize,
+    parsed_files: usize,
+    skipped_files: usize,
+    deleted_files: usize,
+    indexed_at: DateTime<Utc>,
+}
+
+pub fn code_index_target(
+    config: &MemoryConfig,
+) -> Result<Option<(String, String)>, CodeGraphProjectionError> {
+    let branch = configured_code_index_branch(&config.repo_root)?;
+    let Some(commit) = git_target_commit(&config.repo_root, &branch)? else {
+        return Ok(None);
+    };
+    Ok(Some((branch, commit)))
+}
+
+pub fn index_code_repository(
+    config: &MemoryConfig,
+    repo_id: &str,
+) -> Result<CodeIndexReport, CodeGraphProjectionError> {
+    let _guard = CODE_INDEX_WRITE_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| {
+            CodeGraphProjectionError::InvalidRequest(
+                "code index writer lock is poisoned".to_string(),
+            )
+        })?;
+    let indexed_at = Utc::now();
+    let Some((target_branch, commit_sha)) = code_index_target(config)? else {
+        let mut report = code_graph_index_report(config, repo_id)?;
+        report.diagnostics.push(format!(
+            "target branch is unavailable for configured repository {}",
+            config.repo_root.display()
+        ));
+        return Ok(report);
+    };
+
+    // Existing memory stores may predate the snapshot tables. Migrate once
+    // before the read-only previous-snapshot lookup so a first index works on
+    // both empty and previously initialized stores.
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| CodeGraphProjectionError::Memory(
+        MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        },
+    ))?;
+    drop(connection);
+
+    let paths = git_tree_paths(&config.repo_root, &commit_sha)?;
+    let previous = latest_code_snapshot(config, repo_id, &target_branch)?;
+    if previous.as_ref().is_some_and(|(revision, _)| revision == &commit_sha) {
+        let mut report = code_graph_index_report(config, repo_id)?;
+        report.head_revision = Some(commit_sha);
+        report.diagnostics.push("revision already indexed".to_string());
+        return Ok(report);
+    }
+
+    persist_code_snapshot_state(
+        config,
+        CodeSnapshotState {
+            repo_id,
+            commit_sha: &commit_sha,
+            target_branch: &target_branch,
+            status: "running",
+            total_files: 0,
+            parsed_files: 0,
+            skipped_files: 0,
+            deleted_files: 0,
+            indexed_at,
+        },
+    )?;
+
+    let previous_files = previous.map(|(_, files)| files).unwrap_or_default();
+    let mut current_files = BTreeMap::new();
+    let mut memberships = Vec::new();
+    let mut skipped_inputs = Vec::new();
+    let mut skipped_files = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut documents = Vec::new();
+    let mut parsed_files = 0;
+    let mut remaining_files = config.code_intel.ast.max_files_per_request;
+    let mut remaining_matches = config.code_intel.ast.max_matches_per_request;
+    let mut stale_rows = 0;
+    let mut deleted_files = 0;
+
+    for (path, mode, blob_id) in paths {
+        let skipped_directory = path.components().any(|component| {
+            skipped_directory_name(Path::new(component.as_os_str())).is_some()
+        });
+        if mode == "120000" || skipped_directory {
+            let reason = if mode == "120000" {
+                "symlink not indexed"
+            } else {
+                "skipped directory"
+            };
+            let relative_display = path.to_string_lossy().to_string();
+            skipped_files.push(format!("{relative_display}: {reason}"));
+            memberships.push(CodeSnapshotMembershipInput {
+                path: path.clone(),
+                language: "unknown".to_string(),
+                content_sha256: format!("git-blob:{blob_id}"),
+                parser_version: String::new(),
+                query_pack_version: String::new(),
+                analyzed: false,
+                skip_reason: Some(reason.to_string()),
+            });
+            current_files.insert(
+                path.to_string_lossy().to_string(),
+                CodeSnapshotFile {
+                    language: "unknown".to_string(),
+                    content_sha256: format!("git-blob:{blob_id}"),
+                    parser_version: String::new(),
+                    query_pack_version: String::new(),
+                    analyzed: false,
+                    skip_reason: Some(reason.to_string()),
+                },
+            );
+            skipped_inputs.push(CodeIntelSkippedFileInput {
+                path,
+                reason: reason.to_string(),
+                content_sha256: format!("git-blob:{blob_id}"),
+            });
+            continue;
+        }
+        let relative_display = path.to_string_lossy().to_string();
+        let Some(language) = detect_language(&path) else {
+            let bytes = git_blob(&config.repo_root, &commit_sha, &path)?;
+            let content_sha256 = sha256_bytes_hex(&bytes);
+            skipped_files.push(format!("{relative_display}: unsupported language"));
+            memberships.push(CodeSnapshotMembershipInput {
+                path: path.clone(),
+                language: "unknown".to_string(),
+                content_sha256: content_sha256.clone(),
+                parser_version: String::new(),
+                query_pack_version: String::new(),
+                analyzed: false,
+                skip_reason: Some("unsupported language".to_string()),
+            });
+            current_files.insert(
+                relative_display.clone(),
+                CodeSnapshotFile {
+                    language: "unknown".to_string(),
+                    content_sha256: content_sha256.clone(),
+                    parser_version: String::new(),
+                    query_pack_version: String::new(),
+                    analyzed: false,
+                    skip_reason: Some("unsupported language".to_string()),
+                },
+            );
+            skipped_inputs.push(CodeIntelSkippedFileInput {
+                path,
+                reason: "unsupported language".to_string(),
+                content_sha256,
+            });
+            continue;
+        };
+        let language_id = language.id().to_string();
+        if remaining_files == 0 {
+            let content_sha256 = format!("git-blob:{blob_id}");
+            skipped_files.push(format!("{relative_display}: max files per request"));
+            memberships.push(CodeSnapshotMembershipInput {
+                path: path.clone(),
+                language: language_id.clone(),
+                content_sha256: content_sha256.clone(),
+                parser_version: String::new(),
+                query_pack_version: String::new(),
+                analyzed: false,
+                skip_reason: Some("max files per request".to_string()),
+            });
+            current_files.insert(
+                relative_display,
+                CodeSnapshotFile {
+                    language: language_id,
+                    content_sha256: content_sha256.clone(),
+                    parser_version: String::new(),
+                    query_pack_version: String::new(),
+                    analyzed: false,
+                    skip_reason: Some("max files per request".to_string()),
+                },
+            );
+            skipped_inputs.push(CodeIntelSkippedFileInput {
+                path,
+                reason: "max files per request".to_string(),
+                content_sha256,
+            });
+            continue;
+        }
+        remaining_files -= 1;
+
+        let bytes = git_blob(&config.repo_root, &commit_sha, &path)?;
+        let content_sha256 = sha256_bytes_hex(&bytes);
+        if let Some(previous_file) = previous_files.get(&relative_display)
+            && previous_file.content_sha256 == content_sha256
+            && previous_file.language == language_id
+        {
+            current_files.insert(relative_display.clone(), previous_file.clone());
+            memberships.push(CodeSnapshotMembershipInput {
+                path: path.clone(),
+                language: previous_file.language.clone(),
+                content_sha256: previous_file.content_sha256.clone(),
+                parser_version: previous_file.parser_version.clone(),
+                query_pack_version: previous_file.query_pack_version.clone(),
+                analyzed: previous_file.analyzed,
+                skip_reason: previous_file.skip_reason.clone(),
+            });
+            if !previous_file.analyzed {
+                let reason = previous_file
+                    .skip_reason
+                    .clone()
+                    .unwrap_or_else(|| "previously skipped".to_string());
+                skipped_files.push(format!("{relative_display}: {reason}"));
+                skipped_inputs.push(CodeIntelSkippedFileInput {
+                    path,
+                    reason,
+                    content_sha256,
+                });
+            }
+            continue;
+        }
+        if bytes.len() as u64 > config.code_intel.ast.max_file_bytes {
+            let reason = format!(
+                "max file size {} bytes",
+                config.code_intel.ast.max_file_bytes
+            );
+            skipped_files.push(format!("{relative_display}: {reason}"));
+            let file = CodeSnapshotFile {
+                language: language_id.clone(),
+                content_sha256: content_sha256.clone(),
+                parser_version: String::new(),
+                query_pack_version: String::new(),
+                analyzed: false,
+                skip_reason: Some(reason.clone()),
+            };
+            current_files.insert(relative_display, file);
+            memberships.push(CodeSnapshotMembershipInput {
+                path: path.clone(),
+                language: language_id,
+                content_sha256: content_sha256.clone(),
+                parser_version: String::new(),
+                query_pack_version: String::new(),
+                analyzed: false,
+                skip_reason: Some(reason.clone()),
+            });
+            skipped_inputs.push(CodeIntelSkippedFileInput {
+                path,
+                reason,
+                content_sha256,
+            });
+            continue;
+        }
+        let source = match String::from_utf8(bytes) {
+            Ok(source) => source,
+            Err(error) => {
+                let reason = "invalid UTF-8".to_string();
+                skipped_files.push(format!("{relative_display}: {reason}"));
+                diagnostics.push(format!("{relative_display}: {error}"));
+                current_files.insert(
+                    relative_display,
+                    CodeSnapshotFile {
+                        language: language_id.clone(),
+                        content_sha256: content_sha256.clone(),
+                        parser_version: String::new(),
+                        query_pack_version: String::new(),
+                        analyzed: false,
+                        skip_reason: Some(reason.clone()),
+                    },
+                );
+                memberships.push(CodeSnapshotMembershipInput {
+                    path: path.clone(),
+                    language: language_id,
+                    content_sha256: content_sha256.clone(),
+                    parser_version: String::new(),
+                    query_pack_version: String::new(),
+                    analyzed: false,
+                    skip_reason: Some(reason.clone()),
+                });
+                skipped_inputs.push(CodeIntelSkippedFileInput {
+                    path,
+                    reason,
+                    content_sha256,
+                });
+                continue;
+            }
+        };
+        let summary = match parse_path(&path, &source) {
+            Ok(summary) => summary,
+            Err(error) => {
+                let reason = "parse failed".to_string();
+                skipped_files.push(format!("{relative_display}: {reason}"));
+                diagnostics.push(format!("{relative_display}: {error}"));
+                current_files.insert(
+                    relative_display,
+                    CodeSnapshotFile {
+                        language: language_id.clone(),
+                        content_sha256: content_sha256.clone(),
+                        parser_version: String::new(),
+                        query_pack_version: String::new(),
+                        analyzed: false,
+                        skip_reason: Some(reason.clone()),
+                    },
+                );
+                memberships.push(CodeSnapshotMembershipInput {
+                    path: path.clone(),
+                    language: language_id,
+                    content_sha256: content_sha256.clone(),
+                    parser_version: String::new(),
+                    query_pack_version: String::new(),
+                    analyzed: false,
+                    skip_reason: Some(reason.clone()),
+                });
+                skipped_inputs.push(CodeIntelSkippedFileInput {
+                    path,
+                    reason,
+                    content_sha256,
+                });
+                continue;
+            }
+        };
+        let parser_version = format!("{}:{}", summary.versions.grammar, summary.versions.tree_sitter);
+        let query_pack_version = summary.versions.query_pack.clone();
+        let document = code_index_document(
+            path.clone(),
+            &source,
+            &summary,
+            &mut remaining_matches,
+            config.code_intel.ast.max_capture_bytes,
+        );
+        diagnostics.extend(summary.diagnostics.iter().map(|diagnostic| {
+            format!("{relative_display}: {} at {}", diagnostic.node_kind, diagnostic.rendered_span)
+        }));
+        current_files.insert(
+            relative_display,
+            CodeSnapshotFile {
+                language: language_id.clone(),
+                content_sha256: content_sha256.clone(),
+                parser_version: parser_version.clone(),
+                query_pack_version: query_pack_version.clone(),
+                analyzed: true,
+                skip_reason: None,
+            },
+        );
+        memberships.push(CodeSnapshotMembershipInput {
+            path,
+            language: language_id,
+            content_sha256,
+            parser_version,
+            query_pack_version,
+            analyzed: true,
+            skip_reason: None,
+        });
+        documents.push(document);
+        parsed_files += 1;
+    }
+
+    for path in previous_files.keys() {
+        if !current_files.contains_key(path) {
+            deleted_files += 1;
+            stale_rows += stale_current_code_path(config, repo_id, path)?;
+            diagnostics.push(format!("{path}: deleted from target branch"));
+        }
+    }
+
+    let persisted = persist_code_index_documents_in_batches(
+        config,
+        repo_id,
+        &commit_sha,
+        documents,
+    )?;
+    for batch in skipped_inputs.chunks(32) {
+        persist_code_intel_skipped_files(config, repo_id, Some(&commit_sha), false, batch)?;
+    }
+    persist_code_snapshot_membership(config, repo_id, &commit_sha, &memberships)?;
+    let analyzed_documents = memberships.iter().filter(|file| file.analyzed).count();
+    let current_counts = code_index_counts(config, repo_id)?;
+    stale_rows += persisted.stale_rows;
+    persist_code_snapshot_state(
+        config,
+        CodeSnapshotState {
+            repo_id,
+            commit_sha: &commit_sha,
+            target_branch: &target_branch,
+            status: "completed",
+            total_files: memberships.len(),
+            parsed_files,
+            skipped_files: skipped_files.len(),
+            deleted_files,
+            indexed_at,
+        },
+    )?;
+    Ok(CodeIndexReport {
+        schema_version: SchemaVersion::v1(),
+        repo_id: repo_id.to_string(),
+        status: CodeIndexStatus::Completed,
+        head_revision: Some(commit_sha),
+        parsed_files,
+        persisted_documents: analyzed_documents.max(current_counts.documents),
+        persisted_symbols: current_counts.symbols.max(persisted.persisted_symbols),
+        persisted_edges: current_counts.edges.max(persisted.persisted_edges),
+        persisted_diagnostics: current_counts.diagnostics.max(persisted.persisted_diagnostics),
+        stale_rows,
+        skipped_files,
+        diagnostics,
+        cursor: code_graph_cursor(repo_id, indexed_at),
+        indexed_at,
+    })
+}
+
+fn configured_code_index_branch(root: &Path) -> Result<String, CodeGraphProjectionError> {
+    let workflow = root.join("WORKFLOW.md");
+    if !workflow.is_file() {
+        return Ok(DEFAULT_CODE_INDEX_BRANCH.to_string());
+    }
+    let contents = fs::read_to_string(&workflow).map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::ReadFile {
+            path: workflow.clone(),
+            source,
+        })
+    })?;
+    let branch = contents
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Target branch:"))
+        .map(str::trim)
+        .map(|value| value.trim_matches('`').trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_CODE_INDEX_BRANCH.to_string());
+    if branch.starts_with('-')
+        || branch.contains("..")
+        || branch.contains("@{")
+        || branch.contains('`')
+        || branch.split('/').any(|part| part.is_empty())
+    {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "configured target branch is invalid".to_string(),
+        ));
+    }
+    Ok(branch)
+}
+
+fn git_target_commit(
+    root: &Path,
+    branch: &str,
+) -> Result<Option<String>, CodeGraphProjectionError> {
+    for reference in [
+        format!("refs/remotes/origin/{branch}"),
+        format!("refs/heads/{branch}"),
+    ] {
+        let output = Command::new("git")
+            .args(["-C"])
+            .arg(root)
+            .args(["rev-parse", "--verify", "--quiet"])
+            .arg(&reference)
+            .output()
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+                path: root.to_path_buf(),
+                source,
+            }))?;
+        if output.status.success() {
+            return Ok(Some(String::from_utf8_lossy(&output.stdout).trim().to_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn git_tree_paths(
+    root: &Path,
+    commit: &str,
+) -> Result<Vec<(PathBuf, String, String)>, CodeGraphProjectionError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(root)
+        .args(["ls-tree", "-r", "-z", "--full-tree"])
+        .arg(commit)
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: root.to_path_buf(),
+            source,
+        }))?;
+    if !output.status.success() {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "failed to list configured target branch files".to_string(),
+        ));
+    }
+    let entries = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+        .filter_map(|record| {
+            let record = String::from_utf8_lossy(record);
+            let (metadata, path) = record.split_once('\t')?;
+            let mut parts = metadata.split_whitespace();
+            let mode = parts.next()?.to_string();
+            let object_kind = parts.next()?;
+            let blob_id = parts.next()?.to_string();
+            (object_kind == "blob").then(|| (PathBuf::from(path), mode, blob_id))
+        })
+        .collect::<Vec<_>>();
+    for (path, _, _) in &entries {
+        if normalize_code_path(&path.to_string_lossy()).is_err() {
+            return Err(CodeGraphProjectionError::InvalidRequest(format!(
+                "target branch contains an invalid path: {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(entries)
+}
+
+fn git_blob(
+    root: &Path,
+    commit: &str,
+    path: &Path,
+) -> Result<Vec<u8>, CodeGraphProjectionError> {
+    let object = format!("{}:{}", commit, path.to_string_lossy());
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(root)
+        .args(["cat-file", "blob"])
+        .arg(object)
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: root.to_path_buf(),
+            source,
+        }))?;
+    if !output.status.success() {
+        return Err(CodeGraphProjectionError::InvalidRequest(format!(
+            "failed to read target-branch file {}",
+            path.display()
+        )));
+    }
+    Ok(output.stdout)
+}
+
+fn latest_code_snapshot(
+    config: &MemoryConfig,
+    repo_id: &str,
+    target_branch: &str,
+) -> Result<Option<(String, CodeSnapshotFiles)>, CodeGraphProjectionError> {
+    if !config.index_path.exists() {
+        return Ok(None);
+    }
+    let connection = open_index_read_only(config)?;
+    let mut statement = connection
+        .prepare("SELECT commit_sha FROM code_index_snapshots WHERE repo_id = ? AND target_branch = ? AND status = 'completed' ORDER BY indexed_at DESC LIMIT 1")
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    let mut rows = statement
+        .query(params![repo_id, target_branch])
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    let Some(row) = rows.next().map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })? else {
+        return Ok(None);
+    };
+    let revision = row.get::<_, String>(0).map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })?;
+    let mut statement = connection
+        .prepare("SELECT path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? ORDER BY path")
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    let files = statement
+        .query_map(params![repo_id, &revision], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                CodeSnapshotFile {
+                    language: row.get(1)?,
+                    content_sha256: row.get(2)?,
+                    parser_version: row.get(3)?,
+                    query_pack_version: row.get(4)?,
+                    analyzed: row.get(5)?,
+                    skip_reason: row.get(6)?,
+                },
+            ))
+        })
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?
+        .collect::<Result<BTreeMap<_, _>, _>>()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    Ok(Some((revision, files)))
+}
+
+fn persist_code_snapshot_state(
+    config: &MemoryConfig,
+    state: CodeSnapshotState<'_>,
+) -> Result<(), CodeGraphProjectionError> {
+    let connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| CodeGraphProjectionError::Memory(
+        MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        },
+    ))?;
+    connection
+        .execute(
+            "INSERT OR REPLACE INTO code_index_snapshots (repo_id, commit_sha, target_branch, status, total_files, parsed_files, skipped_files, deleted_files, indexed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                state.repo_id,
+                state.commit_sha,
+                state.target_branch,
+                state.status,
+                state.total_files as i64,
+                state.parsed_files as i64,
+                state.skipped_files as i64,
+                state.deleted_files as i64,
+                state.indexed_at.to_rfc3339(),
+            ],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    Ok(())
+}
+
+fn persist_code_snapshot_membership(
+    config: &MemoryConfig,
+    repo_id: &str,
+    commit_sha: &str,
+    files: &[CodeSnapshotMembershipInput],
+) -> Result<(), CodeGraphProjectionError> {
+    for batch in files.chunks(256) {
+        let mut connection = open_index(config)?;
+        migrate_index(&connection).map_err(|source| CodeGraphProjectionError::Memory(
+            MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            },
+        ))?;
+        let transaction = connection.transaction().map_err(|source| {
+            CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })
+        })?;
+        for file in batch {
+            transaction
+                .execute(
+                    "INSERT OR REPLACE INTO code_snapshot_membership (repo_id, commit_sha, path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        repo_id,
+                        commit_sha,
+                        file.path.to_string_lossy().to_string(),
+                        file.language,
+                        file.content_sha256,
+                        file.parser_version,
+                        file.query_pack_version,
+                        if file.analyzed { 1_i64 } else { 0_i64 },
+                        file.skip_reason,
+                    ],
+                )
+                .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                }))?;
+        }
+        transaction.commit().map_err(|source| {
+            CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })
+        })?;
+    }
+    Ok(())
+}
+
+fn persist_code_index_documents_in_batches(
+    config: &MemoryConfig,
+    repo_id: &str,
+    commit_sha: &str,
+    documents: Vec<CodeIntelDocumentInput>,
+) -> Result<CodeIntelPersistReport, CodeGraphProjectionError> {
+    let mut total = CodeIntelPersistReport {
+        parsed_files: 0,
+        persisted_documents: 0,
+        persisted_symbols: 0,
+        persisted_edges: 0,
+        persisted_diagnostics: 0,
+        stale_rows: 0,
+        skipped_files: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    for batch in documents.chunks(32) {
+        let report = persist_code_intel_documents(
+            config,
+            CodeIntelPersistBatch {
+                repo_id: repo_id.to_string(),
+                commit_sha: Some(commit_sha.to_string()),
+                worktree_dirty: false,
+                documents: batch.to_vec(),
+            },
+        )?;
+        total.parsed_files += report.parsed_files;
+        total.persisted_documents += report.persisted_documents;
+        total.persisted_symbols += report.persisted_symbols;
+        total.persisted_edges += report.persisted_edges;
+        total.persisted_diagnostics += report.persisted_diagnostics;
+        total.stale_rows += report.stale_rows;
+    }
+    Ok(total)
+}
+
+fn stale_current_code_path(
+    config: &MemoryConfig,
+    repo_id: &str,
+    path: &str,
+) -> Result<usize, CodeGraphProjectionError> {
+    let mut connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| CodeGraphProjectionError::Memory(
+        MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        },
+    ))?;
+    let transaction = connection.transaction().map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })?;
+    let mut count = 0;
+    for table in ["code_documents", "code_symbols", "code_edges", "code_diagnostics"] {
+        count += transaction
+            .execute(
+                &format!("UPDATE {table} SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'"),
+                params![repo_id, path],
+            )
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            }))?;
+    }
+    transaction.commit().map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })?;
+    Ok(count)
+}
+
+fn code_index_document(
+    path: PathBuf,
+    source: &str,
+    summary: &crate::opensymphony_code_intel::ParsedDocumentSummary,
+    remaining_matches: &mut usize,
+    max_capture_bytes: usize,
+) -> CodeIntelDocumentInput {
+    let parser_version = format!("{}:{}", summary.versions.grammar, summary.versions.tree_sitter);
+    let symbols = summary
+        .symbols
+        .iter()
+        .map(|symbol| {
+            let snippet = source
+                .get(symbol.span.start_byte..symbol.span.end_byte)
+                .unwrap_or(symbol.name.as_str());
+            CodeIntelSymbolInput {
+                kind: symbol_kind_id(&symbol.kind).to_string(),
+                name: symbol.name.clone(),
+                container_chain: symbol.container_chain.clone(),
+                signature: None,
+                start_line: symbol.span.start_line,
+                start_col: symbol.span.start_column,
+                end_line: symbol.span.end_line,
+                end_col: symbol.span.end_column,
+                start_byte: symbol.span.start_byte,
+                end_byte: symbol.span.end_byte,
+                selection_start_line: symbol.span.start_line,
+                selection_end_line: symbol.span.end_line,
+                snippet_sha256: sha256_hex(snippet),
+            }
+        })
+        .collect();
+    let edges = summary
+        .captures
+        .iter()
+        .take(*remaining_matches)
+        .filter_map(|capture| code_index_edge_input(capture, max_capture_bytes))
+        .collect::<Vec<_>>();
+    *remaining_matches = remaining_matches.saturating_sub(edges.len());
+    CodeIntelDocumentInput {
+        path,
+        language: summary.source.language.id().to_string(),
+        content_sha256: summary.source.sha256.clone(),
+        parser_id: summary.versions.provider.clone(),
+        parser_version,
+        query_pack_version: summary.versions.query_pack.clone(),
+        byte_len: summary.source.bytes,
+        line_count: source.lines().count(),
+        symbols,
+        edges,
+        diagnostics: summary
+            .diagnostics
+            .iter()
+            .map(|diagnostic| {
+                let (kind, severity) = match diagnostic.kind {
+                    AstDiagnosticKind::Error => ("error", "error"),
+                    AstDiagnosticKind::Missing => ("missing", "warning"),
+                };
+                CodeIntelDiagnosticInput {
+                    kind: kind.to_string(),
+                    severity: severity.to_string(),
+                    message: format!("{} parse diagnostic", diagnostic.node_kind),
+                    start_line: diagnostic.span.start_line,
+                    start_col: diagnostic.span.start_column,
+                    end_line: diagnostic.span.end_line,
+                    end_col: diagnostic.span.end_column,
+                    start_byte: diagnostic.span.start_byte,
+                    end_byte: diagnostic.span.end_byte,
+                }
+            })
+            .collect(),
+    }
+}
+
+fn code_index_edge_input(
+    capture: &CaptureRecord,
+    max_capture_bytes: usize,
+) -> Option<CodeIntelEdgeInput> {
+    if !matches!(
+        capture.capture_name.split('.').next(),
+        Some("reference" | "import" | "export" | "test")
+    ) {
+        return None;
+    }
+    let end = capture
+        .text
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_capture_bytes)
+        .last()
+        .unwrap_or(0);
+    Some(CodeIntelEdgeInput {
+        edge_kind: capture.capture_name.clone(),
+        target_hint: Some(capture.text[..end].to_string()),
+        confidence: format!("query_pack:{}", capture.query_name),
+        start_line: capture.span.start_line,
+        start_col: capture.span.start_column,
+        end_line: capture.span.end_line,
+        end_col: capture.span.end_column,
+        start_byte: capture.span.start_byte,
+        end_byte: capture.span.end_byte,
     })
 }
 
@@ -1168,6 +2067,30 @@ fn code_revision_indexed(
             return Ok(true);
         }
     }
+    if code_snapshot_membership_read_model_ready(connection, &config.index_path)? {
+        let mut statement = connection
+            .prepare("SELECT 1 FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? LIMIT 1")
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        let mut rows = statement
+            .query(params![repo_id, revision])
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        if rows
+            .next()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .is_some()
+        {
+            return Ok(true);
+        }
+    }
     Ok(false)
 }
 
@@ -1643,6 +2566,38 @@ fn query_revision_documents(
     repo_id: &str,
     revision: &str,
 ) -> Result<BTreeMap<String, RevisionDocumentKey>, MemoryError> {
+    if code_snapshot_membership_read_model_ready(connection, &config.index_path)? {
+        let mut statement = connection
+            .prepare("SELECT path, content_sha256, parser_version, query_pack_version, analyzed FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? ORDER BY path")
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        let rows = statement
+            .query_map(params![repo_id, revision], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    RevisionDocumentKey {
+                        content_sha256: row.get(1)?,
+                        parser_version: row.get(2)?,
+                        query_pack_version: row.get(3)?,
+                        analyzed: row.get(4)?,
+                    },
+                ))
+            })
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<BTreeMap<_, _>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        if !rows.is_empty() {
+            return Ok(rows);
+        }
+    }
     let mut documents = BTreeMap::new();
     if code_document_revisions_read_model_ready(connection, &config.index_path)? {
         documents = query_revision_documents_from_table(
@@ -1768,27 +2723,43 @@ fn revision_path_has_symbols(
     if !code_symbols_read_model_ready(connection, &config.index_path)? {
         return Ok(false);
     }
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
+    let query = if membership_ready {
+        "SELECT 1 FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.content_sha256 = ? AND s.parser_version = ? AND s.query_pack_version = ? AND s.symbol_key != '' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version)) LIMIT 1"
+    } else {
+        "SELECT 1 FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.content_sha256 = ? AND s.parser_version = ? AND s.query_pack_version = ? AND s.symbol_key != '' AND NOT s.worktree_dirty AND s.commit_sha = ? LIMIT 1"
+    };
     let mut statement = connection
-        .prepare(
-            "SELECT 1 FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND symbol_key != '' AND NOT worktree_dirty LIMIT 1",
-        )
+        .prepare(query)
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
             source,
         })?;
-    let mut rows = statement
-        .query(params![
+    let mut rows = if membership_ready {
+        statement.query(params![
             repo_id,
-            revision,
             path,
             document.content_sha256,
             document.parser_version,
             document.query_pack_version,
+            revision,
+            revision,
         ])
-        .map_err(|source| MemoryError::DuckDb {
-            path: config.index_path.clone(),
-            source,
-        })?;
+    } else {
+        statement.query(params![
+            repo_id,
+            path,
+            document.content_sha256,
+            document.parser_version,
+            document.query_pack_version,
+            revision,
+        ])
+    }
+    .map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
     Ok(rows
         .next()
         .map_err(|source| MemoryError::DuckDb {
@@ -1916,6 +2887,26 @@ fn code_skipped_files_read_model_ready(
             "path",
             "content_sha256",
             "worktree_dirty",
+        ],
+    )
+}
+
+fn code_snapshot_membership_read_model_ready(
+    connection: &Connection,
+    path: &Path,
+) -> Result<bool, MemoryError> {
+    table_has_columns(
+        connection,
+        path,
+        "code_snapshot_membership",
+        &[
+            "repo_id",
+            "commit_sha",
+            "path",
+            "content_sha256",
+            "parser_version",
+            "query_pack_version",
+            "analyzed",
         ],
     )
 }
@@ -2074,12 +3065,133 @@ fn code_graph_sequence(timestamp: DateTime<Utc>) -> u64 {
 
 #[cfg(test)]
 mod code_graph_tests {
-    use crate::opensymphony_memory::{KnowledgeScope, KnowledgeScopeKind};
+    use crate::opensymphony_memory::{KnowledgeScope, KnowledgeScopeKind, MemoryConfig};
+    use chrono::Utc;
+    use std::{fs, process::Command, sync::Arc};
+    use tempfile::TempDir;
 
     use super::{
-        code_citation_matches_symbol, code_symbol_span_matches, has_work_item_scope,
+        code_citation_matches_symbol, code_graph_diff_overlay, code_graph_repos,
+        code_symbol_span_matches, has_work_item_scope, index_code_repository,
         repository_scope_matches,
     };
+
+    fn git(root: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(["-C"])
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn target_branch_index_bootstraps_and_advances_immutable_snapshots() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::create_dir_all(repo.path().join("src")).expect("src directory");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "## Branch target\n\nTarget branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn main_branch() {}\n",
+        )
+        .expect("main source");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "main"]);
+        git(repo.path(), &["switch", "-c", "develop"]);
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn develop_branch() { helper(); }\n",
+        )
+        .expect("develop source");
+        fs::write(repo.path().join("src/helper.rs"), "pub fn helper() {}\n")
+            .expect("helper source");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "develop baseline"]);
+        let baseline = git(repo.path(), &["rev-parse", "HEAD"]);
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+
+        let first = index_code_repository(&config, "fixture-repo").expect("baseline index");
+        assert_eq!(first.status, crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Completed);
+        assert_eq!(first.head_revision.as_deref(), Some(baseline.as_str()));
+        assert!(first.persisted_documents > 0);
+        assert!(first.persisted_symbols > 0);
+        assert!(first.persisted_edges > 0);
+
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn develop_branch() {}\n",
+        )
+        .expect("changed source");
+        fs::remove_file(repo.path().join("src/helper.rs")).expect("deleted source");
+        fs::write(repo.path().join("assets.bin"), [1_u8, 2, 3]).expect("skipped source");
+        git(repo.path(), &["add", "-A"]);
+        git(repo.path(), &["commit", "-m", "develop change"]);
+        let changed = git(repo.path(), &["rev-parse", "HEAD"]);
+
+        super::persist_code_snapshot_state(
+            &config,
+            super::CodeSnapshotState {
+                repo_id: "fixture-repo",
+                commit_sha: &changed,
+                target_branch: "develop",
+                status: "running",
+                total_files: 0,
+                parsed_files: 0,
+                skipped_files: 0,
+                deleted_files: 0,
+                indexed_at: Utc::now(),
+            },
+        )
+        .expect("record interrupted index");
+
+        let second = index_code_repository(&config, "fixture-repo").expect("incremental index");
+        assert_eq!(second.head_revision.as_deref(), Some(changed.as_str()));
+        assert_eq!(second.parsed_files, 1);
+        assert!(second.skipped_files.iter().any(|path| path.contains("assets.bin")));
+        let overlay = code_graph_diff_overlay(&config, "fixture-repo", &baseline, &changed, 500)
+            .expect("immutable revisions remain queryable");
+        assert!(!overlay.removed_symbols.is_empty());
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "identical content"]);
+        let identical = git(repo.path(), &["rev-parse", "HEAD"]);
+        let third = index_code_repository(&config, "fixture-repo").expect("identical index");
+        assert_eq!(third.head_revision.as_deref(), Some(identical.as_str()));
+        assert_eq!(third.parsed_files, 0);
+        assert!(code_graph_diff_overlay(&config, "fixture-repo", &changed, &identical, 500).is_ok());
+
+        let repos = code_graph_repos(&config, false).expect("current repo list");
+        assert_eq!(repos.repos.len(), 1);
+        assert_eq!(repos.repos[0].repo_id, "fixture-repo");
+
+        fs::write(repo.path().join("src/new.rs"), "pub fn new_symbol() {}\n")
+            .expect("new source");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "new source"]);
+
+        let config = Arc::new(config);
+        std::thread::scope(|scope| {
+            for _ in 0..2 {
+                let config = Arc::clone(&config);
+                scope.spawn(move || {
+                    index_code_repository(&config, "fixture-repo").expect("serialized reindex");
+                });
+            }
+        });
+    }
 
     #[test]
     fn legacy_code_symbol_refs_match_only_their_exact_span() {

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1070,11 +1070,26 @@ fn configured_code_index_branch(root: &Path) -> Result<String, CodeGraphProjecti
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| DEFAULT_CODE_INDEX_BRANCH.to_string());
     if branch.starts_with('-')
+        || branch.starts_with("origin/")
+        || branch.starts_with("refs/")
+        || branch.starts_with("@{-")
         || branch.contains("..")
         || branch.contains("@{")
         || branch.contains('`')
         || branch.split('/').any(|part| part.is_empty())
     {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "configured target branch is invalid".to_string(),
+        ));
+    }
+    let branch_check = Command::new("git")
+        .args(["check-ref-format", "--branch", &branch])
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: root.to_path_buf(),
+            source,
+        }))?;
+    if !branch_check.status.success() {
         return Err(CodeGraphProjectionError::InvalidRequest(
             "configured target branch is invalid".to_string(),
         ));
@@ -3198,7 +3213,7 @@ fn code_diagnostics_read_model_ready(
 
 fn code_freshness_filter(include_stale: bool) -> &'static str {
     if include_stale {
-        "1 = 1"
+        "freshness IN ('current', 'stale')"
     } else {
         "freshness = 'current'"
     }

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1137,7 +1137,7 @@ fn git_tree_paths(
         let output = Command::new("git")
             .args(["-C"])
             .arg(root)
-            .args(["ls-tree", "-z", "--full-tree"])
+            .args(["ls-tree", "-z"])
             .arg(commit)
             .args(["--", &pathspec])
             .output()
@@ -1321,6 +1321,23 @@ fn persist_code_snapshot_state(
             source,
         },
     ))?;
+    if state.status == "running"
+        && connection
+            .query_row(
+                "SELECT status FROM code_index_snapshots WHERE repo_id = ? AND commit_sha = ?",
+                params![state.repo_id, state.commit_sha],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            }))?
+            .as_deref()
+            == Some("completed")
+    {
+        return Ok(());
+    }
     connection
         .execute(
             "INSERT OR REPLACE INTO code_index_snapshots (repo_id, commit_sha, target_branch, status, total_files, parsed_files, skipped_files, deleted_files, indexed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -1469,8 +1486,9 @@ fn promote_staged_code_snapshot(
     }
     transaction
         .execute(
-            "UPDATE code_index_snapshots SET status = ?, total_files = ?, parsed_files = ?, skipped_files = ?, deleted_files = ?, indexed_at = ? WHERE repo_id = ? AND commit_sha = ?",
+            "UPDATE code_index_snapshots SET target_branch = ?, status = ?, total_files = ?, parsed_files = ?, skipped_files = ?, deleted_files = ?, indexed_at = ? WHERE repo_id = ? AND commit_sha = ?",
             params![
+                completed_state.target_branch,
                 completed_state.status,
                 completed_state.total_files as i64,
                 completed_state.parsed_files as i64,
@@ -3546,6 +3564,33 @@ mod code_graph_tests {
         let refreshed = index_code_repository(&config, "fixture-repo")
             .expect("same revision should be revalidated");
         assert!(refreshed.parsed_files > 0);
+        super::persist_code_snapshot_state(
+            &config,
+            super::CodeSnapshotState {
+                repo_id: "fixture-repo",
+                commit_sha: &baseline,
+                target_branch: "develop",
+                status: "running",
+                total_files: 0,
+                parsed_files: 0,
+                skipped_files: 0,
+                deleted_files: 0,
+                indexed_at: Utc::now(),
+            },
+        )
+        .expect("same-revision reindex should keep completed snapshot");
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let snapshot_status: String = connection
+            .query_row(
+                "SELECT status FROM code_index_snapshots WHERE repo_id = ? AND commit_sha = ?",
+                duckdb::params!["fixture-repo", baseline],
+                |row| row.get(0),
+            )
+            .expect("snapshot should exist");
+        assert_eq!(snapshot_status, "completed");
+        drop(connection);
 
         fs::write(
             repo.path().join("src/lib.rs"),
@@ -3651,6 +3696,31 @@ mod code_graph_tests {
             path != Path::new("node_modules")
                 && path.starts_with(Path::new("node_modules"))
         }));
+    }
+
+    #[test]
+    fn target_tree_listing_is_scoped_to_configured_repository_root() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::create_dir_all(repo.path().join("configured/src")).expect("configured source");
+        fs::write(repo.path().join("outside.rs"), "pub fn outside() {}\n")
+            .expect("outside source");
+        fs::write(repo.path().join("configured/src/lib.rs"), "pub fn inside() {}\n")
+            .expect("inside source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "scoped tree"]);
+        let commit = git(repo.path(), &["rev-parse", "HEAD"]);
+
+        let paths = super::git_tree_paths(&repo.path().join("configured"), &commit)
+            .expect("tree should stay scoped");
+        assert!(paths
+            .iter()
+            .any(|(path, _, _)| path == Path::new("src/lib.rs")));
+        assert!(!paths
+            .iter()
+            .any(|(path, _, _)| path == Path::new("outside.rs")));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -624,6 +624,9 @@ pub fn index_code_repository(
     config: &MemoryConfig,
     repo_id: &str,
 ) -> Result<CodeIndexReport, CodeGraphProjectionError> {
+    if !config.enabled {
+        return index_code_repository_at(config, repo_id, None);
+    }
     let target = code_index_target(config)?;
     index_code_repository_at(config, repo_id, target)
 }
@@ -633,6 +636,25 @@ pub fn index_code_repository_at(
     repo_id: &str,
     target: Option<(String, String)>,
 ) -> Result<CodeIndexReport, CodeGraphProjectionError> {
+    if !config.enabled {
+        let indexed_at = Utc::now();
+        return Ok(CodeIndexReport {
+            schema_version: SchemaVersion::v1(),
+            repo_id: repo_id.to_string(),
+            status: CodeIndexStatus::Unavailable,
+            head_revision: None,
+            parsed_files: 0,
+            persisted_documents: 0,
+            persisted_symbols: 0,
+            persisted_edges: 0,
+            persisted_diagnostics: 0,
+            stale_rows: 0,
+            skipped_files: Vec::new(),
+            diagnostics: vec!["memory is disabled in configuration".to_string()],
+            cursor: code_graph_cursor(repo_id, indexed_at),
+            indexed_at,
+        });
+    }
     let _guard = CODE_INDEX_WRITE_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -708,6 +730,7 @@ pub fn index_code_repository_at(
     let mut stale_rows = 0;
     let mut deleted_files = 0;
     let mut deleted_paths = Vec::new();
+    let mut edge_refresh_paths = Vec::new();
 
     for (path, mode, blob_id) in paths {
         let skipped_directory = path.components().any(|component| {
@@ -817,6 +840,16 @@ pub fn index_code_repository_at(
         let content_sha256 = sha256_bytes_hex(&bytes);
         let versions = current_parser_versions(language);
         let current_parser_version = format!("{}:{}", versions.grammar, versions.tree_sitter);
+        let edge_limit_reparse = previous_files
+            .get(&relative_display)
+            .is_some_and(|previous_file| {
+                previous_file.analyzed
+                    && previous_file.content_sha256 == content_sha256
+                    && previous_file.language == language_id
+                    && previous_file.parser_version == current_parser_version
+                    && previous_file.query_pack_version == versions.query_pack
+                    && !reuse_edge_limits
+            });
         if let Some(previous_file) = previous_files.get(&relative_display)
             && previous_file.content_sha256 == content_sha256
             && previous_file.language == language_id
@@ -968,7 +1001,7 @@ pub fn index_code_repository_at(
             format!("{relative_display}: {} at {}", diagnostic.node_kind, diagnostic.rendered_span)
         }));
         current_files.insert(
-            relative_display,
+            relative_display.clone(),
             CodeSnapshotFile {
                 language: language_id.clone(),
                 content_sha256: content_sha256.clone(),
@@ -988,6 +1021,9 @@ pub fn index_code_repository_at(
             skip_reason: None,
         });
         documents.push(document);
+        if edge_limit_reparse {
+            edge_refresh_paths.push(relative_display.clone());
+        }
         parsed_files += 1;
     }
 
@@ -1018,11 +1054,15 @@ pub fn index_code_repository_at(
             false,
         )?;
     }
-    persist_code_snapshot_membership(config, repo_id, &commit_sha, &memberships)?;
+    let run_id = indexed_at.to_rfc3339();
+    persist_code_snapshot_membership(config, repo_id, &commit_sha, &run_id, &memberships)?;
     let mut promotion_paths = Vec::new();
     for file in &memberships {
-        if !current_code_snapshot_file_matches(config, repo_id, file)? {
-            promotion_paths.push(file.path.to_string_lossy().to_string());
+        let path = file.path.to_string_lossy().to_string();
+        if !edge_refresh_paths.iter().any(|candidate| candidate == &path)
+            && !current_code_snapshot_file_matches(config, repo_id, file)?
+        {
+            promotion_paths.push(path);
         }
     }
     for path in deleted_paths {
@@ -1045,6 +1085,7 @@ pub fn index_code_repository_at(
         repo_id,
         &commit_sha,
         &promotion_paths,
+        &edge_refresh_paths,
         completed_state,
     )?;
     let analyzed_documents = memberships.iter().filter(|file| file.analyzed).count();
@@ -1449,6 +1490,15 @@ fn discard_staged_code_index_rows(
                 source,
             }))?;
     }
+    transaction
+        .execute(
+            "DELETE FROM code_snapshot_membership_staging WHERE repo_id = ?",
+            params![repo_id],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     transaction.commit().map_err(|source| {
         CodeGraphProjectionError::Memory(MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -1462,6 +1512,7 @@ fn persist_code_snapshot_membership(
     config: &MemoryConfig,
     repo_id: &str,
     commit_sha: &str,
+    run_id: &str,
     files: &[CodeSnapshotMembershipInput],
 ) -> Result<(), CodeGraphProjectionError> {
     for batch in files.chunks(256) {
@@ -1481,8 +1532,9 @@ fn persist_code_snapshot_membership(
         for file in batch {
             transaction
                 .execute(
-                    "INSERT OR REPLACE INTO code_snapshot_membership (repo_id, commit_sha, path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT OR REPLACE INTO code_snapshot_membership_staging (run_id, repo_id, commit_sha, path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
+                        run_id,
                         repo_id,
                         commit_sha,
                         file.path.to_string_lossy().to_string(),
@@ -1514,6 +1566,7 @@ fn promote_staged_code_snapshot(
     repo_id: &str,
     commit_sha: &str,
     changed_paths: &[String],
+    edge_refresh_paths: &[String],
     completed_state: CodeSnapshotState<'_>,
 ) -> Result<usize, CodeGraphProjectionError> {
     let mut connection = open_index(config)?;
@@ -1569,6 +1622,21 @@ fn promote_staged_code_snapshot(
                 }))?;
         }
     }
+    for path in edge_refresh_paths {
+        for table in ["code_edges", "code_diagnostics"] {
+            stale_rows += transaction
+                .execute(
+                    &format!(
+                        "UPDATE {table} SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'"
+                    ),
+                    params![repo_id, path],
+                )
+                .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                }))?;
+        }
+    }
     for table in [
         "code_documents",
         "code_document_revisions",
@@ -1591,6 +1659,34 @@ fn promote_staged_code_snapshot(
                 source,
             }))?;
     }
+    let run_id = completed_state.indexed_at.to_rfc3339();
+    transaction
+        .execute(
+            "DELETE FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ?",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
+            "INSERT INTO code_snapshot_membership (repo_id, commit_sha, path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason) SELECT repo_id, commit_sha, path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason FROM code_snapshot_membership_staging WHERE run_id = ? AND repo_id = ? AND commit_sha = ?",
+            params![&run_id, repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
+            "DELETE FROM code_snapshot_membership_staging WHERE run_id = ?",
+            params![&run_id],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     transaction
         .execute(
             "UPDATE code_index_snapshots SET target_branch = ?, status = ?, total_files = ?, parsed_files = ?, skipped_files = ?, deleted_files = ?, config_fingerprint = ?, indexed_at = ? WHERE repo_id = ? AND commit_sha = ?",
@@ -3570,6 +3666,7 @@ mod code_graph_tests {
     use super::{
         code_citation_matches_symbol, code_graph_diff_overlay, code_graph_repos,
         code_index_document, code_symbol_span_matches, has_work_item_scope,
+        CodeSnapshotMembershipInput,
         index_code_repository, index_code_repository_at, open_existing_index_read_only,
         repository_scope_matches,
     };
@@ -3676,6 +3773,52 @@ mod code_graph_tests {
             )
             .expect("target snapshot edge should be current");
         assert_eq!(current_edge_commit, baseline);
+        drop(connection);
+
+        let current_membership_parser: String = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist")
+            .query_row(
+                "SELECT parser_version FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? AND path = ?",
+                duckdb::params!["fixture-repo", baseline, "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("current membership should persist");
+        super::persist_code_snapshot_membership(
+            &config,
+            "fixture-repo",
+            &baseline,
+            "interrupted-membership-run",
+            &[CodeSnapshotMembershipInput {
+                path: PathBuf::from("src/lib.rs"),
+                language: "rust".to_string(),
+                content_sha256: "replacement-hash".to_string(),
+                parser_version: "replacement-parser".to_string(),
+                query_pack_version: "replacement-query-pack".to_string(),
+                analyzed: true,
+                skip_reason: None,
+            }],
+        )
+        .expect("membership should stage separately from the completed snapshot");
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let preserved_membership_parser: String = connection
+            .query_row(
+                "SELECT parser_version FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? AND path = ?",
+                duckdb::params!["fixture-repo", baseline, "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("completed membership should remain readable");
+        let staged_membership_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_snapshot_membership_staging WHERE run_id = ?",
+                duckdb::params!["interrupted-membership-run"],
+                |row| row.get(0),
+            )
+            .expect("staged membership should be isolated");
+        assert_eq!(preserved_membership_parser, current_membership_parser);
+        assert_eq!(staged_membership_count, 1);
         drop(connection);
 
         persist_code_intel_documents(
@@ -4116,12 +4259,12 @@ mod code_graph_tests {
         git(repo.path(), &["add", "."]);
         git(repo.path(), &["commit", "-m", "bounded edges"]);
         let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
-        config.code_intel.ast.max_matches_per_request = 0;
-        let first = index_code_repository(&config, "edge-limit-repo").expect("limited index");
-
-        git(repo.path(), &["commit", "--allow-empty", "-m", "raise edge limit"]);
         config.code_intel.ast.max_matches_per_request = 100;
-        let second = index_code_repository(&config, "edge-limit-repo").expect("expanded index");
+        let first = index_code_repository(&config, "edge-limit-repo").expect("expanded index");
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "lower edge limit"]);
+        config.code_intel.ast.max_matches_per_request = 0;
+        let second = index_code_repository(&config, "edge-limit-repo").expect("limited index");
         assert!(
             first.parsed_files > 0,
             "first parsed {}",
@@ -4138,7 +4281,39 @@ mod code_graph_tests {
                 |row| row.get(0),
             )
             .expect("edge count should be readable");
-        assert!(current_edges > 0);
+        assert_eq!(current_edges, 0);
+        let stale_edges: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_edges WHERE repo_id = ? AND path = ? AND freshness = 'stale'",
+                duckdb::params!["edge-limit-repo", "src.rs"],
+                |row| row.get(0),
+            )
+            .expect("stale edge count should be readable");
+        assert!(stale_edges > 0);
+    }
+
+    #[test]
+    fn code_index_is_unavailable_without_opening_disabled_memory() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(repo.path().join("src.rs"), "pub fn source() {}\n").expect("source");
+        let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        config.enabled = false;
+
+        let report = index_code_repository_at(
+            &config,
+            "disabled-memory-repo",
+            Some(("develop".to_string(), "commit".to_string())),
+        )
+        .expect("disabled memory should return an unavailable report");
+        assert_eq!(
+            report.status,
+            crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Unavailable
+        );
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("memory is disabled")));
+        assert!(!config.index_path.exists());
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -664,6 +664,7 @@ pub fn index_code_repository_at(
     ))?;
     drop(connection);
 
+    discard_staged_code_index_rows(config, repo_id)?;
     let paths = git_tree_paths(&config.repo_root, &commit_sha)?;
     let repo_prefix = git_repo_prefix(&config.repo_root)?;
     let previous = latest_code_snapshot(config, repo_id, &target_branch)?;
@@ -818,7 +819,11 @@ pub fn index_code_repository_at(
                 || (!previous_file.analyzed
                     && previous_file.parser_version.is_empty()
                     && previous_file.query_pack_version.is_empty()
-                    && previous_file.skip_reason.as_deref() != Some("max files per request")))
+                    && previous_file.skip_reason.as_deref() != Some("max files per request")
+                    && !previous_file
+                        .skip_reason
+                        .as_deref()
+                        .is_some_and(|reason| reason.starts_with("max file size "))))
         {
             current_files.insert(relative_display.clone(), previous_file.clone());
             memberships.push(CodeSnapshotMembershipInput {
@@ -1379,6 +1384,52 @@ fn persist_code_snapshot_state(
             path: config.index_path.clone(),
             source,
         }))?;
+    Ok(())
+}
+
+fn discard_staged_code_index_rows(
+    config: &MemoryConfig,
+    repo_id: &str,
+) -> Result<(), CodeGraphProjectionError> {
+    let mut connection = open_index(config)?;
+    migrate_index(&connection).map_err(|source| CodeGraphProjectionError::Memory(
+        MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        },
+    ))?;
+    let transaction = connection.transaction().map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })?;
+    for table in [
+        "code_documents",
+        "code_document_revisions",
+        "code_symbols",
+        "code_edges",
+        "code_edge_revisions",
+        "code_diagnostics",
+        "code_diagnostic_revisions",
+        "code_skipped_files",
+    ] {
+        transaction
+            .execute(
+                &format!("DELETE FROM {table} WHERE repo_id = ? AND freshness = 'staged'"),
+                params![repo_id],
+            )
+            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            }))?;
+    }
+    transaction.commit().map_err(|source| {
+        CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })
+    })?;
     Ok(())
 }
 
@@ -3561,7 +3612,7 @@ mod code_graph_tests {
                 repo_id: "fixture-repo".to_string(),
                 commit_sha: Some("legacy-code-intel".to_string()),
                 worktree_dirty: false,
-                documents: vec![legacy_document],
+                documents: vec![legacy_document.clone()],
             },
         )
         .expect("legacy code-intel document should persist");
@@ -3601,9 +3652,72 @@ mod code_graph_tests {
         assert_eq!(current_edge_commit, baseline);
         drop(connection);
 
+        let before_staged_symbols = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist")
+            .query_row(
+                "SELECT COUNT(*) FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("current symbol count should be readable");
+        super::persist_code_index_documents_in_batches(
+            &config,
+            "fixture-repo",
+            &baseline,
+            vec![legacy_document.clone()],
+            "staged",
+            false,
+        )
+        .expect("same-commit symbols should stage");
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let after_staged_symbols: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_symbols WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["fixture-repo", "src/lib.rs"],
+                |row| row.get(0),
+            )
+            .expect("current symbols should survive staging");
+        assert_eq!(after_staged_symbols, before_staged_symbols);
+        drop(connection);
+
+        let mut stale_document = legacy_document.clone();
+        stale_document.path = PathBuf::from("stale.rs");
+        super::persist_code_index_documents_in_batches(
+            &config,
+            "fixture-repo",
+            &baseline,
+            vec![stale_document],
+            "staged",
+            false,
+        )
+        .expect("interrupted rows should stage");
+
         let refreshed = index_code_repository(&config, "fixture-repo")
             .expect("same revision should be revalidated");
         assert!(refreshed.parsed_files > 0);
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let stale_current: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                duckdb::params!["fixture-repo", "stale.rs"],
+                |row| row.get(0),
+            )
+            .expect("stale staged document query should work");
+        let stale_staged: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'staged'",
+                duckdb::params!["fixture-repo", "stale.rs"],
+                |row| row.get(0),
+            )
+            .expect("staged cleanup query should work");
+        assert_eq!(stale_current, 0);
+        assert_eq!(stale_staged, 0);
+        drop(connection);
         super::persist_code_snapshot_state(
             &config,
             super::CodeSnapshotState {
@@ -3826,6 +3940,37 @@ mod code_graph_tests {
             .skipped_files
             .iter()
             .any(|path| path.contains("max files per request")));
+    }
+
+    #[test]
+    fn target_index_reparses_files_previously_skipped_by_byte_limit() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(repo.path().join("large.rs"), "pub fn large() {}\n")
+            .expect("source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "byte limited tree"]);
+        let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        config.code_intel.ast.max_file_bytes = 1;
+        let first = index_code_repository(&config, "byte-limited-repo").expect("limited index");
+        assert_eq!(first.parsed_files, 0);
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "raise byte limit"]);
+        config.code_intel.ast.max_file_bytes = 1024;
+        let second = index_code_repository(&config, "byte-limited-repo")
+            .expect("expanded index");
+        assert!(second.parsed_files > first.parsed_files);
+        assert!(!second
+            .skipped_files
+            .iter()
+            .any(|path| path.contains("max file size")));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -726,6 +726,14 @@ fn index_code_repository_at_checked(
     let repo_prefix = git_repo_prefix(&config.repo_root)?;
     let config_fingerprint = code_index_config_fingerprint(config);
     let previous = latest_code_snapshot(config, repo_id, &target_branch)?;
+    let changed_paths = previous
+        .as_ref()
+        .filter(|(revision, _, _)| revision != &commit_sha)
+        .map(|(revision, _, _)| {
+            git_changed_tree_paths(&config.repo_root, revision, &commit_sha, &repo_prefix)
+        })
+        .transpose()?
+        .unwrap_or_default();
     let same_revision = previous
         .as_ref()
         .is_some_and(|(revision, _, _)| revision == &commit_sha);
@@ -870,37 +878,59 @@ fn index_code_repository_at_checked(
             continue;
         }
 
-        let bytes = git_blob(&config.repo_root, &repo_prefix, &commit_sha, &path)?;
-        let content_sha256 = sha256_bytes_hex(&bytes);
         let versions = current_parser_versions(language);
         let current_parser_version = format!("{}:{}", versions.grammar, versions.tree_sitter);
-        let edge_limit_reparse = previous_files
-            .get(&relative_display)
-            .is_some_and(|previous_file| {
+        let previous_file = previous_files.get(&relative_display);
+        let path_unchanged = previous_file.is_some_and(|_| {
+            !changed_paths.contains(&relative_display)
+        });
+        let edge_limit_reparse = path_unchanged
+            && previous_file.is_some_and(|previous_file| {
                 previous_file.analyzed
-                    && previous_file.content_sha256 == content_sha256
                     && previous_file.language == language_id
                     && previous_file.parser_version == current_parser_version
                     && previous_file.query_pack_version == versions.query_pack
                     && !reuse_edge_limits
             });
-        if let Some(previous_file) = previous_files.get(&relative_display)
-            && previous_file.content_sha256 == content_sha256
-            && previous_file.language == language_id
-            && !same_revision
-            && ((previous_file.analyzed
-                && reuse_edge_limits
-                && previous_file.parser_version == current_parser_version
-                && previous_file.query_pack_version == versions.query_pack)
-                || (!previous_file.analyzed
-                    && previous_file.parser_version.is_empty()
-                    && previous_file.query_pack_version.is_empty()
-                    && previous_file.skip_reason.as_deref() != Some("max files per request")
-                    && !previous_file
-                        .skip_reason
-                        .as_deref()
-                        .is_some_and(|reason| reason.starts_with("max file size "))))
-        {
+        let reusable_previous = if !same_revision && path_unchanged {
+            previous_file
+                .filter(|previous_file| {
+                    (previous_file.analyzed
+                        && reuse_edge_limits
+                        && previous_file.language == language_id
+                        && previous_file.parser_version == current_parser_version
+                        && previous_file.query_pack_version == versions.query_pack)
+                        || (!previous_file.analyzed
+                            && previous_file.parser_version.is_empty()
+                            && previous_file.query_pack_version.is_empty()
+                            && previous_file.skip_reason.as_deref() != Some("max files per request")
+                            && !previous_file
+                                .skip_reason
+                                .as_deref()
+                                .is_some_and(|reason| reason.starts_with("max file size ")))
+                })
+                .map(|previous_file| {
+                    current_code_snapshot_file_matches(
+                        config,
+                        repo_id,
+                        &CodeSnapshotMembershipInput {
+                            path: path.clone(),
+                            language: previous_file.language.clone(),
+                            content_sha256: previous_file.content_sha256.clone(),
+                            parser_version: previous_file.parser_version.clone(),
+                            query_pack_version: previous_file.query_pack_version.clone(),
+                            analyzed: previous_file.analyzed,
+                            skip_reason: previous_file.skip_reason.clone(),
+                        },
+                    )
+                    .map(|matches| (previous_file, matches))
+                })
+                .transpose()?
+                .and_then(|(previous_file, matches)| matches.then_some(previous_file))
+        } else {
+            None
+        };
+        if let Some(previous_file) = reusable_previous {
             current_files.insert(relative_display.clone(), previous_file.clone());
             memberships.push(CodeSnapshotMembershipInput {
                 path: path.clone(),
@@ -920,13 +950,14 @@ fn index_code_repository_at_checked(
                 skipped_inputs.push(CodeIntelSkippedFileInput {
                     path,
                     reason,
-                    content_sha256,
+                    content_sha256: previous_file.content_sha256.clone(),
                 });
             }
             continue;
         }
         if remaining_files == 0 {
             let reason = "max files per request".to_string();
+            let content_sha256 = format!("git-blob:{blob_id}");
             skipped_files.push(format!("{relative_display}: {reason}"));
             let file = CodeSnapshotFile {
                 language: language_id.clone(),
@@ -954,6 +985,8 @@ fn index_code_repository_at_checked(
             continue;
         }
         remaining_files -= 1;
+        let bytes = git_blob(&config.repo_root, &repo_prefix, &commit_sha, &path)?;
+        let content_sha256 = sha256_bytes_hex(&bytes);
         let source = match String::from_utf8(bytes) {
             Ok(source) => source,
             Err(error) => {
@@ -1302,6 +1335,40 @@ fn git_repo_prefix(root: &Path) -> Result<PathBuf, CodeGraphProjectionError> {
     Ok(PathBuf::from(String::from_utf8_lossy(&output.stdout).trim()))
 }
 
+fn git_changed_tree_paths(
+    root: &Path,
+    base: &str,
+    head: &str,
+    repo_prefix: &Path,
+) -> Result<BTreeSet<String>, CodeGraphProjectionError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(root)
+        .args(["diff", "--name-only", "-z", base, head, "--", "."])
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: root.to_path_buf(),
+            source,
+        }))?;
+    if !output.status.success() {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "failed to compare target branch revisions".to_string(),
+        ));
+    }
+    let prefix = repo_prefix.to_string_lossy().trim_end_matches('/').to_string();
+    Ok(output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| String::from_utf8_lossy(path).to_string())
+        .map(|path| {
+            path.strip_prefix(&format!("{prefix}/"))
+                .unwrap_or(&path)
+                .to_string()
+        })
+        .collect())
+}
+
 fn git_blob(
     root: &Path,
     repo_prefix: &Path,
@@ -1533,6 +1600,15 @@ fn discard_staged_code_index_rows(
     }
     transaction
         .execute(
+            "DELETE FROM code_skipped_files_staging WHERE repo_id = ?",
+            params![repo_id],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
             "DELETE FROM code_documents_staging WHERE repo_id = ?",
             params![repo_id],
         )
@@ -1682,16 +1758,16 @@ fn promote_staged_code_snapshot(
                 path: config.index_path.clone(),
                 source,
             }))?;
-        stale_rows += transaction
-            .execute(
-                "UPDATE code_diagnostics SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'",
-                params![repo_id, path],
-            )
-            .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
-                path: config.index_path.clone(),
-                source,
-            }))?;
     }
+    stale_rows += transaction
+        .execute(
+            "UPDATE code_diagnostics AS current SET freshness = 'stale' WHERE current.repo_id = ? AND current.freshness = 'current' AND EXISTS (SELECT 1 FROM code_diagnostics AS staged WHERE staged.repo_id = current.repo_id AND staged.path = current.path AND staged.commit_sha = ? AND staged.freshness = 'staged')",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
     transaction
         .execute(
             "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) SELECT repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, 'current' FROM code_documents_staging WHERE repo_id = ? AND commit_sha = ?",
@@ -1704,6 +1780,24 @@ fn promote_staged_code_snapshot(
     transaction
         .execute(
             "DELETE FROM code_documents_staging WHERE repo_id = ? AND commit_sha = ?",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
+            "INSERT OR REPLACE INTO code_skipped_files (repo_id, commit_sha, worktree_dirty, path, reason, content_sha256, indexed_at, freshness) SELECT repo_id, commit_sha, false, path, reason, content_sha256, indexed_at, 'current' FROM code_skipped_files_staging WHERE repo_id = ? AND commit_sha = ?",
+            params![repo_id, commit_sha],
+        )
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        }))?;
+    transaction
+        .execute(
+            "DELETE FROM code_skipped_files_staging WHERE repo_id = ? AND commit_sha = ?",
             params![repo_id, commit_sha],
         )
         .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::DuckDb {
@@ -2877,7 +2971,7 @@ fn code_edge_revision_rows_available(
     }
     let mut statement = connection
         .prepare(
-            "SELECT 1 FROM code_edge_revisions WHERE repo_id = ? AND commit_sha = ? AND NOT worktree_dirty LIMIT 1",
+            "SELECT 1 FROM code_edge_revisions WHERE repo_id = ? AND commit_sha = ? AND freshness <> 'staged' AND NOT worktree_dirty LIMIT 1",
         )
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
@@ -3389,9 +3483,9 @@ fn revision_path_has_symbols(
     let membership_ready =
         code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
     let query = if membership_ready {
-        "SELECT 1 FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.content_sha256 = ? AND s.parser_version = ? AND s.query_pack_version = ? AND s.symbol_key != '' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version)) LIMIT 1"
+        "SELECT 1 FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.content_sha256 = ? AND s.parser_version = ? AND s.query_pack_version = ? AND s.symbol_key != '' AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version)) LIMIT 1"
     } else {
-        "SELECT 1 FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.content_sha256 = ? AND s.parser_version = ? AND s.query_pack_version = ? AND s.symbol_key != '' AND NOT s.worktree_dirty AND s.commit_sha = ? LIMIT 1"
+        "SELECT 1 FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.content_sha256 = ? AND s.parser_version = ? AND s.query_pack_version = ? AND s.symbol_key != '' AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND s.commit_sha = ? LIMIT 1"
     };
     let mut statement = connection
         .prepare(query)
@@ -4164,6 +4258,58 @@ mod code_graph_tests {
                 });
             }
         });
+    }
+
+    #[test]
+    fn target_index_reparses_unchanged_dirty_documents() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::write(repo.path().join("WORKFLOW.md"), "Target branch: `develop`\n")
+            .expect("workflow marker");
+        fs::write(repo.path().join("src.rs"), "pub fn indexed() {}\n").expect("source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "dirty reuse baseline"]);
+
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        index_code_repository(&config, "dirty-reuse-repo").expect("baseline index");
+        let source = fs::read_to_string(repo.path().join("src.rs")).expect("source");
+        let summary = parse_path(Path::new("src.rs"), &source).expect("parse");
+        let mut remaining_matches = config.code_intel.ast.max_matches_per_request;
+        let document = code_index_document(
+            PathBuf::from("src.rs"),
+            &source,
+            &summary,
+            &mut remaining_matches,
+            config.code_intel.ast.max_capture_bytes,
+        );
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "dirty-reuse-repo".to_string(),
+                commit_sha: Some("workspace-dirty".to_string()),
+                worktree_dirty: true,
+                documents: vec![document],
+            },
+        )
+        .expect("dirty document should persist");
+
+        git(repo.path(), &["commit", "--allow-empty", "-m", "dirty reuse advance"]);
+        let report = index_code_repository(&config, "dirty-reuse-repo")
+            .expect("unchanged dirty document should be reparsed");
+        assert!(report.parsed_files > 0);
+        let connection = open_existing_index_read_only(&config)
+            .expect("index should open")
+            .expect("index should exist");
+        let dirty_current: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current' AND worktree_dirty",
+                duckdb::params!["dirty-reuse-repo", "src.rs"],
+                |row| row.get(0),
+            )
+            .expect("dirty row count should be readable");
+        assert_eq!(dirty_current, 0);
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -610,6 +610,15 @@ pub fn code_index_target(
     Ok(Some((branch, commit)))
 }
 
+pub fn code_index_repository_is_git(config: &MemoryConfig) -> bool {
+    Command::new("git")
+        .args(["-C"])
+        .arg(&config.repo_root)
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
 pub fn index_code_repository(
     config: &MemoryConfig,
     repo_id: &str,
@@ -2380,17 +2389,31 @@ fn query_retained_inbound_impact_count(
     symbol: &CodeSymbolRecord,
     changed_symbol_keys: &BTreeSet<String>,
 ) -> Result<usize, MemoryError> {
-    let edge_table = if let Some(commit_sha) = symbol.commit_sha.as_deref()
+    let membership_edges = if let Some(commit_sha) = symbol.commit_sha.as_deref() {
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && code_snapshot_status(connection, config, &symbol.repo_id, commit_sha)?
+                == Some("completed".to_string())
+            && code_edge_revisions_read_model_ready(connection, &config.index_path)?
+    } else {
+        false
+    };
+    let edge_table = if !membership_edges
+        && let Some(commit_sha) = symbol.commit_sha.as_deref()
         && code_edge_revision_rows_available(connection, config, &symbol.repo_id, commit_sha)?
     {
         "code_edge_revisions"
     } else {
         "code_edges"
     };
-    let mut statement = connection
-        .prepare(&format!(
+    let query = if membership_edges {
+        "SELECT DISTINCT e.edge_id, e.source_symbol_key FROM code_edge_revisions AS e WHERE e.repo_id = ? AND e.target_symbol_key = ? AND NOT e.worktree_dirty AND (lower(e.edge_kind) LIKE '%call%' OR lower(e.edge_kind) LIKE '%reference%') AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed))"
+    } else {
+        &format!(
             "SELECT DISTINCT edge_id, source_symbol_key FROM {edge_table} WHERE repo_id = ? AND target_symbol_key = ? AND NOT worktree_dirty AND (lower(edge_kind) LIKE '%call%' OR lower(edge_kind) LIKE '%reference%') AND (commit_sha = ? OR (? IS NULL AND commit_sha IS NULL))"
-        ))
+        )
+    };
+    let mut statement = connection
+        .prepare(query)
         .map_err(|source| MemoryError::DuckDb {
             path: config.index_path.clone(),
             source,

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -587,6 +587,15 @@ CREATE TABLE IF NOT EXISTS code_skipped_files (
   freshness TEXT NOT NULL,
   PRIMARY KEY (repo_id, commit_sha, path, content_sha256)
 );
+CREATE TABLE IF NOT EXISTS code_skipped_files_staging (
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  path TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  indexed_at TEXT NOT NULL,
+  PRIMARY KEY (repo_id, commit_sha, path, content_sha256)
+);
 CREATE TABLE IF NOT EXISTS code_diagnostics (
   diagnostic_id TEXT PRIMARY KEY,
   repo_id TEXT NOT NULL,
@@ -712,6 +721,7 @@ CREATE INDEX IF NOT EXISTS idx_code_diagnostics_path ON code_diagnostics(path);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostic_revisions_path ON code_diagnostic_revisions(repo_id, commit_sha, path);
 CREATE INDEX IF NOT EXISTS idx_code_snapshot_membership_staging_repo ON code_snapshot_membership_staging(repo_id, run_id);
 CREATE INDEX IF NOT EXISTS idx_code_documents_staging_repo ON code_documents_staging(repo_id, commit_sha);
+CREATE INDEX IF NOT EXISTS idx_code_skipped_files_staging_repo ON code_skipped_files_staging(repo_id, commit_sha);
 "#,
     ))?;
     for table in [
@@ -1225,9 +1235,28 @@ pub(crate) fn persist_code_intel_skipped_files_with_freshness(
                     source,
                 })?;
         }
-        transaction
-            .execute(
-                "INSERT OR REPLACE INTO code_skipped_files (repo_id, commit_sha, worktree_dirty, path, reason, content_sha256, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        let table = if freshness == "staged" {
+            "code_skipped_files_staging"
+        } else {
+            "code_skipped_files"
+        };
+        let query = if freshness == "staged" {
+            format!(
+                "INSERT OR REPLACE INTO {table} (repo_id, commit_sha, path, reason, content_sha256, indexed_at) VALUES (?, ?, ?, ?, ?, ?)"
+            )
+        } else {
+            format!(
+                "INSERT OR REPLACE INTO {table} (repo_id, commit_sha, worktree_dirty, path, reason, content_sha256, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+        };
+        let result = if freshness == "staged" {
+            transaction.execute(
+                &query,
+                params![repo_id, commit_sha, path, skipped.reason, skipped.content_sha256, indexed_at],
+            )
+        } else {
+            transaction.execute(
+                &query,
                 params![
                     repo_id,
                     commit_sha,
@@ -1239,6 +1268,8 @@ pub(crate) fn persist_code_intel_skipped_files_with_freshness(
                     freshness,
                 ],
             )
+        };
+        result
             .map_err(|source| MemoryError::DuckDb {
                 path: config.index_path.clone(),
                 source,
@@ -3367,6 +3398,49 @@ mod index_tests {
             .expect("dirty current document should remain queryable");
         assert_eq!(commit_sha, "workspace-commit");
         assert!(worktree_dirty);
+        drop(connection);
+
+        persist_code_intel_skipped_files(
+            &config,
+            "dirty-skipped-repo",
+            Some("workspace-commit"),
+            false,
+            &[CodeIntelSkippedFileInput {
+                path: PathBuf::from("src/skipped.rs"),
+                reason: "unsupported".to_string(),
+                content_sha256: "skipped-hash".to_string(),
+            }],
+        )
+        .expect("current skipped row should persist");
+        persist_code_intel_skipped_files_with_freshness(
+            &config,
+            "dirty-skipped-repo",
+            Some("workspace-commit"),
+            false,
+            &[CodeIntelSkippedFileInput {
+                path: PathBuf::from("src/skipped.rs"),
+                reason: "unsupported".to_string(),
+                content_sha256: "skipped-hash".to_string(),
+            }],
+            "staged",
+            false,
+        )
+        .expect("staged skipped row should not replace current coverage");
+        let connection = Connection::open(&config.index_path).expect("index should open");
+        let (freshness, staged_count): (String, i64) = connection
+            .query_row(
+                "SELECT (SELECT freshness FROM code_skipped_files WHERE repo_id = ? AND path = ?), (SELECT COUNT(*) FROM code_skipped_files_staging WHERE repo_id = ? AND path = ?)",
+                params![
+                    "dirty-skipped-repo",
+                    "src/skipped.rs",
+                    "dirty-skipped-repo",
+                    "src/skipped.rs"
+                ],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("skipped staging rows should be readable");
+        assert_eq!(freshness, "current");
+        assert_eq!(staged_count, 1);
         drop(connection);
 
         persist_code_intel_documents_with_freshness(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -1809,6 +1809,9 @@ fn query_symbols_for_revision(
         let Some(mut symbol) = row else {
             continue;
         };
+        if symbol.commit_sha.as_deref() != Some(revision) {
+            symbol.commit_sha = Some(revision.to_string());
+        }
         if !symbols.contains_key(&symbol.symbol_key) {
             fill_container_chain(connection, &mut symbol)?;
             symbols.insert(symbol.symbol_key.clone(), symbol);

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -851,43 +851,61 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
         );
         for prepared in &prepared_symbols {
             let symbol = prepared.symbol;
-            transaction
-                .execute(
-                    "INSERT OR REPLACE INTO code_symbols (symbol_id, symbol_key, repo_id, commit_sha, worktree_dirty, path, language, kind, name, container_symbol_id, container_chain, signature, start_line, start_col, end_line, end_col, start_byte, end_byte, selection_start_line, selection_end_line, content_sha256, snippet_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    params![
-                        prepared.symbol_id,
-                        prepared.symbol_key,
-                        batch.repo_id,
-                        batch.commit_sha.clone(),
-                        worktree_dirty,
-                        path,
-                        document.language,
-                        symbol.kind,
-                        symbol.name,
-                        prepared.container_symbol_id,
-                        symbol.container_chain.join("\u{1f}"),
-                        symbol.signature,
-                        symbol.start_line as i64,
-                        symbol.start_col as i64,
-                        symbol.end_line as i64,
-                        symbol.end_col as i64,
-                        symbol.start_byte as i64,
-                        symbol.end_byte as i64,
-                        symbol.selection_start_line as i64,
-                        symbol.selection_end_line as i64,
-                        document.content_sha256,
-                        symbol.snippet_sha256,
-                        document.parser_version,
-                        document.query_pack_version,
-                        indexed_at,
-                        freshness,
-                    ],
-                )
-                .map_err(|source| MemoryError::DuckDb {
-                    path: config.index_path.clone(),
-                    source,
-                })?;
-            report.persisted_symbols += 1;
+            let current_symbol_exists = if freshness == "staged" {
+                transaction
+                    .query_row(
+                        "SELECT 1 FROM code_symbols WHERE symbol_id = ? AND freshness = 'current' LIMIT 1",
+                        params![prepared.symbol_id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .optional()
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?
+                    .is_some()
+            } else {
+                false
+            };
+            if !current_symbol_exists {
+                transaction
+                    .execute(
+                        "INSERT OR REPLACE INTO code_symbols (symbol_id, symbol_key, repo_id, commit_sha, worktree_dirty, path, language, kind, name, container_symbol_id, container_chain, signature, start_line, start_col, end_line, end_col, start_byte, end_byte, selection_start_line, selection_end_line, content_sha256, snippet_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        params![
+                            prepared.symbol_id,
+                            prepared.symbol_key,
+                            batch.repo_id,
+                            batch.commit_sha.clone(),
+                            worktree_dirty,
+                            path,
+                            document.language,
+                            symbol.kind,
+                            symbol.name,
+                            prepared.container_symbol_id,
+                            symbol.container_chain.join("\u{1f}"),
+                            symbol.signature,
+                            symbol.start_line as i64,
+                            symbol.start_col as i64,
+                            symbol.end_line as i64,
+                            symbol.end_col as i64,
+                            symbol.start_byte as i64,
+                            symbol.end_byte as i64,
+                            symbol.selection_start_line as i64,
+                            symbol.selection_end_line as i64,
+                            document.content_sha256,
+                            symbol.snippet_sha256,
+                            document.parser_version,
+                            document.query_pack_version,
+                            indexed_at,
+                            freshness,
+                        ],
+                    )
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?;
+                report.persisted_symbols += 1;
+            }
         }
 
         for edge in &document.edges {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -595,6 +595,29 @@ CREATE TABLE IF NOT EXISTS code_diagnostics (
   indexed_at TEXT NOT NULL,
   freshness TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS code_diagnostic_revisions (
+  diagnostic_id TEXT NOT NULL,
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  worktree_dirty BOOLEAN NOT NULL,
+  path TEXT NOT NULL,
+  language TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  message TEXT NOT NULL,
+  start_line BIGINT NOT NULL,
+  start_col BIGINT NOT NULL,
+  end_line BIGINT NOT NULL,
+  end_col BIGINT NOT NULL,
+  start_byte BIGINT NOT NULL,
+  end_byte BIGINT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  parser_version TEXT NOT NULL,
+  query_pack_version TEXT NOT NULL,
+  indexed_at TEXT NOT NULL,
+  freshness TEXT NOT NULL,
+  PRIMARY KEY (repo_id, commit_sha, diagnostic_id)
+);
 CREATE TABLE IF NOT EXISTS code_index_snapshots (
   repo_id TEXT NOT NULL,
   commit_sha TEXT NOT NULL,
@@ -657,6 +680,7 @@ CREATE INDEX IF NOT EXISTS idx_code_edges_target_key ON code_edges(target_symbol
 CREATE INDEX IF NOT EXISTS idx_code_edge_revisions_target_key ON code_edge_revisions(target_symbol_key);
 CREATE INDEX IF NOT EXISTS idx_code_skipped_files_revision ON code_skipped_files(repo_id, commit_sha, path);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostics_path ON code_diagnostics(path);
+CREATE INDEX IF NOT EXISTS idx_code_diagnostic_revisions_path ON code_diagnostic_revisions(repo_id, commit_sha, path);
 "#,
     ))?;
     for table in [
@@ -928,7 +952,6 @@ pub fn persist_code_intel_documents(
         for diagnostic in &document.diagnostics {
             let diagnostic_id = code_row_id(&[
                 &batch.repo_id,
-                batch.commit_sha.as_deref().unwrap_or(""),
                 &path,
                 &document.content_sha256,
                 &document.parser_version,
@@ -946,7 +969,7 @@ pub fn persist_code_intel_documents(
                 .execute(
                     "INSERT OR REPLACE INTO code_diagnostics (diagnostic_id, repo_id, commit_sha, worktree_dirty, path, language, kind, severity, message, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
-                        diagnostic_id,
+                        &diagnostic_id,
                         batch.repo_id,
                         batch.commit_sha.clone(),
                         worktree_dirty,
@@ -972,6 +995,40 @@ pub fn persist_code_intel_documents(
                     path: config.index_path.clone(),
                     source,
                 })?;
+            if !batch.worktree_dirty
+                && let Some(commit_sha) = batch.commit_sha.as_deref()
+            {
+                transaction
+                    .execute(
+                        "INSERT OR REPLACE INTO code_diagnostic_revisions (diagnostic_id, repo_id, commit_sha, worktree_dirty, path, language, kind, severity, message, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        params![
+                            &diagnostic_id,
+                            batch.repo_id,
+                            commit_sha,
+                            worktree_dirty,
+                            path,
+                            document.language,
+                            diagnostic.kind,
+                            diagnostic.severity,
+                            diagnostic.message,
+                            diagnostic.start_line as i64,
+                            diagnostic.start_col as i64,
+                            diagnostic.end_line as i64,
+                            diagnostic.end_col as i64,
+                            diagnostic.start_byte as i64,
+                            diagnostic.end_byte as i64,
+                            document.content_sha256,
+                            document.parser_version,
+                            document.query_pack_version,
+                            indexed_at,
+                            MemoryFreshness::Current.as_str(),
+                        ],
+                    )
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?;
+            }
             report.persisted_diagnostics += 1;
         }
     }

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -626,6 +626,7 @@ CREATE TABLE IF NOT EXISTS code_index_snapshots (
   parsed_files BIGINT NOT NULL,
   skipped_files BIGINT NOT NULL,
   deleted_files BIGINT NOT NULL,
+  config_fingerprint TEXT NOT NULL DEFAULT '',
   indexed_at TEXT NOT NULL,
   PRIMARY KEY (repo_id, commit_sha)
 );
@@ -668,6 +669,7 @@ ALTER TABLE code_diagnostics ADD COLUMN IF NOT EXISTS end_byte BIGINT DEFAULT 0;
 UPDATE code_diagnostics SET end_byte = 0 WHERE end_byte IS NULL;
 ALTER TABLE code_diagnostics ADD COLUMN IF NOT EXISTS parser_version TEXT DEFAULT '';
 UPDATE code_diagnostics SET parser_version = '' WHERE parser_version IS NULL;
+ALTER TABLE code_index_snapshots ADD COLUMN IF NOT EXISTS config_fingerprint TEXT DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_code_symbols_name ON code_symbols(name);
 CREATE INDEX IF NOT EXISTS idx_code_symbols_key ON code_symbols(symbol_key);
 CREATE INDEX IF NOT EXISTS idx_code_symbols_path ON code_symbols(path);
@@ -771,7 +773,7 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
         let current_document_exists = if freshness == "staged" {
             transaction
                 .query_row(
-                    "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' LIMIT 1",
+                    "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
                     params![
                         batch.repo_id,
                         path,
@@ -930,7 +932,7 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
             let current_edge_exists = if freshness == "staged" {
                 transaction
                     .query_row(
-                        "SELECT 1 FROM code_edges WHERE edge_id = ? AND freshness = 'current' LIMIT 1",
+                        "SELECT 1 FROM code_edges WHERE edge_id = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
                         params![edge_id],
                         |row| row.get::<_, i64>(0),
                     )
@@ -1039,7 +1041,7 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
             let current_diagnostic_exists = if freshness == "staged" {
                 transaction
                     .query_row(
-                        "SELECT 1 FROM code_diagnostics WHERE diagnostic_id = ? AND freshness = 'current' LIMIT 1",
+                        "SELECT 1 FROM code_diagnostics WHERE diagnostic_id = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
                         params![&diagnostic_id],
                         |row| row.get::<_, i64>(0),
                     )

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -466,6 +466,21 @@ CREATE TABLE IF NOT EXISTS code_documents (
   freshness TEXT NOT NULL,
   PRIMARY KEY (repo_id, path, content_sha256, parser_version, query_pack_version)
 );
+CREATE TABLE IF NOT EXISTS code_documents_staging (
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  worktree_dirty BOOLEAN NOT NULL,
+  path TEXT NOT NULL,
+  language TEXT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  parser_id TEXT NOT NULL,
+  parser_version TEXT NOT NULL,
+  query_pack_version TEXT NOT NULL,
+  byte_len BIGINT NOT NULL,
+  line_count BIGINT NOT NULL,
+  indexed_at TEXT NOT NULL,
+  PRIMARY KEY (repo_id, commit_sha, path, parser_version, query_pack_version)
+);
 CREATE TABLE IF NOT EXISTS code_document_revisions (
   repo_id TEXT NOT NULL,
   commit_sha TEXT NOT NULL,
@@ -696,6 +711,7 @@ CREATE INDEX IF NOT EXISTS idx_code_skipped_files_revision ON code_skipped_files
 CREATE INDEX IF NOT EXISTS idx_code_diagnostics_path ON code_diagnostics(path);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostic_revisions_path ON code_diagnostic_revisions(repo_id, commit_sha, path);
 CREATE INDEX IF NOT EXISTS idx_code_snapshot_membership_staging_repo ON code_snapshot_membership_staging(repo_id, run_id);
+CREATE INDEX IF NOT EXISTS idx_code_documents_staging_repo ON code_documents_staging(repo_id, commit_sha);
 "#,
     ))?;
     for table in [
@@ -784,29 +800,36 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
             })?;
         }
 
-        let current_document_exists = if freshness == "staged" {
+        if freshness == "staged" {
+            let Some(commit_sha) = batch.commit_sha.as_deref() else {
+                return Err(MemoryError::InvalidInput(
+                    "staged code documents require a commit revision".to_string(),
+                ));
+            };
             transaction
-                .query_row(
-                    "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
+                .execute(
+                    "INSERT OR REPLACE INTO code_documents_staging (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
                         batch.repo_id,
+                        commit_sha,
+                        worktree_dirty,
                         path,
+                        document.language,
                         document.content_sha256,
+                        document.parser_id,
                         document.parser_version,
                         document.query_pack_version,
+                        document.byte_len as i64,
+                        document.line_count as i64,
+                        indexed_at,
                     ],
-                    |row| row.get::<_, i64>(0),
                 )
-                .optional()
                 .map_err(|source| MemoryError::DuckDb {
                     path: config.index_path.clone(),
                     source,
-                })?
-                .is_some()
+                })?;
+            report.persisted_documents += 1;
         } else {
-            false
-        };
-        if !current_document_exists {
             transaction
                 .execute(
                     "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -3304,6 +3327,46 @@ mod index_tests {
             )
             .expect("staged diagnostic should remain visible to promotion");
         assert_eq!(staged_diagnostics, 1);
+        drop(connection);
+
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "dirty-repo".to_string(),
+                commit_sha: Some("workspace-commit".to_string()),
+                worktree_dirty: true,
+                documents: vec![test_code_document_with_edges_and_diagnostics(
+                    "src/reused.rs",
+                    "same-hash",
+                )],
+            },
+        )
+        .expect("dirty current document should persist");
+        persist_code_intel_documents_with_freshness(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "dirty-repo".to_string(),
+                commit_sha: Some("next-commit".to_string()),
+                worktree_dirty: false,
+                documents: vec![test_code_document_with_edges_and_diagnostics(
+                    "src/reused.rs",
+                    "same-hash",
+                )],
+            },
+            "staged",
+            false,
+        )
+        .expect("staged document should not replace a dirty current row");
+        let connection = Connection::open(&config.index_path).expect("index should open");
+        let (commit_sha, worktree_dirty): (String, bool) = connection
+            .query_row(
+                "SELECT commit_sha, worktree_dirty FROM code_documents WHERE repo_id = ? AND path = ? AND freshness = 'current'",
+                params!["dirty-repo", "src/reused.rs"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("dirty current document should remain queryable");
+        assert_eq!(commit_sha, "workspace-commit");
+        assert!(worktree_dirty);
         drop(connection);
 
         persist_code_intel_documents_with_freshness(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -595,6 +595,30 @@ CREATE TABLE IF NOT EXISTS code_diagnostics (
   indexed_at TEXT NOT NULL,
   freshness TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS code_index_snapshots (
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  target_branch TEXT NOT NULL,
+  status TEXT NOT NULL,
+  total_files BIGINT NOT NULL,
+  parsed_files BIGINT NOT NULL,
+  skipped_files BIGINT NOT NULL,
+  deleted_files BIGINT NOT NULL,
+  indexed_at TEXT NOT NULL,
+  PRIMARY KEY (repo_id, commit_sha)
+);
+CREATE TABLE IF NOT EXISTS code_snapshot_membership (
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  path TEXT NOT NULL,
+  language TEXT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  parser_version TEXT NOT NULL,
+  query_pack_version TEXT NOT NULL,
+  analyzed BOOLEAN NOT NULL,
+  skip_reason TEXT,
+  PRIMARY KEY (repo_id, commit_sha, path)
+);
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS symbol_key TEXT DEFAULT '';
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS container_chain TEXT DEFAULT '';
 UPDATE code_symbols SET container_chain = '' WHERE container_chain IS NULL;
@@ -904,6 +928,7 @@ pub fn persist_code_intel_documents(
         for diagnostic in &document.diagnostics {
             let diagnostic_id = code_row_id(&[
                 &batch.repo_id,
+                batch.commit_sha.as_deref().unwrap_or(""),
                 &path,
                 &document.content_sha256,
                 &document.parser_version,
@@ -1494,8 +1519,8 @@ pub fn compare_code_symbols(
             dropped_records: 0,
         });
     }
-    let base = query_symbols_for_revision(&connection, repo_id, base_revision)?;
-    let head = query_symbols_for_revision(&connection, repo_id, head_revision)?;
+    let base = query_symbols_for_revision(config, &connection, repo_id, base_revision)?;
+    let head = query_symbols_for_revision(config, &connection, repo_id, head_revision)?;
     let mut keys = base.keys().cloned().collect::<BTreeSet<_>>();
     keys.extend(head.keys().cloned());
     let mut diffs = Vec::new();
@@ -1628,36 +1653,63 @@ fn query_code_symbol_for_edge(
 }
 
 fn query_symbols_for_revision(
+    config: &MemoryConfig,
     connection: &Connection,
     repo_id: &str,
     revision: &str,
 ) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
-    let mut statement = connection
-        .prepare(
-            &format!("SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' ORDER BY symbol_key, indexed_at DESC, symbol_id"),
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
+    let query = if membership_ready {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END FROM code_symbols AS s WHERE s.repo_id = ? AND s.symbol_key != '' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed)) ORDER BY s.symbol_key, s.indexed_at DESC, s.symbol_id"
         )
+    } else {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' ORDER BY symbol_key, indexed_at DESC, symbol_id"
+        )
+    };
+    let mut statement = connection
+        .prepare(&query)
         .map_err(|source| MemoryError::DuckDb {
             path: PathBuf::from("<memory-index>"),
             source,
         })?;
-    let rows = statement
-        .query_map(params![repo_id, revision], |row| {
-            let dirty = row.get::<_, i64>(25)?;
-            if dirty != 0 {
-                Ok(None)
-            } else {
-                code_symbol_from_row(row).map(Some)
-            }
-        })
-        .map_err(|source| MemoryError::DuckDb {
-            path: PathBuf::from("<memory-index>"),
-            source,
-        })?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|source| MemoryError::DuckDb {
-            path: PathBuf::from("<memory-index>"),
-            source,
-        })?;
+    let rows = if membership_ready {
+        statement
+            .query_map(params![repo_id, revision, revision], |row| {
+                let dirty = row.get::<_, i64>(25)?;
+                if dirty != 0 {
+                    Ok(None)
+                } else {
+                    code_symbol_from_row(row).map(Some)
+                }
+            })
+            .map_err(|source| MemoryError::DuckDb {
+                path: PathBuf::from("<memory-index>"),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+    } else {
+        statement
+            .query_map(params![repo_id, revision], |row| {
+                let dirty = row.get::<_, i64>(25)?;
+                if dirty != 0 {
+                    Ok(None)
+                } else {
+                    code_symbol_from_row(row).map(Some)
+                }
+            })
+            .map_err(|source| MemoryError::DuckDb {
+                path: PathBuf::from("<memory-index>"),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+    }
+    .map_err(|source| MemoryError::DuckDb {
+        path: PathBuf::from("<memory-index>"),
+        source,
+    })?;
     let mut symbols = BTreeMap::new();
     for row in rows {
         let Some(mut symbol) = row else {
@@ -1830,20 +1882,12 @@ fn stale_code_rows(
         params![key.repo_id, key.path, key.content_sha256, key.parser_version, key.query_pack_version],
     )?;
     stale_rows += connection.execute(
-        "UPDATE code_document_revisions SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current' AND NOT (content_sha256 = ? AND parser_version = ? AND query_pack_version = ?)",
-        params![key.repo_id, key.path, key.content_sha256, key.parser_version, key.query_pack_version],
-    )?;
-    stale_rows += connection.execute(
         "UPDATE code_symbols SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current' AND NOT (content_sha256 = ? AND parser_version = ? AND query_pack_version = ?)",
         params![key.repo_id, key.path, key.content_sha256, key.parser_version, key.query_pack_version],
     )?;
     stale_rows += connection.execute(
         "UPDATE code_edges SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current' AND NOT (content_sha256 = ? AND parser_version = ? AND query_pack_version = ?)",
         params![key.repo_id, key.path, key.content_sha256, key.parser_version, key.query_pack_version],
-    )?;
-    stale_rows += connection.execute(
-        "UPDATE code_skipped_files SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'",
-        params![key.repo_id, key.path],
     )?;
     stale_rows += connection.execute(
         "UPDATE code_diagnostics SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current' AND NOT (content_sha256 = ? AND parser_version = ? AND query_pack_version = ?)",
@@ -1860,10 +1904,6 @@ fn stale_code_rows_for_skipped_file(
     let mut stale_rows = 0;
     stale_rows += connection.execute(
         "UPDATE code_documents SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'",
-        params![repo_id, path],
-    )?;
-    stale_rows += connection.execute(
-        "UPDATE code_document_revisions SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current'",
         params![repo_id, path],
     )?;
     stale_rows += connection.execute(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -756,6 +756,7 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
                 &CodeFreshnessKey {
                     repo_id: &batch.repo_id,
                     path: &path,
+                    commit_sha: batch.commit_sha.as_deref(),
                     content_sha256: &document.content_sha256,
                     parser_version: &document.parser_version,
                     query_pack_version: &document.query_pack_version,
@@ -1665,15 +1666,14 @@ fn query_code_symbol_by_key(
     symbol_key: &str,
     current_only: bool,
 ) -> Result<Option<CodeSymbolRecord>, MemoryError> {
-    let sql = if current_only {
-        format!(
-            "SELECT {CODE_SYMBOL_SELECT} FROM code_symbols WHERE symbol_key = ? AND freshness = 'current' ORDER BY indexed_at DESC, symbol_id LIMIT 1"
-        )
+    let freshness = if current_only {
+        "freshness = 'current'"
     } else {
-        format!(
-            "SELECT {CODE_SYMBOL_SELECT} FROM code_symbols WHERE symbol_key = ? ORDER BY CASE WHEN freshness = 'current' THEN 0 ELSE 1 END, indexed_at DESC, symbol_id LIMIT 1"
-        )
+        code_freshness_filter(true)
     };
+    let sql = format!(
+        "SELECT {CODE_SYMBOL_SELECT} FROM code_symbols WHERE symbol_key = ? AND {freshness} ORDER BY CASE WHEN freshness = 'current' THEN 0 ELSE 1 END, indexed_at DESC, symbol_id LIMIT 1"
+    );
     let mut statement = connection
         .prepare(&sql)
         .map_err(|source| MemoryError::DuckDb {
@@ -1825,11 +1825,7 @@ fn query_edges_for_symbol_key_with_stale(
     symbol_key: &str,
     include_stale: bool,
 ) -> Result<Vec<CodeEdgeRecord>, MemoryError> {
-    let freshness = if include_stale {
-        "1 = 1"
-    } else {
-        "freshness = 'current'"
-    };
+    let freshness = code_freshness_filter(include_stale);
     let mut statement = connection
         .prepare(&format!(
             "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges WHERE {freshness} AND (source_symbol_key = ? OR target_symbol_key = ?) ORDER BY edge_kind, path, start_line, start_col, edge_id"
@@ -1964,6 +1960,7 @@ fn symbol_contains_point(symbol: &CodeSymbolRecord, line: usize, column: usize) 
 struct CodeFreshnessKey<'a> {
     repo_id: &'a str,
     path: &'a str,
+    commit_sha: Option<&'a str>,
     content_sha256: &'a str,
     parser_version: &'a str,
     query_pack_version: &'a str,
@@ -1990,6 +1987,12 @@ fn stale_code_rows(
         "UPDATE code_diagnostics SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND freshness = 'current' AND NOT (content_sha256 = ? AND parser_version = ? AND query_pack_version = ?)",
         params![key.repo_id, key.path, key.content_sha256, key.parser_version, key.query_pack_version],
     )?;
+    if let Some(commit_sha) = key.commit_sha {
+        stale_rows += connection.execute(
+            "UPDATE code_skipped_files SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND commit_sha = ? AND freshness = 'current'",
+            params![key.repo_id, key.path, commit_sha],
+        )?;
+    }
     Ok(stale_rows)
 }
 
@@ -3071,6 +3074,22 @@ fn all_known_areas(config: &MemoryConfig, issues: &[IndexedIssue]) -> Vec<AreaCo
 mod index_tests {
     use super::*;
 
+    fn test_code_document(path: &str, content_sha256: &str) -> CodeIntelDocumentInput {
+        CodeIntelDocumentInput {
+            path: PathBuf::from(path),
+            language: "rust".to_string(),
+            content_sha256: content_sha256.to_string(),
+            parser_id: "tree-sitter".to_string(),
+            parser_version: "test-parser".to_string(),
+            query_pack_version: "test-query-pack".to_string(),
+            byte_len: 1,
+            line_count: 1,
+            symbols: Vec::new(),
+            edges: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
     #[test]
     fn issue_log_date_uses_stable_sentinel_for_malformed_timestamps() {
         let issue = IndexedIssue {
@@ -3102,5 +3121,80 @@ mod index_tests {
         };
 
         assert_eq!(issue_log_date(&issue), UNDATED_LOG_DATE);
+    }
+
+    #[test]
+    fn staged_code_rows_are_hidden_and_parsed_files_stale_same_revision_skips() {
+        let repo = tempfile::TempDir::new().expect("repository tempdir");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+
+        persist_code_intel_documents_with_freshness(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "fixture-repo".to_string(),
+                commit_sha: Some("staged-commit".to_string()),
+                worktree_dirty: false,
+                documents: vec![test_code_document("src/staged.rs", "staged-hash")],
+            },
+            "staged",
+            false,
+        )
+        .expect("staged document should persist");
+        assert!(
+            code_graph_repos(&config, true)
+                .expect("staged rows should be hidden")
+                .repos
+                .is_empty()
+        );
+
+        persist_code_intel_skipped_files(
+            &config,
+            "fixture-repo",
+            Some("commit"),
+            false,
+            &[CodeIntelSkippedFileInput {
+                path: PathBuf::from("src/lib.rs"),
+                reason: "oversized".to_string(),
+                content_sha256: "skipped-hash".to_string(),
+            }],
+        )
+        .expect("skip coverage should persist");
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "fixture-repo".to_string(),
+                commit_sha: Some("commit".to_string()),
+                worktree_dirty: false,
+                documents: vec![test_code_document("src/lib.rs", "parsed-hash")],
+            },
+        )
+        .expect("parsed document should persist");
+
+        let connection = Connection::open(&config.index_path).expect("index should open");
+        let freshness: String = connection
+            .query_row(
+                "SELECT freshness FROM code_skipped_files WHERE repo_id = ? AND path = ? AND commit_sha = ?",
+                params!["fixture-repo", "src/lib.rs", "commit"],
+                |row| row.get(0),
+            )
+            .expect("skip coverage should remain queryable");
+        assert_eq!(freshness, "stale");
+    }
+
+    #[test]
+    fn configured_target_branch_rejects_invalid_git_branch_marker() {
+        let repo = tempfile::TempDir::new().expect("repository tempdir");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "## Branch target\n\nTarget branch: `HEAD`\n",
+        )
+        .expect("workflow marker");
+
+        let result = configured_code_index_branch(repo.path());
+        assert!(matches!(
+            result,
+            Err(CodeGraphProjectionError::InvalidRequest(message))
+                if message == "configured target branch is invalid"
+        ));
     }
 }

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -768,30 +768,54 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
             })?;
         }
 
-        transaction
-            .execute(
-                "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        let current_document_exists = if freshness == "staged" {
+            transaction
+                .query_row(
+                    "SELECT 1 FROM code_documents WHERE repo_id = ? AND path = ? AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND freshness = 'current' LIMIT 1",
                     params![
                         batch.repo_id,
-                    batch.commit_sha.clone(),
+                        path,
+                        document.content_sha256,
+                        document.parser_version,
+                        document.query_pack_version,
+                    ],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?
+                .is_some()
+        } else {
+            false
+        };
+        if !current_document_exists {
+            transaction
+                .execute(
+                    "INSERT OR REPLACE INTO code_documents (repo_id, commit_sha, worktree_dirty, path, language, content_sha256, parser_id, parser_version, query_pack_version, byte_len, line_count, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        batch.repo_id,
+                        batch.commit_sha.clone(),
                         worktree_dirty,
-                    path,
-                    document.language,
-                    document.content_sha256,
-                    document.parser_id,
-                    document.parser_version,
-                    document.query_pack_version,
-                    document.byte_len as i64,
-                    document.line_count as i64,
-                    indexed_at,
-                    freshness,
-                ],
-            )
-            .map_err(|source| MemoryError::DuckDb {
-                path: config.index_path.clone(),
-                source,
-        })?;
-        report.persisted_documents += 1;
+                        path,
+                        document.language,
+                        document.content_sha256,
+                        document.parser_id,
+                        document.parser_version,
+                        document.query_pack_version,
+                        document.byte_len as i64,
+                        document.line_count as i64,
+                        indexed_at,
+                        freshness,
+                    ],
+                )
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?;
+            report.persisted_documents += 1;
+        }
         if !batch.worktree_dirty
             && let Some(commit_sha) = batch.commit_sha.as_deref()
         {
@@ -3128,10 +3152,44 @@ mod index_tests {
         let repo = tempfile::TempDir::new().expect("repository tempdir");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
 
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "fixture-repo".to_string(),
+                commit_sha: Some("base-commit".to_string()),
+                worktree_dirty: false,
+                documents: vec![test_code_document("src/reused.rs", "same-hash")],
+            },
+        )
+        .expect("current document should persist");
         persist_code_intel_documents_with_freshness(
             &config,
             CodeIntelPersistBatch {
                 repo_id: "fixture-repo".to_string(),
+                commit_sha: Some("next-commit".to_string()),
+                worktree_dirty: false,
+                documents: vec![test_code_document("src/reused.rs", "same-hash")],
+            },
+            "staged",
+            false,
+        )
+        .expect("staged reuse should persist revision rows");
+        let connection = Connection::open(&config.index_path).expect("index should open");
+        let (commit_sha, freshness): (String, String) = connection
+            .query_row(
+                "SELECT commit_sha, freshness FROM code_documents WHERE repo_id = ? AND path = ?",
+                params!["fixture-repo", "src/reused.rs"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("current document should remain queryable");
+        assert_eq!(commit_sha, "base-commit");
+        assert_eq!(freshness, "current");
+        drop(connection);
+
+        persist_code_intel_documents_with_freshness(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "staged-repo".to_string(),
                 commit_sha: Some("staged-commit".to_string()),
                 worktree_dirty: false,
                 documents: vec![test_code_document("src/staged.rs", "staged-hash")],
@@ -3140,12 +3198,11 @@ mod index_tests {
             false,
         )
         .expect("staged document should persist");
-        assert!(
-            code_graph_repos(&config, true)
-                .expect("staged rows should be hidden")
-                .repos
-                .is_empty()
-        );
+        assert!(!code_graph_repos(&config, true)
+            .expect("staged rows should be hidden")
+            .repos
+            .iter()
+            .any(|repo| repo.repo_id == "staged-repo"));
 
         persist_code_intel_skipped_files(
             &config,

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -642,6 +642,19 @@ CREATE TABLE IF NOT EXISTS code_snapshot_membership (
   skip_reason TEXT,
   PRIMARY KEY (repo_id, commit_sha, path)
 );
+CREATE TABLE IF NOT EXISTS code_snapshot_membership_staging (
+  run_id TEXT NOT NULL,
+  repo_id TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  path TEXT NOT NULL,
+  language TEXT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  parser_version TEXT NOT NULL,
+  query_pack_version TEXT NOT NULL,
+  analyzed BOOLEAN NOT NULL,
+  skip_reason TEXT,
+  PRIMARY KEY (run_id, repo_id, commit_sha, path)
+);
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS symbol_key TEXT DEFAULT '';
 ALTER TABLE code_symbols ADD COLUMN IF NOT EXISTS container_chain TEXT DEFAULT '';
 UPDATE code_symbols SET container_chain = '' WHERE container_chain IS NULL;
@@ -682,6 +695,7 @@ CREATE INDEX IF NOT EXISTS idx_code_edge_revisions_target_key ON code_edge_revis
 CREATE INDEX IF NOT EXISTS idx_code_skipped_files_revision ON code_skipped_files(repo_id, commit_sha, path);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostics_path ON code_diagnostics(path);
 CREATE INDEX IF NOT EXISTS idx_code_diagnostic_revisions_path ON code_diagnostic_revisions(repo_id, commit_sha, path);
+CREATE INDEX IF NOT EXISTS idx_code_snapshot_membership_staging_repo ON code_snapshot_membership_staging(repo_id, run_id);
 "#,
     ))?;
     for table in [
@@ -1038,28 +1052,20 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
                 &diagnostic.start_byte.to_string(),
                 &diagnostic.end_byte.to_string(),
             ]);
-            let current_diagnostic_exists = if freshness == "staged" {
-                transaction
-                    .query_row(
-                        "SELECT 1 FROM code_diagnostics WHERE diagnostic_id = ? AND freshness = 'current' AND NOT worktree_dirty LIMIT 1",
-                        params![&diagnostic_id],
-                        |row| row.get::<_, i64>(0),
-                    )
-                    .optional()
-                    .map_err(|source| MemoryError::DuckDb {
-                        path: config.index_path.clone(),
-                        source,
-                    })?
-                    .is_some()
+            let read_model_diagnostic_id = if freshness == "staged" {
+                code_row_id(&[
+                    &diagnostic_id,
+                    batch.commit_sha.as_deref().unwrap_or(""),
+                    &indexed_at,
+                ])
             } else {
-                false
+                diagnostic_id.clone()
             };
-            if !current_diagnostic_exists {
-                transaction
+            transaction
                     .execute(
                         "INSERT OR REPLACE INTO code_diagnostics (diagnostic_id, repo_id, commit_sha, worktree_dirty, path, language, kind, severity, message, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                         params![
-                            &diagnostic_id,
+                            &read_model_diagnostic_id,
                             batch.repo_id,
                             batch.commit_sha.clone(),
                             worktree_dirty,
@@ -1081,11 +1087,10 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
                             freshness,
                         ],
                     )
-                    .map_err(|source| MemoryError::DuckDb {
-                        path: config.index_path.clone(),
-                        source,
-                    })?;
-            }
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?;
             if !batch.worktree_dirty
                 && let Some(commit_sha) = batch.commit_sha.as_deref()
             {
@@ -3284,13 +3289,21 @@ mod index_tests {
         assert_eq!(freshness, "current");
         let (commit_sha, freshness): (String, String) = connection
             .query_row(
-                "SELECT commit_sha, freshness FROM code_diagnostics WHERE repo_id = ? AND path = ?",
+                "SELECT commit_sha, freshness FROM code_diagnostics WHERE repo_id = ? AND path = ? AND freshness = 'current'",
                 params!["fixture-repo", "src/reused.rs"],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .expect("current diagnostic should remain queryable");
         assert_eq!(commit_sha, "base-commit");
         assert_eq!(freshness, "current");
+        let staged_diagnostics: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM code_diagnostics WHERE repo_id = ? AND path = ? AND commit_sha = ? AND freshness = 'staged'",
+                params!["fixture-repo", "src/reused.rs", "next-commit"],
+                |row| row.get(0),
+            )
+            .expect("staged diagnostic should remain visible to promotion");
+        assert_eq!(staged_diagnostics, 1);
         drop(connection);
 
         persist_code_intel_documents_with_freshness(

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -63,7 +63,6 @@ fn index_capture_plan(config: &MemoryConfig, plan: &CapturePlan) -> Result<(), M
                 path: config.index_path.clone(),
                 source,
             })?;
-
         transaction
             .execute(
                 "DELETE FROM issue_areas WHERE issue_key = ?",
@@ -717,6 +716,15 @@ pub fn persist_code_intel_documents(
     config: &MemoryConfig,
     batch: CodeIntelPersistBatch,
 ) -> Result<CodeIntelPersistReport, MemoryError> {
+    persist_code_intel_documents_with_freshness(config, batch, "current", true)
+}
+
+pub(crate) fn persist_code_intel_documents_with_freshness(
+    config: &MemoryConfig,
+    batch: CodeIntelPersistBatch,
+    freshness: &str,
+    stale_existing: bool,
+) -> Result<CodeIntelPersistReport, MemoryError> {
     let mut connection = open_index(config)?;
     migrate_index(&connection).map_err(|source| MemoryError::DuckDb {
         path: config.index_path.clone(),
@@ -742,20 +750,22 @@ pub fn persist_code_intel_documents(
     let worktree_dirty = if batch.worktree_dirty { 1_i64 } else { 0_i64 };
     for document in batch.documents {
         let path = document.path.to_string_lossy().to_string();
-        report.stale_rows += stale_code_rows(
-            &transaction,
-            &CodeFreshnessKey {
-                repo_id: &batch.repo_id,
-                path: &path,
-                content_sha256: &document.content_sha256,
-                parser_version: &document.parser_version,
-                query_pack_version: &document.query_pack_version,
-            },
-        )
-        .map_err(|source| MemoryError::DuckDb {
-            path: config.index_path.clone(),
-            source,
-        })?;
+        if stale_existing {
+            report.stale_rows += stale_code_rows(
+                &transaction,
+                &CodeFreshnessKey {
+                    repo_id: &batch.repo_id,
+                    path: &path,
+                    content_sha256: &document.content_sha256,
+                    parser_version: &document.parser_version,
+                    query_pack_version: &document.query_pack_version,
+                },
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        }
 
         transaction
             .execute(
@@ -773,7 +783,7 @@ pub fn persist_code_intel_documents(
                     document.byte_len as i64,
                     document.line_count as i64,
                     indexed_at,
-                    MemoryFreshness::Current.as_str(),
+                    freshness,
                 ],
             )
             .map_err(|source| MemoryError::DuckDb {
@@ -798,7 +808,7 @@ pub fn persist_code_intel_documents(
                         document.parser_version,
                         document.query_pack_version,
                         indexed_at,
-                        MemoryFreshness::Current.as_str(),
+                        freshness,
                     ],
                 )
                 .map_err(|source| MemoryError::DuckDb {
@@ -845,7 +855,7 @@ pub fn persist_code_intel_documents(
                         document.parser_version,
                         document.query_pack_version,
                         indexed_at,
-                        MemoryFreshness::Current.as_str(),
+                        freshness,
                     ],
                 )
                 .map_err(|source| MemoryError::DuckDb {
@@ -901,7 +911,7 @@ pub fn persist_code_intel_documents(
                         document.parser_version,
                         document.query_pack_version,
                         indexed_at,
-                        MemoryFreshness::Current.as_str(),
+                        freshness,
                     ],
                 )
                 .map_err(|source| MemoryError::DuckDb {
@@ -938,7 +948,7 @@ pub fn persist_code_intel_documents(
                             document.parser_version,
                             document.query_pack_version,
                             indexed_at,
-                            MemoryFreshness::Current.as_str(),
+                            freshness,
                         ],
                     )
                     .map_err(|source| MemoryError::DuckDb {
@@ -988,7 +998,7 @@ pub fn persist_code_intel_documents(
                         document.parser_version,
                         document.query_pack_version,
                         indexed_at,
-                        MemoryFreshness::Current.as_str(),
+                        freshness,
                     ],
                 )
                 .map_err(|source| MemoryError::DuckDb {
@@ -1021,7 +1031,7 @@ pub fn persist_code_intel_documents(
                             document.parser_version,
                             document.query_pack_version,
                             indexed_at,
-                            MemoryFreshness::Current.as_str(),
+                            freshness,
                         ],
                     )
                     .map_err(|source| MemoryError::DuckDb {
@@ -1049,6 +1059,26 @@ pub fn persist_code_intel_skipped_files(
     worktree_dirty: bool,
     skipped_files: &[CodeIntelSkippedFileInput],
 ) -> Result<usize, MemoryError> {
+    persist_code_intel_skipped_files_with_freshness(
+        config,
+        repo_id,
+        commit_sha,
+        worktree_dirty,
+        skipped_files,
+        "current",
+        true,
+    )
+}
+
+pub(crate) fn persist_code_intel_skipped_files_with_freshness(
+    config: &MemoryConfig,
+    repo_id: &str,
+    commit_sha: Option<&str>,
+    worktree_dirty: bool,
+    skipped_files: &[CodeIntelSkippedFileInput],
+    freshness: &str,
+    stale_existing: bool,
+) -> Result<usize, MemoryError> {
     let Some(commit_sha) = commit_sha.filter(|_| !worktree_dirty) else {
         return Ok(0);
     };
@@ -1069,21 +1099,23 @@ pub fn persist_code_intel_skipped_files(
     let indexed_at = Utc::now().to_rfc3339();
     for skipped in skipped_files {
         let path = skipped.path.to_string_lossy().to_string();
-        stale_code_rows_for_skipped_file(&transaction, repo_id, &path).map_err(|source| {
-            MemoryError::DuckDb {
-                path: config.index_path.clone(),
-                source,
-            }
-        })?;
-        transaction
-            .execute(
-                "UPDATE code_skipped_files SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND commit_sha = ? AND freshness = 'current' AND content_sha256 != ?",
-                params![repo_id, path, commit_sha, skipped.content_sha256],
-            )
-            .map_err(|source| MemoryError::DuckDb {
-                path: config.index_path.clone(),
-                source,
+        if stale_existing {
+            stale_code_rows_for_skipped_file(&transaction, repo_id, &path).map_err(|source| {
+                MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                }
             })?;
+            transaction
+                .execute(
+                    "UPDATE code_skipped_files SET freshness = 'stale' WHERE repo_id = ? AND path = ? AND commit_sha = ? AND freshness = 'current' AND content_sha256 != ?",
+                    params![repo_id, path, commit_sha, skipped.content_sha256],
+                )
+                .map_err(|source| MemoryError::DuckDb {
+                    path: config.index_path.clone(),
+                    source,
+                })?;
+        }
         transaction
             .execute(
                 "INSERT OR REPLACE INTO code_skipped_files (repo_id, commit_sha, worktree_dirty, path, reason, content_sha256, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
@@ -1095,7 +1127,7 @@ pub fn persist_code_intel_skipped_files(
                     skipped.reason,
                     skipped.content_sha256,
                     indexed_at,
-                    MemoryFreshness::Current.as_str(),
+                    freshness,
                 ],
             )
             .map_err(|source| MemoryError::DuckDb {
@@ -1715,6 +1747,11 @@ fn query_symbols_for_revision(
     repo_id: &str,
     revision: &str,
 ) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
+    if let Some(status) = code_snapshot_status(connection, config, repo_id, revision)?
+        && status != "completed"
+    {
+        return Ok(BTreeMap::new());
+    }
     let membership_ready =
         code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
     let query = if membership_ready {

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -1807,20 +1807,17 @@ fn query_symbols_for_revision(
     repo_id: &str,
     revision: &str,
 ) -> Result<BTreeMap<String, CodeSymbolRecord>, MemoryError> {
-    if let Some(status) = code_snapshot_status(connection, config, repo_id, revision)?
-        && status != "completed"
-    {
-        return Ok(BTreeMap::new());
-    }
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
     let membership_ready =
-        code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
     let query = if membership_ready {
         format!(
-            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END FROM code_symbols AS s WHERE s.repo_id = ? AND s.symbol_key != '' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed)) ORDER BY s.symbol_key, s.indexed_at DESC, s.symbol_id"
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END FROM code_symbols AS s WHERE s.repo_id = ? AND s.symbol_key != '' AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed)) ORDER BY s.symbol_key, s.indexed_at DESC, s.symbol_id"
         )
     } else {
         format!(
-            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' ORDER BY symbol_key, indexed_at DESC, symbol_id"
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND commit_sha = ? AND symbol_key != '' AND freshness <> 'staged' ORDER BY symbol_key, indexed_at DESC, symbol_id"
         )
     };
     let mut statement = connection

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -909,40 +909,58 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
                 &edge.start_byte.to_string(),
                 &edge.end_byte.to_string(),
             ]);
-            transaction
-                .execute(
-                    "INSERT OR REPLACE INTO code_edges (edge_id, repo_id, commit_sha, worktree_dirty, path, language, edge_kind, source_symbol_id, source_symbol_key, target_symbol_id, target_symbol_key, target_hint, confidence, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    params![
-                        edge_id,
-                        batch.repo_id,
-                        batch.commit_sha.clone(),
-                        worktree_dirty,
-                        path,
-                        document.language,
-                        edge.edge_kind,
-                        resolved.source_symbol_id,
-                        resolved.source_symbol_key,
-                        resolved.target_symbol_id,
-                        resolved.target_symbol_key,
-                        edge.target_hint,
-                        normalized_confidence,
-                        edge.start_line as i64,
-                        edge.start_col as i64,
-                        edge.end_line as i64,
-                        edge.end_col as i64,
-                        edge.start_byte as i64,
-                        edge.end_byte as i64,
-                        document.content_sha256,
-                        document.parser_version,
-                        document.query_pack_version,
-                        indexed_at,
-                        freshness,
-                    ],
-                )
-                .map_err(|source| MemoryError::DuckDb {
-                    path: config.index_path.clone(),
-                    source,
-                })?;
+            let current_edge_exists = if freshness == "staged" {
+                transaction
+                    .query_row(
+                        "SELECT 1 FROM code_edges WHERE edge_id = ? AND freshness = 'current' LIMIT 1",
+                        params![edge_id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .optional()
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?
+                    .is_some()
+            } else {
+                false
+            };
+            if !current_edge_exists {
+                transaction
+                    .execute(
+                        "INSERT OR REPLACE INTO code_edges (edge_id, repo_id, commit_sha, worktree_dirty, path, language, edge_kind, source_symbol_id, source_symbol_key, target_symbol_id, target_symbol_key, target_hint, confidence, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        params![
+                            edge_id,
+                            batch.repo_id,
+                            batch.commit_sha.clone(),
+                            worktree_dirty,
+                            path,
+                            document.language,
+                            edge.edge_kind,
+                            resolved.source_symbol_id,
+                            resolved.source_symbol_key,
+                            resolved.target_symbol_id,
+                            resolved.target_symbol_key,
+                            edge.target_hint,
+                            normalized_confidence,
+                            edge.start_line as i64,
+                            edge.start_col as i64,
+                            edge.end_line as i64,
+                            edge.end_col as i64,
+                            edge.start_byte as i64,
+                            edge.end_byte as i64,
+                            document.content_sha256,
+                            document.parser_version,
+                            document.query_pack_version,
+                            indexed_at,
+                            freshness,
+                        ],
+                    )
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?;
+            }
             if !batch.worktree_dirty
                 && let Some(commit_sha) = batch.commit_sha.as_deref()
             {
@@ -1000,36 +1018,54 @@ pub(crate) fn persist_code_intel_documents_with_freshness(
                 &diagnostic.start_byte.to_string(),
                 &diagnostic.end_byte.to_string(),
             ]);
-            transaction
-                .execute(
-                    "INSERT OR REPLACE INTO code_diagnostics (diagnostic_id, repo_id, commit_sha, worktree_dirty, path, language, kind, severity, message, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    params![
-                        &diagnostic_id,
-                        batch.repo_id,
-                        batch.commit_sha.clone(),
-                        worktree_dirty,
-                        path,
-                        document.language,
-                        diagnostic.kind,
-                        diagnostic.severity,
-                        diagnostic.message,
-                        diagnostic.start_line as i64,
-                        diagnostic.start_col as i64,
-                        diagnostic.end_line as i64,
-                        diagnostic.end_col as i64,
-                        diagnostic.start_byte as i64,
-                        diagnostic.end_byte as i64,
-                        document.content_sha256,
-                        document.parser_version,
-                        document.query_pack_version,
-                        indexed_at,
-                        freshness,
-                    ],
-                )
-                .map_err(|source| MemoryError::DuckDb {
-                    path: config.index_path.clone(),
-                    source,
-                })?;
+            let current_diagnostic_exists = if freshness == "staged" {
+                transaction
+                    .query_row(
+                        "SELECT 1 FROM code_diagnostics WHERE diagnostic_id = ? AND freshness = 'current' LIMIT 1",
+                        params![&diagnostic_id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .optional()
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?
+                    .is_some()
+            } else {
+                false
+            };
+            if !current_diagnostic_exists {
+                transaction
+                    .execute(
+                        "INSERT OR REPLACE INTO code_diagnostics (diagnostic_id, repo_id, commit_sha, worktree_dirty, path, language, kind, severity, message, start_line, start_col, end_line, end_col, start_byte, end_byte, content_sha256, parser_version, query_pack_version, indexed_at, freshness) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        params![
+                            &diagnostic_id,
+                            batch.repo_id,
+                            batch.commit_sha.clone(),
+                            worktree_dirty,
+                            path,
+                            document.language,
+                            diagnostic.kind,
+                            diagnostic.severity,
+                            diagnostic.message,
+                            diagnostic.start_line as i64,
+                            diagnostic.start_col as i64,
+                            diagnostic.end_line as i64,
+                            diagnostic.end_col as i64,
+                            diagnostic.start_byte as i64,
+                            diagnostic.end_byte as i64,
+                            document.content_sha256,
+                            document.parser_version,
+                            document.query_pack_version,
+                            indexed_at,
+                            freshness,
+                        ],
+                    )
+                    .map_err(|source| MemoryError::DuckDb {
+                        path: config.index_path.clone(),
+                        source,
+                    })?;
+            }
             if !batch.worktree_dirty
                 && let Some(commit_sha) = batch.commit_sha.as_deref()
             {
@@ -3114,6 +3150,36 @@ mod index_tests {
         }
     }
 
+    fn test_code_document_with_edges_and_diagnostics(
+        path: &str,
+        content_sha256: &str,
+    ) -> CodeIntelDocumentInput {
+        let mut document = test_code_document(path, content_sha256);
+        document.edges.push(CodeIntelEdgeInput {
+            edge_kind: "reference".to_string(),
+            target_hint: Some("helper".to_string()),
+            confidence: "exact".to_string(),
+            start_line: 1,
+            start_col: 1,
+            end_line: 1,
+            end_col: 7,
+            start_byte: 0,
+            end_byte: 6,
+        });
+        document.diagnostics.push(CodeIntelDiagnosticInput {
+            kind: "syntax".to_string(),
+            severity: "warning".to_string(),
+            message: "test diagnostic".to_string(),
+            start_line: 1,
+            start_col: 1,
+            end_line: 1,
+            end_col: 2,
+            start_byte: 0,
+            end_byte: 1,
+        });
+        document
+    }
+
     #[test]
     fn issue_log_date_uses_stable_sentinel_for_malformed_timestamps() {
         let issue = IndexedIssue {
@@ -3158,7 +3224,10 @@ mod index_tests {
                 repo_id: "fixture-repo".to_string(),
                 commit_sha: Some("base-commit".to_string()),
                 worktree_dirty: false,
-                documents: vec![test_code_document("src/reused.rs", "same-hash")],
+                documents: vec![test_code_document_with_edges_and_diagnostics(
+                    "src/reused.rs",
+                    "same-hash",
+                )],
             },
         )
         .expect("current document should persist");
@@ -3168,7 +3237,10 @@ mod index_tests {
                 repo_id: "fixture-repo".to_string(),
                 commit_sha: Some("next-commit".to_string()),
                 worktree_dirty: false,
-                documents: vec![test_code_document("src/reused.rs", "same-hash")],
+                documents: vec![test_code_document_with_edges_and_diagnostics(
+                    "src/reused.rs",
+                    "same-hash",
+                )],
             },
             "staged",
             false,
@@ -3182,6 +3254,24 @@ mod index_tests {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .expect("current document should remain queryable");
+        assert_eq!(commit_sha, "base-commit");
+        assert_eq!(freshness, "current");
+        let (commit_sha, freshness): (String, String) = connection
+            .query_row(
+                "SELECT commit_sha, freshness FROM code_edges WHERE repo_id = ? AND path = ?",
+                params!["fixture-repo", "src/reused.rs"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("current edge should remain queryable");
+        assert_eq!(commit_sha, "base-commit");
+        assert_eq!(freshness, "current");
+        let (commit_sha, freshness): (String, String) = connection
+            .query_row(
+                "SELECT commit_sha, freshness FROM code_diagnostics WHERE repo_id = ? AND path = ?",
+                params!["fixture-repo", "src/reused.rs"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("current diagnostic should remain queryable");
         assert_eq!(commit_sha, "base-commit");
         assert_eq!(freshness, "current");
         drop(connection);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,17 @@ The supported model is now:
 
 This keeps one canonical Linear API surface for the agent path.
 
+### 3.7 Code Graph snapshots are repository-owned
+
+The Code Graph indexer resolves the configured repository and target branch
+server-side from `WORKFLOW.md`. It reads Git tree/blob objects and sends source
+text through the bounded Tree-sitter provider; it does not execute target-repo
+code or accept client filesystem roots. Snapshot membership is immutable by
+repository and commit, while current read-model rows may be marked stale for
+deletions. A single process-wide writer owner serializes index mutations so
+DuckDB reads remain available during gateway jobs. Issue-workspace code remains
+an overlay concern rather than being folded into the shared baseline.
+
 ## 4. Component model
 
 ### Internal subsystem modules
@@ -126,7 +137,8 @@ This keeps one canonical Linear API surface for the agent path.
 - `opensymphony_linear`
   - Linear GraphQL read adapter and guarded archive mutation
 - `opensymphony_memory`
-  - issue capsules, DuckDB memory index, docs sync, and archive eligibility
+  - issue capsules, DuckDB memory index, repository code snapshots, docs sync,
+    and archive eligibility
 - `opensymphony_code_intel`
   - built-in Tree-sitter parser provider skeletons, starting with Rust source
     summaries, one-based spans, symbols, and recoverable AST diagnostics

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -48,6 +48,35 @@ are rendered from local files on demand.
 There is no filesystem watcher in V1. Re-run `memory.context` after editing
 source files.
 
+## Target-branch repository snapshots
+
+The Code Graph repository index is an explicit, server-side operation:
+
+```text
+POST /api/v1/code/repos/{repo_id}/index
+code_index_repo(repoId)
+```
+
+The server resolves the configured repository root and target branch from the
+target repository's `WORKFLOW.md`. It reads the selected commit through Git's
+tree and blob objects, never accepts a client filesystem root, and never runs
+target-repository code. The branch marker defaults to `develop` when it is not
+present; `main`, `master`, and `origin/HEAD` are not implicit fallbacks.
+
+Each completed run stores an immutable snapshot keyed by repository and commit,
+including complete file membership. Parsed documents, symbols, edges,
+diagnostics, and skipped-file coverage are persisted in bounded batches. When a
+later target-branch commit exists, unchanged files reuse their prior snapshot
+membership and only changed, added, or deleted paths are parsed or staled.
+DuckDB writes are serialized through the repository index writer; reads remain
+available while a gateway request performs the background job.
+
+The gateway returns `accepted`, `progress`, `completed`, `unavailable`, or
+`failed` reports and journals progress/failure events plus `code_graph_updated`
+after completion. This shared target-branch baseline is not the live truth for
+an issue workspace; workspace-specific code belongs to the overlay/composite
+graph path.
+
 ## Agent Workflow
 
 Use memory first, then code-intelligence context after file discovery:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,12 @@ opensymphony update --target-branch release/next
 opensymphony update --target-branch release/next --code-review openhands
 ```
 
+The target-branch marker is also the source of truth for persistent Code Graph
+indexing. `POST /api/v1/code/repos/{repo_id}/index` and
+`code_index_repo` resolve that branch server-side; they do not accept a client
+path. If the marker is absent, the indexer uses `develop`. Ensure the selected
+branch is available as `origin/<branch>` or a local branch before indexing.
+
 The template repository is still the upstream source of those starter assets,
 but it is an implementation detail of `opensymphony init`, not a required
 manual setup step:

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -7,6 +7,27 @@ last_memory_sync: 2026-06-21T19:11:22.242702+00:00
 
 # Gateway
 
+## Code Graph repository indexing
+
+The repository index route is a server-side, bounded job:
+
+```text
+POST /api/v1/code/repos/{repo_id}/index
+```
+
+It resolves the configured repository and `WORKFLOW.md` target branch, reads
+the target commit's Git tree/blob objects, and persists an immutable snapshot.
+The request does not accept a filesystem root and indexing never executes
+repository code. A first response is `accepted`; background progress and the
+terminal `completed`, `unavailable`, or `failed` result are written to the event
+journal. Completion also emits `code_graph_updated`. Re-indexing a later commit
+parses only changed/added paths, records deletions as stale current rows, and
+retains older snapshot membership for revision queries.
+
+The Tauri `code_index_repo` command is a thin native mirror of this route and
+uses the same DTOs and event behavior. The persistent index is a target-branch
+baseline, not an issue-workspace overlay.
+
 <!-- BEGIN OPENSYMPHONY MANAGED MEMORY SYNC -->
 
 ## Current model

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -232,6 +232,26 @@ ephemeral loopback port, and workers receive the resulting MCP endpoint through
 `OPENSYMPHONY_MEMORY_ENDPOINT`. Workers receive only the normal read token;
 admin tools require a separate `OPENSYMPHONY_MEMORY_ADMIN_TOKEN`.
 
+### Persistent Code Graph indexing
+
+`POST /api/v1/code/repos/{repo_id}/index` and the native `code_index_repo`
+command build a bounded repository snapshot for the target branch recorded in
+`WORKFLOW.md` (default `develop`). The server resolves the repository root and
+commit; clients cannot provide arbitrary roots. Files are read from Git tree and
+blob objects, so indexing does not execute target-repository code.
+
+Snapshot membership is immutable and keyed by repository, commit, and path.
+Documents, symbols, edges, diagnostics, and skipped coverage are persisted in
+batches. A later commit reuses unchanged membership, parses changed or added
+paths, and marks deleted current rows stale without rewriting older revisions.
+One process-wide index writer lock serializes concurrent indexing requests while
+DuckDB read paths remain usable. The gateway journals accepted/progress,
+completed, unavailable, and failed outcomes; `code_graph_updated` is emitted
+only after a completed snapshot is available.
+
+This index is a shared target-branch baseline. It must not be treated as the
+live code state of an issue workspace; workspace overlays provide that view.
+
 Initialize the shared memory policy and learned ontology file once:
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -300,6 +300,24 @@ When the configured transport uses managed local OpenHands, `doctor` can
 bootstrap the pinned tooling into the configured `openhands.tool_dir` before
 continuing the rest of its checks.
 
+## 4.0 Code Graph repository indexing
+
+Trigger a target-branch repository snapshot through the gateway or desktop
+native mirror:
+
+```bash
+curl -X POST http://127.0.0.1:2468/api/v1/code/repos/opensymphony/index
+```
+
+The server reads the branch marker in `WORKFLOW.md` (default `develop`) and
+resolves the commit from `origin/<branch>` or the local branch. It reads Git
+objects without running repository code, applies the configured Tree-sitter
+limits, and writes immutable revision membership in bounded batches. Repeated
+indexing of a later commit reuses unchanged paths and records deletions without
+removing older revisions. Requests return an accepted report; inspect the event
+journal for progress and the terminal completion/failure event. Concurrent
+requests are serialized by the index writer.
+
 ## 4.1 Subscription Credential Operations
 
 OpenAI ChatGPT/Codex subscription mode is explicit and feature-gated. Build or

--- a/docs/specs/code-graph-view-spec.md
+++ b/docs/specs/code-graph-view-spec.md
@@ -345,7 +345,20 @@ Returns the graph-diff DTO for any two indexed revisions of the repo. This revis
 POST /api/v1/code/repos/{repo_id}/index
 ```
 
-Operator-triggered batch ingest (equivalent to admin `memory.ingest_code_intel` with `persist=true`), local-trusted by default and admin-gated in hosted mode. The initial gateway route may report the current read-model index state when no async indexer is configured; successful ingest/reindex emits `code_graph_updated` on completion.
+Operator-triggered, bounded repository indexing (equivalent to admin
+`memory.ingest_code_intel` with `persist=true`), local-trusted by default and
+admin-gated in hosted mode. The server resolves the configured repository root
+and the target branch marker in `WORKFLOW.md` (default `develop`); clients never
+provide arbitrary filesystem roots. It reads the selected Git tree and blob
+objects without executing target-repository code and persists an immutable
+repository/commit snapshot with complete membership and skipped coverage.
+
+The initial response reports `accepted`. Background progress and terminal
+`completed`, `unavailable`, or `failed` reports are journaled. A later commit
+reuses unchanged file membership, parses changed or added paths, records
+deletions in the current read model, and emits `code_graph_updated` only after a
+completed snapshot is available. The indexed repository is the shared
+target-branch baseline, not the live truth for an issue workspace overlay.
 
 ### 8.5 Events
 
@@ -362,6 +375,12 @@ Operator-triggered batch ingest (equivalent to admin `memory.ingest_code_intel` 
 ```
 
 Fired after ingest/reindex completes and after a diff-overlay computation persists fresh rows. Cursors use the same strictly monotonic sequence semantics as memory-graph cursors. A future incremental watch path fires the same event; consumers do not change.
+
+Repository indexing also journals `code_index_progress` with the serialized
+`CodeIndexReport` for accepted/progress/completed/unavailable states and
+`code_index_failed` for terminal failures. Consumers can use these reports for
+bounded counts and diagnostics; `code_graph_updated` remains the completion
+signal for refreshed graph reads.
 
 ### 8.6 Tauri native commands
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -196,6 +196,22 @@ and login -> Enable device code authorization for Codex before retrying.
 - preserve the Markdown body exactly after the front matter terminator
 - treat whitespace-only prompt bodies as absent so `DEFAULT_PROMPT_TEMPLATE` still applies
 
+## 3.1.1 Code Graph repository indexing
+
+- bootstrap an empty DuckDB index from the configured target branch and assert
+  nonzero documents, symbols, and edges for supported source
+- keep base and later commits independently queryable, including identical
+  content hashes
+- re-index a changed and deleted path incrementally and verify deletion/stale
+  membership plus skipped-directory, unsupported-language, and size coverage
+- verify target-branch selection when `develop` and `main` point to different
+  commits; reject client filesystem roots and never execute target-repository
+  code
+- serialize concurrent index requests through one writer and keep reads
+  available during a background job
+- cover gateway and native-command parity for accepted, progress, completed,
+  unavailable, and failed reports/events
+
 ## 3.2 Workspace manager
 
 - sanitize issue identifiers

--- a/packages/gateway-schema/src/code_graph.ts
+++ b/packages/gateway-schema/src/code_graph.ts
@@ -222,7 +222,7 @@ export interface CodeDiffBlastRadius {
 export interface CodeIndexReport {
   schema_version: SchemaVersion;
   repo_id: string;
-  status: "accepted" | "completed" | "unavailable";
+  status: "accepted" | "progress" | "completed" | "unavailable" | "failed";
   head_revision?: string | null;
   parsed_files: number;
   persisted_documents: number;


### PR DESCRIPTION
## Summary

Turn the Code Graph index-report stub into a bounded target-branch repository snapshot job with revision-safe staging and incremental updates.

## Changes

- Resolve the configured repository and `WORKFLOW.md` target branch server-side and read Git tree/blob objects without executing repository code.
- Persist immutable repository/commit snapshot membership, bounded Tree-sitter/DuckDB batches, incremental changed/deleted paths, skipped coverage, and diagnostics.
- Return accepted/progress/completed/unavailable/failed reports, journal index progress/failure events, and emit `code_graph_updated` after completion.
- Preserve older revision reads and document the shared baseline versus workspace overlay boundary.
- Keep staged rows out of current/stale reads; preserve current documents, symbols, edges, and diagnostics during interrupted staging; reuse unchanged clean rows; prune skipped Git subtrees while recording directory coverage; and bind background jobs to accepted commits.
- Preserve completed snapshot state during interrupted same-revision reindexing, scope Git scans/blobs to configured repository roots, stage matching edge revisions, retry files released from request/byte limits, and handle dirty-row replacement and edge-limit refreshes safely.
- Revalidate the configured target branch immediately before promotion, retry unchanged files previously skipped for unsupported-language or parse-failed reasons, and exclude skipped-only membership from repository document summaries.

## Evidence

### Test output

```
cargo test-system-duckdb
829 library tests passed; all integration suites and doc-tests passed

cargo test-system-duckdb --lib code_graph_tests
15 passed

cargo test-system-duckdb --test memory
46 passed

cargo test-system-duckdb --test gateway
71 passed

cargo test-system-duckdb --test gateway_schema
57 passed

cargo clippy-system-duckdb
passed

cargo fmt --all -- --check
git diff --check
passed
```

### Verification

The memory regressions cover empty bootstrap, configured develop-versus-main selection, immutable and identical-content revisions, changed/deleted files, skipped coverage, interrupted staging, concurrent requests, dirty-row replacement, edge-limit refresh, staged-row visibility, and repository-root containment. The latest focused regression verifies that a snapshot containing only skipped membership reports zero graph documents and no language entries. Promotion rechecks the configured target ref after staging and discards staged rows when the branch advances. Unchanged files skipped for unsupported language or parse failure are retried so parser support changes can produce graph documents.

## Checklist

- [x] Tests pass (`cargo test-system-duckdb`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated
- [x] AGENTS.md updated (not needed; no repository knowledge changed)
- [x] Evidence section filled out

## Type of change

- [x] Bug fix
- [x] New feature

## Breaking changes

None.

## Related issues

Linear: COE-542

## Additional notes

The frontend package type-check/test commands were attempted but this checkout does not have `tsc` or `jest` installed; the CI TypeScript job is the authoritative package validation and no dependency changes were introduced.
