### PR TITLE
feat(code-graph): compose workspace overlays

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1165,6 +1165,34 @@ pub async fn code_graph(
     gateway_get_json(state, &path).await
 }
 
+/// Get a run-scoped code graph snapshot through the active gateway.
+#[command(rename_all = "camelCase")]
+pub async fn run_code_graph(
+    state: tauri::State<'_, RwLock<GatewayConnection>>,
+    run_id: String,
+    repo_id: Option<String>,
+    mode: Option<String>,
+    path: Option<String>,
+    symbol_key: Option<String>,
+    depth: Option<u64>,
+    aggregate: Option<String>,
+    include_stale: Option<bool>,
+) -> CommandResult<serde_json::Value> {
+    let mut params = Vec::new();
+    push_query_param(&mut params, "repo_id", repo_id.as_deref());
+    push_query_param(&mut params, "mode", mode.as_deref());
+    push_query_param(&mut params, "path", path.as_deref());
+    push_query_param(&mut params, "symbol_key", symbol_key.as_deref());
+    push_query_param_value(&mut params, "depth", depth);
+    push_query_param(&mut params, "aggregate", aggregate.as_deref());
+    push_query_param_value(&mut params, "include_stale", include_stale);
+    let path = path_with_query(
+        &format!("/api/v1/runs/{}/code/graph", urlencoding::encode(&run_id)),
+        &params,
+    );
+    gateway_get_json(state, &path).await
+}
+
 /// Get code symbol details through the active gateway.
 #[command(rename_all = "camelCase")]
 pub async fn code_symbol_detail(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -70,6 +70,7 @@ pub fn run() {
             commands::memory_completed_tasks,
             commands::code_repos,
             commands::code_graph,
+            commands::run_code_graph,
             commands::code_symbol_detail,
             commands::code_diff_overlay,
             commands::run_code_outline,

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -165,6 +165,17 @@ function createDesktopNativeCodeGraphApi(invoke: TauriInvoke): NativeCodeGraphAp
         aggregate: options?.aggregate ?? null,
         includeStale: options?.includeStale ?? null,
       }),
+    getRunGraphSnapshot: (runId, repoId, options?: CodeGraphRequestOptions) =>
+      invoke<CodeGraphSnapshot>("run_code_graph", {
+        runId,
+        repoId: repoId ?? null,
+        mode: options?.mode ?? null,
+        path: options?.path ?? null,
+        symbolKey: options?.symbolKey ?? null,
+        depth: options?.depth ?? null,
+        aggregate: options?.aggregate ?? null,
+        includeStale: options?.includeStale ?? null,
+      }),
     getSymbolDetail: (repoId, symbolKey, options) =>
       invoke<CodeSymbolDetail>("code_symbol_detail", {
         repoId,

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3344,17 +3344,18 @@ fn workspace_comparison_base(
         None => "develop".to_owned(),
     };
     let mut references = vec![format!("origin/{target_branch}"), target_branch];
-    references.extend([
-        // Legacy workspaces without WORKFLOW.md may still expose one of
-        // these refs; configured target branches remain authoritative when
-        // present.
-        "origin/main".to_string(),
-        "main".to_string(),
-        "origin/master".to_string(),
-        "master".to_string(),
-        "origin/HEAD".to_string(),
-        "HEAD".to_string(),
-    ]);
+    if trusted_target_branch.is_none() {
+        references.extend([
+            // Legacy workspaces without a trusted target may still expose
+            // one of these refs.
+            "origin/main".to_string(),
+            "main".to_string(),
+            "origin/master".to_string(),
+            "master".to_string(),
+            "origin/HEAD".to_string(),
+            "HEAD".to_string(),
+        ]);
+    }
     for reference in references {
         if git_ref_exists(workspace_path, &reference)? {
             return Ok(WorkspaceComparisonBase {
@@ -6254,6 +6255,31 @@ exit 2
         assert_eq!(untrusted.merge_base, develop_revision);
         assert_eq!(trusted.merge_base, develop_revision);
         assert_ne!(untrusted.merge_base, head_revision);
+
+        let missing_target = tempfile::tempdir().expect("missing target workspace");
+        std::fs::write(missing_target.path().join("README.md"), "feature\n")
+            .expect("write missing-target baseline");
+        run_git(missing_target.path(), &["init"]);
+        run_git(
+            missing_target.path(),
+            &["checkout", "-B", "feature/worktree"],
+        );
+        run_git(missing_target.path(), &["add", "."]);
+        run_git(
+            missing_target.path(),
+            &[
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "feature",
+                "--no-gpg-sign",
+            ],
+        );
+        let missing_target_branch = Ok("develop".to_owned());
+        assert!(
+            workspace_comparison_base(missing_target.path(), Some(&missing_target_branch)).is_err()
+        );
     }
 
     #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2030,17 +2030,19 @@ async fn get_run_code_outline(
     let run_identifier = issue.identifier.clone();
     if let (Some(repo_id), Some(config)) = (repo_id.clone(), state.memory_config.clone()) {
         let comparison_bases = state.comparison_bases.clone();
+        let overlay_run_identifier = run_identifier.clone();
+        let overlay_relative_path = relative_path.clone();
         let snapshot = tokio::task::spawn_blocking(move || {
             let base = comparison_bases
-                .resolve(&run_identifier, &workspace_path)
+                .resolve(&overlay_run_identifier, &workspace_path)
                 .map_err(CodeGraphProjectionError::InvalidRequest)?;
             code_file_outline_from_workspace(
                 &config,
                 &repo_id,
                 &workspace_path,
-                &run_identifier,
+                &overlay_run_identifier,
                 &base.merge_base,
-                &relative_path,
+                &overlay_relative_path,
             )
         })
         .await
@@ -2048,9 +2050,13 @@ async fn get_run_code_outline(
             Err(CodeGraphProjectionError::InvalidRequest(format!(
                 "code outline resolver task failed: {error}"
             )))
-        })
-        .map_err(code_graph_error)?;
-        return Ok(Json(snapshot));
+        });
+        match snapshot {
+            Ok(snapshot) => return Ok(Json(snapshot)),
+            Err(CodeGraphProjectionError::IndexUnavailable)
+            | Err(CodeGraphProjectionError::RevisionNotFound(_)) => {}
+            Err(error) => return Err(code_graph_error(error)),
+        }
     }
     let source = tokio::fs::read_to_string(&file_path).await.map_err(|_| {
         code_graph_response(
@@ -2371,6 +2377,11 @@ fn configured_code_memory(
 fn code_graph_error(error: CodeGraphProjectionError) -> (StatusCode, Json<serde_json::Value>) {
     let message = error.to_string();
     match error {
+        CodeGraphProjectionError::IndexUnavailable => code_graph_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "code_graph_unavailable",
+            &message,
+        ),
         CodeGraphProjectionError::RepoNotFound(_) => {
             code_graph_response(StatusCode::NOT_FOUND, "code_repo_not_found", &message)
         }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2199,7 +2199,7 @@ async fn get_run_code_graph(
         symbol_key: params.symbol_key,
         depth: params.depth.unwrap_or(1).clamp(1, 8),
         aggregate: parse_code_graph_aggregate(params.aggregate.as_deref())?,
-        include_stale: false,
+        include_stale: params.include_stale.unwrap_or(false),
     };
     let comparison_bases = state.comparison_bases.clone();
     let snapshot = tokio::task::spawn_blocking(move || {

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -341,14 +341,23 @@ impl Clone for GatewayState {
 #[derive(Clone, Default)]
 pub struct WorkspaceScans {
     state: Arc<tokio::sync::Mutex<HashMap<PathBuf, WorkspaceScanReceiver>>>,
+    trusted_target_branch: Option<Result<String, String>>,
 }
 
 #[derive(Clone, Default)]
 pub struct WorkspaceComparisonBases {
     state: Arc<Mutex<HashMap<String, (PathBuf, WorkspaceComparisonBase)>>>,
+    trusted_target_branch: Option<Result<String, String>>,
 }
 
 impl WorkspaceComparisonBases {
+    fn with_target_branch(target_branch: Option<Result<String, String>>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            trusted_target_branch: target_branch,
+        }
+    }
+
     fn resolve(
         &self,
         run_id: &str,
@@ -363,7 +372,7 @@ impl WorkspaceComparisonBases {
         {
             return Ok(base.clone());
         }
-        let base = workspace_comparison_base(workspace_path)?;
+        let base = workspace_comparison_base(workspace_path, self.trusted_target_branch.as_ref())?;
         state.insert(
             run_id.to_string(),
             (workspace_path.to_path_buf(), base.clone()),
@@ -383,7 +392,15 @@ pub(crate) struct WorkspaceScanOutcome {
 }
 
 impl WorkspaceScans {
+    fn with_target_branch(target_branch: Option<Result<String, String>>) -> Self {
+        Self {
+            state: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            trusted_target_branch: target_branch,
+        }
+    }
+
     pub(crate) async fn scan(&self, workspace_path: PathBuf) -> WorkspaceScanOutcome {
+        let trusted_target_branch = self.trusted_target_branch.clone();
         let mut receiver = {
             let mut state = self.state.lock().await;
             if let Some(receiver) = state.get(&workspace_path) {
@@ -395,13 +412,15 @@ impl WorkspaceScans {
                 let path = workspace_path.clone();
                 tokio::spawn(async move {
                     let scan_path = path.clone();
-                    let outcome =
-                        tokio::task::spawn_blocking(move || compute_workspace_scan(&scan_path))
-                            .await
-                            .unwrap_or_else(|error| WorkspaceScanOutcome {
-                                comparison_base: None,
-                                files: Err(format!("workspace scan task failed: {error}")),
-                            });
+                    let target_branch = trusted_target_branch.clone();
+                    let outcome = tokio::task::spawn_blocking(move || {
+                        compute_workspace_scan(&scan_path, target_branch.as_ref())
+                    })
+                    .await
+                    .unwrap_or_else(|error| WorkspaceScanOutcome {
+                        comparison_base: None,
+                        files: Err(format!("workspace scan task failed: {error}")),
+                    });
                     let _ = sender.send(Some(outcome));
                     entries.lock().await.remove(&path);
                 });
@@ -424,8 +443,11 @@ impl WorkspaceScans {
     }
 }
 
-fn compute_workspace_scan(workspace_path: &StdPath) -> WorkspaceScanOutcome {
-    match workspace_comparison_base(workspace_path) {
+fn compute_workspace_scan(
+    workspace_path: &StdPath,
+    trusted_target_branch: Option<&Result<String, String>>,
+) -> WorkspaceScanOutcome {
+    match workspace_comparison_base(workspace_path, trusted_target_branch) {
         Ok(base) => {
             let files =
                 build_workspace_run_file_changes_with_base(workspace_path, &base).map(Arc::new);
@@ -689,6 +711,10 @@ impl GatewayServer {
 
     /// Install the local memory catalog used by `/api/v1/memory/*` reads.
     pub fn with_memory_config(mut self, config: Option<MemoryConfig>) -> Self {
+        let target_branch = config
+            .as_ref()
+            .map(|config| code_index_branch(&config.repo_root).map_err(|error| error.to_string()));
+        self.comparison_bases = WorkspaceComparisonBases::with_target_branch(target_branch);
         self.memory_config = config;
         self
     }
@@ -726,7 +752,9 @@ impl GatewayServer {
             memory_config: self.memory_config.clone(),
             active_states: self.active_states.clone(),
             codex_readiness_cache: Arc::new(CodexReadinessCache::default()),
-            workspace_scans: WorkspaceScans::default(),
+            workspace_scans: WorkspaceScans::with_target_branch(self.memory_config.as_ref().map(
+                |config| code_index_branch(&config.repo_root).map_err(|error| error.to_string()),
+            )),
             comparison_bases: self.comparison_bases.clone(),
             pr_urls: PrUrls::default(),
         };
@@ -3286,7 +3314,7 @@ async fn issue_file_changes_coalesced(
 fn build_workspace_run_file_changes(
     workspace_path: &StdPath,
 ) -> Result<Vec<WorkspaceRunFileChange>, String> {
-    let comparison_base = workspace_comparison_base(workspace_path)?;
+    let comparison_base = workspace_comparison_base(workspace_path, None)?;
     build_workspace_run_file_changes_with_base(workspace_path, &comparison_base)
 }
 
@@ -3305,8 +3333,15 @@ struct WorkspaceComparisonBase {
     merge_base: String,
 }
 
-fn workspace_comparison_base(workspace_path: &StdPath) -> Result<WorkspaceComparisonBase, String> {
-    let target_branch = code_index_branch(workspace_path).map_err(|error| error.to_string())?;
+fn workspace_comparison_base(
+    workspace_path: &StdPath,
+    trusted_target_branch: Option<&Result<String, String>>,
+) -> Result<WorkspaceComparisonBase, String> {
+    let target_branch = match trusted_target_branch {
+        Some(Ok(branch)) => branch.clone(),
+        Some(Err(error)) => return Err(error.clone()),
+        None => code_index_branch(workspace_path).map_err(|error| error.to_string())?,
+    };
     let mut references = vec![format!("origin/{target_branch}"), target_branch];
     references.extend([
         // Legacy workspaces without WORKFLOW.md may still expose one of
@@ -3503,7 +3538,7 @@ fn workspace_diff_for_change(
     let comparison_base = if change.status_code.starts_with("??") {
         None
     } else {
-        Some(workspace_comparison_base(workspace_path)?)
+        Some(workspace_comparison_base(workspace_path, None)?)
     };
     workspace_diff_for_change_with_base(workspace_path, change, comparison_base.as_ref())
 }
@@ -6162,6 +6197,61 @@ exit 2
             .expect("tracked change");
         assert_eq!(modified.change_kind, ControlPlaneFileChangeKind::Modified);
         assert!(modified.lines_added > 0);
+    }
+
+    #[test]
+    fn workspace_comparison_base_uses_trusted_target_branch_over_mutable_workflow() {
+        let temp = tempfile::tempdir().expect("temp workspace");
+        let workspace = temp.path();
+        std::fs::write(workspace.join("WORKFLOW.md"), "Target branch: `develop`\n")
+            .expect("write workflow");
+        std::fs::write(workspace.join("README.md"), "baseline\n").expect("write baseline");
+
+        run_git(workspace, &["init"]);
+        run_git(workspace, &["checkout", "-B", "develop"]);
+        run_git(workspace, &["add", "."]);
+        run_git(
+            workspace,
+            &[
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "baseline",
+                "--no-gpg-sign",
+            ],
+        );
+        let develop_revision =
+            command_single_line(workspace, "git", &["rev-parse", "HEAD"]).expect("revision");
+        run_git(workspace, &["checkout", "-B", "feature/worktree"]);
+        std::fs::write(workspace.join("README.md"), "feature\n").expect("write feature");
+        run_git(workspace, &["add", "README.md"]);
+        run_git(
+            workspace,
+            &[
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "feature",
+                "--no-gpg-sign",
+            ],
+        );
+        std::fs::write(
+            workspace.join("WORKFLOW.md"),
+            "Target branch: `feature/worktree`\n",
+        )
+        .expect("mutate workflow target");
+
+        let untrusted = workspace_comparison_base(workspace, None).expect("workspace target");
+        let trusted_target = Ok("develop".to_owned());
+        let trusted =
+            workspace_comparison_base(workspace, Some(&trusted_target)).expect("configured target");
+
+        let head_revision =
+            command_single_line(workspace, "git", &["rev-parse", "HEAD"]).expect("revision");
+        assert_eq!(untrusted.merge_base, head_revision);
+        assert_eq!(trusted.merge_base, develop_revision);
     }
 
     #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     convert::Infallible,
     ffi::OsStr,
     path::{Path as StdPath, PathBuf},
@@ -7,6 +7,9 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
+
+#[cfg(test)]
+use std::collections::BTreeSet;
 
 use chrono::{DateTime, Utc};
 use serde_json::json;
@@ -45,12 +48,14 @@ use crate::opensymphony_gateway_schema::{
 use crate::opensymphony_memory::{
     CodeGraphProjectionError, CodeGraphSnapshotOptions, DEFAULT_MEMORY_GRAPH_BUNDLE_ID,
     MemoryConfig, MemoryError, MemoryGraphAccess, MemoryGraphCommunityOptions,
-    MemoryGraphProjectionError, code_file_outline_from_source, code_graph_diff_overlay,
-    code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_symbol_detail,
-    code_graph_updated_event, code_index_repository_is_git, code_index_target,
-    index_code_repository_at, index_code_repository_at_current_target, memory_completed_task_rows,
-    memory_concept_detail, memory_graph_bundles, memory_graph_communities_with_options,
-    memory_graph_search as search_memory_graph, memory_graph_snapshot_with_options,
+    MemoryGraphProjectionError, code_file_outline_from_source, code_file_outline_from_workspace,
+    code_graph_diff_overlay, code_graph_index_report, code_graph_repos, code_graph_snapshot,
+    code_graph_symbol_detail, code_graph_updated_event, code_graph_workspace_diff_overlay,
+    code_graph_workspace_snapshot, code_index_branch, code_index_repository_is_git,
+    code_index_target, index_code_repository_at, index_code_repository_at_current_target,
+    memory_completed_task_rows, memory_concept_detail, memory_graph_bundles,
+    memory_graph_communities_with_options, memory_graph_search as search_memory_graph,
+    memory_graph_snapshot_with_options,
 };
 
 pub mod action_handler;
@@ -301,6 +306,7 @@ pub struct GatewayState {
     pub active_states: Arc<HashSet<String>>,
     pub codex_readiness_cache: Arc<CodexReadinessCache>,
     pub workspace_scans: WorkspaceScans,
+    pub comparison_bases: WorkspaceComparisonBases,
     pub pr_urls: PrUrls,
 }
 
@@ -319,6 +325,7 @@ impl Clone for GatewayState {
             active_states: self.active_states.clone(),
             codex_readiness_cache: self.codex_readiness_cache.clone(),
             workspace_scans: self.workspace_scans.clone(),
+            comparison_bases: self.comparison_bases.clone(),
             pr_urls: self.pr_urls.clone(),
         }
     }
@@ -334,6 +341,35 @@ impl Clone for GatewayState {
 #[derive(Clone, Default)]
 pub struct WorkspaceScans {
     state: Arc<tokio::sync::Mutex<HashMap<PathBuf, WorkspaceScanReceiver>>>,
+}
+
+#[derive(Clone, Default)]
+pub struct WorkspaceComparisonBases {
+    state: Arc<Mutex<HashMap<String, (PathBuf, WorkspaceComparisonBase)>>>,
+}
+
+impl WorkspaceComparisonBases {
+    fn resolve(
+        &self,
+        run_id: &str,
+        workspace_path: &StdPath,
+    ) -> Result<WorkspaceComparisonBase, String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "workspace comparison base cache poisoned".to_string())?;
+        if let Some((cached_path, base)) = state.get(run_id)
+            && cached_path == workspace_path
+        {
+            return Ok(base.clone());
+        }
+        let base = workspace_comparison_base(workspace_path)?;
+        state.insert(
+            run_id.to_string(),
+            (workspace_path.to_path_buf(), base.clone()),
+        );
+        Ok(base)
+    }
 }
 
 type WorkspaceScanReceiver = tokio::sync::watch::Receiver<Option<WorkspaceScanOutcome>>;
@@ -502,6 +538,12 @@ impl axum::extract::FromRef<GatewayState> for WorkspaceScans {
     }
 }
 
+impl axum::extract::FromRef<GatewayState> for WorkspaceComparisonBases {
+    fn from_ref(state: &GatewayState) -> Self {
+        state.comparison_bases.clone()
+    }
+}
+
 impl axum::extract::FromRef<GatewayState> for PrUrls {
     fn from_ref(state: &GatewayState) -> Self {
         state.pr_urls.clone()
@@ -519,6 +561,7 @@ pub struct GatewayServer {
     linear_task_graph: Option<Arc<dyn LinearTaskGraphClient>>,
     memory_config: Option<MemoryConfig>,
     active_states: Arc<HashSet<String>>,
+    comparison_bases: WorkspaceComparisonBases,
     terminal_ingest_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -533,6 +576,7 @@ impl Clone for GatewayServer {
             linear_task_graph: self.linear_task_graph.clone(),
             memory_config: self.memory_config.clone(),
             active_states: self.active_states.clone(),
+            comparison_bases: self.comparison_bases.clone(),
             // Each cloned server owns its own ingest handle. The task is tied
             // to the specific server instance that spawned it, so Drop aborts
             // reliably without depending on Arc uniqueness.
@@ -589,6 +633,7 @@ impl GatewayServer {
             linear_task_graph: None,
             memory_config: None,
             active_states: Arc::new(HashSet::new()),
+            comparison_bases: WorkspaceComparisonBases::default(),
             terminal_ingest_handle: Mutex::new(None),
         }
     }
@@ -608,6 +653,7 @@ impl GatewayServer {
             linear_task_graph: None,
             memory_config: None,
             active_states: Arc::new(HashSet::new()),
+            comparison_bases: WorkspaceComparisonBases::default(),
             terminal_ingest_handle: Mutex::new(None),
         }
     }
@@ -681,6 +727,7 @@ impl GatewayServer {
             active_states: self.active_states.clone(),
             codex_readiness_cache: Arc::new(CodexReadinessCache::default()),
             workspace_scans: WorkspaceScans::default(),
+            comparison_bases: self.comparison_bases.clone(),
             pr_urls: PrUrls::default(),
         };
 
@@ -781,6 +828,7 @@ impl GatewayServer {
                 "/api/v1/runs/{run_id}/code/diff-overlay",
                 get(get_run_code_diff_overlay),
             )
+            .route("/api/v1/runs/{run_id}/code/graph", get(get_run_code_graph))
             .route("/api/v1/runs/{run_id}/events", get(get_run_events))
             .route("/api/v1/runs/{run_id}/files", get(get_run_files))
             .route("/api/v1/runs/{run_id}/diffs", get(get_run_diffs))
@@ -1567,6 +1615,7 @@ struct CodeReposQuery {
 
 #[derive(Debug, Default, serde::Deserialize)]
 struct CodeGraphQuery {
+    repo_id: Option<String>,
     mode: Option<String>,
     path: Option<String>,
     symbol_key: Option<String>,
@@ -1601,14 +1650,6 @@ struct RunCodeOutlineQuery {
 struct RunCodeDiffOverlayQuery {
     repo_id: Option<String>,
     limit: Option<usize>,
-}
-
-struct RunCodeDiffOverlayResolution {
-    base_revision: String,
-    indexed_head_revision: String,
-    head_revision: String,
-    unanalyzed_files: Vec<String>,
-    worktree_dirty: bool,
 }
 
 async fn get_code_repos(
@@ -1983,6 +2024,34 @@ async fn get_run_code_outline(
     let relative_path = validate_workspace_relative_path(raw_path)?;
     let file_path = contained_workspace_path(&workspace_path, &relative_path)?;
     let file_path = resolve_contained_workspace_file(&workspace_path, &file_path).await?;
+    let repo_id = params
+        .repo_id
+        .or_else(|| code_repo_id_for_workspace(&workspace_path));
+    let run_identifier = issue.identifier.clone();
+    if let (Some(repo_id), Some(config)) = (repo_id.clone(), state.memory_config.clone()) {
+        let comparison_bases = state.comparison_bases.clone();
+        let snapshot = tokio::task::spawn_blocking(move || {
+            let base = comparison_bases
+                .resolve(&run_identifier, &workspace_path)
+                .map_err(CodeGraphProjectionError::InvalidRequest)?;
+            code_file_outline_from_workspace(
+                &config,
+                &repo_id,
+                &workspace_path,
+                &run_identifier,
+                &base.merge_base,
+                &relative_path,
+            )
+        })
+        .await
+        .unwrap_or_else(|error| {
+            Err(CodeGraphProjectionError::InvalidRequest(format!(
+                "code outline resolver task failed: {error}"
+            )))
+        })
+        .map_err(code_graph_error)?;
+        return Ok(Json(snapshot));
+    }
     let source = tokio::fs::read_to_string(&file_path).await.map_err(|_| {
         code_graph_response(
             StatusCode::NOT_FOUND,
@@ -1990,12 +2059,8 @@ async fn get_run_code_outline(
             "requested run file is not available",
         )
     })?;
-    let repo_id = params
-        .repo_id
-        .or_else(|| code_repo_id_for_workspace(&workspace_path));
-    let run_id = issue.identifier.clone();
     tokio::task::spawn_blocking(move || {
-        code_file_outline_from_source(&run_id, repo_id, &relative_path, &source)
+        code_file_outline_from_source(&run_identifier, repo_id, &relative_path, &source)
     })
     .await
     .unwrap_or_else(|error| {
@@ -2034,66 +2099,95 @@ async fn get_run_code_diff_overlay(
                 "run code diff overlay requires a repo id",
             )
         })?;
-    let resolution = tokio::task::spawn_blocking({
+    let comparison_bases = state.comparison_bases.clone();
+    let config = config.clone();
+    let limit = params.limit.unwrap_or(500).clamp(1, 5_000);
+    let overlay = tokio::task::spawn_blocking({
         let workspace_path = workspace_path.clone();
+        let repo_id = repo_id.clone();
+        let run_id = run_id.clone();
         move || {
-            let base = workspace_comparison_base(&workspace_path)?;
-            let dirty_status =
-                command_single_line(&workspace_path, "git", &["status", "--porcelain"])?;
-            let head = command_single_line(&workspace_path, "git", &["rev-parse", "HEAD"])?;
-            let worktree_dirty = !dirty_status.is_empty();
-            let unanalyzed_files = if worktree_dirty {
-                dirty_workspace_paths(&workspace_path)?
-            } else {
-                Vec::new()
-            };
-            let head_revision = if worktree_dirty {
-                format!("{head}+worktree")
-            } else {
-                head.clone()
-            };
-            Ok::<_, String>(RunCodeDiffOverlayResolution {
-                base_revision: base.merge_base,
-                indexed_head_revision: head,
-                head_revision,
-                unanalyzed_files,
-                worktree_dirty,
-            })
+            let base = comparison_bases
+                .resolve(&run_id, &workspace_path)
+                .map_err(CodeGraphProjectionError::InvalidRequest)?;
+            code_graph_workspace_diff_overlay(
+                &config,
+                &repo_id,
+                &workspace_path,
+                &run_id,
+                &base.merge_base,
+                limit,
+            )
         }
     })
     .await
-    .unwrap_or_else(|error| Err(format!("code diff resolver task failed: {error}")))
-    .map_err(|_| {
+    .unwrap_or_else(|error| {
+        Err(CodeGraphProjectionError::InvalidRequest(format!(
+            "code diff resolver task failed: {error}"
+        )))
+    })
+    .map_err(code_graph_error)?;
+    Ok(Json(overlay))
+}
+
+async fn get_run_code_graph(
+    State(state): State<GatewayState>,
+    AxumPath(run_id): AxumPath<String>,
+    Query(params): Query<CodeGraphQuery>,
+) -> Result<Json<CodeGraphSnapshot>, (StatusCode, Json<serde_json::Value>)> {
+    let config = configured_code_memory(&state)?.clone();
+    let envelope = state.store.current().await;
+    let issue = find_issue_snapshot(&envelope, &run_id).ok_or_else(|| {
+        code_graph_response(StatusCode::NOT_FOUND, "run_not_found", "run not found")
+    })?;
+    let workspace_path = workspace_path_for_issue(&envelope, issue).ok_or_else(|| {
         code_graph_response(
-            StatusCode::CONFLICT,
-            "revision_unavailable",
-            "run revisions could not be resolved",
+            StatusCode::NOT_FOUND,
+            "workspace_not_found",
+            "run workspace is not available",
         )
     })?;
-    if resolution.worktree_dirty {
-        let mut overlay = code_graph_diff_overlay(
-            config,
+    let repo_id = params
+        .repo_id
+        .or_else(|| code_repo_id_for_workspace(&workspace_path))
+        .ok_or_else(|| {
+            code_graph_response(
+                StatusCode::BAD_REQUEST,
+                "repo_id_required",
+                "run code graph requires a repo id",
+            )
+        })?;
+    let options = CodeGraphSnapshotOptions {
+        mode: parse_code_graph_mode(params.mode.as_deref())?,
+        path: params.path,
+        symbol_key: params.symbol_key,
+        depth: params.depth.unwrap_or(1).clamp(1, 8),
+        aggregate: parse_code_graph_aggregate(params.aggregate.as_deref())?,
+        include_stale: false,
+    };
+    let comparison_bases = state.comparison_bases.clone();
+    let snapshot = tokio::task::spawn_blocking(move || {
+        let base = comparison_bases
+            .resolve(&run_id, &workspace_path)
+            .map_err(CodeGraphProjectionError::InvalidRequest)?;
+        code_graph_workspace_snapshot(
+            &config,
             &repo_id,
-            &resolution.base_revision,
-            &resolution.indexed_head_revision,
-            params.limit.unwrap_or(500).clamp(1, 5_000),
+            &workspace_path,
+            &run_id,
+            &base.merge_base,
+            options,
         )
-        .map_err(code_graph_error)?;
-        overlay.head_revision = resolution.head_revision;
-        overlay.unanalyzed_files.extend(resolution.unanalyzed_files);
-        overlay.unanalyzed_files.sort();
-        overlay.unanalyzed_files.dedup();
-        return Ok(Json(overlay));
-    }
-    code_graph_diff_overlay(
-        config,
-        &repo_id,
-        &resolution.base_revision,
-        &resolution.head_revision,
-        params.limit.unwrap_or(500).clamp(1, 5_000),
-    )
+    })
+    .await
+    .unwrap_or_else(|error| {
+        Err(CodeGraphProjectionError::InvalidRequest(format!(
+            "code graph resolver task failed: {error}"
+        )))
+    })
     .map(Json)
-    .map_err(code_graph_error)
+    .map_err(code_graph_error)?;
+    Ok(snapshot)
 }
 
 fn revision_param(
@@ -3194,51 +3288,32 @@ fn build_workspace_run_file_changes_with_base(
     Ok(files)
 }
 
-fn dirty_workspace_paths(workspace_path: &StdPath) -> Result<Vec<String>, String> {
-    let mut paths = BTreeSet::new();
-    for output in [
-        command_output_args(
-            workspace_path,
-            "git",
-            ["diff", "--name-only", "-z", "HEAD", "--"],
-        )?,
-        command_output_args(
-            workspace_path,
-            "git",
-            ["ls-files", "--others", "--exclude-standard", "-z"],
-        )?,
-    ] {
-        paths.extend(
-            output
-                .split_terminator('\0')
-                .map(str::trim)
-                .filter(|path| !path.is_empty())
-                .map(str::to_owned),
-        );
-    }
-    Ok(paths.into_iter().collect())
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct WorkspaceComparisonBase {
     merge_base: String,
 }
 
 fn workspace_comparison_base(workspace_path: &StdPath) -> Result<WorkspaceComparisonBase, String> {
-    for reference in [
-        "main",
-        "origin/main",
-        "master",
-        "origin/master",
-        "origin/HEAD",
-        "HEAD",
-    ] {
-        if git_ref_exists(workspace_path, reference)? {
+    let target_branch = code_index_branch(workspace_path).map_err(|error| error.to_string())?;
+    let mut references = vec![format!("origin/{target_branch}"), target_branch];
+    references.extend([
+        // Legacy workspaces without WORKFLOW.md may still expose one of
+        // these refs; configured target branches remain authoritative when
+        // present.
+        "origin/main".to_string(),
+        "main".to_string(),
+        "origin/master".to_string(),
+        "master".to_string(),
+        "origin/HEAD".to_string(),
+        "HEAD".to_string(),
+    ]);
+    for reference in references {
+        if git_ref_exists(workspace_path, &reference)? {
             return Ok(WorkspaceComparisonBase {
                 merge_base: command_single_line(
                     workspace_path,
                     "git",
-                    &["merge-base", "HEAD", reference],
+                    &["merge-base", "HEAD", &reference],
                 )?,
             });
         }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2083,7 +2083,8 @@ async fn get_run_code_outline(
             Ok(snapshot) => return Ok(Json(snapshot)),
             Err(CodeGraphProjectionError::IndexUnavailable)
             | Err(CodeGraphProjectionError::RepoNotFound(_))
-            | Err(CodeGraphProjectionError::RevisionNotFound(_)) => {}
+            | Err(CodeGraphProjectionError::RevisionNotFound(_))
+            | Err(CodeGraphProjectionError::FileNotFound(_)) => {}
             Err(error) => return Err(code_graph_error(error)),
         }
     }

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -3340,7 +3340,7 @@ fn workspace_comparison_base(
     let target_branch = match trusted_target_branch {
         Some(Ok(branch)) => branch.clone(),
         Some(Err(error)) => return Err(error.clone()),
-        None => code_index_branch(workspace_path).map_err(|error| error.to_string())?,
+        None => "develop".to_owned(),
     };
     let mut references = vec![format!("origin/{target_branch}"), target_branch];
     references.extend([
@@ -6250,8 +6250,9 @@ exit 2
 
         let head_revision =
             command_single_line(workspace, "git", &["rev-parse", "HEAD"]).expect("revision");
-        assert_eq!(untrusted.merge_base, head_revision);
+        assert_eq!(untrusted.merge_base, develop_revision);
         assert_eq!(trusted.merge_base, develop_revision);
+        assert_ne!(untrusted.merge_base, head_revision);
     }
 
     #[test]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2061,9 +2061,10 @@ async fn get_run_code_outline(
         let overlay_run_identifier = run_identifier.clone();
         let overlay_relative_path = relative_path.clone();
         let snapshot = tokio::task::spawn_blocking(move || {
-            let base = comparison_bases
-                .resolve(&overlay_run_identifier, &workspace_path)
-                .map_err(CodeGraphProjectionError::InvalidRequest)?;
+            let Ok(base) = comparison_bases.resolve(&overlay_run_identifier, &workspace_path)
+            else {
+                return Ok(None);
+            };
             code_file_outline_from_workspace(
                 &config,
                 &repo_id,
@@ -2072,6 +2073,7 @@ async fn get_run_code_outline(
                 &base.merge_base,
                 &overlay_relative_path,
             )
+            .map(Some)
         })
         .await
         .unwrap_or_else(|error| {
@@ -2080,7 +2082,8 @@ async fn get_run_code_outline(
             )))
         });
         match snapshot {
-            Ok(snapshot) => return Ok(Json(snapshot)),
+            Ok(Some(snapshot)) => return Ok(Json(snapshot)),
+            Ok(None) => {}
             Err(CodeGraphProjectionError::IndexUnavailable)
             | Err(CodeGraphProjectionError::RepoNotFound(_))
             | Err(CodeGraphProjectionError::RevisionNotFound(_))

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2054,6 +2054,7 @@ async fn get_run_code_outline(
         match snapshot {
             Ok(snapshot) => return Ok(Json(snapshot)),
             Err(CodeGraphProjectionError::IndexUnavailable)
+            | Err(CodeGraphProjectionError::RepoNotFound(_))
             | Err(CodeGraphProjectionError::RevisionNotFound(_)) => {}
             Err(error) => return Err(code_graph_error(error)),
         }

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -3355,20 +3355,23 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
         .expect("decode dirty run code diff overlay");
     assert_eq!(dirty_overlay.repo_id, "opensymphony");
     assert_eq!(dirty_overlay.base_revision, base_revision);
-    assert!(dirty_overlay.head_revision.ends_with("+worktree"));
-    assert_eq!(
-        dirty_overlay.unanalyzed_files,
-        vec![
-            "src/added_empty.rs".to_string(),
-            "src/deleted_empty.rs".to_string(),
-            "src/empty.rs".to_string(),
-            "src/lib.rs".to_string()
-        ]
-    );
+    assert_eq!(dirty_overlay.head_revision, head_revision);
+    assert!(dirty_overlay.unanalyzed_files.is_empty());
     assert!(
         !dirty_overlay.added_symbols.is_empty(),
         "dirty overlays should keep indexed base-to-HEAD symbol diffs"
     );
+    let graph = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/runs/COE-533/code/graph?repo_id=opensymphony&mode=file&path=src/lib.rs"
+        ))
+        .send()
+        .await
+        .expect("fetch dirty run code graph")
+        .json::<CodeGraphSnapshot>()
+        .await
+        .expect("decode dirty run code graph");
+    assert!(graph.nodes.iter().any(|node| node.label == "dirty"));
     let dirty_overlay_json = serde_json::to_string(&dirty_overlay).expect("overlay serializes");
     assert!(!dirty_overlay_json.contains("workspace_path"));
     assert!(!dirty_overlay_json.contains(&root.path().display().to_string()));

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -416,6 +416,7 @@ fn write_code_graph_fixture_with_revisions(
                     ],
                     Vec::new(),
                 ),
+                code_graph_diagnostic_document(),
                 code_graph_document_with_path(
                     "src/empty.rs",
                     "empty-base",
@@ -449,6 +450,7 @@ fn write_code_graph_fixture_with_revisions(
             worktree_dirty: false,
             documents: vec![
                 code_graph_head_document(),
+                code_graph_diagnostic_document(),
                 code_graph_document_with_path(
                     "src/empty.rs",
                     "empty-content",
@@ -577,6 +579,33 @@ fn code_graph_head_document() -> CodeIntelDocumentInput {
                 end_byte: 14,
             },
         ],
+    )
+}
+
+fn code_graph_diagnostic_document() -> CodeIntelDocumentInput {
+    code_graph_document_with_path(
+        "src/diag.rs",
+        "diag-content",
+        vec![code_graph_symbol(
+            "function",
+            "diagnosed",
+            &[],
+            "fn diagnosed()",
+            (1, 0, 22),
+            "diag-symbol",
+        )],
+        Vec::new(),
+        vec![CodeIntelDiagnosticInput {
+            kind: "warning".to_string(),
+            severity: "warning".to_string(),
+            message: "diagnostic fixture".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: 22,
+            start_byte: 0,
+            end_byte: 22,
+        }],
     )
 }
 
@@ -2419,7 +2448,7 @@ async fn gateway_serves_code_graph_contract_endpoints() {
     assert_eq!(repos.schema_version.major, 1);
     assert_eq!(repos.repos.len(), 1);
     assert_eq!(repos.repos[0].repo_id, "opensymphony");
-    assert_eq!(repos.repos[0].document_count, 5);
+    assert_eq!(repos.repos[0].document_count, 6);
     assert_eq!(repos.repos[0].freshness, CodeGraphFreshness::Current);
     assert!(
         !serde_json::to_string(&repos)
@@ -2800,11 +2829,11 @@ async fn gateway_serves_code_graph_contract_endpoints() {
         .await
         .expect("decode code index report");
     assert_eq!(report.status, CodeIndexStatus::Completed);
-    assert_eq!(report.parsed_files, 5);
-    assert_eq!(report.persisted_documents, 5);
-    assert_eq!(report.persisted_symbols, 4);
+    assert_eq!(report.parsed_files, 6);
+    assert_eq!(report.persisted_documents, 6);
+    assert_eq!(report.persisted_symbols, 6);
     assert_eq!(report.persisted_edges, 4);
-    assert_eq!(report.persisted_diagnostics, 2);
+    assert_eq!(report.persisted_diagnostics, 3);
     assert!(report.stale_rows > 0);
     assert_eq!(report.cursor.partition, "code-graph:opensymphony");
     let second_report = client
@@ -3285,12 +3314,15 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
     let workspace = root.path().join("COE-533");
     std::fs::create_dir_all(workspace.join("src")).expect("workspace dirs");
     run_git(&workspace, &["init"]);
-    run_git(&workspace, &["checkout", "-b", "main"]);
+    run_git(&workspace, &["checkout", "-b", "develop"]);
     run_git(&workspace, &["config", "user.email", "test@example.com"]);
     run_git(&workspace, &["config", "user.name", "Test User"]);
     std::fs::write(workspace.join(".gitignore"), "generated.rs\n").expect("gitignore");
+    std::fs::write(workspace.join("src/deleted_empty.rs"), "").expect("deleted empty file");
+    std::fs::write(workspace.join("src/diag.rs"), "pub fn diagnosed() {}\n")
+        .expect("diagnostic file");
     std::fs::write(workspace.join("src/lib.rs"), "pub fn base() {}\n").expect("base file");
-    run_git(&workspace, &["add", ".gitignore", "src/lib.rs"]);
+    run_git(&workspace, &["add", "."]);
     run_git(&workspace, &["commit", "-m", "base"]);
     let base_revision = run_git(&workspace, &["rev-parse", "HEAD"]);
     run_git(&workspace, &["checkout", "-b", "feat/code-graph"]);
@@ -3299,7 +3331,8 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
         "pub fn base() {}\npub fn head() {}\n",
     )
     .expect("head file");
-    run_git(&workspace, &["add", "src/lib.rs"]);
+    std::fs::remove_file(workspace.join("src/deleted_empty.rs")).expect("delete empty file");
+    run_git(&workspace, &["add", "-A"]);
     run_git(&workspace, &["commit", "-m", "head"]);
     let head_revision = run_git(&workspace, &["rev-parse", "HEAD"]);
     let config =
@@ -3381,10 +3414,37 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
     assert_eq!(dirty_overlay.repo_id, "opensymphony");
     assert_eq!(dirty_overlay.base_revision, base_revision);
     assert_eq!(dirty_overlay.head_revision, head_revision);
-    assert!(dirty_overlay.unanalyzed_files.is_empty());
     assert!(
         !dirty_overlay.added_symbols.is_empty(),
         "dirty overlays should keep indexed base-to-HEAD symbol diffs"
+    );
+    assert!(
+        dirty_overlay
+            .unanalyzed_files
+            .iter()
+            .any(|path| path == "src/deleted_empty.rs")
+    );
+    let diagnostic_response = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/runs/COE-533/code/graph?repo_id=opensymphony&mode=atlas"
+        ))
+        .send()
+        .await
+        .expect("fetch unchanged diagnostic graph");
+    assert_eq!(diagnostic_response.status(), reqwest::StatusCode::OK);
+    let diagnostic_graph = diagnostic_response
+        .json::<CodeGraphSnapshot>()
+        .await
+        .expect("decode unchanged diagnostic graph");
+    let diagnostic_node = diagnostic_graph
+        .nodes
+        .iter()
+        .find(|node| node.label == "diagnosed")
+        .expect("diagnosed symbol node");
+    assert_eq!(diagnostic_node.diagnostic_count, 1);
+    assert_eq!(
+        diagnostic_node.diagnostic_severity.as_deref(),
+        Some("warning")
     );
     let graph = reqwest::Client::new()
         .get(format!(

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -3426,7 +3426,7 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
     );
     let diagnostic_response = reqwest::Client::new()
         .get(format!(
-            "http://{address}/api/v1/runs/COE-533/code/graph?repo_id=opensymphony&mode=atlas"
+            "http://{address}/api/v1/runs/COE-533/code/graph?repo_id=opensymphony&mode=atlas&include_stale=true"
         ))
         .send()
         .await
@@ -3436,6 +3436,11 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
         .json::<CodeGraphSnapshot>()
         .await
         .expect("decode unchanged diagnostic graph");
+    assert!(
+        diagnostic_graph
+            .filters_applied
+            .contains(&"include_stale:true".to_string())
+    );
     let diagnostic_node = diagnostic_graph
         .nodes
         .iter()

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -3288,8 +3288,9 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
     run_git(&workspace, &["checkout", "-b", "main"]);
     run_git(&workspace, &["config", "user.email", "test@example.com"]);
     run_git(&workspace, &["config", "user.name", "Test User"]);
+    std::fs::write(workspace.join(".gitignore"), "generated.rs\n").expect("gitignore");
     std::fs::write(workspace.join("src/lib.rs"), "pub fn base() {}\n").expect("base file");
-    run_git(&workspace, &["add", "src/lib.rs"]);
+    run_git(&workspace, &["add", ".gitignore", "src/lib.rs"]);
     run_git(&workspace, &["commit", "-m", "base"]);
     let base_revision = run_git(&workspace, &["rev-parse", "HEAD"]);
     run_git(&workspace, &["checkout", "-b", "feat/code-graph"]);
@@ -3320,6 +3321,30 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
             .await
             .expect("test gateway server should serve")
     });
+
+    std::fs::write(
+        workspace.join("generated.rs"),
+        "pub fn generated_outline() {}\n",
+    )
+    .expect("ignored generated file");
+    let generated_outline = reqwest::Client::new()
+        .get(format!(
+            "http://{address}/api/v1/runs/COE-533/code/outline?file_path=generated.rs&repo_id=opensymphony"
+        ))
+        .send()
+        .await
+        .expect("fetch ignored generated outline");
+    assert_eq!(generated_outline.status(), reqwest::StatusCode::OK);
+    let generated_outline = generated_outline
+        .json::<CodeFileOutline>()
+        .await
+        .expect("decode ignored generated outline");
+    assert!(
+        generated_outline
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "generated_outline")
+    );
 
     let overlay = reqwest::Client::new()
         .get(format!(

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -3211,6 +3211,8 @@ async fn gateway_serves_code_graph_contract_endpoints() {
 
 #[tokio::test]
 async fn gateway_serves_run_code_outline_without_workspace_root_leakage() {
+    let memory_repo = tempfile::tempdir().expect("memory repository");
+    let memory_config = MemoryConfig::load(memory_repo.path(), None).expect("memory config");
     let root = tempfile::tempdir().expect("workspace root");
     let workspace = root.path().join("COE-533");
     std::fs::create_dir_all(workspace.join("src")).expect("workspace dirs");
@@ -3225,7 +3227,7 @@ async fn gateway_serves_run_code_outline_without_workspace_root_leakage() {
     snapshot.issues[0].identifier = "COE-533".to_string();
     snapshot.issues[0].workspace_path_suffix = "COE-533".to_string();
     let store = SnapshotStore::new(snapshot);
-    let server = GatewayServer::new(store);
+    let server = GatewayServer::new(store).with_memory_config(Some(memory_config));
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind test listener");
@@ -3413,7 +3415,10 @@ async fn gateway_serves_run_code_diff_overlay_with_resolved_revisions() {
         .expect("decode dirty run code diff overlay");
     assert_eq!(dirty_overlay.repo_id, "opensymphony");
     assert_eq!(dirty_overlay.base_revision, base_revision);
-    assert_eq!(dirty_overlay.head_revision, head_revision);
+    assert_eq!(
+        dirty_overlay.head_revision,
+        format!("{head_revision}+worktree")
+    );
     assert!(
         !dirty_overlay.added_symbols.is_empty(),
         "dirty overlays should keep indexed base-to-HEAD symbol diffs"

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -792,7 +792,7 @@ fn code_graph_workspace_focused_overlay(
                     "neighborhood mode requires `symbol_key`".to_string(),
                 )
             })?;
-            let (live_symbols, live_edges, analyzed_paths, unanalyzed_files) =
+            let (live_symbols, mut live_edges, analyzed_paths, unanalyzed_files) =
                 workspace_live_changed_records(config, repo_id, workspace_path, &changed_paths, &tombstones)?;
             let mut symbols = BTreeMap::new();
             let mut base_symbols = BTreeMap::new();
@@ -813,6 +813,10 @@ fn code_graph_workspace_focused_overlay(
             } else {
                 return Err(CodeGraphProjectionError::SymbolNotFound(center.to_string()));
             }
+
+            let mut live_edge_resolution_symbols = live_symbols.clone();
+            live_edge_resolution_symbols.extend(symbols.clone());
+            re_resolve_workspace_edges(&mut live_edges, &live_edge_resolution_symbols);
 
             let mut edges = BTreeMap::new();
             let mut base_edges = BTreeMap::new();
@@ -1488,7 +1492,7 @@ fn render_workspace_graph_snapshot(
         mode,
         nodes,
         edges,
-        false,
+        options.include_stale,
         options.aggregate,
         truncation(
             dropped_paths + dropped_symbols,
@@ -5721,6 +5725,8 @@ mod code_graph_tests {
             "pub fn baseline() {}\npub fn removed_from_live() {}\npub fn caller() { baseline(); }\n",
         )
         .expect("baseline source");
+        fs::write(repo.path().join("src/target.rs"), "pub fn target() {}\n")
+            .expect("unchanged target source");
         fs::write(repo.path().join("src/remove.rs"), "pub fn removed() {}\n")
             .expect("removed source");
         fs::write(repo.path().join("src/delete_empty.rs"), "").expect("empty deleted source");
@@ -5746,7 +5752,7 @@ mod code_graph_tests {
 
         fs::write(
             repo.path().join("src/lib.rs"),
-            "pub fn baseline() { changed(); }\npub fn changed() {}\npub fn caller() { baseline(); }\n",
+            "pub fn baseline() { changed(); }\npub fn changed() {}\npub fn caller() { baseline(); }\npub fn changed_caller() { target(); }\n",
         )
         .expect("modified source");
         fs::remove_file(repo.path().join("src/remove.rs")).expect("deleted source");
@@ -5859,6 +5865,32 @@ mod code_graph_tests {
             .nodes
             .iter()
             .any(|node| node.label == "baseline"));
+        let target_key = overlay
+            .base_symbols
+            .values()
+            .find(|symbol| symbol.name == "target")
+            .map(|symbol| symbol.symbol_key.clone())
+            .expect("unchanged baseline target symbol");
+        let target_neighborhood = code_graph_workspace_snapshot(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::Neighborhood,
+                path: None,
+                symbol_key: Some(target_key),
+                depth: 1,
+                aggregate: None,
+                include_stale: false,
+            },
+        )
+        .expect("focused neighborhood should include changed caller edges");
+        assert!(target_neighborhood
+            .nodes
+            .iter()
+            .any(|node| node.label == "changed_caller"));
         let removed_from_live_key = overlay
             .base_symbols
             .values()

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -49,6 +49,40 @@ pub struct CodeGraphSnapshotOptions {
     pub include_stale: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeWorkspaceOverlay {
+    pub run_id: String,
+    pub base_revision: String,
+    pub head_revision: String,
+    pub workspace_content_digest: String,
+    pub base_symbols: BTreeMap<String, CodeSymbolRecord>,
+    pub base_paths: BTreeSet<String>,
+    pub base_edges: Vec<CodeEdgeRecord>,
+    pub symbols: BTreeMap<String, CodeSymbolRecord>,
+    pub edges: Vec<CodeEdgeRecord>,
+    pub changed_paths: BTreeSet<String>,
+    pub tombstones: BTreeSet<String>,
+    pub unanalyzed_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct WorkspaceDocumentCacheKey {
+    repo_id: String,
+    path: String,
+    content_sha256: String,
+    max_capture_bytes: usize,
+    max_matches: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkspaceDocumentRecords {
+    symbols: Vec<CodeSymbolRecord>,
+    edges: Vec<CodeEdgeRecord>,
+}
+
+static WORKSPACE_DOCUMENT_CACHE: OnceLock<Mutex<BTreeMap<WorkspaceDocumentCacheKey, WorkspaceDocumentRecords>>> =
+    OnceLock::new();
+
 pub fn code_graph_repos(
     config: &MemoryConfig,
     include_stale: bool,
@@ -531,6 +565,770 @@ pub fn code_graph_diff_overlay(
     })
 }
 
+pub fn code_graph_workspace_overlay(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    run_id: &str,
+    base_revision: &str,
+) -> Result<CodeWorkspaceOverlay, CodeGraphProjectionError> {
+    if !workspace_path.is_dir() {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "run workspace is not available".to_string(),
+        ));
+    }
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Err(CodeGraphProjectionError::RepoNotFound(repo_id.to_string()));
+    };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Err(CodeGraphProjectionError::RevisionNotFound(
+            base_revision.to_string(),
+        ));
+    }
+
+    let base_symbols = query_symbols_for_revision(config, &connection, repo_id, base_revision)?;
+    let base_paths = query_revision_documents(&connection, config, repo_id, base_revision)?
+        .into_keys()
+        .collect::<BTreeSet<_>>();
+    let base_edges = query_code_edges_for_revision(&connection, config, repo_id, base_revision)?;
+    let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
+    let (changed_paths, tombstones, workspace_content_digest) =
+        workspace_changed_paths(workspace_path, base_revision)?;
+
+    let mut symbols = base_symbols.clone();
+    let mut edges = base_edges
+        .clone()
+        .into_iter()
+        .map(|edge| (edge.edge_id.clone(), edge))
+        .collect::<BTreeMap<_, _>>();
+    let mut unanalyzed_files = BTreeSet::new();
+    let mut remaining_files = config.code_intel.ast.max_files_per_request;
+
+    for path in &changed_paths {
+        symbols.retain(|_, symbol| symbol.path != *path);
+        edges.retain(|_, edge| edge.path != *path);
+
+        let file_path = workspace_path.join(path);
+        if !file_path.is_file() {
+            if !base_symbols.values().any(|symbol| symbol.path == *path) {
+                unanalyzed_files.insert(path.clone());
+            }
+            continue;
+        }
+        if remaining_files == 0 {
+            unanalyzed_files.insert(path.clone());
+            continue;
+        }
+        remaining_files = remaining_files.saturating_sub(1);
+
+        let Some(records) = workspace_document_records(
+            config,
+            repo_id,
+            workspace_path,
+            path,
+        )?
+        else {
+            unanalyzed_files.insert(path.clone());
+            continue;
+        };
+        if records.symbols.is_empty() {
+            unanalyzed_files.insert(path.clone());
+        }
+        for symbol in records.symbols {
+            symbols.insert(symbol.symbol_key.clone(), symbol);
+        }
+        for edge in records.edges {
+            edges.insert(edge.edge_id.clone(), edge);
+        }
+    }
+
+    re_resolve_workspace_edges(&mut edges, &symbols);
+    Ok(CodeWorkspaceOverlay {
+        run_id: run_id.to_string(),
+        base_revision: base_revision.to_string(),
+        head_revision,
+        workspace_content_digest,
+        base_symbols,
+        base_paths,
+        base_edges,
+        symbols,
+        edges: edges.into_values().collect(),
+        changed_paths,
+        tombstones,
+        unanalyzed_files: unanalyzed_files.into_iter().collect(),
+    })
+}
+
+pub fn code_graph_workspace_diff_overlay(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    run_id: &str,
+    base_revision: &str,
+    max_records: usize,
+) -> Result<CodeDiffOverlay, CodeGraphProjectionError> {
+    let overlay = code_graph_workspace_overlay(
+        config,
+        repo_id,
+        workspace_path,
+        run_id,
+        base_revision,
+    )?;
+    let mut keys = overlay.base_symbols.keys().cloned().collect::<BTreeSet<_>>();
+    keys.extend(overlay.symbols.keys().cloned());
+    let max_records = max_records.max(1);
+    let mut diffs = Vec::new();
+    let mut dropped_records = 0;
+    for key in keys {
+        let diff = match (overlay.base_symbols.get(&key), overlay.symbols.get(&key)) {
+            (None, Some(head)) => Some(CodeDiffSymbol {
+                symbol_key: key,
+                status: DtoDiffStatus::Added,
+                before: None,
+                after: Some(diff_side_from_symbol(head)),
+            }),
+            (Some(base), None) => Some(CodeDiffSymbol {
+                symbol_key: key,
+                status: DtoDiffStatus::Removed,
+                before: Some(diff_side_from_symbol(base)),
+                after: None,
+            }),
+            (Some(base), Some(head)) if base.snippet_sha256 != head.snippet_sha256 => {
+                Some(CodeDiffSymbol {
+                    symbol_key: key,
+                    status: DtoDiffStatus::Modified,
+                    before: Some(diff_side_from_symbol(base)),
+                    after: Some(diff_side_from_symbol(head)),
+                })
+            }
+            _ => None,
+        };
+        if let Some(diff) = diff {
+            if diffs.len() == max_records {
+                dropped_records += 1;
+            } else {
+                diffs.push(diff);
+            }
+        }
+    }
+
+    let changed_keys = diffs
+        .iter()
+        .map(|diff| diff.symbol_key.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut blast_radius = Vec::new();
+    for diff in &diffs {
+        let graph_edges = if diff.status == DtoDiffStatus::Removed {
+            &overlay.base_edges
+        } else {
+            &overlay.edges
+        };
+        let inbound_edges = graph_edges
+            .iter()
+            .filter(|edge| edge.target_symbol_key.as_deref() == Some(diff.symbol_key.as_str()))
+            .collect::<Vec<_>>();
+        let inbound_count = inbound_edges
+            .iter()
+            .filter(|edge| is_blast_radius_edge(edge))
+            .filter(|edge| {
+                edge.source_symbol_key
+                    .as_deref()
+                    .is_none_or(|source| !changed_keys.contains(source))
+            })
+            .count();
+        let outbound_count = graph_edges
+            .iter()
+            .filter(|edge| edge.source_symbol_key.as_deref() == Some(diff.symbol_key.as_str()))
+            .filter(|edge| is_blast_radius_edge(edge))
+            .count();
+        if inbound_count > 0 || outbound_count > 0 {
+            blast_radius.push(CodeDiffBlastRadius {
+                symbol_key: diff.symbol_key.clone(),
+                inbound_count,
+                outbound_count,
+            });
+        }
+    }
+
+    Ok(CodeDiffOverlay {
+        schema_version: SchemaVersion::v1(),
+        repo_id: repo_id.to_string(),
+        base_revision: overlay.base_revision,
+        head_revision: overlay.head_revision,
+        added_symbols: diffs
+            .iter()
+            .filter(|diff| diff.status == DtoDiffStatus::Added)
+            .cloned()
+            .collect(),
+        removed_symbols: diffs
+            .iter()
+            .filter(|diff| diff.status == DtoDiffStatus::Removed)
+            .cloned()
+            .collect(),
+        modified_symbols: diffs
+            .iter()
+            .filter(|diff| diff.status == DtoDiffStatus::Modified)
+            .cloned()
+            .collect(),
+        blast_radius,
+        unanalyzed_files: overlay.unanalyzed_files,
+        truncation: truncation(dropped_records, 0, "workspace overlay symbols capped"),
+        generated_at: Utc::now(),
+    })
+}
+
+pub fn code_file_outline_from_workspace(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    run_id: &str,
+    base_revision: &str,
+    raw_path: &str,
+) -> Result<CodeFileOutline, CodeGraphProjectionError> {
+    let path = normalize_code_path(raw_path).map_err(CodeGraphProjectionError::InvalidRequest)?;
+    if !workspace_path.join(&path).is_file() {
+        return Err(CodeGraphProjectionError::FileNotFound(path));
+    }
+    let overlay = code_graph_workspace_overlay(
+        config,
+        repo_id,
+        workspace_path,
+        run_id,
+        base_revision,
+    )?;
+    let symbols = overlay
+        .symbols
+        .values()
+        .filter(|symbol| symbol.path == path)
+        .map(|symbol| CodeOutlineSymbol {
+            symbol_key: symbol.symbol_key.clone(),
+            name: symbol.name.clone(),
+            kind: symbol.kind.clone(),
+            path: symbol.path.clone(),
+            span: span_from_symbol(symbol),
+            selection_span: selection_span_from_symbol(symbol),
+            container_chain: symbol.container_chain.clone(),
+        })
+        .collect();
+    Ok(CodeFileOutline {
+        schema_version: SchemaVersion::v1(),
+        run_id: run_id.to_string(),
+        repo_id: Some(repo_id.to_string()),
+        path,
+        symbols,
+        generated_at: Utc::now(),
+    })
+}
+
+pub fn code_graph_workspace_snapshot(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    run_id: &str,
+    base_revision: &str,
+    options: CodeGraphSnapshotOptions,
+) -> Result<CodeGraphSnapshot, CodeGraphProjectionError> {
+    if options.aggregate == Some(CodeGraphAggregate::Community) {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "community aggregation is not available for workspace code graphs".to_string(),
+        ));
+    }
+    let mode = options.mode;
+    let overlay = code_graph_workspace_overlay(
+        config,
+        repo_id,
+        workspace_path,
+        run_id,
+        base_revision,
+    )?;
+    let mut paths = BTreeSet::new();
+    let mut selected_keys = BTreeSet::new();
+    match mode {
+        CodeGraphMode::Atlas => {
+            selected_keys.extend(overlay.symbols.keys().cloned());
+            paths.extend(overlay.base_paths.iter().cloned());
+            paths.extend(
+                overlay
+                    .changed_paths
+                    .iter()
+                    .filter(|path| !overlay.tombstones.contains(*path))
+                    .cloned(),
+            );
+        }
+        CodeGraphMode::File => {
+            let path = options.path.as_deref().ok_or_else(|| {
+                CodeGraphProjectionError::InvalidRequest("file mode requires `path`".to_string())
+            })?;
+            let path = normalize_code_path(path).map_err(CodeGraphProjectionError::InvalidRequest)?;
+            if !overlay.symbols.values().any(|symbol| symbol.path == path)
+                && !overlay.changed_paths.contains(&path)
+            {
+                return Err(CodeGraphProjectionError::FileNotFound(path));
+            }
+            paths.insert(path.clone());
+            selected_keys.extend(
+                overlay
+                    .symbols
+                    .values()
+                    .filter(|symbol| symbol.path == path)
+                    .map(|symbol| symbol.symbol_key.clone()),
+            );
+        }
+        CodeGraphMode::Neighborhood => {
+            let center = options.symbol_key.as_deref().ok_or_else(|| {
+                CodeGraphProjectionError::InvalidRequest(
+                    "neighborhood mode requires `symbol_key`".to_string(),
+                )
+            })?;
+            if !overlay.symbols.contains_key(center) {
+                return Err(CodeGraphProjectionError::SymbolNotFound(center.to_string()));
+            }
+            selected_keys.insert(center.to_string());
+            let mut frontier = BTreeSet::from([center.to_string()]);
+            for _ in 0..options.depth.max(1) {
+                let mut next = BTreeSet::new();
+                for edge in &overlay.edges {
+                    let source = edge.source_symbol_key.as_deref();
+                    let target = edge.target_symbol_key.as_deref();
+                    if source.is_some_and(|source| frontier.contains(source))
+                        && let Some(target) =
+                            target.filter(|target| overlay.symbols.contains_key(*target))
+                    {
+                        next.insert(target.to_string());
+                    }
+                    if target.is_some_and(|target| frontier.contains(target))
+                        && let Some(source) =
+                            source.filter(|source| overlay.symbols.contains_key(*source))
+                    {
+                        next.insert(source.to_string());
+                    }
+                }
+                next.retain(|key| !selected_keys.contains(key));
+                if next.is_empty() {
+                    break;
+                }
+                selected_keys.extend(next.iter().cloned());
+                frontier = next;
+            }
+        }
+    }
+
+    let dropped_symbols = selected_keys.len().saturating_sub(CODE_GRAPH_MAX_RECORDS);
+    selected_keys = selected_keys
+        .into_iter()
+        .take(CODE_GRAPH_MAX_RECORDS)
+        .collect();
+    for key in &selected_keys {
+        if let Some(symbol) = overlay.symbols.get(key) {
+            paths.insert(symbol.path.clone());
+        }
+    }
+
+    let mut nodes = BTreeMap::new();
+    let mut graph_edges = BTreeMap::new();
+    for path in paths {
+        if overlay.tombstones.contains(&path) {
+            continue;
+        }
+        let language = overlay
+            .symbols
+            .values()
+            .find(|symbol| symbol.path == path)
+            .map(|symbol| symbol.language.clone())
+            .or_else(|| detect_language(Path::new(&path)).map(|language| language.id().to_string()));
+        insert_path_nodes(
+            &mut nodes,
+            &mut graph_edges,
+            &path,
+            language,
+            CodeGraphFreshness::Current,
+        );
+    }
+    for key in &selected_keys {
+        let Some(symbol) = overlay.symbols.get(key) else {
+            continue;
+        };
+        let node = workspace_symbol_node(symbol);
+        let file_id = file_node_id(&symbol.path);
+        insert_code_graph_edge(
+            &mut graph_edges,
+            "contains".to_string(),
+            file_id,
+            node.id.clone(),
+            CodeGraphConfidence::Exact,
+            false,
+            None,
+        );
+        nodes.insert(node.id.clone(), node);
+    }
+
+    let mut dropped_edges = 0;
+    for edge in &overlay.edges {
+        let Some(source) = edge.source_symbol_key.as_deref() else {
+            continue;
+        };
+        if !selected_keys.contains(source) {
+            continue;
+        }
+        let target_id = match edge.target_symbol_key.as_deref() {
+            Some(target) if selected_keys.contains(target) => symbol_node_id(target),
+            Some(_) => continue,
+            None => format!("hint:{}", edge.edge_id),
+        };
+        if graph_edges.len() >= CODE_GRAPH_MAX_RECORDS {
+            dropped_edges += 1;
+            continue;
+        }
+        if edge.target_symbol_key.is_none() {
+            nodes
+                .entry(target_id.clone())
+                .or_insert_with(|| hint_node(&target_id, edge.target_hint.as_deref()));
+        }
+        insert_code_graph_edge(
+            &mut graph_edges,
+            edge.edge_kind.clone(),
+            symbol_node_id(source),
+            target_id,
+            confidence_from_str(&edge.confidence),
+            edge.unresolved,
+            edge.target_hint.clone(),
+        );
+    }
+
+    let mut nodes = nodes.into_values().collect::<Vec<_>>();
+    let edges = graph_edges.into_values().collect::<Vec<_>>();
+    apply_code_node_metrics(&mut nodes, &edges);
+    Ok(snapshot(
+        repo_id,
+        mode,
+        nodes,
+        edges,
+        false,
+        options.aggregate,
+        truncation(dropped_symbols, dropped_edges, "workspace graph records capped"),
+    ))
+}
+
+fn workspace_document_records(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    path: &str,
+) -> Result<Option<WorkspaceDocumentRecords>, CodeGraphProjectionError> {
+    let file_path = workspace_path.join(path);
+    let Ok(bytes) = fs::read(&file_path) else {
+        return Ok(None);
+    };
+    let Some(language) = detect_language(Path::new(path)) else {
+        return Ok(None);
+    };
+    if bytes.len() as u64 > config.code_intel.ast.max_file_bytes {
+        return Ok(None);
+    }
+    let Ok(source) = String::from_utf8(bytes) else {
+        return Ok(None);
+    };
+    let content_sha256 = sha256_hex(&source);
+    let key = WorkspaceDocumentCacheKey {
+        repo_id: repo_id.to_string(),
+        path: path.to_string(),
+        content_sha256,
+        max_capture_bytes: config.code_intel.ast.max_capture_bytes,
+        max_matches: config.code_intel.ast.max_matches_per_request,
+    };
+    if let Some(cached) = WORKSPACE_DOCUMENT_CACHE
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .map_err(|_| CodeGraphProjectionError::InvalidRequest("workspace overlay cache poisoned".to_string()))?
+        .get(&key)
+        .cloned()
+    {
+        return Ok(Some(cached));
+    }
+
+    let Ok(summary) = parse_path(Path::new(path), &source) else {
+        return Ok(None);
+    };
+    let mut remaining_matches = config.code_intel.ast.max_matches_per_request;
+    let document = code_index_document(
+        PathBuf::from(path),
+        &source,
+        &summary,
+        &mut remaining_matches,
+        config.code_intel.ast.max_capture_bytes,
+    );
+    let prepared = prepare_code_symbols(repo_id, None, true, path, &document);
+    let indexed_at = Utc::now().to_rfc3339();
+    let symbols = prepared
+        .iter()
+        .map(|prepared| {
+            let symbol = prepared.symbol;
+            CodeSymbolRecord {
+                symbol_id: prepared.symbol_id.clone(),
+                symbol_key: prepared.symbol_key.clone(),
+                repo_id: repo_id.to_string(),
+                commit_sha: None,
+                path: path.to_string(),
+                language: language.id().to_string(),
+                kind: symbol.kind.clone(),
+                name: symbol.name.clone(),
+                container_symbol_id: prepared.container_symbol_id.clone(),
+                container_chain: symbol.container_chain.clone(),
+                signature: symbol.signature.clone(),
+                start_line: symbol.start_line,
+                start_col: symbol.start_col,
+                end_line: symbol.end_line,
+                end_col: symbol.end_col,
+                start_byte: symbol.start_byte,
+                end_byte: symbol.end_byte,
+                selection_start_line: symbol.selection_start_line,
+                selection_end_line: symbol.selection_end_line,
+                content_sha256: document.content_sha256.clone(),
+                snippet_sha256: symbol.snippet_sha256.clone(),
+                parser_version: document.parser_version.clone(),
+                query_pack_version: document.query_pack_version.clone(),
+                freshness: "current".to_string(),
+                indexed_at: indexed_at.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+    let edges = document
+        .edges
+        .iter()
+        .enumerate()
+        .map(|(index, edge)| {
+            let resolved = resolve_code_edge(edge, &prepared);
+            CodeEdgeRecord {
+                edge_id: code_row_id(&[
+                    repo_id,
+                    path,
+                    &document.content_sha256,
+                    &document.parser_version,
+                    &document.query_pack_version,
+                    &edge.edge_kind,
+                    edge.target_hint.as_deref().unwrap_or(""),
+                    &edge.start_line.to_string(),
+                    &edge.start_col.to_string(),
+                    &edge.end_line.to_string(),
+                    &edge.end_col.to_string(),
+                    &edge.start_byte.to_string(),
+                    &edge.end_byte.to_string(),
+                    &index.to_string(),
+                ]),
+                edge_kind: edge.edge_kind.clone(),
+                source_symbol_key: resolved.source_symbol_key,
+                target_symbol_key: resolved.target_symbol_key,
+                target_hint: edge.target_hint.clone(),
+                confidence: normalize_edge_confidence(&edge.confidence, resolved.target_resolved).to_string(),
+                unresolved: !resolved.target_resolved,
+                path: path.to_string(),
+                commit_sha: None,
+                freshness: "current".to_string(),
+                start_line: edge.start_line,
+                start_col: edge.start_col,
+                end_line: edge.end_line,
+                end_col: edge.end_col,
+            }
+        })
+        .filter(|edge| edge.source_symbol_key.is_some())
+        .collect::<Vec<_>>();
+    let records = WorkspaceDocumentRecords { symbols, edges };
+    let mut cache = WORKSPACE_DOCUMENT_CACHE
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .map_err(|_| CodeGraphProjectionError::InvalidRequest("workspace overlay cache poisoned".to_string()))?;
+    if cache.len() >= 128
+        && let Some(first) = cache.keys().next().cloned()
+    {
+        cache.remove(&first);
+    }
+    cache.insert(key, records.clone());
+    Ok(Some(records))
+}
+
+fn workspace_changed_paths(
+    workspace_path: &Path,
+    base_revision: &str,
+) -> Result<(BTreeSet<String>, BTreeSet<String>, String), CodeGraphProjectionError> {
+    let diff = workspace_git_bytes(
+        workspace_path,
+        ["diff", "--name-status", "--find-renames", "-z", base_revision, "--"],
+    )?;
+    let mut changed = BTreeSet::new();
+    let mut tombstones = BTreeSet::new();
+    let fields = diff
+        .split(|byte| *byte == 0)
+        .filter(|field| !field.is_empty())
+        .map(|field| String::from_utf8_lossy(field).into_owned())
+        .collect::<Vec<_>>();
+    let mut index = 0;
+    while index < fields.len() {
+        let status = &fields[index];
+        index += 1;
+        if status.starts_with('R') || status.starts_with('C') {
+            let old = fields.get(index).cloned().unwrap_or_default();
+            let new = fields.get(index + 1).cloned().unwrap_or_default();
+            index += 2;
+            if !old.is_empty() {
+                changed.insert(old.clone());
+                tombstones.insert(old);
+            }
+            if !new.is_empty() {
+                changed.insert(new);
+            }
+        } else if let Some(path) = fields.get(index) {
+            index += 1;
+            if !path.is_empty() {
+                changed.insert(path.clone());
+                if status.starts_with('D') {
+                    tombstones.insert(path.clone());
+                }
+            }
+        }
+    }
+    for path in String::from_utf8_lossy(&workspace_git_bytes(
+        workspace_path,
+        ["ls-files", "--others", "--exclude-standard", "-z"],
+    )?)
+    .split('\0')
+    .filter(|path| !path.is_empty())
+    {
+        changed.insert(path.to_string());
+    }
+
+    let mut digest_input = Vec::new();
+    for path in &changed {
+        digest_input.extend_from_slice(path.as_bytes());
+        digest_input.push(0);
+        match fs::read(workspace_path.join(path)) {
+            Ok(bytes) => digest_input.extend_from_slice(&bytes),
+            Err(_) => digest_input.extend_from_slice(b"<deleted>"),
+        }
+        digest_input.push(0);
+    }
+    Ok((changed, tombstones, sha256_bytes_hex(&digest_input)))
+}
+
+fn workspace_git_line<const N: usize>(
+    workspace_path: &Path,
+    args: [&str; N],
+) -> Result<String, CodeGraphProjectionError> {
+    Ok(String::from_utf8_lossy(&workspace_git_bytes(workspace_path, args)?)
+        .trim()
+        .to_string())
+}
+
+fn workspace_git_bytes<const N: usize>(
+    workspace_path: &Path,
+    args: [&str; N],
+) -> Result<Vec<u8>, CodeGraphProjectionError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_path)
+        .args(args)
+        .output()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: workspace_path.to_path_buf(),
+            source,
+        }))?;
+    if !output.status.success() {
+        return Err(CodeGraphProjectionError::InvalidRequest(format!(
+            "git command failed in workspace {}",
+            workspace_path.display()
+        )));
+    }
+    Ok(output.stdout)
+}
+
+fn re_resolve_workspace_edges(
+    edges: &mut BTreeMap<String, CodeEdgeRecord>,
+    symbols: &BTreeMap<String, CodeSymbolRecord>,
+) {
+    let mut names = BTreeMap::<String, Option<String>>::new();
+    for symbol in symbols.values() {
+        names
+            .entry(symbol.name.clone())
+            .and_modify(|value| *value = None)
+            .or_insert_with(|| Some(symbol.symbol_key.clone()));
+    }
+    edges.retain(|_, edge| {
+        if edge
+            .source_symbol_key
+            .as_deref()
+            .is_none_or(|source| !symbols.contains_key(source))
+        {
+            return false;
+        }
+        if edge
+            .target_symbol_key
+            .as_deref()
+            .is_some_and(|target| !symbols.contains_key(target))
+        {
+            edge.target_symbol_key = None;
+            edge.unresolved = true;
+        }
+        if edge.target_symbol_key.is_none()
+            && let Some(name) = edge
+                .target_hint
+                .as_deref()
+                .and_then(edge_target_name)
+            && let Some(Some(target)) = names.get(name)
+        {
+            edge.target_symbol_key = Some(target.clone());
+            edge.unresolved = false;
+            edge.confidence = normalize_edge_confidence(&edge.confidence, true).to_string();
+        }
+        true
+    });
+}
+
+fn is_blast_radius_edge(edge: &CodeEdgeRecord) -> bool {
+    let kind = edge.edge_kind.to_ascii_lowercase();
+    kind.contains("call") || kind.contains("reference")
+}
+
+fn query_code_edges_for_revision(
+    connection: &Connection,
+    config: &MemoryConfig,
+    repo_id: &str,
+    revision: &str,
+) -> Result<Vec<CodeEdgeRecord>, MemoryError> {
+    let membership_ready = matches!(
+        code_snapshot_status(connection, config, repo_id, revision)?.as_deref(),
+        None | Some("completed")
+    ) && code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
+    let query = if membership_ready {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed)) ORDER BY e.path, e.start_line, e.start_col, e.edge_id"
+    } else {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges WHERE repo_id = ? AND commit_sha = ? AND freshness <> 'staged' AND NOT worktree_dirty ORDER BY path, start_line, start_col, edge_id"
+    };
+    let mut statement = connection.prepare(query).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let rows = if membership_ready {
+        statement
+            .query_map(params![repo_id, revision, revision], code_edge_from_row)
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+    } else {
+        statement
+            .query_map(params![repo_id, revision], code_edge_from_row)
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+    };
+    rows.map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })
+}
+
 pub fn code_graph_index_report(
     config: &MemoryConfig,
     repo_id: &str,
@@ -604,7 +1402,7 @@ struct CodeSnapshotState<'a> {
 pub fn code_index_target(
     config: &MemoryConfig,
 ) -> Result<Option<(String, String)>, CodeGraphProjectionError> {
-    let branch = configured_code_index_branch(&config.repo_root)?;
+    let branch = code_index_branch(&config.repo_root)?;
     let Some(commit) = git_target_commit(&config.repo_root, &branch)? else {
         return Ok(None);
     };
@@ -1201,7 +1999,7 @@ fn index_code_repository_at_checked(
     })
 }
 
-fn configured_code_index_branch(root: &Path) -> Result<String, CodeGraphProjectionError> {
+pub fn code_index_branch(root: &Path) -> Result<String, CodeGraphProjectionError> {
     let workflow = root.join("WORKFLOW.md");
     if !workflow.is_file() {
         return Ok(DEFAULT_CODE_INDEX_BRANCH.to_string());
@@ -3041,6 +3839,27 @@ fn symbol_node(
     })
 }
 
+fn workspace_symbol_node(symbol: &CodeSymbolRecord) -> CodeGraphNode {
+    CodeGraphNode {
+        id: symbol_node_id(&symbol.symbol_key),
+        kind: CodeGraphNodeKind::Symbol,
+        label: symbol.name.clone(),
+        symbol_kind: Some(symbol.kind.clone()),
+        symbol_key: Some(symbol.symbol_key.clone()),
+        symbol_id: Some(symbol.symbol_id.clone()),
+        path_display: Some(symbol.path.clone()),
+        language: Some(symbol.language.clone()),
+        container_chain: symbol.container_chain.clone(),
+        signature: symbol.signature.clone(),
+        span: Some(span_from_symbol(symbol)),
+        selection_span: Some(selection_span_from_symbol(symbol)),
+        freshness: CodeGraphFreshness::Current,
+        diagnostic_count: 0,
+        diagnostic_severity: None,
+        metrics: CodeGraphNodeMetrics::default(),
+    }
+}
+
 fn diagnostic_severity_rank(severity: &str) -> u8 {
     match severity.trim().to_ascii_lowercase().as_str() {
         "fatal" | "error" => 4,
@@ -3878,11 +4697,12 @@ mod code_graph_tests {
 
     use super::{
         code_citation_matches_symbol, code_graph_diff_overlay, code_graph_repos,
+        code_graph_workspace_diff_overlay, code_graph_workspace_overlay,
         code_index_document, code_symbol_span_matches, has_work_item_scope,
         CodeSnapshotMembershipInput,
         index_code_repository, index_code_repository_at, index_code_repository_at_current_target,
         open_existing_index_read_only,
-        repository_scope_matches,
+        repository_scope_matches, CodeGraphProjectionError,
     };
 
     fn git(root: &Path, args: &[&str]) -> String {
@@ -3899,6 +4719,212 @@ mod code_graph_tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn workspace_overlay_composes_live_changes_and_coverage() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::create_dir_all(repo.path().join("src")).expect("source directory");
+        fs::write(
+            repo.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn baseline() {}\npub fn caller() { baseline(); }\n",
+        )
+            .expect("baseline source");
+        fs::write(repo.path().join("src/remove.rs"), "pub fn removed() {}\n")
+            .expect("removed source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "overlay baseline"]);
+        let base = git(repo.path(), &["rev-parse", "HEAD"]);
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        index_code_repository_at(
+            &config,
+            "overlay-repo",
+            Some(("develop".to_string(), base.clone())),
+        )
+        .expect("baseline index");
+
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn baseline() { changed(); }\npub fn changed() {}\npub fn caller() { baseline(); }\n",
+        )
+        .expect("modified source");
+        fs::remove_file(repo.path().join("src/remove.rs")).expect("deleted source");
+        fs::write(repo.path().join("src/new.rs"), "pub fn added() {}\n").expect("added source");
+        fs::write(repo.path().join("notes.txt"), "unsupported\n").expect("unsupported source");
+        fs::write(
+            repo.path().join("src/large.rs"),
+            "pub fn too_large() {}\n".repeat(10),
+        )
+        .expect("oversized source");
+        let mut limited_config = config.clone();
+        limited_config.code_intel.ast.max_file_bytes = 128;
+
+        let overlay = code_graph_workspace_overlay(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+        )
+        .expect("workspace overlay");
+        assert!(overlay.changed_paths.contains("src/lib.rs"));
+        assert!(overlay.changed_paths.contains("src/new.rs"));
+        assert!(overlay.changed_paths.contains("src/remove.rs"));
+        assert!(overlay.tombstones.contains("src/remove.rs"));
+        assert!(overlay
+            .symbols
+            .values()
+            .any(|symbol| symbol.name == "changed"));
+        assert!(overlay.symbols.values().any(|symbol| symbol.name == "added"));
+        assert!(!overlay.symbols.values().any(|symbol| symbol.name == "removed"));
+        assert!(overlay
+            .unanalyzed_files
+            .iter()
+            .any(|path| path == "notes.txt"));
+        assert!(overlay
+            .unanalyzed_files
+            .iter()
+            .any(|path| path == "src/large.rs"));
+        assert_eq!(overlay.base_revision, base);
+        assert_eq!(overlay.run_id, "COE-543");
+        assert!(!overlay.workspace_content_digest.is_empty());
+        let diff = code_graph_workspace_diff_overlay(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            500,
+        )
+        .expect("workspace diff overlay");
+        assert!(diff
+            .added_symbols
+            .iter()
+            .any(|symbol| symbol.after.as_ref().is_some_and(|side| side.name == "added")));
+        assert!(diff
+            .removed_symbols
+            .iter()
+            .any(|symbol| symbol.before.as_ref().is_some_and(|side| side.name == "removed")));
+        assert!(diff
+            .modified_symbols
+            .iter()
+            .any(|symbol| symbol.after.as_ref().is_some_and(|side| side.name == "baseline")));
+        assert!(diff.blast_radius.iter().any(|radius| {
+            diff.modified_symbols
+                .iter()
+                .find(|symbol| symbol.after.as_ref().is_some_and(|side| side.name == "baseline"))
+                .is_some_and(|symbol| symbol.symbol_key == radius.symbol_key)
+                && radius.inbound_count > 0
+        }));
+    }
+
+    #[test]
+    fn workspace_overlays_are_isolated_and_rebuild_without_persisted_state() {
+        let source = TempDir::new().expect("source repository tempdir");
+        fs::create_dir_all(source.path().join("src")).expect("source directory");
+        fs::write(
+            source.path().join("WORKFLOW.md"),
+            "Target branch: `develop`\n",
+        )
+        .expect("workflow marker");
+        fs::write(source.path().join("src/lib.rs"), "pub fn baseline() {}\n")
+            .expect("baseline source");
+        git(source.path(), &["init", "-b", "develop"]);
+        git(source.path(), &["config", "user.email", "test@example.com"]);
+        git(source.path(), &["config", "user.name", "Test User"]);
+        git(source.path(), &["add", "."]);
+        git(source.path(), &["commit", "-m", "shared baseline"]);
+        let base = git(source.path(), &["rev-parse", "HEAD"]);
+        let config = MemoryConfig::load(source.path(), None).expect("memory config");
+        index_code_repository_at(
+            &config,
+            "shared-repo",
+            Some(("develop".to_string(), base.clone())),
+        )
+        .expect("shared baseline index");
+
+        let left = TempDir::new().expect("left workspace tempdir");
+        let right = TempDir::new().expect("right workspace tempdir");
+        git(
+            left.path(),
+            &[
+                "clone",
+                source.path().to_string_lossy().as_ref(),
+                left.path().join("workspace").to_string_lossy().as_ref(),
+            ],
+        );
+        git(
+            right.path(),
+            &[
+                "clone",
+                source.path().to_string_lossy().as_ref(),
+                right.path().join("workspace").to_string_lossy().as_ref(),
+            ],
+        );
+        let left_workspace = left.path().join("workspace");
+        let right_workspace = right.path().join("workspace");
+        fs::write(left_workspace.join("src/lib.rs"), "pub fn left_only() {}\n")
+            .expect("left edit");
+        fs::write(right_workspace.join("src/lib.rs"), "pub fn right_only() {}\n")
+            .expect("right edit");
+
+        let left_overlay = code_graph_workspace_overlay(
+            &config,
+            "shared-repo",
+            &left_workspace,
+            "COE-543-left",
+            &base,
+        )
+        .expect("left overlay");
+        let right_overlay = code_graph_workspace_overlay(
+            &config,
+            "shared-repo",
+            &right_workspace,
+            "COE-543-right",
+            &base,
+        )
+        .expect("right overlay");
+        assert!(left_overlay.symbols.values().any(|symbol| symbol.name == "left_only"));
+        assert!(!left_overlay.symbols.values().any(|symbol| symbol.name == "right_only"));
+        assert!(right_overlay
+            .symbols
+            .values()
+            .any(|symbol| symbol.name == "right_only"));
+        assert!(!right_overlay.symbols.values().any(|symbol| symbol.name == "left_only"));
+        assert_ne!(
+            left_overlay.workspace_content_digest,
+            right_overlay.workspace_content_digest
+        );
+
+        let rebuilt = code_graph_workspace_overlay(
+            &config,
+            "shared-repo",
+            &left_workspace,
+            "COE-543-left",
+            &base,
+        )
+        .expect("overlay should rebuild after process-local cache reuse");
+        assert_eq!(rebuilt.workspace_content_digest, left_overlay.workspace_content_digest);
+        assert_eq!(rebuilt.symbols, left_overlay.symbols);
+        fs::remove_dir_all(&left_workspace).expect("workspace cleanup");
+        assert!(matches!(
+            code_graph_workspace_overlay(
+                &config,
+                "shared-repo",
+                &left_workspace,
+                "COE-543-left",
+                &base,
+            ),
+            Err(CodeGraphProjectionError::InvalidRequest(_))
+        ));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -588,7 +588,7 @@ pub fn code_graph_workspace_overlay(
         .into_keys()
         .collect::<BTreeSet<_>>();
     let base_edges = query_code_edges_for_revision(&connection, config, repo_id, base_revision)?;
-    let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
+    let head_revision = workspace_head_revision(workspace_path)?;
     let (changed_paths, tombstones, workspace_content_digest) = workspace_changed_paths(
         workspace_path,
         base_revision,
@@ -696,7 +696,7 @@ fn code_graph_workspace_focused_overlay(
     options: &CodeGraphSnapshotOptions,
 ) -> Result<CodeWorkspaceOverlay, CodeGraphProjectionError> {
     let connection = open_workspace_graph_connection(config, repo_id, workspace_path, base_revision)?;
-    let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
+    let head_revision = workspace_head_revision(workspace_path)?;
     let (changed_paths, tombstones, workspace_content_digest) = workspace_changed_paths(
         workspace_path,
         base_revision,
@@ -1037,6 +1037,20 @@ pub fn code_graph_workspace_diff_overlay(
     base_revision: &str,
     max_records: usize,
 ) -> Result<CodeDiffOverlay, CodeGraphProjectionError> {
+    let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
+    if !workspace_has_uncommitted_changes(workspace_path)?
+        && let Some(connection) = open_existing_index_read_only(config)?
+        && code_revision_indexed(&connection, config, repo_id, base_revision)?
+        && code_revision_indexed(&connection, config, repo_id, &head_revision)?
+    {
+        return code_graph_diff_overlay(
+            config,
+            repo_id,
+            base_revision,
+            &head_revision,
+            max_records,
+        );
+    }
     let overlay = code_graph_workspace_overlay(
         config,
         repo_id,
@@ -1807,6 +1821,22 @@ fn workspace_git_line<const N: usize>(
     Ok(String::from_utf8_lossy(&workspace_git_bytes(workspace_path, args)?)
         .trim()
         .to_string())
+}
+
+fn workspace_has_uncommitted_changes(
+    workspace_path: &Path,
+) -> Result<bool, CodeGraphProjectionError> {
+    Ok(!workspace_git_bytes(workspace_path, ["status", "--porcelain", "--untracked-files=all"])?
+        .is_empty())
+}
+
+fn workspace_head_revision(workspace_path: &Path) -> Result<String, CodeGraphProjectionError> {
+    let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
+    if workspace_has_uncommitted_changes(workspace_path)? {
+        Ok(format!("{head_revision}+worktree"))
+    } else {
+        Ok(head_revision)
+    }
 }
 
 fn workspace_git_bytes<const N: usize>(
@@ -4448,7 +4478,7 @@ fn query_symbol_diagnostics(
         let freshness = code_freshness_filter(include_stale);
         let mut statement = connection
             .prepare(&format!(
-                "SELECT commit_sha, kind, severity, message, start_line, start_col, end_line, end_col FROM code_diagnostic_revisions WHERE repo_id = ? AND path = ? AND {freshness} AND content_sha256 = ? ORDER BY start_line, start_col, diagnostic_id"
+                "SELECT commit_sha, kind, severity, message, start_line, start_col, end_line, end_col FROM code_diagnostic_revisions WHERE repo_id = ? AND path = ? AND {freshness} AND content_sha256 = ? AND start_line <= ? AND end_line >= ? ORDER BY start_line, start_col, diagnostic_id"
             ))
             .map_err(|source| MemoryError::DuckDb {
                 path: config.index_path.clone(),
@@ -4456,7 +4486,13 @@ fn query_symbol_diagnostics(
             })?;
         let rows = statement
             .query_map(
-                params![&symbol.repo_id, &symbol.path, &symbol.content_sha256],
+                params![
+                    &symbol.repo_id,
+                    &symbol.path,
+                    &symbol.content_sha256,
+                    symbol.end_line as i64,
+                    symbol.start_line as i64
+                ],
                 |row| {
                     Ok((
                         row.get::<_, String>(0)?,
@@ -5676,7 +5712,8 @@ fn code_graph_sequence(timestamp: DateTime<Utc>) -> u64 {
 mod code_graph_tests {
     use crate::opensymphony_code_intel::{CaptureRecord, SourceSpan, parse_path};
     use crate::opensymphony_memory::{
-        CodeIntelPersistBatch, KnowledgeScope, KnowledgeScopeKind, MemoryConfig,
+        CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelPersistBatch,
+        CodeIntelSymbolInput, KnowledgeScope, KnowledgeScopeKind, MemoryConfig,
         persist_code_intel_documents,
     };
     use chrono::Utc;
@@ -5685,7 +5722,8 @@ mod code_graph_tests {
 
     use super::{
         code_citation_matches_symbol, code_file_outline_from_workspace, code_graph_diff_overlay,
-        code_graph_repos, code_graph_workspace_diff_overlay, code_graph_workspace_overlay,
+        code_graph_repos, code_graph_snapshot, code_graph_workspace_diff_overlay,
+        code_graph_workspace_overlay,
         code_graph_workspace_snapshot,
         code_index_document, code_symbol_span_matches, has_work_item_scope,
         CodeSnapshotMembershipInput,
@@ -5709,6 +5747,157 @@ mod code_graph_tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn workspace_diff_overlay_uses_indexed_clean_head() {
+        let repo = TempDir::new().expect("repository tempdir");
+        fs::create_dir_all(repo.path().join("src")).expect("source directory");
+        fs::write(repo.path().join("src/lib.rs"), "pub fn base() {}\n")
+            .expect("base source");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        let base = git(repo.path(), &["rev-parse", "HEAD"]);
+        fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn base() {}\npub fn head() {}\n",
+        )
+        .expect("head source");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "head"]);
+        let head = git(repo.path(), &["rev-parse", "HEAD"]);
+        let memory_root = TempDir::new().expect("memory root tempdir");
+        let mut config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        config.memory_root = memory_root.path().to_path_buf();
+        config.index_path = memory_root.path().join("index.duckdb");
+        index_code_repository_at(
+            &config,
+            "clean-head-repo",
+            Some(("develop".to_string(), base.clone())),
+        )
+        .expect("base index");
+        index_code_repository_at(
+            &config,
+            "clean-head-repo",
+            Some(("develop".to_string(), head.clone())),
+        )
+        .expect("head index");
+
+        let mut limited_config = config.clone();
+        limited_config.code_intel.ast.max_files_per_request = 0;
+        let overlay = code_graph_workspace_diff_overlay(
+            &limited_config,
+            "clean-head-repo",
+            repo.path(),
+            "COE-543-clean-head",
+            &base,
+            500,
+        )
+        .expect("clean indexed head diff");
+        assert_eq!(overlay.head_revision, head);
+        assert!(overlay
+            .added_symbols
+            .iter()
+            .any(|symbol| symbol.after.as_ref().is_some_and(|side| side.name == "head")));
+        assert!(overlay.unanalyzed_files.is_empty());
+    }
+
+    #[test]
+    fn revision_diagnostics_are_scoped_to_symbol_spans() {
+        let repo = TempDir::new().expect("repository tempdir");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        persist_code_intel_documents(
+            &config,
+            CodeIntelPersistBatch {
+                repo_id: "diagnostic-repo".to_string(),
+                commit_sha: Some("diagnostic-revision".to_string()),
+                worktree_dirty: false,
+                documents: vec![CodeIntelDocumentInput {
+                    path: PathBuf::from("src/diagnostics.rs"),
+                    language: "rust".to_string(),
+                    content_sha256: "diagnostic-content".to_string(),
+                    parser_id: "tree-sitter".to_string(),
+                    parser_version: "test-parser".to_string(),
+                    query_pack_version: "test-query-pack".to_string(),
+                    byte_len: 64,
+                    line_count: 12,
+                    symbols: vec![
+                        CodeIntelSymbolInput {
+                            kind: "function".to_string(),
+                            name: "first".to_string(),
+                            container_chain: Vec::new(),
+                            signature: Some("fn first()".to_string()),
+                            start_line: 1,
+                            start_col: 0,
+                            end_line: 2,
+                            end_col: 1,
+                            start_byte: 0,
+                            end_byte: 16,
+                            selection_start_line: 1,
+                            selection_end_line: 1,
+                            snippet_sha256: "first-snippet".to_string(),
+                        },
+                        CodeIntelSymbolInput {
+                            kind: "function".to_string(),
+                            name: "second".to_string(),
+                            container_chain: Vec::new(),
+                            signature: Some("fn second()".to_string()),
+                            start_line: 10,
+                            start_col: 0,
+                            end_line: 11,
+                            end_col: 1,
+                            start_byte: 32,
+                            end_byte: 50,
+                            selection_start_line: 10,
+                            selection_end_line: 10,
+                            snippet_sha256: "second-snippet".to_string(),
+                        },
+                    ],
+                    edges: Vec::new(),
+                    diagnostics: vec![CodeIntelDiagnosticInput {
+                        kind: "warning".to_string(),
+                        severity: "warning".to_string(),
+                        message: "first only".to_string(),
+                        start_line: 1,
+                        start_col: 0,
+                        end_line: 1,
+                        end_col: 1,
+                        start_byte: 0,
+                        end_byte: 1,
+                    }],
+                }],
+            },
+        )
+        .expect("diagnostic fixture");
+
+        let snapshot = code_graph_snapshot(
+            &config,
+            "diagnostic-repo",
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::File,
+                path: Some("src/diagnostics.rs".to_string()),
+                symbol_key: None,
+                depth: 1,
+                aggregate: None,
+                include_stale: false,
+            },
+        )
+        .expect("diagnostic graph");
+        let first = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.label == "first")
+            .expect("first symbol node");
+        let second = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.label == "second")
+            .expect("second symbol node");
+        assert_eq!(first.diagnostic_count, 1);
+        assert_eq!(second.diagnostic_count, 0);
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -606,6 +606,9 @@ pub fn code_graph_workspace_overlay(
 
     for path in &changed_paths {
         if tombstones.contains(path) {
+            if !base_symbols.values().any(|symbol| symbol.path == *path) {
+                unanalyzed_files.insert(path.clone());
+            }
             symbols.retain(|_, symbol| symbol.path != *path);
             edges.retain(|_, edge| edge.path != *path);
             continue;
@@ -863,12 +866,13 @@ fn code_graph_workspace_focused_overlay(
                     {
                         continue;
                     }
-                    let (symbol, from_baseline) = if let Some(symbol) =
-                        live_symbols.values().find(|symbol| symbol.name == name)
-                    {
-                        (Some(symbol.clone()), false)
-                    } else {
-                        (
+                    let live_matches = live_symbols
+                        .values()
+                        .filter(|symbol| symbol.name == name)
+                        .collect::<Vec<_>>();
+                    let (symbol, from_baseline) = match live_matches.as_slice() {
+                        [symbol] => (Some((*symbol).clone()), false),
+                        [] => (
                             query_revision_symbol_by_name(
                                 config,
                                 &connection,
@@ -877,7 +881,8 @@ fn code_graph_workspace_focused_overlay(
                                 name,
                             )?,
                             true,
-                        )
+                        ),
+                        _ => (None, false),
                     };
                     let Some(symbol) = symbol else {
                         continue;
@@ -1231,7 +1236,7 @@ pub fn code_graph_workspace_snapshot(
             base_revision,
             &options,
         )?;
-        return render_workspace_graph_snapshot(repo_id, options, overlay);
+        return render_workspace_graph_snapshot(config, repo_id, options, overlay);
     }
     let overlay = code_graph_workspace_overlay(
         config,
@@ -1240,14 +1245,21 @@ pub fn code_graph_workspace_snapshot(
         run_id,
         base_revision,
     )?;
-    render_workspace_graph_snapshot(repo_id, options, overlay)
+    render_workspace_graph_snapshot(config, repo_id, options, overlay)
 }
 
 fn render_workspace_graph_snapshot(
+    config: &MemoryConfig,
     repo_id: &str,
     options: CodeGraphSnapshotOptions,
     overlay: CodeWorkspaceOverlay,
 ) -> Result<CodeGraphSnapshot, CodeGraphProjectionError> {
+    let connection = open_existing_index_read_only(config)?;
+    let diagnostics_ready = if let Some(connection) = connection.as_ref() {
+        code_diagnostics_read_model_ready(connection, &config.index_path)?
+    } else {
+        false
+    };
     let mode = options.mode;
     let mut paths = BTreeSet::new();
     let mut selected_keys = BTreeSet::new();
@@ -1255,16 +1267,28 @@ fn render_workspace_graph_snapshot(
     let mut tombstoned_file = false;
     match mode {
         CodeGraphMode::Atlas => {
-            paths.extend(overlay.base_paths.iter().cloned());
-            paths.extend(
-                overlay
-                    .changed_paths
-                    .iter()
-                    .filter(|path| !overlay.tombstones.contains(*path))
-                    .cloned(),
-            );
-            dropped_paths = paths.len().saturating_sub(CODE_GRAPH_MAX_RECORDS);
-            paths = paths.into_iter().take(CODE_GRAPH_MAX_RECORDS).collect();
+            let changed_paths = overlay
+                .changed_paths
+                .iter()
+                .filter(|path| !overlay.tombstones.contains(*path))
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let prioritized_paths = changed_paths
+                .iter()
+                .cloned()
+                .chain(
+                    overlay
+                        .base_paths
+                        .iter()
+                        .filter(|path| !changed_paths.contains(*path))
+                        .cloned(),
+                )
+                .collect::<Vec<_>>();
+            dropped_paths = prioritized_paths.len().saturating_sub(CODE_GRAPH_MAX_RECORDS);
+            paths = prioritized_paths
+                .into_iter()
+                .take(CODE_GRAPH_MAX_RECORDS)
+                .collect();
             selected_keys.extend(
                 overlay
                     .symbols
@@ -1392,7 +1416,16 @@ fn render_workspace_graph_snapshot(
         let Some(symbol) = symbol else {
             continue;
         };
-        let mut node = workspace_symbol_node(symbol);
+        let mut node = if diagnostics_ready {
+            symbol_node(
+                connection.as_ref().expect("diagnostics require an index connection"),
+                config,
+                symbol,
+                options.include_stale,
+            )?
+        } else {
+            workspace_symbol_node(symbol)
+        };
         if tombstoned_file {
             node.freshness = CodeGraphFreshness::Stale;
         }
@@ -1786,10 +1819,9 @@ fn workspace_git_bytes<const N: usize>(
             source,
         }))?;
     if !output.status.success() {
-        return Err(CodeGraphProjectionError::InvalidRequest(format!(
-            "git command failed in workspace {}",
-            workspace_path.display()
-        )));
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "git command failed in run workspace".to_string(),
+        ));
     }
     Ok(output.stdout)
 }
@@ -4406,6 +4438,54 @@ fn query_symbol_diagnostics(
     symbol: &CodeSymbolRecord,
     include_stale: bool,
 ) -> Result<Vec<CodeDiagnostic>, MemoryError> {
+    if let Some(commit_sha) = symbol.commit_sha.as_deref()
+        && code_diagnostic_revisions_read_model_ready(connection, &config.index_path)?
+    {
+        let freshness = code_freshness_filter(include_stale);
+        let mut statement = connection
+            .prepare(&format!(
+                "SELECT commit_sha, kind, severity, message, start_line, start_col, end_line, end_col FROM code_diagnostic_revisions WHERE repo_id = ? AND path = ? AND {freshness} AND content_sha256 = ? ORDER BY start_line, start_col, diagnostic_id"
+            ))
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        let rows = statement
+            .query_map(
+                params![&symbol.repo_id, &symbol.path, &symbol.content_sha256],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        CodeDiagnostic {
+                            kind: row.get(1)?,
+                            severity: row.get(2)?,
+                            message: row.get(3)?,
+                            span: CodeSpan {
+                                start_line: row.get::<_, i64>(4)? as usize,
+                                start_col: row.get::<_, i64>(5)? as usize,
+                                end_line: row.get::<_, i64>(6)? as usize,
+                                end_col: row.get::<_, i64>(7)? as usize,
+                            },
+                        },
+                    ))
+                },
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .filter_map(|row| match row {
+                Ok((revision, diagnostic)) if revision == commit_sha => Some(Ok(diagnostic)),
+                Ok(_) => None,
+                Err(source) => Some(Err(source)),
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        return Ok(rows);
+    }
     let freshness = code_freshness_filter(include_stale);
     let mut statement = connection
         .prepare(&format!(
@@ -5436,6 +5516,18 @@ fn code_diagnostics_read_model_ready(
     )
 }
 
+fn code_diagnostic_revisions_read_model_ready(
+    connection: &Connection,
+    path: &Path,
+) -> Result<bool, MemoryError> {
+    table_has_columns(
+        connection,
+        path,
+        "code_diagnostic_revisions",
+        &["repo_id", "commit_sha", "path", "content_sha256", "freshness"],
+    )
+}
+
 fn code_freshness_filter(include_stale: bool) -> &'static str {
     if include_stale {
         "freshness IN ('current', 'stale')"
@@ -5596,7 +5688,7 @@ mod code_graph_tests {
         CodeGraphMode, CodeGraphSnapshotOptions,
         index_code_repository, index_code_repository_at, index_code_repository_at_current_target,
         open_existing_index_read_only,
-        repository_scope_matches, CodeGraphProjectionError,
+        repository_scope_matches, workspace_git_bytes, CodeGraphProjectionError,
     };
 
     fn git(root: &Path, args: &[&str]) -> String {
@@ -5631,6 +5723,7 @@ mod code_graph_tests {
         .expect("baseline source");
         fs::write(repo.path().join("src/remove.rs"), "pub fn removed() {}\n")
             .expect("removed source");
+        fs::write(repo.path().join("src/delete_empty.rs"), "").expect("empty deleted source");
         fs::write(
             repo.path().join("src/large.rs"),
             "pub fn baseline_large() {}\n",
@@ -5657,6 +5750,7 @@ mod code_graph_tests {
         )
         .expect("modified source");
         fs::remove_file(repo.path().join("src/remove.rs")).expect("deleted source");
+        fs::remove_file(repo.path().join("src/delete_empty.rs")).expect("deleted empty source");
         fs::write(repo.path().join("src/new.rs"), "pub fn added() {}\n").expect("added source");
         fs::write(repo.path().join("src/zchanged_empty.rs"), "").expect("empty added source");
         fs::write(repo.path().join("notes.txt"), "unsupported\n").expect("unsupported source");
@@ -5822,6 +5916,10 @@ mod code_graph_tests {
             .unanalyzed_files
             .iter()
             .any(|path| path == "src/large.rs"));
+        assert!(overlay
+            .unanalyzed_files
+            .iter()
+            .any(|path| path == "src/delete_empty.rs"));
         #[cfg(unix)]
         {
             assert!(overlay
@@ -5877,6 +5975,17 @@ mod code_graph_tests {
             .unanalyzed_files
             .iter()
             .any(|path| path == "src/lib.rs"));
+    }
+
+    #[test]
+    fn workspace_git_errors_do_not_include_workspace_paths() {
+        let workspace = TempDir::new().expect("workspace tempdir");
+        let error = workspace_git_bytes(workspace.path(), ["status"])
+            .expect_err("non-git workspace should fail");
+        assert!(!error.to_string().contains(&workspace.path().display().to_string()));
+        assert!(error
+            .to_string()
+            .contains("git command failed in run workspace"));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -598,8 +598,11 @@ pub fn code_graph_workspace_overlay(
         .collect::<BTreeSet<_>>();
     let base_edges = query_code_edges_for_revision(&connection, config, repo_id, base_revision)?;
     let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
-    let (changed_paths, tombstones, workspace_content_digest) =
-        workspace_changed_paths(workspace_path, base_revision)?;
+    let (changed_paths, tombstones, workspace_content_digest) = workspace_changed_paths(
+        workspace_path,
+        base_revision,
+        config.code_intel.ast.max_file_bytes,
+    )?;
 
     let mut symbols = base_symbols.clone();
     let mut edges = base_edges
@@ -611,8 +614,11 @@ pub fn code_graph_workspace_overlay(
     let mut remaining_files = config.code_intel.ast.max_files_per_request;
 
     for path in &changed_paths {
-        symbols.retain(|_, symbol| symbol.path != *path);
-        edges.retain(|_, edge| edge.path != *path);
+        if tombstones.contains(path) {
+            symbols.retain(|_, symbol| symbol.path != *path);
+            edges.retain(|_, edge| edge.path != *path);
+            continue;
+        }
 
         let Some(file_path) = workspace_file_path(workspace_path, path)? else {
             unanalyzed_files.insert(path.clone());
@@ -634,6 +640,8 @@ pub fn code_graph_workspace_overlay(
             continue;
         };
         remaining_files = remaining_files.saturating_sub(1);
+        symbols.retain(|_, symbol| symbol.path != *path);
+        edges.retain(|_, edge| edge.path != *path);
         if records.symbols.is_empty() {
             unanalyzed_files.insert(path.clone());
         }
@@ -789,20 +797,47 @@ pub fn code_file_outline_from_workspace(
     raw_path: &str,
 ) -> Result<CodeFileOutline, CodeGraphProjectionError> {
     let path = normalize_code_path(raw_path).map_err(CodeGraphProjectionError::InvalidRequest)?;
-    if !workspace_path.join(&path).is_file() {
+    let Some(file_path) = workspace_file_path(workspace_path, &path)? else {
         return Err(CodeGraphProjectionError::FileNotFound(path));
+    };
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Err(CodeGraphProjectionError::IndexUnavailable);
+    };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Err(CodeGraphProjectionError::IndexUnavailable);
     }
-    let overlay = code_graph_workspace_overlay(
+    ensure_code_repo(config, repo_id, true)?;
+    if !code_revision_indexed(&connection, config, repo_id, base_revision)? {
+        return Err(CodeGraphProjectionError::RevisionNotFound(
+            base_revision.to_string(),
+        ));
+    }
+
+    let changed = workspace_path_changed(workspace_path, base_revision, &path)?;
+    let symbols = if changed {
+        match workspace_document_records(config, repo_id, &path, &file_path)? {
+            Some(records) => records.symbols,
+            None => query_revision_file_symbols(
+                config,
+                &connection,
+                repo_id,
+                base_revision,
+                &path,
+            )?,
+        }
+    } else if query_revision_file_exists(
+        &connection,
         config,
         repo_id,
-        workspace_path,
-        run_id,
         base_revision,
-    )?;
-    let symbols = overlay
-        .symbols
-        .values()
-        .filter(|symbol| symbol.path == path)
+        &path,
+    )? {
+        query_revision_file_symbols(config, &connection, repo_id, base_revision, &path)?
+    } else {
+        return Err(CodeGraphProjectionError::FileNotFound(path));
+    };
+    let symbols = symbols
+        .iter()
         .map(|symbol| CodeOutlineSymbol {
             symbol_key: symbol.symbol_key.clone(),
             name: symbol.name.clone(),
@@ -846,9 +881,9 @@ pub fn code_graph_workspace_snapshot(
     )?;
     let mut paths = BTreeSet::new();
     let mut selected_keys = BTreeSet::new();
+    let mut dropped_paths = 0;
     match mode {
         CodeGraphMode::Atlas => {
-            selected_keys.extend(overlay.symbols.keys().cloned());
             paths.extend(overlay.base_paths.iter().cloned());
             paths.extend(
                 overlay
@@ -856,6 +891,15 @@ pub fn code_graph_workspace_snapshot(
                     .iter()
                     .filter(|path| !overlay.tombstones.contains(*path))
                     .cloned(),
+            );
+            dropped_paths = paths.len().saturating_sub(CODE_GRAPH_MAX_RECORDS);
+            paths = paths.into_iter().take(CODE_GRAPH_MAX_RECORDS).collect();
+            selected_keys.extend(
+                overlay
+                    .symbols
+                    .iter()
+                    .filter(|(_, symbol)| paths.contains(&symbol.path))
+                    .map(|(key, _)| key.clone()),
             );
         }
         CodeGraphMode::File => {
@@ -865,6 +909,7 @@ pub fn code_graph_workspace_snapshot(
             let path = normalize_code_path(path).map_err(CodeGraphProjectionError::InvalidRequest)?;
             if !overlay.symbols.values().any(|symbol| symbol.path == path)
                 && !overlay.changed_paths.contains(&path)
+                && !overlay.base_paths.contains(&path)
             {
                 return Err(CodeGraphProjectionError::FileNotFound(path));
             }
@@ -1008,7 +1053,11 @@ pub fn code_graph_workspace_snapshot(
         edges,
         false,
         options.aggregate,
-        truncation(dropped_symbols, dropped_edges, "workspace graph records capped"),
+        truncation(
+            dropped_paths + dropped_symbols,
+            dropped_edges,
+            "workspace graph records capped",
+        ),
     ))
 }
 
@@ -1151,6 +1200,7 @@ fn workspace_document_records(
 fn workspace_changed_paths(
     workspace_path: &Path,
     base_revision: &str,
+    max_file_bytes: u64,
 ) -> Result<(BTreeSet<String>, BTreeSet<String>, String), CodeGraphProjectionError> {
     let diff = workspace_git_bytes(
         workspace_path,
@@ -1204,6 +1254,17 @@ fn workspace_changed_paths(
         hasher.update([0]);
         match workspace_file_path(workspace_path, path)? {
             Some(file_path) => {
+                let Ok(metadata) = fs::metadata(&file_path) else {
+                    hasher.update(b"<unreadable>");
+                    hasher.update([0]);
+                    continue;
+                };
+                if metadata.len() > max_file_bytes {
+                    hasher.update(b"<oversized>");
+                    hasher.update(metadata.len().to_le_bytes());
+                    hasher.update([0]);
+                    continue;
+                }
                 let mut file = match fs::File::open(file_path) {
                     Ok(file) => file,
                     Err(_) => {
@@ -1234,6 +1295,26 @@ fn workspace_changed_paths(
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();
     Ok((changed, tombstones, digest))
+}
+
+fn workspace_path_changed(
+    workspace_path: &Path,
+    base_revision: &str,
+    path: &str,
+) -> Result<bool, CodeGraphProjectionError> {
+    if !workspace_git_bytes(
+        workspace_path,
+        ["diff", "--name-only", base_revision, "--", path],
+    )?
+    .is_empty()
+    {
+        return Ok(true);
+    }
+    Ok(!workspace_git_bytes(
+        workspace_path,
+        ["ls-files", "--others", "--exclude-standard", "--", path],
+    )?
+    .is_empty())
 }
 
 fn workspace_file_path(
@@ -3460,6 +3541,120 @@ fn query_file_symbols(
         .collect()
 }
 
+fn query_revision_file_symbols(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    path: &str,
+) -> Result<Vec<CodeSymbolRecord>, MemoryError> {
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
+    let query = if membership_ready {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END FROM code_symbols AS s WHERE s.repo_id = ? AND s.path = ? AND s.symbol_key != '' AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed)) ORDER BY s.symbol_key, s.indexed_at DESC, s.symbol_id"
+        )
+    } else {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND path = ? AND commit_sha = ? AND symbol_key != '' AND freshness <> 'staged' ORDER BY symbol_key, indexed_at DESC, symbol_id"
+        )
+    };
+    let mut statement = connection
+        .prepare(&query)
+        .map_err(|source| MemoryError::DuckDb {
+            path: PathBuf::from("<memory-index>"),
+            source,
+        })?;
+    let rows = if membership_ready {
+        statement
+            .query_map(params![repo_id, path, revision, revision], |row| {
+                let dirty = row.get::<_, i64>(25)?;
+                if dirty != 0 {
+                    Ok(None)
+                } else {
+                    code_symbol_from_row(row).map(Some)
+                }
+            })
+            .map_err(|source| MemoryError::DuckDb {
+                path: PathBuf::from("<memory-index>"),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+    } else {
+        statement
+            .query_map(params![repo_id, path, revision], |row| {
+                let dirty = row.get::<_, i64>(25)?;
+                if dirty != 0 {
+                    Ok(None)
+                } else {
+                    code_symbol_from_row(row).map(Some)
+                }
+            })
+            .map_err(|source| MemoryError::DuckDb {
+                path: PathBuf::from("<memory-index>"),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+    }
+    .map_err(|source| MemoryError::DuckDb {
+        path: PathBuf::from("<memory-index>"),
+        source,
+    })?;
+    let mut symbols = BTreeMap::new();
+    for row in rows {
+        let Some(mut symbol) = row else {
+            continue;
+        };
+        if symbol.commit_sha.as_deref() != Some(revision) {
+            symbol.commit_sha = Some(revision.to_string());
+        }
+        if !symbols.contains_key(&symbol.symbol_key) {
+            fill_container_chain(connection, &mut symbol)?;
+            symbols.insert(symbol.symbol_key.clone(), symbol);
+        }
+    }
+    Ok(symbols.into_values().collect())
+}
+
+fn query_revision_file_exists(
+    connection: &Connection,
+    config: &MemoryConfig,
+    repo_id: &str,
+    revision: &str,
+    path: &str,
+) -> Result<bool, MemoryError> {
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
+    let query = if membership_ready {
+        "SELECT 1 FROM code_snapshot_membership WHERE repo_id = ? AND commit_sha = ? AND path = ? LIMIT 1"
+    } else {
+        "SELECT 1 FROM code_documents WHERE repo_id = ? AND commit_sha = ? AND path = ? AND freshness <> 'staged' AND NOT worktree_dirty LIMIT 1"
+    };
+    let mut statement = connection
+        .prepare(query)
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let mut rows = statement
+        .query(params![repo_id, revision, path])
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    Ok(rows
+        .next()
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?
+        .is_some())
+}
+
 fn query_code_document(
     connection: &Connection,
     config: &MemoryConfig,
@@ -4750,10 +4945,12 @@ mod code_graph_tests {
     use tempfile::TempDir;
 
     use super::{
-        code_citation_matches_symbol, code_graph_diff_overlay, code_graph_repos,
-        code_graph_workspace_diff_overlay, code_graph_workspace_overlay,
+        code_citation_matches_symbol, code_file_outline_from_workspace, code_graph_diff_overlay,
+        code_graph_repos, code_graph_workspace_diff_overlay, code_graph_workspace_overlay,
+        code_graph_workspace_snapshot,
         code_index_document, code_symbol_span_matches, has_work_item_scope,
         CodeSnapshotMembershipInput,
+        CodeGraphMode, CodeGraphSnapshotOptions,
         index_code_repository, index_code_repository_at, index_code_repository_at_current_target,
         open_existing_index_read_only,
         repository_scope_matches, CodeGraphProjectionError,
@@ -4788,9 +4985,15 @@ mod code_graph_tests {
             repo.path().join("src/lib.rs"),
             "pub fn baseline() {}\npub fn caller() { baseline(); }\n",
         )
-            .expect("baseline source");
+        .expect("baseline source");
         fs::write(repo.path().join("src/remove.rs"), "pub fn removed() {}\n")
             .expect("removed source");
+        fs::write(
+            repo.path().join("src/large.rs"),
+            "pub fn baseline_large() {}\n",
+        )
+        .expect("baseline oversized source");
+        fs::write(repo.path().join("src/empty.rs"), "").expect("baseline empty source");
         git(repo.path(), &["init", "-b", "develop"]);
         git(repo.path(), &["config", "user.email", "test@example.com"]);
         git(repo.path(), &["config", "user.name", "Test User"]);
@@ -4850,6 +5053,40 @@ mod code_graph_tests {
             .values()
             .any(|symbol| symbol.name == "changed"));
         assert!(overlay.symbols.values().any(|symbol| symbol.name == "added"));
+        assert!(overlay
+            .symbols
+            .values()
+            .any(|symbol| symbol.name == "baseline_large"));
+        let outline = code_file_outline_from_workspace(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            "src/large.rs",
+        )
+        .expect("oversized edit should retain baseline outline");
+        assert!(outline.symbols.iter().any(|symbol| symbol.name == "baseline_large"));
+        let empty_snapshot = code_graph_workspace_snapshot(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::File,
+                path: Some("src/empty.rs".to_string()),
+                symbol_key: None,
+                depth: 1,
+                aggregate: None,
+                include_stale: false,
+            },
+        )
+        .expect("indexed empty file should have a file graph");
+        assert!(empty_snapshot
+            .nodes
+            .iter()
+            .any(|node| node.id == "file:src/empty.rs"));
         assert!(!overlay.symbols.values().any(|symbol| symbol.name == "removed"));
         assert!(overlay
             .unanalyzed_files

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -797,7 +797,7 @@ pub fn code_file_outline_from_workspace(
     raw_path: &str,
 ) -> Result<CodeFileOutline, CodeGraphProjectionError> {
     let path = normalize_code_path(raw_path).map_err(CodeGraphProjectionError::InvalidRequest)?;
-    let Some(file_path) = workspace_file_path(workspace_path, &path)? else {
+    let Some(file_path) = workspace_outline_file_path(workspace_path, &path)? else {
         return Err(CodeGraphProjectionError::FileNotFound(path));
     };
     let Some(connection) = open_existing_index_read_only(config)? else {
@@ -882,6 +882,7 @@ pub fn code_graph_workspace_snapshot(
     let mut paths = BTreeSet::new();
     let mut selected_keys = BTreeSet::new();
     let mut dropped_paths = 0;
+    let mut tombstoned_file = false;
     match mode {
         CodeGraphMode::Atlas => {
             paths.extend(overlay.base_paths.iter().cloned());
@@ -907,6 +908,7 @@ pub fn code_graph_workspace_snapshot(
                 CodeGraphProjectionError::InvalidRequest("file mode requires `path`".to_string())
             })?;
             let path = normalize_code_path(path).map_err(CodeGraphProjectionError::InvalidRequest)?;
+            tombstoned_file = overlay.tombstones.contains(&path);
             if !overlay.symbols.values().any(|symbol| symbol.path == path)
                 && !overlay.changed_paths.contains(&path)
                 && !overlay.base_paths.contains(&path)
@@ -914,13 +916,23 @@ pub fn code_graph_workspace_snapshot(
                 return Err(CodeGraphProjectionError::FileNotFound(path));
             }
             paths.insert(path.clone());
-            selected_keys.extend(
-                overlay
-                    .symbols
-                    .values()
-                    .filter(|symbol| symbol.path == path)
-                    .map(|symbol| symbol.symbol_key.clone()),
-            );
+            if tombstoned_file {
+                selected_keys.extend(
+                    overlay
+                        .base_symbols
+                        .values()
+                        .filter(|symbol| symbol.path == path)
+                        .map(|symbol| symbol.symbol_key.clone()),
+                );
+            } else {
+                selected_keys.extend(
+                    overlay
+                        .symbols
+                        .values()
+                        .filter(|symbol| symbol.path == path)
+                        .map(|symbol| symbol.symbol_key.clone()),
+                );
+            }
         }
         CodeGraphMode::Neighborhood => {
             let center = options.symbol_key.as_deref().ok_or_else(|| {
@@ -967,7 +979,12 @@ pub fn code_graph_workspace_snapshot(
         .take(CODE_GRAPH_MAX_RECORDS)
         .collect();
     for key in &selected_keys {
-        if let Some(symbol) = overlay.symbols.get(key) {
+        let symbol = if tombstoned_file {
+            overlay.base_symbols.get(key)
+        } else {
+            overlay.symbols.get(key)
+        };
+        if let Some(symbol) = symbol {
             paths.insert(symbol.path.clone());
         }
     }
@@ -975,7 +992,7 @@ pub fn code_graph_workspace_snapshot(
     let mut nodes = BTreeMap::new();
     let mut graph_edges = BTreeMap::new();
     for path in paths {
-        if overlay.tombstones.contains(&path) {
+        if overlay.tombstones.contains(&path) && !tombstoned_file {
             continue;
         }
         let language = overlay
@@ -989,14 +1006,26 @@ pub fn code_graph_workspace_snapshot(
             &mut graph_edges,
             &path,
             language,
-            CodeGraphFreshness::Current,
+            if tombstoned_file {
+                CodeGraphFreshness::Stale
+            } else {
+                CodeGraphFreshness::Current
+            },
         );
     }
     for key in &selected_keys {
-        let Some(symbol) = overlay.symbols.get(key) else {
+        let symbol = if tombstoned_file {
+            overlay.base_symbols.get(key)
+        } else {
+            overlay.symbols.get(key)
+        };
+        let Some(symbol) = symbol else {
             continue;
         };
-        let node = workspace_symbol_node(symbol);
+        let mut node = workspace_symbol_node(symbol);
+        if tombstoned_file {
+            node.freshness = CodeGraphFreshness::Stale;
+        }
         let file_id = file_node_id(&symbol.path);
         insert_code_graph_edge(
             &mut graph_edges,
@@ -1011,7 +1040,12 @@ pub fn code_graph_workspace_snapshot(
     }
 
     let mut dropped_edges = 0;
-    for edge in &overlay.edges {
+    let graph_source_edges = if tombstoned_file {
+        &overlay.base_edges
+    } else {
+        &overlay.edges
+    };
+    for edge in graph_source_edges {
         let Some(source) = edge.source_symbol_key.as_deref() else {
             continue;
         };
@@ -1321,6 +1355,21 @@ fn workspace_file_path(
     workspace_path: &Path,
     path: &str,
 ) -> Result<Option<PathBuf>, CodeGraphProjectionError> {
+    workspace_file_path_with_symlink_policy(workspace_path, path, false)
+}
+
+fn workspace_outline_file_path(
+    workspace_path: &Path,
+    path: &str,
+) -> Result<Option<PathBuf>, CodeGraphProjectionError> {
+    workspace_file_path_with_symlink_policy(workspace_path, path, true)
+}
+
+fn workspace_file_path_with_symlink_policy(
+    workspace_path: &Path,
+    path: &str,
+    allow_contained_symlink: bool,
+) -> Result<Option<PathBuf>, CodeGraphProjectionError> {
     let relative = normalize_code_path(path).map_err(CodeGraphProjectionError::InvalidRequest)?;
     let root = workspace_path
         .canonicalize()
@@ -1332,7 +1381,7 @@ fn workspace_file_path(
     let Ok(metadata) = fs::symlink_metadata(&candidate) else {
         return Ok(None);
     };
-    if metadata.file_type().is_symlink() {
+    if metadata.file_type().is_symlink() && !allow_contained_symlink {
         return Ok(None);
     }
     let Ok(resolved) = candidate.canonicalize() else {
@@ -5087,6 +5136,30 @@ mod code_graph_tests {
             .nodes
             .iter()
             .any(|node| node.id == "file:src/empty.rs"));
+        let deleted_snapshot = code_graph_workspace_snapshot(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::File,
+                path: Some("src/remove.rs".to_string()),
+                symbol_key: None,
+                depth: 1,
+                aggregate: None,
+                include_stale: false,
+            },
+        )
+        .expect("deleted file should retain its baseline graph");
+        assert!(deleted_snapshot
+            .nodes
+            .iter()
+            .any(|node| node.id == "file:src/remove.rs"));
+        assert!(deleted_snapshot
+            .nodes
+            .iter()
+            .any(|node| node.label == "removed" && node.freshness == super::CodeGraphFreshness::Stale));
         assert!(!overlay.symbols.values().any(|symbol| symbol.name == "removed"));
         assert!(overlay
             .unanalyzed_files

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -832,7 +832,7 @@ fn code_graph_workspace_focused_overlay(
                         key,
                     )?;
                     for edge in baseline_edges {
-                        if changed_paths.contains(&edge.path) {
+                        if analyzed_paths.contains(&edge.path) {
                             continue;
                         }
                         base_edges.insert(edge.edge_id.clone(), edge.clone());
@@ -1307,13 +1307,15 @@ fn render_workspace_graph_snapshot(
                 .into_iter()
                 .take(CODE_GRAPH_MAX_RECORDS)
                 .collect();
-            selected_keys.extend(
-                overlay
-                    .symbols
-                    .iter()
-                    .filter(|(_, symbol)| paths.contains(&symbol.path))
-                    .map(|(key, _)| key.clone()),
-            );
+            if options.aggregate != Some(CodeGraphAggregate::Directory) {
+                selected_keys.extend(
+                    overlay
+                        .symbols
+                        .iter()
+                        .filter(|(_, symbol)| paths.contains(&symbol.path))
+                        .map(|(key, _)| key.clone()),
+                );
+            }
         }
         CodeGraphMode::File => {
             let path = options.path.as_deref().ok_or_else(|| {
@@ -1879,6 +1881,7 @@ fn re_resolve_workspace_edges(
         {
             return false;
         }
+        let was_unresolved = edge.target_symbol_key.is_none() && edge.unresolved;
         if edge
             .target_symbol_key
             .as_deref()
@@ -1887,7 +1890,8 @@ fn re_resolve_workspace_edges(
             edge.target_symbol_key = None;
             edge.unresolved = true;
         }
-        if edge.target_symbol_key.is_none()
+        if was_unresolved
+            && edge.target_symbol_key.is_none()
             && let Some(name) = edge
                 .target_hint
                 .as_deref()
@@ -4472,13 +4476,13 @@ fn query_symbol_diagnostics(
     symbol: &CodeSymbolRecord,
     include_stale: bool,
 ) -> Result<Vec<CodeDiagnostic>, MemoryError> {
-    if let Some(commit_sha) = symbol.commit_sha.as_deref()
+    if symbol.commit_sha.is_some()
         && code_diagnostic_revisions_read_model_ready(connection, &config.index_path)?
     {
         let freshness = code_freshness_filter(include_stale);
         let mut statement = connection
             .prepare(&format!(
-                "SELECT commit_sha, kind, severity, message, start_line, start_col, end_line, end_col FROM code_diagnostic_revisions WHERE repo_id = ? AND path = ? AND {freshness} AND content_sha256 = ? AND start_line <= ? AND end_line >= ? ORDER BY start_line, start_col, diagnostic_id"
+                "SELECT DISTINCT kind, severity, message, start_line, start_col, end_line, end_col FROM code_diagnostic_revisions WHERE repo_id = ? AND path = ? AND {freshness} AND content_sha256 = ? AND parser_version = ? AND query_pack_version = ? AND start_line <= ? AND end_line >= ? ORDER BY start_line, start_col, message"
             ))
             .map_err(|source| MemoryError::DuckDb {
                 path: config.index_path.clone(),
@@ -4490,35 +4494,29 @@ fn query_symbol_diagnostics(
                     &symbol.repo_id,
                     &symbol.path,
                     &symbol.content_sha256,
+                    &symbol.parser_version,
+                    &symbol.query_pack_version,
                     symbol.end_line as i64,
                     symbol.start_line as i64
                 ],
                 |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        CodeDiagnostic {
-                            kind: row.get(1)?,
-                            severity: row.get(2)?,
-                            message: row.get(3)?,
-                            span: CodeSpan {
-                                start_line: row.get::<_, i64>(4)? as usize,
-                                start_col: row.get::<_, i64>(5)? as usize,
-                                end_line: row.get::<_, i64>(6)? as usize,
-                                end_col: row.get::<_, i64>(7)? as usize,
-                            },
+                    Ok(CodeDiagnostic {
+                        kind: row.get(0)?,
+                        severity: row.get(1)?,
+                        message: row.get(2)?,
+                        span: CodeSpan {
+                            start_line: row.get::<_, i64>(3)? as usize,
+                            start_col: row.get::<_, i64>(4)? as usize,
+                            end_line: row.get::<_, i64>(5)? as usize,
+                            end_col: row.get::<_, i64>(6)? as usize,
                         },
-                    ))
+                    })
                 },
             )
             .map_err(|source| MemoryError::DuckDb {
                 path: config.index_path.clone(),
                 source,
             })?
-            .filter_map(|row| match row {
-                Ok((revision, diagnostic)) if revision == commit_sha => Some(Ok(diagnostic)),
-                Ok(_) => None,
-                Err(source) => Some(Err(source)),
-            })
             .collect::<Result<Vec<_>, _>>()
             .map_err(|source| MemoryError::DuckDb {
                 path: config.index_path.clone(),
@@ -5717,7 +5715,7 @@ mod code_graph_tests {
         persist_code_intel_documents,
     };
     use chrono::Utc;
-    use std::{fs, path::{Path, PathBuf}, process::Command, sync::Arc};
+    use std::{collections::BTreeMap, fs, path::{Path, PathBuf}, process::Command, sync::Arc};
     use tempfile::TempDir;
 
     use super::{
@@ -5729,7 +5727,9 @@ mod code_graph_tests {
         CodeSnapshotMembershipInput,
         CodeGraphMode, CodeGraphSnapshotOptions,
         index_code_repository, index_code_repository_at, index_code_repository_at_current_target,
-        open_existing_index_read_only,
+        migrate_index, open_existing_index_read_only, open_index,
+        query_revision_file_symbols, query_symbol_diagnostics, re_resolve_workspace_edges,
+        CodeEdgeRecord, CodeSymbolRecord,
         repository_scope_matches, workspace_git_bytes, CodeGraphProjectionError,
     };
 
@@ -5747,6 +5747,77 @@ mod code_graph_tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn workspace_edges_do_not_retarget_disappeared_symbols() {
+        let symbol = |symbol_key: &str, name: &str| CodeSymbolRecord {
+            symbol_id: symbol_key.to_string(),
+            symbol_key: symbol_key.to_string(),
+            repo_id: "repo".to_string(),
+            commit_sha: None,
+            path: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            kind: "function".to_string(),
+            name: name.to_string(),
+            container_symbol_id: None,
+            container_chain: Vec::new(),
+            signature: None,
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: 1,
+            start_byte: 0,
+            end_byte: 1,
+            selection_start_line: 1,
+            selection_end_line: 1,
+            content_sha256: "content".to_string(),
+            snippet_sha256: "snippet".to_string(),
+            parser_version: "parser".to_string(),
+            query_pack_version: "query-pack".to_string(),
+            freshness: "current".to_string(),
+            indexed_at: "now".to_string(),
+        };
+        let symbols = BTreeMap::from([
+            ("source".to_string(), symbol("source", "source")),
+            ("replacement".to_string(), symbol("replacement", "helper")),
+        ]);
+        let edge = |edge_id: &str, target_symbol_key: Option<&str>, unresolved: bool| {
+            CodeEdgeRecord {
+                edge_id: edge_id.to_string(),
+                edge_kind: "call".to_string(),
+                source_symbol_key: Some("source".to_string()),
+                target_symbol_key: target_symbol_key.map(str::to_string),
+                target_hint: Some("helper".to_string()),
+                confidence: "exact".to_string(),
+                unresolved,
+                path: "src/lib.rs".to_string(),
+                commit_sha: None,
+                freshness: "current".to_string(),
+                start_line: 1,
+                start_col: 0,
+                end_line: 1,
+                end_col: 1,
+            }
+        };
+        let mut edges = BTreeMap::from([
+            ("resolved".to_string(), edge("resolved", Some("deleted"), false)),
+            ("unresolved".to_string(), edge("unresolved", None, true)),
+        ]);
+
+        re_resolve_workspace_edges(&mut edges, &symbols);
+
+        let disappeared = edges.get("resolved").expect("disappeared edge retained");
+        assert_eq!(disappeared.target_symbol_key, None);
+        assert!(disappeared.unresolved);
+        assert_eq!(
+            edges
+                .get("unresolved")
+                .expect("unresolved edge retained")
+                .target_symbol_key
+                .as_deref(),
+            Some("replacement")
+        );
     }
 
     #[test]
@@ -5898,6 +5969,47 @@ mod code_graph_tests {
             .expect("second symbol node");
         assert_eq!(first.diagnostic_count, 1);
         assert_eq!(second.diagnostic_count, 0);
+
+        let connection = open_index(&config).expect("open diagnostic index");
+        migrate_index(&connection).expect("migrate diagnostic index");
+        connection
+            .execute(
+                "INSERT INTO code_snapshot_membership (repo_id, commit_sha, path, language, content_sha256, parser_version, query_pack_version, analyzed, skip_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                duckdb::params![
+                    "diagnostic-repo",
+                    "diagnostic-snapshot",
+                    "src/diagnostics.rs",
+                    "rust",
+                    "diagnostic-content",
+                    "test-parser",
+                    "test-query-pack",
+                    1_i64,
+                    Option::<String>::None,
+                ],
+            )
+            .expect("snapshot membership");
+        drop(connection);
+        let connection = open_existing_index_read_only(&config)
+            .expect("diagnostic index should open")
+            .expect("diagnostic index should exist");
+        let reused_symbol = query_revision_file_symbols(
+            &config,
+            &connection,
+            "diagnostic-repo",
+            "diagnostic-snapshot",
+            "src/diagnostics.rs",
+        )
+        .expect("reused snapshot symbols")
+        .into_iter()
+        .find(|symbol| symbol.name == "first")
+        .expect("reused first symbol");
+        assert_eq!(reused_symbol.commit_sha.as_deref(), Some("diagnostic-snapshot"));
+        assert_eq!(
+            query_symbol_diagnostics(&connection, &config, &reused_symbol, false)
+                .expect("reused diagnostics")
+                .len(),
+            1
+        );
     }
 
     #[test]
@@ -6024,6 +6136,26 @@ mod code_graph_tests {
             .nodes
             .iter()
             .any(|node| node.id == "file:src/empty.rs"));
+        let directory_snapshot = code_graph_workspace_snapshot(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::Atlas,
+                path: None,
+                symbol_key: None,
+                depth: 1,
+                aggregate: Some(super::CodeGraphAggregate::Directory),
+                include_stale: false,
+            },
+        )
+        .expect("directory atlas graph");
+        assert!(directory_snapshot
+            .nodes
+            .iter()
+            .all(|node| !node.id.starts_with("symbol:") && !node.id.starts_with("hint:")));
         let caller_key = overlay
             .symbols
             .values()
@@ -6196,6 +6328,34 @@ mod code_graph_tests {
             .unanalyzed_files
             .iter()
             .any(|path| path == "src/lib.rs"));
+        let mut no_parse_config = limited_config.clone();
+        no_parse_config.code_intel.ast.max_files_per_request = 0;
+        let baseline_key = overlay
+            .base_symbols
+            .values()
+            .find(|symbol| symbol.name == "baseline")
+            .map(|symbol| symbol.symbol_key.clone())
+            .expect("baseline symbol");
+        let unanalyzed_neighborhood = code_graph_workspace_snapshot(
+            &no_parse_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543-unparsed",
+            &base,
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::Neighborhood,
+                path: None,
+                symbol_key: Some(baseline_key),
+                depth: 1,
+                aggregate: None,
+                include_stale: false,
+            },
+        )
+        .expect("unanalyzed baseline neighborhood");
+        assert!(unanalyzed_neighborhood
+            .nodes
+            .iter()
+            .any(|node| node.label == "caller"));
     }
 
     #[test]

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -85,6 +85,7 @@ struct WorkspaceDocumentRecords {
 type WorkspaceLiveChangedRecords = (
     BTreeMap<String, CodeSymbolRecord>,
     BTreeMap<String, CodeEdgeRecord>,
+    BTreeSet<String>,
     Vec<String>,
 );
 
@@ -788,7 +789,7 @@ fn code_graph_workspace_focused_overlay(
                     "neighborhood mode requires `symbol_key`".to_string(),
                 )
             })?;
-            let (live_symbols, live_edges, unanalyzed_files) =
+            let (live_symbols, live_edges, analyzed_paths, unanalyzed_files) =
                 workspace_live_changed_records(config, repo_id, workspace_path, &changed_paths, &tombstones)?;
             let mut symbols = BTreeMap::new();
             let mut base_symbols = BTreeMap::new();
@@ -801,7 +802,7 @@ fn code_graph_workspace_focused_overlay(
                 base_revision,
                 center,
             )? {
-                if tombstones.contains(&symbol.path) {
+                if tombstones.contains(&symbol.path) || analyzed_paths.contains(&symbol.path) {
                     return Err(CodeGraphProjectionError::SymbolNotFound(center.to_string()));
                 }
                 base_symbols.insert(center.to_string(), symbol.clone());
@@ -862,16 +863,30 @@ fn code_graph_workspace_focused_overlay(
                     {
                         continue;
                     }
-                    let Some(symbol) = query_revision_symbol_by_name(
-                        config,
-                        &connection,
-                        repo_id,
-                        base_revision,
-                        name,
-                    )?
-                    else {
+                    let (symbol, from_baseline) = if let Some(symbol) =
+                        live_symbols.values().find(|symbol| symbol.name == name)
+                    {
+                        (Some(symbol.clone()), false)
+                    } else {
+                        (
+                            query_revision_symbol_by_name(
+                                config,
+                                &connection,
+                                repo_id,
+                                base_revision,
+                                name,
+                            )?,
+                            true,
+                        )
+                    };
+                    let Some(symbol) = symbol else {
                         continue;
                     };
+                    if tombstones.contains(&symbol.path)
+                        || (from_baseline && analyzed_paths.contains(&symbol.path))
+                    {
+                        continue;
+                    }
                     base_symbols
                         .entry(symbol.symbol_key.clone())
                         .or_insert_with(|| symbol.clone());
@@ -904,23 +919,28 @@ fn code_graph_workspace_focused_overlay(
                     if symbols.contains_key(&neighbor) {
                         continue;
                     }
-                    let symbol = if let Some(symbol) = live_symbols.get(&neighbor) {
-                        Some(symbol.clone())
+                    let (symbol, from_baseline) = if let Some(symbol) = live_symbols.get(&neighbor) {
+                        (Some(symbol.clone()), false)
                     } else if let Some(symbol) = base_symbols.get(&neighbor) {
-                        Some(symbol.clone())
+                        (Some(symbol.clone()), true)
                     } else {
-                        query_revision_symbol_by_key(
-                            config,
-                            &connection,
-                            repo_id,
-                            base_revision,
-                            &neighbor,
-                        )?
+                        (
+                            query_revision_symbol_by_key(
+                                config,
+                                &connection,
+                                repo_id,
+                                base_revision,
+                                &neighbor,
+                            )?,
+                            true,
+                        )
                     };
                     let Some(symbol) = symbol else {
                         continue;
                     };
-                    if tombstones.contains(&symbol.path) {
+                    if tombstones.contains(&symbol.path)
+                        || (from_baseline && analyzed_paths.contains(&symbol.path))
+                    {
                         continue;
                     }
                     base_symbols
@@ -964,6 +984,7 @@ fn workspace_live_changed_records(
 ) -> Result<WorkspaceLiveChangedRecords, CodeGraphProjectionError> {
     let mut symbols = BTreeMap::new();
     let mut edges = BTreeMap::new();
+    let mut analyzed_paths = BTreeSet::new();
     let mut unanalyzed_files = BTreeSet::new();
     let mut remaining_files = config.code_intel.ast.max_files_per_request;
     for path in changed_paths {
@@ -982,6 +1003,7 @@ fn workspace_live_changed_records(
             unanalyzed_files.insert(path.clone());
             continue;
         };
+        analyzed_paths.insert(path.clone());
         remaining_files = remaining_files.saturating_sub(1);
         for symbol in records.symbols {
             symbols.insert(symbol.symbol_key.clone(), symbol);
@@ -990,7 +1012,12 @@ fn workspace_live_changed_records(
             edges.insert(edge.edge_id.clone(), edge);
         }
     }
-    Ok((symbols, edges, unanalyzed_files.into_iter().collect()))
+    Ok((
+        symbols,
+        edges,
+        analyzed_paths,
+        unanalyzed_files.into_iter().collect(),
+    ))
 }
 
 pub fn code_graph_workspace_diff_overlay(
@@ -5599,7 +5626,7 @@ mod code_graph_tests {
         .expect("workflow marker");
         fs::write(
             repo.path().join("src/lib.rs"),
-            "pub fn baseline() {}\npub fn caller() { baseline(); }\n",
+            "pub fn baseline() {}\npub fn removed_from_live() {}\npub fn caller() { baseline(); }\n",
         )
         .expect("baseline source");
         fs::write(repo.path().join("src/remove.rs"), "pub fn removed() {}\n")
@@ -5738,6 +5765,30 @@ mod code_graph_tests {
             .nodes
             .iter()
             .any(|node| node.label == "baseline"));
+        let removed_from_live_key = overlay
+            .base_symbols
+            .values()
+            .find(|symbol| symbol.name == "removed_from_live")
+            .map(|symbol| symbol.symbol_key.clone())
+            .expect("baseline-only symbol");
+        assert!(matches!(
+            code_graph_workspace_snapshot(
+                &limited_config,
+                "overlay-repo",
+                repo.path(),
+                "COE-543",
+                &base,
+                CodeGraphSnapshotOptions {
+                    mode: CodeGraphMode::Neighborhood,
+                    path: None,
+                    symbol_key: Some(removed_from_live_key),
+                    depth: 1,
+                    aggregate: None,
+                    include_stale: false,
+                },
+            ),
+            Err(CodeGraphProjectionError::SymbolNotFound(_))
+        ));
         let deleted_snapshot = code_graph_workspace_snapshot(
             &limited_config,
             "overlay-repo",

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -25,6 +25,8 @@ const DEFAULT_CODE_INDEX_BRANCH: &str = "develop";
 
 #[derive(Debug, thiserror::Error)]
 pub enum CodeGraphProjectionError {
+    #[error("code graph index is unavailable")]
+    IndexUnavailable,
     #[error("unknown code repo `{0}`")]
     RepoNotFound(String),
     #[error("unknown indexed code file `{0}`")]
@@ -578,9 +580,13 @@ pub fn code_graph_workspace_overlay(
         ));
     }
     let Some(connection) = open_existing_index_read_only(config)? else {
-        return Err(CodeGraphProjectionError::RepoNotFound(repo_id.to_string()));
+        return Err(CodeGraphProjectionError::IndexUnavailable);
     };
     if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Err(CodeGraphProjectionError::IndexUnavailable);
+    }
+    ensure_code_repo(config, repo_id, true)?;
+    if !code_revision_indexed(&connection, config, repo_id, base_revision)? {
         return Err(CodeGraphProjectionError::RevisionNotFound(
             base_revision.to_string(),
         ));
@@ -608,29 +614,26 @@ pub fn code_graph_workspace_overlay(
         symbols.retain(|_, symbol| symbol.path != *path);
         edges.retain(|_, edge| edge.path != *path);
 
-        let file_path = workspace_path.join(path);
-        if !file_path.is_file() {
-            if !base_symbols.values().any(|symbol| symbol.path == *path) {
-                unanalyzed_files.insert(path.clone());
-            }
+        let Some(file_path) = workspace_file_path(workspace_path, path)? else {
+            unanalyzed_files.insert(path.clone());
             continue;
-        }
+        };
         if remaining_files == 0 {
             unanalyzed_files.insert(path.clone());
             continue;
         }
-        remaining_files = remaining_files.saturating_sub(1);
 
         let Some(records) = workspace_document_records(
             config,
             repo_id,
-            workspace_path,
             path,
+            &file_path,
         )?
         else {
             unanalyzed_files.insert(path.clone());
             continue;
         };
+        remaining_files = remaining_files.saturating_sub(1);
         if records.symbols.is_empty() {
             unanalyzed_files.insert(path.clone());
         }
@@ -1012,20 +1015,19 @@ pub fn code_graph_workspace_snapshot(
 fn workspace_document_records(
     config: &MemoryConfig,
     repo_id: &str,
-    workspace_path: &Path,
     path: &str,
+    file_path: &Path,
 ) -> Result<Option<WorkspaceDocumentRecords>, CodeGraphProjectionError> {
-    let file_path = workspace_path.join(path);
-    let Ok(bytes) = fs::read(&file_path) else {
-        return Ok(None);
-    };
     let Some(language) = detect_language(Path::new(path)) else {
         return Ok(None);
     };
-    if bytes.len() as u64 > config.code_intel.ast.max_file_bytes {
+    let Ok(metadata) = fs::metadata(file_path) else {
+        return Ok(None);
+    };
+    if metadata.len() > config.code_intel.ast.max_file_bytes {
         return Ok(None);
     }
-    let Ok(source) = String::from_utf8(bytes) else {
+    let Ok(source) = fs::read_to_string(file_path) else {
         return Ok(None);
     };
     let content_sha256 = sha256_hex(&source);
@@ -1196,17 +1198,69 @@ fn workspace_changed_paths(
         changed.insert(path.to_string());
     }
 
-    let mut digest_input = Vec::new();
+    let mut hasher = Sha256::new();
     for path in &changed {
-        digest_input.extend_from_slice(path.as_bytes());
-        digest_input.push(0);
-        match fs::read(workspace_path.join(path)) {
-            Ok(bytes) => digest_input.extend_from_slice(&bytes),
-            Err(_) => digest_input.extend_from_slice(b"<deleted>"),
+        hasher.update(path.as_bytes());
+        hasher.update([0]);
+        match workspace_file_path(workspace_path, path)? {
+            Some(file_path) => {
+                let mut file = match fs::File::open(file_path) {
+                    Ok(file) => file,
+                    Err(_) => {
+                        hasher.update(b"<unreadable>");
+                        hasher.update([0]);
+                        continue;
+                    }
+                };
+                let mut buffer = [0_u8; 64 * 1024];
+                loop {
+                    match io::Read::read(&mut file, &mut buffer) {
+                        Ok(0) => break,
+                        Ok(read) => hasher.update(&buffer[..read]),
+                        Err(_) => {
+                            hasher.update(b"<unreadable>");
+                            break;
+                        }
+                    }
+                }
+            }
+            None => hasher.update(b"<deleted-or-outside-workspace>"),
         }
-        digest_input.push(0);
+        hasher.update([0]);
     }
-    Ok((changed, tombstones, sha256_bytes_hex(&digest_input)))
+    let digest = hasher.finalize();
+    let digest = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok((changed, tombstones, digest))
+}
+
+fn workspace_file_path(
+    workspace_path: &Path,
+    path: &str,
+) -> Result<Option<PathBuf>, CodeGraphProjectionError> {
+    let relative = normalize_code_path(path).map_err(CodeGraphProjectionError::InvalidRequest)?;
+    let root = workspace_path
+        .canonicalize()
+        .map_err(|source| CodeGraphProjectionError::Memory(MemoryError::ResolvePath {
+            path: workspace_path.to_path_buf(),
+            source,
+        }))?;
+    let candidate = workspace_path.join(relative);
+    let Ok(metadata) = fs::symlink_metadata(&candidate) else {
+        return Ok(None);
+    };
+    if metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    let Ok(resolved) = candidate.canonicalize() else {
+        return Ok(None);
+    };
+    if !resolved.starts_with(root) || !resolved.is_file() {
+        return Ok(None);
+    }
+    Ok(Some(resolved))
 }
 
 fn workspace_git_line<const N: usize>(
@@ -4764,6 +4818,18 @@ mod code_graph_tests {
             "pub fn too_large() {}\n".repeat(10),
         )
         .expect("oversized source");
+        #[cfg(unix)]
+        let _outside = {
+            let outside = TempDir::new().expect("outside tempdir");
+            fs::write(outside.path().join("escaped.rs"), "pub fn escaped() {}\n")
+                .expect("outside source");
+            std::os::unix::fs::symlink(
+                outside.path().join("escaped.rs"),
+                repo.path().join("src/linked.rs"),
+            )
+            .expect("workspace symlink");
+            outside
+        };
         let mut limited_config = config.clone();
         limited_config.code_intel.ast.max_file_bytes = 128;
 
@@ -4793,6 +4859,14 @@ mod code_graph_tests {
             .unanalyzed_files
             .iter()
             .any(|path| path == "src/large.rs"));
+        #[cfg(unix)]
+        {
+            assert!(overlay
+                .unanalyzed_files
+                .iter()
+                .any(|path| path == "src/linked.rs"));
+            assert!(!overlay.symbols.values().any(|symbol| symbol.name == "escaped"));
+        }
         assert_eq!(overlay.base_revision, base);
         assert_eq!(overlay.run_id, "COE-543");
         assert!(!overlay.workspace_content_digest.is_empty());
@@ -4824,6 +4898,22 @@ mod code_graph_tests {
                 .is_some_and(|symbol| symbol.symbol_key == radius.symbol_key)
                 && radius.inbound_count > 0
         }));
+
+        let mut budget_config = limited_config.clone();
+        budget_config.code_intel.ast.max_files_per_request = 1;
+        let budget_overlay = code_graph_workspace_overlay(
+            &budget_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543-budget",
+            &base,
+        )
+        .expect("workspace overlay with file budget");
+        assert!(budget_overlay.symbols.values().any(|symbol| symbol.name == "changed"));
+        assert!(!budget_overlay
+            .unanalyzed_files
+            .iter()
+            .any(|path| path == "src/lib.rs"));
     }
 
     #[test]
@@ -4850,6 +4940,27 @@ mod code_graph_tests {
             Some(("develop".to_string(), base.clone())),
         )
         .expect("shared baseline index");
+
+        assert!(matches!(
+            code_graph_workspace_overlay(
+                &config,
+                "missing-repo",
+                source.path(),
+                "COE-543-missing-repo",
+                &base,
+            ),
+            Err(CodeGraphProjectionError::RepoNotFound(_))
+        ));
+        assert!(matches!(
+            code_graph_workspace_overlay(
+                &config,
+                "shared-repo",
+                source.path(),
+                "COE-543-missing-revision",
+                "missing-revision",
+            ),
+            Err(CodeGraphProjectionError::RevisionNotFound(_))
+        ));
 
         let left = TempDir::new().expect("left workspace tempdir");
         let right = TempDir::new().expect("right workspace tempdir");

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -82,6 +82,12 @@ struct WorkspaceDocumentRecords {
     edges: Vec<CodeEdgeRecord>,
 }
 
+type WorkspaceLiveChangedRecords = (
+    BTreeMap<String, CodeSymbolRecord>,
+    BTreeMap<String, CodeEdgeRecord>,
+    Vec<String>,
+);
+
 static WORKSPACE_DOCUMENT_CACHE: OnceLock<Mutex<BTreeMap<WorkspaceDocumentCacheKey, WorkspaceDocumentRecords>>> =
     OnceLock::new();
 
@@ -574,23 +580,7 @@ pub fn code_graph_workspace_overlay(
     run_id: &str,
     base_revision: &str,
 ) -> Result<CodeWorkspaceOverlay, CodeGraphProjectionError> {
-    if !workspace_path.is_dir() {
-        return Err(CodeGraphProjectionError::InvalidRequest(
-            "run workspace is not available".to_string(),
-        ));
-    }
-    let Some(connection) = open_existing_index_read_only(config)? else {
-        return Err(CodeGraphProjectionError::IndexUnavailable);
-    };
-    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
-        return Err(CodeGraphProjectionError::IndexUnavailable);
-    }
-    ensure_code_repo(config, repo_id, true)?;
-    if !code_revision_indexed(&connection, config, repo_id, base_revision)? {
-        return Err(CodeGraphProjectionError::RevisionNotFound(
-            base_revision.to_string(),
-        ));
-    }
+    let connection = open_workspace_graph_connection(config, repo_id, workspace_path, base_revision)?;
 
     let base_symbols = query_symbols_for_revision(config, &connection, repo_id, base_revision)?;
     let base_paths = query_revision_documents(&connection, config, repo_id, base_revision)?
@@ -642,9 +632,6 @@ pub fn code_graph_workspace_overlay(
         remaining_files = remaining_files.saturating_sub(1);
         symbols.retain(|_, symbol| symbol.path != *path);
         edges.retain(|_, edge| edge.path != *path);
-        if records.symbols.is_empty() {
-            unanalyzed_files.insert(path.clone());
-        }
         for symbol in records.symbols {
             symbols.insert(symbol.symbol_key.clone(), symbol);
         }
@@ -668,6 +655,342 @@ pub fn code_graph_workspace_overlay(
         tombstones,
         unanalyzed_files: unanalyzed_files.into_iter().collect(),
     })
+}
+
+fn open_workspace_graph_connection(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    base_revision: &str,
+) -> Result<Connection, CodeGraphProjectionError> {
+    if !workspace_path.is_dir() {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "run workspace is not available".to_string(),
+        ));
+    }
+    let Some(connection) = open_existing_index_read_only(config)? else {
+        return Err(CodeGraphProjectionError::IndexUnavailable);
+    };
+    if !code_symbols_read_model_ready(&connection, &config.index_path)? {
+        return Err(CodeGraphProjectionError::IndexUnavailable);
+    }
+    ensure_code_repo(config, repo_id, true)?;
+    if !code_revision_indexed(&connection, config, repo_id, base_revision)? {
+        return Err(CodeGraphProjectionError::RevisionNotFound(
+            base_revision.to_string(),
+        ));
+    }
+    Ok(connection)
+}
+
+fn code_graph_workspace_focused_overlay(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    run_id: &str,
+    base_revision: &str,
+    options: &CodeGraphSnapshotOptions,
+) -> Result<CodeWorkspaceOverlay, CodeGraphProjectionError> {
+    let connection = open_workspace_graph_connection(config, repo_id, workspace_path, base_revision)?;
+    let head_revision = workspace_git_line(workspace_path, ["rev-parse", "HEAD"])?;
+    let (changed_paths, tombstones, workspace_content_digest) = workspace_changed_paths(
+        workspace_path,
+        base_revision,
+        config.code_intel.ast.max_file_bytes,
+    )?;
+
+    match options.mode {
+        CodeGraphMode::File => {
+            let raw_path = options.path.as_deref().ok_or_else(|| {
+                CodeGraphProjectionError::InvalidRequest("file mode requires `path`".to_string())
+            })?;
+            let path = normalize_code_path(raw_path).map_err(CodeGraphProjectionError::InvalidRequest)?;
+            let base_exists = query_revision_file_exists(
+                &connection,
+                config,
+                repo_id,
+                base_revision,
+                &path,
+            )?;
+            let changed = changed_paths.contains(&path);
+            if !base_exists && !changed {
+                return Err(CodeGraphProjectionError::FileNotFound(path));
+            }
+            let base_symbols = if base_exists {
+                query_revision_file_symbols(config, &connection, repo_id, base_revision, &path)?
+            } else {
+                Vec::new()
+            };
+            let base_edges = if base_exists {
+                query_revision_file_edges(config, &connection, repo_id, base_revision, &path)?
+            } else {
+                Vec::new()
+            };
+            let mut unanalyzed_files = BTreeSet::new();
+            let live_records = if tombstones.contains(&path) {
+                None
+            } else if changed {
+                match workspace_file_path(workspace_path, &path)? {
+                    Some(file_path) => match workspace_document_records(config, repo_id, &path, &file_path)? {
+                        Some(records) => Some(records),
+                        None => {
+                            unanalyzed_files.insert(path.clone());
+                            None
+                        }
+                    },
+                    None => {
+                        unanalyzed_files.insert(path.clone());
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            let (symbols, edges) = match live_records {
+                Some(records) => (records.symbols, records.edges),
+                None => (base_symbols.clone(), base_edges.clone()),
+            };
+            let mut base_symbol_map = base_symbols
+                .into_iter()
+                .map(|symbol| (symbol.symbol_key.clone(), symbol))
+                .collect::<BTreeMap<_, _>>();
+            let mut symbol_map = symbols
+                .into_iter()
+                .map(|symbol| (symbol.symbol_key.clone(), symbol))
+                .collect::<BTreeMap<_, _>>();
+            let mut base_paths = BTreeSet::new();
+            if base_exists {
+                base_paths.insert(path.clone());
+            }
+            let mut edge_map = edges
+                .into_iter()
+                .map(|edge| (edge.edge_id.clone(), edge))
+                .collect::<BTreeMap<_, _>>();
+            re_resolve_workspace_edges(&mut edge_map, &symbol_map);
+            Ok(CodeWorkspaceOverlay {
+                run_id: run_id.to_string(),
+                base_revision: base_revision.to_string(),
+                head_revision,
+                workspace_content_digest,
+                base_symbols: std::mem::take(&mut base_symbol_map),
+                base_paths,
+                base_edges,
+                symbols: std::mem::take(&mut symbol_map),
+                edges: edge_map.into_values().collect(),
+                changed_paths,
+                tombstones,
+                unanalyzed_files: unanalyzed_files.into_iter().collect(),
+            })
+        }
+        CodeGraphMode::Neighborhood => {
+            let center = options.symbol_key.as_deref().ok_or_else(|| {
+                CodeGraphProjectionError::InvalidRequest(
+                    "neighborhood mode requires `symbol_key`".to_string(),
+                )
+            })?;
+            let (live_symbols, live_edges, unanalyzed_files) =
+                workspace_live_changed_records(config, repo_id, workspace_path, &changed_paths, &tombstones)?;
+            let mut symbols = BTreeMap::new();
+            let mut base_symbols = BTreeMap::new();
+            if let Some(symbol) = live_symbols.get(center) {
+                symbols.insert(center.to_string(), symbol.clone());
+            } else if let Some(symbol) = query_revision_symbol_by_key(
+                config,
+                &connection,
+                repo_id,
+                base_revision,
+                center,
+            )? {
+                if tombstones.contains(&symbol.path) {
+                    return Err(CodeGraphProjectionError::SymbolNotFound(center.to_string()));
+                }
+                base_symbols.insert(center.to_string(), symbol.clone());
+                symbols.insert(center.to_string(), symbol);
+            } else {
+                return Err(CodeGraphProjectionError::SymbolNotFound(center.to_string()));
+            }
+
+            let mut edges = BTreeMap::new();
+            let mut base_edges = BTreeMap::new();
+            let mut frontier = BTreeSet::from([center.to_string()]);
+            for _ in 0..options.depth.max(1) {
+                let mut next = BTreeSet::new();
+                for key in &frontier {
+                    let baseline_edges = query_revision_edges_for_symbol(
+                        config,
+                        &connection,
+                        repo_id,
+                        base_revision,
+                        key,
+                    )?;
+                    for edge in baseline_edges {
+                        if changed_paths.contains(&edge.path) {
+                            continue;
+                        }
+                        base_edges.insert(edge.edge_id.clone(), edge.clone());
+                        edges.insert(edge.edge_id.clone(), edge);
+                    }
+                    for edge in live_edges.values().filter(|edge| {
+                        edge.source_symbol_key.as_deref() == Some(key.as_str())
+                            || edge.target_symbol_key.as_deref() == Some(key.as_str())
+                    }) {
+                        edges.insert(edge.edge_id.clone(), edge.clone());
+                    }
+                }
+
+                let edge_ids = edges.keys().cloned().collect::<Vec<_>>();
+                for edge_id in edge_ids {
+                    let Some((source_in_frontier, target_hint)) = edges.get(&edge_id).map(|edge| {
+                        (
+                            edge.source_symbol_key
+                                .as_ref()
+                                .is_some_and(|source| frontier.contains(source)),
+                            edge.target_hint.clone(),
+                        )
+                    }) else {
+                        continue;
+                    };
+                    if !source_in_frontier {
+                        continue;
+                    }
+                    let Some(name) = target_hint.as_deref().and_then(edge_target_name) else {
+                        continue;
+                    };
+                    if edges
+                        .get(&edge_id)
+                        .is_some_and(|edge| edge.target_symbol_key.is_some())
+                    {
+                        continue;
+                    }
+                    let Some(symbol) = query_revision_symbol_by_name(
+                        config,
+                        &connection,
+                        repo_id,
+                        base_revision,
+                        name,
+                    )?
+                    else {
+                        continue;
+                    };
+                    base_symbols
+                        .entry(symbol.symbol_key.clone())
+                        .or_insert_with(|| symbol.clone());
+                    if let Some(edge) = edges.get_mut(&edge_id) {
+                        edge.target_symbol_key = Some(symbol.symbol_key);
+                        edge.unresolved = false;
+                        edge.confidence = normalize_edge_confidence(&edge.confidence, true).to_string();
+                    }
+                }
+
+                for edge in edges.values() {
+                    let neighbor = if edge
+                        .source_symbol_key
+                        .as_ref()
+                        .is_some_and(|source| frontier.contains(source))
+                    {
+                        edge.target_symbol_key.clone()
+                    } else if edge
+                        .target_symbol_key
+                        .as_ref()
+                        .is_some_and(|target| frontier.contains(target))
+                    {
+                        edge.source_symbol_key.clone()
+                    } else {
+                        None
+                    };
+                    let Some(neighbor) = neighbor else {
+                        continue;
+                    };
+                    if symbols.contains_key(&neighbor) {
+                        continue;
+                    }
+                    let symbol = if let Some(symbol) = live_symbols.get(&neighbor) {
+                        Some(symbol.clone())
+                    } else if let Some(symbol) = base_symbols.get(&neighbor) {
+                        Some(symbol.clone())
+                    } else {
+                        query_revision_symbol_by_key(
+                            config,
+                            &connection,
+                            repo_id,
+                            base_revision,
+                            &neighbor,
+                        )?
+                    };
+                    let Some(symbol) = symbol else {
+                        continue;
+                    };
+                    if tombstones.contains(&symbol.path) {
+                        continue;
+                    }
+                    base_symbols
+                        .entry(neighbor.clone())
+                        .or_insert_with(|| symbol.clone());
+                    symbols.insert(neighbor.clone(), symbol);
+                    next.insert(neighbor);
+                }
+                if next.is_empty() {
+                    break;
+                }
+                frontier = next;
+            }
+            let mut edge_map = edges;
+            re_resolve_workspace_edges(&mut edge_map, &symbols);
+            Ok(CodeWorkspaceOverlay {
+                run_id: run_id.to_string(),
+                base_revision: base_revision.to_string(),
+                head_revision,
+                workspace_content_digest,
+                base_symbols,
+                base_paths: symbols.values().map(|symbol| symbol.path.clone()).collect(),
+                base_edges: base_edges.into_values().collect(),
+                symbols,
+                edges: edge_map.into_values().collect(),
+                changed_paths,
+                tombstones,
+                unanalyzed_files,
+            })
+        }
+        CodeGraphMode::Atlas => unreachable!("focused overlay only handles file and neighborhood modes"),
+    }
+}
+
+fn workspace_live_changed_records(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    changed_paths: &BTreeSet<String>,
+    tombstones: &BTreeSet<String>,
+) -> Result<WorkspaceLiveChangedRecords, CodeGraphProjectionError> {
+    let mut symbols = BTreeMap::new();
+    let mut edges = BTreeMap::new();
+    let mut unanalyzed_files = BTreeSet::new();
+    let mut remaining_files = config.code_intel.ast.max_files_per_request;
+    for path in changed_paths {
+        if tombstones.contains(path) {
+            continue;
+        }
+        let Some(file_path) = workspace_file_path(workspace_path, path)? else {
+            unanalyzed_files.insert(path.clone());
+            continue;
+        };
+        if remaining_files == 0 {
+            unanalyzed_files.insert(path.clone());
+            continue;
+        }
+        let Some(records) = workspace_document_records(config, repo_id, path, &file_path)? else {
+            unanalyzed_files.insert(path.clone());
+            continue;
+        };
+        remaining_files = remaining_files.saturating_sub(1);
+        for symbol in records.symbols {
+            symbols.insert(symbol.symbol_key.clone(), symbol);
+        }
+        for edge in records.edges {
+            edges.insert(edge.edge_id.clone(), edge);
+        }
+    }
+    Ok((symbols, edges, unanalyzed_files.into_iter().collect()))
 }
 
 pub fn code_graph_workspace_diff_overlay(
@@ -872,6 +1195,17 @@ pub fn code_graph_workspace_snapshot(
         ));
     }
     let mode = options.mode;
+    if matches!(mode, CodeGraphMode::File | CodeGraphMode::Neighborhood) {
+        let overlay = code_graph_workspace_focused_overlay(
+            config,
+            repo_id,
+            workspace_path,
+            run_id,
+            base_revision,
+            &options,
+        )?;
+        return render_workspace_graph_snapshot(repo_id, options, overlay);
+    }
     let overlay = code_graph_workspace_overlay(
         config,
         repo_id,
@@ -879,6 +1213,15 @@ pub fn code_graph_workspace_snapshot(
         run_id,
         base_revision,
     )?;
+    render_workspace_graph_snapshot(repo_id, options, overlay)
+}
+
+fn render_workspace_graph_snapshot(
+    repo_id: &str,
+    options: CodeGraphSnapshotOptions,
+    overlay: CodeWorkspaceOverlay,
+) -> Result<CodeGraphSnapshot, CodeGraphProjectionError> {
+    let mode = options.mode;
     let mut paths = BTreeSet::new();
     let mut selected_keys = BTreeSet::new();
     let mut dropped_paths = 0;
@@ -3667,6 +4010,230 @@ fn query_revision_file_symbols(
     Ok(symbols.into_values().collect())
 }
 
+fn query_revision_symbol_by_key(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    symbol_key: &str,
+) -> Result<Option<CodeSymbolRecord>, MemoryError> {
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
+    let query = if membership_ready {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END FROM code_symbols AS s WHERE s.repo_id = ? AND s.symbol_key = ? AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed)) ORDER BY s.indexed_at DESC, s.symbol_id"
+        )
+    } else {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND symbol_key = ? AND commit_sha = ? AND freshness <> 'staged' ORDER BY indexed_at DESC, symbol_id"
+        )
+    };
+    let mut statement = connection
+        .prepare(&query)
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let mut rows = if membership_ready {
+        statement
+            .query(params![repo_id, symbol_key, revision, revision])
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    } else {
+        statement
+            .query(params![repo_id, symbol_key, revision])
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    };
+    let Some(row) = rows.next().map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?
+    else {
+        return Ok(None);
+    };
+    if row
+        .get::<_, i64>(25)
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?
+        != 0
+    {
+        return Ok(None);
+    }
+    let mut symbol = code_symbol_from_row(row).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    if symbol.commit_sha.as_deref() != Some(revision) {
+        symbol.commit_sha = Some(revision.to_string());
+    }
+    fill_container_chain(connection, &mut symbol)?;
+    Ok(Some(symbol))
+}
+
+fn query_revision_symbol_by_name(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    name: &str,
+) -> Result<Option<CodeSymbolRecord>, MemoryError> {
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
+    let query = if membership_ready {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END FROM code_symbols AS s WHERE s.repo_id = ? AND s.name = ? AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed)) ORDER BY s.path, s.start_line, s.start_col, s.symbol_key"
+        )
+    } else {
+        format!(
+            "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN worktree_dirty THEN 1 ELSE 0 END FROM code_symbols WHERE repo_id = ? AND name = ? AND commit_sha = ? AND freshness <> 'staged' ORDER BY path, start_line, start_col, symbol_key"
+        )
+    };
+    let mut statement = connection
+        .prepare(&query)
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let mut rows = if membership_ready {
+        statement
+            .query(params![repo_id, name, revision, revision])
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    } else {
+        statement
+            .query(params![repo_id, name, revision])
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    };
+    let mut candidate = None;
+    while let Some(row) = rows.next().map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })? {
+        if row
+            .get::<_, i64>(25)
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            != 0
+        {
+            continue;
+        }
+        let mut symbol = code_symbol_from_row(row).map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+        if symbol.commit_sha.as_deref() != Some(revision) {
+            symbol.commit_sha = Some(revision.to_string());
+        }
+        if candidate
+            .as_ref()
+            .is_some_and(|previous: &CodeSymbolRecord| previous.symbol_key != symbol.symbol_key)
+        {
+            return Ok(None);
+        }
+        candidate = Some(symbol);
+    }
+    if let Some(symbol) = candidate.as_mut() {
+        fill_container_chain(connection, symbol)?;
+    }
+    Ok(candidate)
+}
+
+fn query_revision_file_edges(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    path: &str,
+) -> Result<Vec<CodeEdgeRecord>, MemoryError> {
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
+    let query = if membership_ready {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.path = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed)) ORDER BY e.start_line, e.start_col, e.edge_id"
+    } else {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.path = ? AND e.commit_sha = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty ORDER BY e.start_line, e.start_col, e.edge_id"
+    };
+    let mut statement = connection
+        .prepare(query)
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let rows = if membership_ready {
+        statement
+            .query_map(params![repo_id, path, revision, revision], code_edge_from_row)
+    } else {
+        statement.query_map(params![repo_id, path, revision], code_edge_from_row)
+    }
+    .map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })
+}
+
+fn query_revision_edges_for_symbol(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    symbol_key: &str,
+) -> Result<Vec<CodeEdgeRecord>, MemoryError> {
+    let snapshot_status = code_snapshot_status(connection, config, repo_id, revision)?;
+    let membership_ready =
+        code_snapshot_membership_read_model_ready(connection, &config.index_path)?
+            && matches!(snapshot_status.as_deref(), None | Some("completed"));
+    let query = if membership_ready {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed)) AND (e.source_symbol_key = ? OR e.target_symbol_key = ?) ORDER BY e.path, e.start_line, e.start_col, e.edge_id"
+    } else {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.commit_sha = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (e.source_symbol_key = ? OR e.target_symbol_key = ?) ORDER BY e.path, e.start_line, e.start_col, e.edge_id"
+    };
+    let mut statement = connection
+        .prepare(query)
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?;
+    let rows = if membership_ready {
+        statement.query_map(
+            params![repo_id, revision, revision, symbol_key, symbol_key],
+            code_edge_from_row,
+        )
+    } else {
+        statement.query_map(params![repo_id, revision, symbol_key, symbol_key], code_edge_from_row)
+    }
+    .map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })
+}
+
 fn query_revision_file_exists(
     connection: &Connection,
     config: &MemoryConfig,
@@ -5064,6 +5631,7 @@ mod code_graph_tests {
         .expect("modified source");
         fs::remove_file(repo.path().join("src/remove.rs")).expect("deleted source");
         fs::write(repo.path().join("src/new.rs"), "pub fn added() {}\n").expect("added source");
+        fs::write(repo.path().join("src/zchanged_empty.rs"), "").expect("empty added source");
         fs::write(repo.path().join("notes.txt"), "unsupported\n").expect("unsupported source");
         fs::write(
             repo.path().join("src/large.rs"),
@@ -5102,6 +5670,10 @@ mod code_graph_tests {
             .values()
             .any(|symbol| symbol.name == "changed"));
         assert!(overlay.symbols.values().any(|symbol| symbol.name == "added"));
+        assert!(!overlay
+            .unanalyzed_files
+            .iter()
+            .any(|path| path == "src/zchanged_empty.rs"));
         assert!(overlay
             .symbols
             .values()
@@ -5136,6 +5708,36 @@ mod code_graph_tests {
             .nodes
             .iter()
             .any(|node| node.id == "file:src/empty.rs"));
+        let caller_key = overlay
+            .symbols
+            .values()
+            .find(|symbol| symbol.name == "caller")
+            .map(|symbol| symbol.symbol_key.clone())
+            .expect("changed caller symbol");
+        let neighborhood_snapshot = code_graph_workspace_snapshot(
+            &limited_config,
+            "overlay-repo",
+            repo.path(),
+            "COE-543",
+            &base,
+            CodeGraphSnapshotOptions {
+                mode: CodeGraphMode::Neighborhood,
+                path: None,
+                symbol_key: Some(caller_key),
+                depth: 1,
+                aggregate: None,
+                include_stale: false,
+            },
+        )
+        .expect("focused neighborhood graph");
+        assert!(neighborhood_snapshot
+            .nodes
+            .iter()
+            .any(|node| node.label == "caller"));
+        assert!(neighborhood_snapshot
+            .nodes
+            .iter()
+            .any(|node| node.label == "baseline"));
         let deleted_snapshot = code_graph_workspace_snapshot(
             &limited_config,
             "overlay-repo",

--- a/crates/opensymphony-memory/src/index.rs
+++ b/crates/opensymphony-memory/src/index.rs
@@ -3504,7 +3504,7 @@ mod index_tests {
         )
         .expect("workflow marker");
 
-        let result = configured_code_index_branch(repo.path());
+        let result = code_index_branch(repo.path());
         assert!(matches!(
             result,
             Err(CodeGraphProjectionError::InvalidRequest(message))

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -77,6 +77,30 @@ after completion. This shared target-branch baseline is not the live truth for
 an issue workspace; workspace-specific code belongs to the overlay/composite
 graph path.
 
+## Workspace overlays
+
+Run-scoped code reads compose the pinned target-branch merge-base snapshot with
+the owning issue workspace. Git changes are enumerated as committed, staged,
+unstaged, untracked, and deleted paths; renames are represented as a tombstone
+plus an added path. Only changed supported files are parsed, and parsed
+records are reused by content hash within the process. Unsupported, oversized,
+failed, and limit-skipped paths remain in `unanalyzed_files` coverage.
+
+The composite is an ephemeral projection: baseline rows are never mutated and
+no fake worktree revision is persisted. The gateway pins a run's comparison
+base and scopes the projection by repository, run, workspace, base revision,
+and workspace content digest. It is therefore safe for concurrent workspaces
+to edit the same path. The run endpoints are:
+
+```text
+GET /api/v1/runs/{run_id}/code/graph
+GET /api/v1/runs/{run_id}/code/diff-overlay
+```
+
+Both reads rebuild from the recoverable workspace after a process restart;
+workspace removal makes the projection unavailable. There is no continuous
+watcher or second per-workspace DuckDB index.
+
 ## Agent Workflow
 
 Use memory first, then code-intelligence context after file discovery:

--- a/packages/graph/__tests__/code-graph.test.ts
+++ b/packages/graph/__tests__/code-graph.test.ts
@@ -328,6 +328,8 @@ describe("Code Graph adapters and state", () => {
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/code/repos?include_stale=true");
     await http.getGraphSnapshot("opensymphony", { mode: "atlas", includeStale: true });
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/code/repos/opensymphony/graph?mode=atlas&include_stale=true");
+    await http.getRunGraphSnapshot!("COE-543", "opensymphony", { mode: "file", path: "src/lib.rs", depth: 1 });
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/runs/COE-543/code/graph?mode=file&path=src%2Flib.rs&depth=1&repo_id=opensymphony");
     await http.getSymbolDetail("opensymphony", "staleSymbol", { includeStale: true });
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/code/repos/opensymphony/symbols/staleSymbol?include_stale=true");
     const publicHttp = createHttpCodeGraphAdapter("http://localhost:2468", fetchMock, {
@@ -348,7 +350,7 @@ describe("Code Graph adapters and state", () => {
     expect(() => publicNative.getSymbolDetail("opensymphony", "privateSymbol", { visibility: "all_accessible" }))
       .toThrow('Code graph visibility "all_accessible" exceeds adapter policy "public"');
     await native.listRepos();
-    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
   });
 
   it("keeps edge-heavy scale tiers and aggregated Atlas within their budgets", () => {

--- a/packages/graph/src/code-graph.ts
+++ b/packages/graph/src/code-graph.ts
@@ -62,6 +62,7 @@ export interface CodeGraphAdapterPolicy {
 export interface CodeGraphAdapter {
   listRepos(options?: CodeRepoListRequestOptions): Promise<CodeRepoList>;
   getGraphSnapshot(repoId: string, options?: CodeGraphRequestOptions): Promise<CodeGraphSnapshot>;
+  getRunGraphSnapshot?(runId: string, repoId?: string, options?: CodeGraphRequestOptions): Promise<CodeGraphSnapshot>;
   getSymbolDetail(repoId: string, symbolKey: string, options?: CodeSymbolDetailRequestOptions): Promise<CodeSymbolDetail>;
   getFileOutline(runId: string, filePath: string, repoId?: string): Promise<CodeFileOutline>;
   getDiffOverlay(
@@ -638,6 +639,11 @@ export function createHttpCodeGraphAdapter(
     getGraphSnapshot: (repoId, options) => {
       const params = codeGraphRequestParams(options);
       return read<CodeGraphSnapshot>(`/api/v1/code/repos/${encodeURIComponent(repoId)}/graph`, params);
+    },
+    getRunGraphSnapshot: (runId, repoId, options) => {
+      const params = codeGraphRequestParams(options);
+      if (repoId) params.set("repo_id", repoId);
+      return read<CodeGraphSnapshot>(`/api/v1/runs/${encodeURIComponent(runId)}/code/graph`, params);
     },
     getSymbolDetail: (repoId, symbolKey, options) => {
       const params = new URLSearchParams();

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1354,6 +1354,7 @@ describe("OpenSymphonyApp mount", () => {
     document.body.appendChild(root);
     const fixtureCodeGraphAdapter = createFixtureCodeGraphAdapter();
     const graphRequests: Array<{ mode?: string; includeStale?: boolean; path?: string; symbolKey?: string }> = [];
+    const runGraphRequests: Array<{ runId: string; repoId?: string; mode?: string; path?: string }> = [];
     const repoRequests: Array<{ includeStale?: boolean }> = [];
     const codeGraphAdapter = {
       ...fixtureCodeGraphAdapter,
@@ -1364,6 +1365,10 @@ describe("OpenSymphonyApp mount", () => {
       async getGraphSnapshot(repoId: string, options?: Parameters<typeof fixtureCodeGraphAdapter.getGraphSnapshot>[1]) {
         graphRequests.push(options ?? {});
         return fixtureCodeGraphAdapter.getGraphSnapshot(repoId, options);
+      },
+      async getRunGraphSnapshot(runId: string, repoId?: string, options?: Parameters<typeof fixtureCodeGraphAdapter.getGraphSnapshot>[1]) {
+        runGraphRequests.push({ runId, repoId, ...options });
+        return fixtureCodeGraphAdapter.getGraphSnapshot(repoId ?? "opensymphony", options);
       },
     };
     const handle = renderOpenSymphonyApp({
@@ -1446,6 +1451,14 @@ describe("OpenSymphonyApp mount", () => {
       app.drillIntoCodeNode(directory!);
       await flushUntil(() => app.state.codeGraph.filters.pathPrefixes.includes("packages/graph"));
       expect(app.state.codeGraph.mode).toBe("atlas");
+      expect(await handle.openCodeDeepLink("opensymphony://code/opensymphony/files/packages/graph/src/index.ts?run_id=COE-449")).toBe(true);
+      await flushUntil(() => runGraphRequests.some((request) => request.runId === "COE-449"));
+      expect(runGraphRequests.at(-1)).toMatchObject({
+        runId: "COE-449",
+        repoId: "opensymphony",
+        mode: "file",
+        path: "packages/graph/src/index.ts",
+      });
     } finally {
       await handle.destroy();
     }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -1184,14 +1184,23 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     const mode = code.mode === "diff"
       ? code.path ? "file" : code.symbolKey ? "neighborhood" : "atlas"
       : code.mode;
-    const snapshot = await this.codeGraphAdapter.getGraphSnapshot(repoId, {
-      mode,
-      path: code.path ?? undefined,
-      symbolKey: code.symbolKey ?? undefined,
-      depth: code.depth,
-      aggregate: mode === "atlas" ? "directory" : undefined,
-      includeStale: codeGraphNeedsBroadFreshness(code.filters),
-    });
+    const snapshot = code.runId && this.codeGraphAdapter.getRunGraphSnapshot
+      ? await this.codeGraphAdapter.getRunGraphSnapshot(code.runId, repoId, {
+        mode,
+        path: code.path ?? undefined,
+        symbolKey: code.symbolKey ?? undefined,
+        depth: code.depth,
+        aggregate: mode === "atlas" ? "directory" : undefined,
+        includeStale: codeGraphNeedsBroadFreshness(code.filters),
+      })
+      : await this.codeGraphAdapter.getGraphSnapshot(repoId, {
+        mode,
+        path: code.path ?? undefined,
+        symbolKey: code.symbolKey ?? undefined,
+        depth: code.depth,
+        aggregate: mode === "atlas" ? "directory" : undefined,
+        includeStale: codeGraphNeedsBroadFreshness(code.filters),
+      });
     if (this.destroyed || navigationVersion !== this.codeGraphNavigationVersion || requestKey !== this.codeGraphRequestKey()) return;
     this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "SNAPSHOT_LOADED", snapshot });
     if (this.state.codeGraph.snapshot !== previousSnapshot && (!previousSnapshot || !sameCodeGraphTopology(previousSnapshot, snapshot))) {


### PR DESCRIPTION
## Summary

Compose immutable target-branch code snapshots with live issue-workspace Tree-sitter overlays for run-scoped code reads.

## Changes

- Add content-hash cached changed-file parsing, tombstones, coverage, and workspace-isolated composite symbols/edges.
- Re-resolve graph endpoints over the composed symbol set and preserve baseline blast-radius callers.
- Pin configured target-branch comparison bases and wire run outline, graph, and diff-overlay routes.
- Document the overlay lifecycle and no-per-workspace-index model.

## Evidence

### Test output

```text
34 code-intel unit tests; 46 memory integration tests; 71 gateway tests; 30 scheduler/orchestrator tests; 24 workspace tests: all passed
cargo fmt --check: passed
cargo clippy-system-duckdb: passed
git diff --check: passed
```

### Verification

The focused composite fixtures cover modified, added, deleted, untracked, unsupported, oversized, failed, conflicting concurrent workspaces, rebuild, cleanup, diff classification, and baseline blast radius. The gateway fixture proves dirty outline, graph, and diff reads contain live symbols without a fake worktree revision.

## Checklist

- [x] Tests pass
- [x] Code is formatted
- [x] Clippy is clean
- [x] Documentation updated
- [ ] AGENTS.md updated (not needed; no durable guidance change)
- [x] Evidence section filled out

## Type of change

- [x] New feature

## Breaking changes

None.

## Related issues

Linear: COE-543

## Additional notes

Comparison bases are cached per run and workspace path; physical overlay state remains ephemeral and baseline DuckDB rows are read-only.