### PR TITLE
feat(memory): add indexed agent code context

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -200,7 +200,7 @@ workflow.
     - If the ticket description/comment context includes `Validation`, `Test Plan`, or `Testing` sections, copy those requirements into the workpad `Acceptance Criteria` and `Validation` sections as required checkboxes (no optional downgrade).
 8.  Run a principal-style self-review of the plan and refine it in the comment.
 9.  Before implementing, capture a concrete reproduction signal and record it in the workpad `Notes` section (command/output, screenshot, or deterministic UI behavior).
-10. After initial file discovery, re-run `opensymphony memory context --issue {{ issue.identifier }} --paths <path1>,<path2> --include-code-intel` for touched areas when memory is configured, record useful references in the workpad, and treat current source files and tests as authoritative over generated context.
+10. If the exact files are not known after initial memory context, use the read-only indexed `code.graph.context` MCP operation with bounded query/path/symbol, depth, and result selectors; when a run identity is available, use its workspace-overlay provenance. After discovery, re-run `opensymphony memory context --issue {{ issue.identifier }} --paths <path1>,<path2> --include-code-intel` for touched areas before edits and after every touched-file change, record useful references in the workpad, and treat current source files and tests as authoritative over generated context.
 11. Run the `pull` skill to sync with the latest configured target branch before any code edits, then record the pull/sync result in the workpad `Notes`.
     - Include a `pull skill evidence` note with:
       - merge source(s),

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -1963,7 +1963,7 @@ async fn call_code_graph_context_tool(
                 query: optional_string_arg(&arguments, "query"),
                 path: optional_string_arg(&arguments, "path"),
                 symbol: optional_string_arg(&arguments, "symbol"),
-                depth: usize_arg(&arguments, "depth", 1).min(8),
+                depth: usize_arg_allow_zero(&arguments, "depth", 1).min(8),
                 limit: usize_arg(&arguments, "limit", 20)
                     .min(config.code_intel.ast.max_matches_per_request.max(1)),
             },
@@ -3878,6 +3878,14 @@ fn usize_arg(arguments: &Value, key: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+fn usize_arg_allow_zero(arguments: &Value, key: &str, default: usize) -> usize {
+    arguments
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(default)
+}
+
 fn bool_arg(arguments: &Value, key: &str) -> bool {
     arguments.get(key).and_then(Value::as_bool).unwrap_or(false)
 }
@@ -5117,7 +5125,7 @@ mod tests {
             &config,
             json!({
                 "name": "code.graph.context",
-                "arguments": { "repository": repo_id, "query": "answer", "limit": 1 }
+                "arguments": { "repository": repo_id, "query": "lib", "limit": 1 }
             }),
         )
         .await
@@ -5132,6 +5140,35 @@ mod tests {
         );
         assert_eq!(bounded["truncated"], true);
         assert!(bounded["dropped"].as_u64().expect("dropped count") > 0);
+
+        let caller_key = evidence
+            .iter()
+            .find(|item| item["kind"] == "symbol" && item["name"] == "caller")
+            .and_then(|item| item["symbolKey"].as_str())
+            .expect("caller symbol key");
+        assert!(
+            evidence
+                .iter()
+                .any(|item| { item["kind"] == "edge" && item["sourceSymbolKey"] == caller_key })
+        );
+
+        let zero_depth = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.graph.context",
+                "arguments": { "repository": repo_id, "symbol": "answer", "depth": 0, "limit": 10 }
+            }),
+        )
+        .await
+        .expect("zero-depth graph context");
+        assert_eq!(zero_depth["depth"], 0);
+        assert!(
+            zero_depth["evidence"]
+                .as_array()
+                .expect("zero-depth evidence")
+                .iter()
+                .all(|item| item["kind"] != "symbol" || item["relation"] != "caller")
+        );
 
         let outside = call_memory_tool(
             &config,
@@ -5187,7 +5224,7 @@ mod tests {
         .expect("workspace edit");
 
         let response = call_code_graph_context_tool(
-            config,
+            config.clone(),
             json!({
                 "repository": repo_id,
                 "symbol": "replacement",
@@ -5213,6 +5250,41 @@ mod tests {
                 && item["freshness"] == "current"
         }));
         assert!(evidence.iter().all(|item| item.get("snippet").is_none()));
+
+        std::fs::write(
+            workspace.join("src/lib.rs"),
+            "pub fn stale_baseline_should_not_survive() {}\n".repeat(64),
+        )
+        .expect("oversized workspace edit");
+        let mut unanalyzed_config = config;
+        unanalyzed_config.code_intel.ast.max_file_bytes = 128;
+        let unanalyzed = call_code_graph_context_tool(
+            unanalyzed_config,
+            json!({
+                "repository": repo_id,
+                "symbol": "answer",
+                "runId": "COE-544",
+                "depth": 0,
+                "limit": 10
+            }),
+            Some(workspaces.path().to_path_buf()),
+        )
+        .await
+        .expect("unanalyzed overlay graph context");
+        assert!(
+            unanalyzed["evidence"]
+                .as_array()
+                .expect("unanalyzed evidence")
+                .iter()
+                .all(|item| item["name"] != "answer")
+        );
+        assert!(
+            unanalyzed["unanalyzedFiles"]
+                .as_array()
+                .expect("unanalyzed files")
+                .iter()
+                .any(|path| path == "src/lib.rs")
+        );
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -30,10 +30,10 @@ use crate::{
         CodeWorkspaceOverlay, CommentEvidence, DocsSyncPlan, IssueEvidence, IssueLinkEvidence,
         IssueSelection, LintSeverity, MemoryConfig, MemoryContextOptions, MemoryError,
         MemoryReindexReport, MemoryScopeFilter, MemoryVisibility, SourceFile,
-        archive_blocking_warning_count, brief, code_graph_context, code_graph_workspace_overlay,
-        code_index_branch, context_for_issue_with_options, docs_for_area_with_scope,
-        expand_issue_range, export_okf_bundle, import_okf_bundle, lint, lint_okf_bundle,
-        load_source_file, mark_archived, persist_code_intel_documents,
+        archive_blocking_warning_count, brief, code_graph_context,
+        code_graph_workspace_context_overlay, code_index_branch, context_for_issue_with_options,
+        docs_for_area_with_scope, expand_issue_range, export_okf_bundle, import_okf_bundle, lint,
+        lint_okf_bundle, load_source_file, mark_archived, persist_code_intel_documents,
         persist_code_intel_skipped_files, plan_archive, plan_capture, plan_docs_sync,
         plan_memory_init, refresh_memory_index, refresh_memory_index_from_okf,
         related_by_area_with_scope, related_by_issue_with_scope, related_by_paths_with_scope,
@@ -1950,26 +1950,29 @@ async fn call_code_graph_context_tool(
                     .unwrap_or("repo")
                     .to_string()
             });
+        let context_query = CodeGraphContextQuery {
+            repo_id: repo_id.clone(),
+            query: optional_string_arg(&arguments, "query"),
+            path: optional_string_arg(&arguments, "path"),
+            symbol: optional_string_arg(&arguments, "symbol"),
+            depth: usize_arg_allow_zero(&arguments, "depth", 1).min(8),
+            limit: usize_arg(&arguments, "limit", 20)
+                .min(config.code_intel.ast.max_matches_per_request.max(1)),
+        };
         let overlay = optional_string_arg(&arguments, "runId")
             .or_else(|| optional_string_arg(&arguments, "run"))
             .map(|run_id| {
-                resolve_code_graph_overlay(&config, workspace_root.as_deref(), &repo_id, &run_id)
+                resolve_code_graph_overlay(
+                    &config,
+                    workspace_root.as_deref(),
+                    &repo_id,
+                    &run_id,
+                    &context_query,
+                )
             })
             .transpose()?;
-        code_graph_context(
-            &config,
-            CodeGraphContextQuery {
-                repo_id,
-                query: optional_string_arg(&arguments, "query"),
-                path: optional_string_arg(&arguments, "path"),
-                symbol: optional_string_arg(&arguments, "symbol"),
-                depth: usize_arg_allow_zero(&arguments, "depth", 1).min(8),
-                limit: usize_arg(&arguments, "limit", 20)
-                    .min(config.code_intel.ast.max_matches_per_request.max(1)),
-            },
-            overlay.as_ref(),
-        )
-        .map_err(|error| MemoryError::InvalidInput(error.to_string()))
+        code_graph_context(&config, context_query, overlay.as_ref())
+            .map_err(|error| MemoryError::InvalidInput(error.to_string()))
     })
     .await
 }
@@ -1979,6 +1982,7 @@ fn resolve_code_graph_overlay(
     workspace_root: Option<&Path>,
     repo_id: &str,
     run_id: &str,
+    context_query: &CodeGraphContextQuery,
 ) -> Result<CodeWorkspaceOverlay, MemoryError> {
     let workspace_root = workspace_root.ok_or_else(|| {
         MemoryError::InvalidInput(
@@ -2047,8 +2051,15 @@ fn resolve_code_graph_overlay(
     let branch = code_index_branch(&config.repo_root)
         .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
     let base_revision = workspace_merge_base(&workspace_path, &branch)?;
-    code_graph_workspace_overlay(config, repo_id, &workspace_path, run_id, &base_revision)
-        .map_err(|error| MemoryError::InvalidInput(error.to_string()))
+    code_graph_workspace_context_overlay(
+        config,
+        repo_id,
+        &workspace_path,
+        run_id,
+        &base_revision,
+        context_query,
+    )
+    .map_err(|error| MemoryError::InvalidInput(error.to_string()))
 }
 
 fn workspace_merge_base(workspace_path: &Path, branch: &str) -> Result<String, MemoryError> {
@@ -5004,10 +5015,10 @@ mod tests {
         resolve_code_intel_repo, trim_auto_memory_status_log,
     };
     use crate::opensymphony_memory::{
-        CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
-        CodeIntelPersistBatch, CodeIntelSymbolInput, CodeSymbolDiffStatus, MemoryConfig,
-        MemoryError, code_symbol_detail, code_symbol_neighborhood, code_symbols_containing_span,
-        compare_code_symbols, persist_code_intel_documents,
+        CodeGraphContextQuery, CodeIntelDiagnosticInput, CodeIntelDocumentInput,
+        CodeIntelEdgeInput, CodeIntelPersistBatch, CodeIntelSymbolInput, CodeSymbolDiffStatus,
+        MemoryConfig, MemoryError, code_symbol_detail, code_symbol_neighborhood,
+        code_symbols_containing_span, compare_code_symbols, persist_code_intel_documents,
     };
     use crate::opensymphony_workspace::IssueManifest;
     use axum::http::{HeaderMap, HeaderValue, header};
@@ -5334,8 +5345,40 @@ mod tests {
                 .expect("diagnostic evidence")
                 .iter()
                 .any(|item| item["kind"] == "diagnostic"
-                    && item["provenance"].is_null()
+                    && item["provenance"] == "workspace_overlay"
+                    && item["parserVersion"].is_string()
+                    && item["queryPackVersion"].is_string()
                     && item["overlayDigest"].is_string())
+        );
+
+        std::fs::write(workspace.join("src/lib.rs"), "let = ;\n")
+            .expect("workspace diagnostic-only edit");
+        let diagnostic_only = call_code_graph_context_tool(
+            config.clone(),
+            json!({
+                "repository": repo_id,
+                "path": "src/lib.rs",
+                "runId": "COE-544",
+                "depth": 0,
+                "limit": 10
+            }),
+            Some(workspaces.path().to_path_buf()),
+        )
+        .await
+        .expect("diagnostic-only overlay graph context");
+        assert!(
+            diagnostic_only["evidence"]
+                .as_array()
+                .expect("diagnostic-only evidence")
+                .iter()
+                .any(|item| {
+                    item["kind"] == "diagnostic"
+                        && item["path"] == "src/lib.rs"
+                        && item["symbolKey"].is_null()
+                        && item["provenance"] == "workspace_overlay"
+                        && item["parserVersion"].is_string()
+                        && item["queryPackVersion"].is_string()
+                })
         );
 
         std::fs::write(
@@ -5374,10 +5417,19 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn code_graph_context_rejects_foreign_and_symlinked_workspaces() {
         let repo = TempDir::new().expect("repo");
         let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let context_query = CodeGraphContextQuery {
+            repo_id: "repo".to_string(),
+            query: Some("answer".to_string()),
+            path: None,
+            symbol: None,
+            depth: 0,
+            limit: 1,
+        };
         let workspace_root = TempDir::new().expect("workspace root");
         let workspace = workspace_root.path().join("COE-544");
         std::fs::create_dir_all(workspace.join(".opensymphony")).expect("metadata");
@@ -5398,18 +5450,28 @@ mod tests {
             .expect("manifest json"),
         )
         .expect("manifest");
-        let foreign =
-            resolve_code_graph_overlay(&config, Some(workspace_root.path()), "repo", "COE-544")
-                .expect_err("foreign workspace must be rejected");
+        let foreign = resolve_code_graph_overlay(
+            &config,
+            Some(workspace_root.path()),
+            "repo",
+            "COE-544",
+            &context_query,
+        )
+        .expect_err("foreign workspace must be rejected");
         assert!(foreign.to_string().contains("ownership"));
 
         std::fs::remove_dir_all(&workspace).expect("remove foreign workspace");
         let symlink_target = TempDir::new().expect("symlink target");
         std::fs::create_dir_all(symlink_target.path()).expect("symlink target directory");
         std::os::unix::fs::symlink(symlink_target.path(), &workspace).expect("workspace symlink");
-        let symlinked =
-            resolve_code_graph_overlay(&config, Some(workspace_root.path()), "repo", "COE-544")
-                .expect_err("symlinked workspace must be rejected");
+        let symlinked = resolve_code_graph_overlay(
+            &config,
+            Some(workspace_root.path()),
+            "repo",
+            "COE-544",
+            &context_query,
+        )
+        .expect_err("symlinked workspace must be rejected");
         assert!(symlinked.to_string().contains("symlink"));
     }
 

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -5276,7 +5276,11 @@ mod tests {
                 .as_array()
                 .expect("unanalyzed evidence")
                 .iter()
-                .all(|item| item["name"] != "answer")
+                .any(|item| {
+                    item["kind"] == "symbol"
+                        && item["name"] == "answer"
+                        && item["provenance"] == "indexed_baseline"
+                })
         );
         assert!(
             unanalyzed["unanalyzedFiles"]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -47,7 +47,7 @@ use crate::{
     },
     opensymphony_workflow::WorkflowDefinition,
     opensymphony_workspace::{
-        CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig,
+        CleanupConfig, HookConfig, IssueManifest, WorkspaceManager, WorkspaceManagerConfig,
         workspace_path_for_root,
     },
 };
@@ -1992,18 +1992,57 @@ fn resolve_code_graph_overlay(
                 path: workspace_root.to_path_buf(),
                 source,
             })?;
-    let workspace_path = workspace_path_for_root(&workspace_root, run_id)
-        .map_err(|error| MemoryError::InvalidInput(error.to_string()))?
-        .canonicalize()
-        .map_err(|source| MemoryError::ResolvePath {
-            path: workspace_root.join(run_id),
-            source,
-        })?;
+    let workspace_candidate = workspace_path_for_root(&workspace_root, run_id)
+        .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
+    if let Ok(metadata) = fs::symlink_metadata(&workspace_candidate)
+        && metadata.file_type().is_symlink()
+    {
+        return Err(MemoryError::InvalidInput(
+            "run workspace root must not be a symlink".to_string(),
+        ));
+    }
+    let workspace_path =
+        workspace_candidate
+            .canonicalize()
+            .map_err(|source| MemoryError::ResolvePath {
+                path: workspace_candidate.clone(),
+                source,
+            })?;
     if !workspace_path.starts_with(&workspace_root) {
         return Err(MemoryError::PathOutsideRepo {
             path: workspace_path,
             repo_root: workspace_root,
         });
+    }
+    let manifest_path = workspace_path.join(".opensymphony/issue.json");
+    let manifest = fs::read_to_string(&manifest_path).map_err(|source| MemoryError::ReadFile {
+        path: manifest_path.clone(),
+        source,
+    })?;
+    let manifest: IssueManifest = serde_json::from_str(&manifest).map_err(|source| {
+        MemoryError::InvalidInput(format!(
+            "invalid run workspace ownership manifest: {source}"
+        ))
+    })?;
+    let workspace_key = workspace_candidate
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let manifest_workspace_path =
+        manifest
+            .workspace_path
+            .canonicalize()
+            .map_err(|source| MemoryError::ResolvePath {
+                path: manifest.workspace_path.clone(),
+                source,
+            })?;
+    if (manifest.identifier != run_id && manifest.issue_id != run_id)
+        || manifest.sanitized_workspace_key != workspace_key
+        || manifest_workspace_path != workspace_path
+    {
+        return Err(MemoryError::InvalidInput(
+            "run workspace ownership manifest does not match the requested run".to_string(),
+        ));
     }
     let branch = code_index_branch(&config.repo_root)
         .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
@@ -4961,8 +5000,8 @@ mod tests {
         call_code_graph_context_tool, call_memory_ingest_code_intel_tool, call_memory_tool,
         context_source_from_mcp, memory_server_health_payload, memory_tool_descriptors,
         origin_is_localhost, parse_remote_memory_response, remote_memory_tool_token,
-        replace_or_append_managed_section, required_access_for_request, resolve_code_intel_repo,
-        trim_auto_memory_status_log,
+        replace_or_append_managed_section, required_access_for_request, resolve_code_graph_overlay,
+        resolve_code_intel_repo, trim_auto_memory_status_log,
     };
     use crate::opensymphony_memory::{
         CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
@@ -4970,7 +5009,9 @@ mod tests {
         MemoryError, code_symbol_detail, code_symbol_neighborhood, code_symbols_containing_span,
         compare_code_symbols, persist_code_intel_documents,
     };
+    use crate::opensymphony_workspace::IssueManifest;
     use axum::http::{HeaderMap, HeaderValue, header};
+    use chrono::Utc;
     use duckdb::{Connection, params};
     use serde_json::json;
     use tempfile::TempDir;
@@ -5217,6 +5258,24 @@ mod tests {
                 .expect("git clone")
                 .success()
         );
+        std::fs::create_dir_all(workspace.join(".opensymphony")).expect("workspace metadata");
+        let now = Utc::now();
+        std::fs::write(
+            workspace.join(".opensymphony/issue.json"),
+            serde_json::to_vec(&IssueManifest {
+                issue_id: "issue-544".to_string(),
+                identifier: "COE-544".to_string(),
+                title: "Indexed Agent Code Context And Retrieval".to_string(),
+                current_state: "started".to_string(),
+                sanitized_workspace_key: "COE-544".to_string(),
+                workspace_path: workspace.clone(),
+                created_at: now,
+                updated_at: now,
+                last_seen_tracker_refresh_at: None,
+            })
+            .expect("workspace manifest json"),
+        )
+        .expect("workspace manifest");
         std::fs::write(
             workspace.join("src/lib.rs"),
             "pub fn replacement() -> u8 { 43 }\n",
@@ -5253,6 +5312,34 @@ mod tests {
 
         std::fs::write(
             workspace.join("src/lib.rs"),
+            "pub fn replacement() -> u8 { let = ; 43 }\n",
+        )
+        .expect("workspace diagnostic edit");
+        let diagnostics = call_code_graph_context_tool(
+            config.clone(),
+            json!({
+                "repository": repo_id,
+                "symbol": "replacement",
+                "runId": "COE-544",
+                "depth": 0,
+                "limit": 10
+            }),
+            Some(workspaces.path().to_path_buf()),
+        )
+        .await
+        .expect("overlay diagnostic graph context");
+        assert!(
+            diagnostics["evidence"]
+                .as_array()
+                .expect("diagnostic evidence")
+                .iter()
+                .any(|item| item["kind"] == "diagnostic"
+                    && item["provenance"].is_null()
+                    && item["overlayDigest"].is_string())
+        );
+
+        std::fs::write(
+            workspace.join("src/lib.rs"),
             "pub fn stale_baseline_should_not_survive() {}\n".repeat(64),
         )
         .expect("oversized workspace edit");
@@ -5276,11 +5363,7 @@ mod tests {
                 .as_array()
                 .expect("unanalyzed evidence")
                 .iter()
-                .any(|item| {
-                    item["kind"] == "symbol"
-                        && item["name"] == "answer"
-                        && item["provenance"] == "indexed_baseline"
-                })
+                .all(|item| !(item["kind"] == "symbol" && item["name"] == "answer"))
         );
         assert!(
             unanalyzed["unanalyzedFiles"]
@@ -5289,6 +5372,45 @@ mod tests {
                 .iter()
                 .any(|path| path == "src/lib.rs")
         );
+    }
+
+    #[test]
+    fn code_graph_context_rejects_foreign_and_symlinked_workspaces() {
+        let repo = TempDir::new().expect("repo");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        let workspace_root = TempDir::new().expect("workspace root");
+        let workspace = workspace_root.path().join("COE-544");
+        std::fs::create_dir_all(workspace.join(".opensymphony")).expect("metadata");
+        let now = Utc::now();
+        std::fs::write(
+            workspace.join(".opensymphony/issue.json"),
+            serde_json::to_vec(&IssueManifest {
+                issue_id: "issue-544".to_string(),
+                identifier: "COE-545".to_string(),
+                title: "foreign".to_string(),
+                current_state: "started".to_string(),
+                sanitized_workspace_key: "COE-544".to_string(),
+                workspace_path: workspace.clone(),
+                created_at: now,
+                updated_at: now,
+                last_seen_tracker_refresh_at: None,
+            })
+            .expect("manifest json"),
+        )
+        .expect("manifest");
+        let foreign =
+            resolve_code_graph_overlay(&config, Some(workspace_root.path()), "repo", "COE-544")
+                .expect_err("foreign workspace must be rejected");
+        assert!(foreign.to_string().contains("ownership"));
+
+        std::fs::remove_dir_all(&workspace).expect("remove foreign workspace");
+        let symlink_target = TempDir::new().expect("symlink target");
+        std::fs::create_dir_all(symlink_target.path()).expect("symlink target directory");
+        std::os::unix::fs::symlink(symlink_target.path(), &workspace).expect("workspace symlink");
+        let symlinked =
+            resolve_code_graph_overlay(&config, Some(workspace_root.path()), "repo", "COE-544")
+                .expect_err("symlinked workspace must be rejected");
+        assert!(symlinked.to_string().contains("symlink"));
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -25,26 +25,31 @@ use crate::{
     opensymphony_domain::{TrackerIssue, TrackerIssueBlocker, TrackerIssueRef},
     opensymphony_linear::{LinearClient, LinearConfig},
     opensymphony_memory::{
-        ArchivePlan, CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
-        CodeIntelPersistBatch, CodeIntelSkippedFileInput, CodeIntelSymbolInput, CommentEvidence,
-        DocsSyncPlan, IssueEvidence, IssueLinkEvidence, IssueSelection, LintSeverity, MemoryConfig,
-        MemoryContextOptions, MemoryError, MemoryReindexReport, MemoryScopeFilter,
-        MemoryVisibility, SourceFile, archive_blocking_warning_count, brief,
-        context_for_issue_with_options, docs_for_area_with_scope, expand_issue_range,
-        export_okf_bundle, import_okf_bundle, lint, lint_okf_bundle, load_source_file,
-        mark_archived, persist_code_intel_documents, persist_code_intel_skipped_files,
-        plan_archive, plan_capture, plan_docs_sync, plan_memory_init, refresh_memory_index,
-        refresh_memory_index_from_okf, related_by_area_with_scope, related_by_issue_with_scope,
-        related_by_paths_with_scope, render_archive_plan, render_capture_dry_run,
-        search_with_scope, sha256_bytes_hex, sha256_hex, status_with_scope, write_capture_plan,
-        write_docs_sync_plan, write_memory_init_plan,
+        ArchivePlan, CodeGraphContextQuery, CodeIntelDiagnosticInput, CodeIntelDocumentInput,
+        CodeIntelEdgeInput, CodeIntelPersistBatch, CodeIntelSkippedFileInput, CodeIntelSymbolInput,
+        CodeWorkspaceOverlay, CommentEvidence, DocsSyncPlan, IssueEvidence, IssueLinkEvidence,
+        IssueSelection, LintSeverity, MemoryConfig, MemoryContextOptions, MemoryError,
+        MemoryReindexReport, MemoryScopeFilter, MemoryVisibility, SourceFile,
+        archive_blocking_warning_count, brief, code_graph_context, code_graph_workspace_overlay,
+        code_index_branch, context_for_issue_with_options, docs_for_area_with_scope,
+        expand_issue_range, export_okf_bundle, import_okf_bundle, lint, lint_okf_bundle,
+        load_source_file, mark_archived, persist_code_intel_documents,
+        persist_code_intel_skipped_files, plan_archive, plan_capture, plan_docs_sync,
+        plan_memory_init, refresh_memory_index, refresh_memory_index_from_okf,
+        related_by_area_with_scope, related_by_issue_with_scope, related_by_paths_with_scope,
+        render_archive_plan, render_capture_dry_run, search_with_scope, sha256_bytes_hex,
+        sha256_hex, status_with_scope, write_capture_plan, write_docs_sync_plan,
+        write_memory_init_plan,
     },
     opensymphony_openhands::{
         ConversationMoveOutcome, ConversationStoreKind, IssueConversationManifest,
         OpenHandsConversationStorePaths,
     },
     opensymphony_workflow::WorkflowDefinition,
-    opensymphony_workspace::{CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig},
+    opensymphony_workspace::{
+        CleanupConfig, HookConfig, WorkspaceManager, WorkspaceManagerConfig,
+        workspace_path_for_root,
+    },
 };
 
 const MEMORY_MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
@@ -1401,6 +1406,7 @@ fn print_reindex_report(report: MemoryReindexReport) {
 struct MemoryServerState {
     config: MemoryConfig,
     auth: MemoryServerAuth,
+    workspace_root: Option<PathBuf>,
 }
 
 #[derive(Clone, Default)]
@@ -1432,6 +1438,7 @@ async fn run_serve(config: MemoryConfig, args: ServeArgs) -> Result<(), MemoryEr
             read_token: args.token,
             admin_token: args.admin_token,
         },
+        None,
     )
     .await?;
     println!(
@@ -1471,10 +1478,11 @@ impl MemoryServerHandle {
     }
 }
 
-pub(crate) async fn start_memory_server(
+pub(crate) async fn start_memory_server_with_workspace_root(
     config: MemoryConfig,
     addr: SocketAddr,
     token: Option<String>,
+    workspace_root: Option<PathBuf>,
 ) -> Result<MemoryServerHandle, MemoryError> {
     start_memory_server_with_auth(
         config,
@@ -1483,6 +1491,7 @@ pub(crate) async fn start_memory_server(
             read_token: token,
             admin_token: None,
         },
+        workspace_root,
     )
     .await
 }
@@ -1491,6 +1500,7 @@ async fn start_memory_server_with_auth(
     config: MemoryConfig,
     addr: SocketAddr,
     auth: MemoryServerAuth,
+    workspace_root: Option<PathBuf>,
 ) -> Result<MemoryServerHandle, MemoryError> {
     let listener = tokio::net::TcpListener::bind(addr).await.map_err(|error| {
         MemoryError::InvalidInput(format!("failed to bind memory server {addr}: {error}"))
@@ -1498,7 +1508,11 @@ async fn start_memory_server_with_auth(
     let local_addr = listener.local_addr().map_err(|error| {
         MemoryError::InvalidInput(format!("failed to read memory server address: {error}"))
     })?;
-    let state = MemoryServerState { config, auth };
+    let state = MemoryServerState {
+        config,
+        auth,
+        workspace_root,
+    };
     let app = axum::Router::new()
         .route("/health", axum::routing::get(memory_server_health))
         .route("/mcp", axum::routing::post(memory_server_mcp))
@@ -1554,7 +1568,11 @@ async fn memory_server_mcp(
         })),
         "tools/call" => match tokio::time::timeout(
             MEMORY_MCP_TOOL_TIMEOUT,
-            call_memory_tool(&state.config, request.params),
+            call_memory_tool_with_workspace(
+                &state.config,
+                request.params,
+                state.workspace_root.as_deref(),
+            ),
         )
         .await
         {
@@ -1618,6 +1636,26 @@ fn memory_tool_descriptors(config: &MemoryConfig, auth: &MemoryServerAuth) -> Ve
         json!({ "name": "memory.import_okf", "description": "Import an OKF memory bundle", "access": "admin" }),
         json!({ "name": "memory.ingest_code_intel", "description": "Generate code-intelligence artifacts for future ingestion", "access": "admin" }),
     ];
+    if config.code_intel.enabled {
+        tools.push(json!({
+            "name": "code.graph.context",
+            "description": "Bounded read-only indexed code discovery with optional workspace overlay",
+            "access": "read",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "repository": { "type": "string", "description": "Indexed repository id" },
+                    "query": { "type": "string", "description": "Case-insensitive symbol/path search" },
+                    "path": { "type": "string", "description": "Repository-relative path or directory" },
+                    "symbol": { "type": "string", "description": "Symbol name or stable symbol key" },
+                    "runId": { "type": "string", "description": "Optional issue run identity for workspace overlay reads" },
+                    "depth": { "type": "integer", "minimum": 0, "maximum": 8, "default": 1 },
+                    "limit": { "type": "integer", "minimum": 1, "maximum": 500, "default": 20 }
+                }
+            }
+        }));
+    }
     if ast_tools_enabled(config) {
         tools.extend(AST_MCP_TOOL_NAMES.iter().map(|name| {
             json!({
@@ -1744,7 +1782,16 @@ fn origin_is_localhost(origin: &str) -> bool {
     )
 }
 
+#[cfg(test)]
 async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value, MemoryError> {
+    call_memory_tool_with_workspace(config, params, None).await
+}
+
+async fn call_memory_tool_with_workspace(
+    config: &MemoryConfig,
+    params: Value,
+    workspace_root: Option<&Path>,
+) -> Result<Value, MemoryError> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
@@ -1753,6 +1800,11 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
     if AST_MCP_TOOL_NAMES.contains(&name) && !ast_tools_enabled(config) {
         return Err(MemoryError::InvalidInput(
             "AST code-intelligence tools are disabled".to_string(),
+        ));
+    }
+    if name == "code.graph.context" && !config.code_intel.enabled {
+        return Err(MemoryError::InvalidInput(
+            "indexed code graph tools are disabled".to_string(),
         ));
     }
     match name {
@@ -1850,6 +1902,14 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
                 })).collect::<Vec<_>>()
             }))
         }
+        "code.graph.context" => {
+            call_code_graph_context_tool(
+                config.clone(),
+                arguments.clone(),
+                workspace_root.map(Path::to_path_buf),
+            )
+            .await
+        }
         "code.ast.status" => call_code_ast_status_tool(config),
         "code.ast.outline" => call_code_ast_outline_tool(config.clone(), arguments.clone()).await,
         "code.ast.symbols" => call_code_ast_symbols_tool(config.clone(), arguments.clone()).await,
@@ -1872,6 +1932,117 @@ async fn call_memory_tool(config: &MemoryConfig, params: Value) -> Result<Value,
             "unsupported memory tool `{other}`"
         ))),
     }
+}
+
+async fn call_code_graph_context_tool(
+    config: MemoryConfig,
+    arguments: Value,
+    workspace_root: Option<PathBuf>,
+) -> Result<Value, MemoryError> {
+    ast_mcp_tool_blocking("code.graph.context", move || {
+        let repo_id = optional_string_arg(&arguments, "repository")
+            .or_else(|| optional_string_arg(&arguments, "repo"))
+            .unwrap_or_else(|| {
+                config
+                    .repo_root
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("repo")
+                    .to_string()
+            });
+        let overlay = optional_string_arg(&arguments, "runId")
+            .or_else(|| optional_string_arg(&arguments, "run"))
+            .map(|run_id| {
+                resolve_code_graph_overlay(&config, workspace_root.as_deref(), &repo_id, &run_id)
+            })
+            .transpose()?;
+        code_graph_context(
+            &config,
+            CodeGraphContextQuery {
+                repo_id,
+                query: optional_string_arg(&arguments, "query"),
+                path: optional_string_arg(&arguments, "path"),
+                symbol: optional_string_arg(&arguments, "symbol"),
+                depth: usize_arg(&arguments, "depth", 1).min(8),
+                limit: usize_arg(&arguments, "limit", 20)
+                    .min(config.code_intel.ast.max_matches_per_request.max(1)),
+            },
+            overlay.as_ref(),
+        )
+        .map_err(|error| MemoryError::InvalidInput(error.to_string()))
+    })
+    .await
+}
+
+fn resolve_code_graph_overlay(
+    config: &MemoryConfig,
+    workspace_root: Option<&Path>,
+    repo_id: &str,
+    run_id: &str,
+) -> Result<CodeWorkspaceOverlay, MemoryError> {
+    let workspace_root = workspace_root.ok_or_else(|| {
+        MemoryError::InvalidInput(
+            "run-scoped code graph context requires a configured workspace root".to_string(),
+        )
+    })?;
+    let workspace_root =
+        workspace_root
+            .canonicalize()
+            .map_err(|source| MemoryError::ResolvePath {
+                path: workspace_root.to_path_buf(),
+                source,
+            })?;
+    let workspace_path = workspace_path_for_root(&workspace_root, run_id)
+        .map_err(|error| MemoryError::InvalidInput(error.to_string()))?
+        .canonicalize()
+        .map_err(|source| MemoryError::ResolvePath {
+            path: workspace_root.join(run_id),
+            source,
+        })?;
+    if !workspace_path.starts_with(&workspace_root) {
+        return Err(MemoryError::PathOutsideRepo {
+            path: workspace_path,
+            repo_root: workspace_root,
+        });
+    }
+    let branch = code_index_branch(&config.repo_root)
+        .map_err(|error| MemoryError::InvalidInput(error.to_string()))?;
+    let base_revision = workspace_merge_base(&workspace_path, &branch)?;
+    code_graph_workspace_overlay(config, repo_id, &workspace_path, run_id, &base_revision)
+        .map_err(|error| MemoryError::InvalidInput(error.to_string()))
+}
+
+fn workspace_merge_base(workspace_path: &Path, branch: &str) -> Result<String, MemoryError> {
+    for reference in [format!("origin/{branch}"), branch.to_string()] {
+        let verified = process::Command::new("git")
+            .current_dir(workspace_path)
+            .args(["rev-parse", "--verify", "--quiet"])
+            .arg(&reference)
+            .output()
+            .map_err(|source| {
+                MemoryError::InvalidInput(format!("failed to inspect git workspace: {source}"))
+            })?;
+        if !verified.status.success() {
+            continue;
+        }
+        let output = process::Command::new("git")
+            .current_dir(workspace_path)
+            .args(["merge-base", "HEAD"])
+            .arg(&reference)
+            .output()
+            .map_err(|source| {
+                MemoryError::InvalidInput(format!("failed to resolve git merge base: {source}"))
+            })?;
+        if output.status.success() {
+            let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !revision.is_empty() {
+                return Ok(revision);
+            }
+        }
+    }
+    Err(MemoryError::InvalidInput(format!(
+        "no usable git comparison base found for branch `{branch}`"
+    )))
 }
 
 struct AstDocument {
@@ -4779,10 +4950,11 @@ mod tests {
     use super::{
         LINEAR_MEMORY_STATUS_BEGIN, LINEAR_MEMORY_STATUS_END, MemoryMcpRequest, MemoryServerAccess,
         MemoryServerAuth, RUST_QUERY_PACK_VERSION, authorize_memory_request,
-        call_memory_ingest_code_intel_tool, call_memory_tool, context_source_from_mcp,
-        memory_server_health_payload, memory_tool_descriptors, origin_is_localhost,
-        parse_remote_memory_response, remote_memory_tool_token, replace_or_append_managed_section,
-        required_access_for_request, resolve_code_intel_repo, trim_auto_memory_status_log,
+        call_code_graph_context_tool, call_memory_ingest_code_intel_tool, call_memory_tool,
+        context_source_from_mcp, memory_server_health_payload, memory_tool_descriptors,
+        origin_is_localhost, parse_remote_memory_response, remote_memory_tool_token,
+        replace_or_append_managed_section, required_access_for_request, resolve_code_intel_repo,
+        trim_auto_memory_status_log,
     };
     use crate::opensymphony_memory::{
         CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
@@ -4814,6 +4986,27 @@ mod tests {
         assert!(names.contains(&"memory.reindex".to_string()));
         assert!(names.contains(&"memory.export_okf".to_string()));
         assert!(names.contains(&"memory.import_okf".to_string()));
+        let graph_tool = memory_tool_descriptors(&config, &MemoryServerAuth::default())
+            .into_iter()
+            .find(|tool| tool["name"] == "code.graph.context")
+            .expect("indexed graph context tool");
+        assert_eq!(graph_tool["access"], "read");
+        assert_eq!(graph_tool["inputSchema"]["additionalProperties"], false);
+        assert!(
+            graph_tool["inputSchema"]["properties"]
+                .get("visibility")
+                .is_none()
+        );
+        assert!(
+            graph_tool["inputSchema"]["properties"]
+                .get("snippet")
+                .is_none()
+        );
+        assert!(
+            graph_tool["inputSchema"]["properties"]
+                .get("repoRoot")
+                .is_none()
+        );
         assert!(names.contains(&"code.ast.status".to_string()));
         assert!(names.contains(&"code.ast.outline".to_string()));
         assert!(names.contains(&"code.ast.symbols".to_string()));
@@ -4843,6 +5036,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(names.contains(&"memory.context".to_string()));
+        assert!(!names.contains(&"code.graph.context".to_string()));
         assert!(!names.iter().any(|name| name.starts_with("code.ast.")));
 
         std::fs::write(
@@ -4862,6 +5056,293 @@ mod tests {
 
         assert!(names.contains(&"memory.context".to_string()));
         assert!(!names.iter().any(|name| name.starts_with("code.ast.")));
+    }
+
+    #[tokio::test]
+    async fn code_graph_context_finds_symbols_callers_and_bounds_evidence() {
+        let repo = TempDir::new().expect("temp repo");
+        std::fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        std::fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\nfn caller() -> u8 { answer() }\n",
+        )
+        .expect("source");
+        init_test_git_repo(repo.path(), "develop");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        call_memory_ingest_code_intel_tool(
+            &config,
+            &json!({ "paths": ["src/lib.rs"], "persist": true, "limit": 20 }),
+        )
+        .await
+        .expect("persist indexed source");
+        let repo_id = repo
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("repo id")
+            .to_string();
+
+        let response = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.graph.context",
+                "arguments": {
+                    "repository": repo_id,
+                    "symbol": "answer",
+                    "depth": 1,
+                    "limit": 10
+                }
+            }),
+        )
+        .await
+        .expect("graph context");
+        let evidence = response["evidence"].as_array().expect("evidence array");
+        assert!(evidence.iter().any(|item| {
+            item["kind"] == "symbol"
+                && item["name"] == "answer"
+                && item["provenance"] == "indexed_baseline"
+        }));
+        assert!(evidence.iter().any(|item| item["relation"] == "caller"));
+        assert!(evidence.iter().all(|item| item.get("snippet").is_none()));
+        assert!(evidence.iter().all(|item| {
+            item["path"].is_string()
+                && item["span"].is_object()
+                && item["parserVersion"].is_string()
+                && item["queryPackVersion"].is_string()
+                && item["freshness"].is_string()
+                && item["sourceRef"].is_string()
+        }));
+
+        let bounded = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.graph.context",
+                "arguments": { "repository": repo_id, "query": "answer", "limit": 1 }
+            }),
+        )
+        .await
+        .expect("bounded graph context");
+        assert_eq!(bounded["limit"], 1);
+        assert_eq!(
+            bounded["evidence"]
+                .as_array()
+                .expect("bounded evidence")
+                .len(),
+            1
+        );
+        assert_eq!(bounded["truncated"], true);
+        assert!(bounded["dropped"].as_u64().expect("dropped count") > 0);
+
+        let outside = call_memory_tool(
+            &config,
+            json!({
+                "name": "code.graph.context",
+                "arguments": { "repository": repo_id, "path": "../outside" }
+            }),
+        )
+        .await
+        .expect_err("path traversal must be rejected");
+        assert!(outside.to_string().contains("parent traversal"));
+    }
+
+    #[tokio::test]
+    async fn code_graph_context_replaces_baseline_records_with_run_overlay() {
+        let target = TempDir::new().expect("target repo");
+        std::fs::create_dir_all(target.path().join("src")).expect("src dir");
+        std::fs::write(
+            target.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("baseline source");
+        init_test_git_repo(target.path(), "develop");
+        let config = MemoryConfig::load(target.path(), None).expect("memory config");
+        call_memory_ingest_code_intel_tool(
+            &config,
+            &json!({ "paths": ["src/lib.rs"], "persist": true, "limit": 20 }),
+        )
+        .await
+        .expect("persist baseline");
+        let repo_id = target
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("repo id")
+            .to_string();
+
+        let workspaces = TempDir::new().expect("workspace root");
+        let workspace = workspaces.path().join("COE-544");
+        assert!(
+            std::process::Command::new("git")
+                .args(["clone", "--quiet"])
+                .arg(target.path())
+                .arg(&workspace)
+                .status()
+                .expect("git clone")
+                .success()
+        );
+        std::fs::write(
+            workspace.join("src/lib.rs"),
+            "pub fn replacement() -> u8 { 43 }\n",
+        )
+        .expect("workspace edit");
+
+        let response = call_code_graph_context_tool(
+            config,
+            json!({
+                "repository": repo_id,
+                "symbol": "replacement",
+                "runId": "COE-544",
+                "depth": 1,
+                "limit": 10
+            }),
+            Some(workspaces.path().to_path_buf()),
+        )
+        .await
+        .expect("overlay graph context");
+        assert_eq!(response["provenance"]["kind"], "workspace_overlay");
+        assert!(
+            response["overlayDigest"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())
+        );
+        let evidence = response["evidence"].as_array().expect("overlay evidence");
+        assert!(evidence.iter().any(|item| {
+            item["kind"] == "symbol"
+                && item["name"] == "replacement"
+                && item["provenance"] == "workspace_overlay"
+                && item["freshness"] == "current"
+        }));
+        assert!(evidence.iter().all(|item| item.get("snippet").is_none()));
+    }
+
+    #[tokio::test]
+    async fn live_memory_context_revalidates_source_after_indexed_discovery() {
+        let repo = TempDir::new().expect("repo");
+        std::fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        std::fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("baseline source");
+        init_test_git_repo(repo.path(), "develop");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        call_memory_ingest_code_intel_tool(
+            &config,
+            &json!({ "paths": ["src/lib.rs"], "persist": true, "limit": 20 }),
+        )
+        .await
+        .expect("persist baseline");
+        std::fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn replacement() -> u8 { 43 }\n",
+        )
+        .expect("edited source");
+
+        let context = call_memory_tool(
+            &config,
+            json!({
+                "name": "memory.context",
+                "arguments": {
+                    "issue": "COE-544",
+                    "paths": ["src/lib.rs"],
+                    "includeCodeIntel": true
+                }
+            }),
+        )
+        .await
+        .expect("live context");
+        let text = context["content"][0]["text"]
+            .as_str()
+            .expect("context text");
+        assert!(text.contains("function `replacement`"));
+        assert!(!text.contains("function `answer`"));
+    }
+
+    #[tokio::test]
+    async fn memory_server_http_exposes_graph_discovery_and_live_ast_context() {
+        let repo = TempDir::new().expect("repo");
+        std::fs::create_dir_all(repo.path().join("src")).expect("src dir");
+        std::fs::write(
+            repo.path().join("src/lib.rs"),
+            "pub fn answer() -> u8 { 42 }\n",
+        )
+        .expect("source");
+        init_test_git_repo(repo.path(), "develop");
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+        call_memory_ingest_code_intel_tool(
+            &config,
+            &json!({ "paths": ["src/lib.rs"], "persist": true, "limit": 20 }),
+        )
+        .await
+        .expect("persist baseline");
+        let repo_id = repo
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("repo id")
+            .to_string();
+        let handle = super::start_memory_server_with_workspace_root(
+            config,
+            "127.0.0.1:0".parse().expect("address"),
+            None,
+            None,
+        )
+        .await
+        .expect("start memory server");
+        let client = reqwest::Client::new();
+        let list = client
+            .post(handle.endpoint())
+            .json(&json!({ "id": 1, "method": "tools/list", "params": {} }))
+            .send()
+            .await
+            .expect("tools list request")
+            .json::<serde_json::Value>()
+            .await
+            .expect("tools list response");
+        let tools = list["result"]["tools"].as_array().expect("tools");
+        assert!(
+            tools
+                .iter()
+                .any(|tool| tool["name"] == "code.graph.context")
+        );
+        assert!(tools.iter().any(|tool| tool["name"] == "code.ast.context"));
+
+        let graph = client
+            .post(handle.endpoint())
+            .json(&json!({
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "code.graph.context",
+                    "arguments": { "repository": repo_id, "symbol": "answer", "limit": 5 }
+                }
+            }))
+            .send()
+            .await
+            .expect("graph request")
+            .json::<serde_json::Value>()
+            .await
+            .expect("graph response");
+        assert!(graph["result"]["evidence"].as_array().is_some());
+
+        let ast = client
+            .post(handle.endpoint())
+            .json(&json!({
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "code.ast.context",
+                    "arguments": { "paths": ["src/lib.rs"], "limit": 5 }
+                }
+            }))
+            .send()
+            .await
+            .expect("AST request")
+            .json::<serde_json::Value>()
+            .await
+            .expect("AST response");
+        assert!(ast["result"]["markdown"].as_str().is_some());
+        handle.abort();
     }
 
     #[test]
@@ -4886,6 +5367,22 @@ mod tests {
 
         assert_eq!(query_tool["access"], "admin");
         assert_eq!(outline_tool["access"], "read");
+    }
+
+    #[test]
+    fn workflow_guidance_discovers_from_index_before_live_revalidation() {
+        let workflow = include_str!("../../../WORKFLOW.md");
+        let indexed = workflow
+            .find("code.graph.context")
+            .expect("indexed discovery guidance");
+        let live = workflow
+            .find("--include-code-intel")
+            .expect("live revalidation guidance");
+        assert!(
+            indexed < live,
+            "indexed discovery must precede live AST guidance"
+        );
+        assert!(workflow.contains("before edits and after every touched-file change"));
     }
 
     #[test]
@@ -4944,12 +5441,31 @@ mod tests {
             method: "tools/call".to_string(),
             params: json!({ "name": "code.ast.query" }),
         };
+        let graph_request = MemoryMcpRequest {
+            id: json!("test"),
+            method: "tools/call".to_string(),
+            params: json!({ "name": "code.graph.context" }),
+        };
         assert_eq!(
             required_access_for_request(&ast_outline_request, &MemoryServerAuth::default()),
             MemoryServerAccess::Read
         );
         assert_eq!(
             required_access_for_request(&ast_query_request, &MemoryServerAuth::default()),
+            MemoryServerAccess::Read
+        );
+        assert_eq!(
+            required_access_for_request(&graph_request, &MemoryServerAuth::default()),
+            MemoryServerAccess::Read
+        );
+        assert_eq!(
+            required_access_for_request(
+                &graph_request,
+                &MemoryServerAuth {
+                    read_token: Some("read-token".to_string()),
+                    admin_token: Some("admin-token".to_string()),
+                },
+            ),
             MemoryServerAccess::Read
         );
         assert_eq!(
@@ -6219,6 +6735,43 @@ CREATE TABLE code_edges (
                 end_byte: 6,
             }],
         }
+    }
+
+    fn init_test_git_repo(root: &std::path::Path, branch: &str) {
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "-b", branch])
+                .current_dir(root)
+                .status()
+                .expect("git init")
+                .success()
+        );
+        for (key, value) in [("user.email", "test@example.com"), ("user.name", "Test")] {
+            assert!(
+                std::process::Command::new("git")
+                    .args(["config", key, value])
+                    .current_dir(root)
+                    .status()
+                    .expect("git config")
+                    .success()
+            );
+        }
+        assert!(
+            std::process::Command::new("git")
+                .args(["add", "."])
+                .current_dir(root)
+                .status()
+                .expect("git add")
+                .success()
+        );
+        assert!(
+            std::process::Command::new("git")
+                .args(["commit", "-m", "baseline"])
+                .current_dir(root)
+                .status()
+                .expect("git commit")
+                .success()
+        );
     }
 
     fn count_rows(connection: &Connection, table: &str, freshness: &str) -> i64 {

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -591,10 +591,15 @@ async fn start_runtime_memory_server(
         return Ok(None);
     };
     let config = crate::opensymphony_memory::MemoryConfig::load(&runtime.target_repo, None)?;
-    super::memory::start_memory_server(config, server.bind, server.token.clone())
-        .await
-        .map(Some)
-        .map_err(RunCommandError::MemoryServer)
+    super::memory::start_memory_server_with_workspace_root(
+        config,
+        server.bind,
+        server.token.clone(),
+        Some(runtime.workflow.config.workspace.root.clone()),
+    )
+    .await
+    .map(Some)
+    .map_err(RunCommandError::MemoryServer)
 }
 
 async fn publish_auto_capture_event(

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -67,6 +67,339 @@ pub struct CodeWorkspaceOverlay {
     pub unanalyzed_files: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeGraphContextQuery {
+    pub repo_id: String,
+    pub query: Option<String>,
+    pub path: Option<String>,
+    pub symbol: Option<String>,
+    pub depth: usize,
+    pub limit: usize,
+}
+
+/// Return bounded, source-cited discovery evidence from the indexed graph.
+///
+/// The optional overlay is already resolved by the caller so this read path
+/// cannot accept a client filesystem root or accidentally persist workspace
+/// text. Changed paths in the overlay replace the baseline maps before the
+/// selectors and neighborhood traversal run.
+pub fn code_graph_context(
+    config: &MemoryConfig,
+    options: CodeGraphContextQuery,
+    overlay: Option<&CodeWorkspaceOverlay>,
+) -> Result<serde_json::Value, CodeGraphProjectionError> {
+    if options.query.as_deref().is_none_or(|value| value.trim().is_empty())
+        && options.path.as_deref().is_none_or(|value| value.trim().is_empty())
+        && options
+            .symbol
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+    {
+        return Err(CodeGraphProjectionError::InvalidRequest(
+            "code graph context requires query, path, or symbol".to_string(),
+        ));
+    }
+    ensure_code_repo(config, &options.repo_id, false)?;
+
+    let path = options
+        .path
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(normalize_code_path)
+        .transpose()
+        .map_err(CodeGraphProjectionError::InvalidRequest)?;
+    let query = options
+        .query
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_ascii_lowercase());
+    let symbol_selector = options
+        .symbol
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_ascii_lowercase());
+    let base_revision = match overlay {
+        Some(overlay) => Some(overlay.base_revision.clone()),
+        None => code_graph_repos(config, false)?
+            .repos
+            .into_iter()
+            .find(|repo| repo.repo_id == options.repo_id)
+            .and_then(|repo| repo.head_revision),
+    }
+    .ok_or(CodeGraphProjectionError::IndexUnavailable)?;
+    let connection = open_existing_index_read_only(config)?;
+    let (symbols, edges) = if let Some(overlay) = overlay {
+        (overlay.symbols.clone(), overlay.edges.clone())
+    } else {
+        let Some(connection) = connection.as_ref() else {
+            return Err(CodeGraphProjectionError::IndexUnavailable);
+        };
+        (
+            query_symbols_for_revision(config, connection, &options.repo_id, &base_revision)?,
+            query_code_edges_for_revision(connection, config, &options.repo_id, &base_revision)?,
+        )
+    };
+    let depth = options.depth.min(8);
+    let limit = options.limit.clamp(1, CODE_GRAPH_MAX_RECORDS);
+    let mut selected = BTreeMap::<String, (CodeSymbolRecord, &'static str)>::new();
+    for candidate in symbols.values().filter(|candidate| {
+        let path_matches = path.as_deref().is_none_or(|path| {
+            candidate.path == path || candidate.path.starts_with(&format!("{path}/"))
+        });
+        let query_matches = query.as_deref().is_none_or(|query| {
+            candidate.name.to_ascii_lowercase().contains(query)
+                || candidate.path.to_ascii_lowercase().contains(query)
+                || candidate
+                    .container_chain
+                    .iter()
+                    .any(|container| container.to_ascii_lowercase().contains(query))
+        });
+        let symbol_matches = symbol_selector.as_deref().is_none_or(|selector| {
+            candidate.symbol_key.to_ascii_lowercase() == selector
+                || candidate.name.to_ascii_lowercase() == selector
+                || candidate.name.to_ascii_lowercase().contains(selector)
+        });
+        path_matches && query_matches && symbol_matches
+    }) {
+        if selected.len() >= limit {
+            break;
+        }
+        selected.insert(candidate.symbol_key.clone(), (candidate.clone(), "match"));
+    }
+
+    let mut frontier = selected.keys().cloned().collect::<BTreeSet<_>>();
+    let mut dropped_neighbors = 0;
+    for _ in 0..depth {
+        let mut next_frontier = BTreeSet::new();
+        for edge in &edges {
+            let adjacent = if edge
+                .source_symbol_key
+                .as_deref()
+                .is_some_and(|key| frontier.contains(key))
+            {
+                edge.target_symbol_key.as_deref()
+            } else if edge
+                .target_symbol_key
+                .as_deref()
+                .is_some_and(|key| frontier.contains(key))
+            {
+                edge.source_symbol_key.as_deref()
+            } else {
+                None
+            };
+            let Some(adjacent) = adjacent else {
+                continue;
+            };
+            if selected.contains_key(adjacent) {
+                continue;
+            }
+            let Some(symbol) = symbols.get(adjacent) else {
+                continue;
+            };
+            if selected.len() >= limit {
+                dropped_neighbors += 1;
+                continue;
+            }
+            let relation = if is_test_code_symbol(symbol) {
+                "related_test"
+            } else if edge
+                .target_symbol_key
+                .as_deref()
+                .is_some_and(|key| frontier.contains(key))
+            {
+                "caller"
+            } else {
+                "reference"
+            };
+            selected.insert(adjacent.to_string(), (symbol.clone(), relation));
+            next_frontier.insert(adjacent.to_string());
+        }
+        if next_frontier.is_empty() {
+            break;
+        }
+        frontier = next_frontier;
+    }
+
+    let provenance = overlay
+        .map(|overlay| {
+            serde_json::json!({
+                "kind": "workspace_overlay",
+                "runId": overlay.run_id,
+                "baseRevision": overlay.base_revision,
+                "headRevision": overlay.head_revision,
+                "overlayDigest": overlay.workspace_content_digest
+            })
+        })
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "kind": "indexed_baseline",
+                "baseRevision": base_revision
+            })
+        });
+    let mut evidence = Vec::new();
+    for (key, (symbol, relation)) in &selected {
+        evidence.push(context_symbol_json(
+            &options.repo_id,
+            &base_revision,
+            overlay,
+            symbol,
+            relation,
+        ));
+        for edge in edges.iter().filter(|edge| {
+            edge.source_symbol_key.as_deref() == Some(key.as_str())
+                || edge.target_symbol_key.as_deref() == Some(key.as_str())
+        }) {
+            let edge_relation = if edge.target_symbol_key.as_deref() == Some(key.as_str()) {
+                "caller"
+            } else {
+                "reference"
+            };
+            evidence.push(context_edge_json(
+                &options.repo_id,
+                &base_revision,
+                overlay,
+                edge,
+                symbols.get(key),
+                edge_relation,
+            ));
+        }
+        if let Some(connection) = connection.as_ref()
+            && !overlay.is_some_and(|overlay| overlay.changed_paths.contains(&symbol.path))
+        {
+            for diagnostic in query_symbol_diagnostics(connection, config, symbol, false)? {
+                evidence.push(serde_json::json!({
+                    "kind": "diagnostic",
+                    "repository": options.repo_id,
+                    "path": symbol.path,
+                    "symbolKey": symbol.symbol_key,
+                    "span": context_span_json(&diagnostic.span),
+                    "message": diagnostic.message,
+                    "diagnosticKind": diagnostic.kind,
+                    "severity": diagnostic.severity,
+                    "baseRevision": base_revision,
+                    "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
+                    "freshness": symbol.freshness,
+                    "sourceRef": context_source_ref(&symbol.path, diagnostic.span.start_line, diagnostic.span.start_col, diagnostic.span.end_line, diagnostic.span.end_col)
+                }));
+            }
+        }
+    }
+
+    let dropped = dropped_neighbors + evidence.len().saturating_sub(limit);
+    evidence.truncate(limit);
+    Ok(serde_json::json!({
+        "repository": options.repo_id,
+        "baseRevision": base_revision,
+        "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
+        "provenance": provenance,
+        "depth": depth,
+        "limit": limit,
+        "truncated": dropped > 0,
+        "dropped": dropped,
+        "evidence": evidence,
+        "unanalyzedFiles": overlay.map(|overlay| overlay.unanalyzed_files.clone()).unwrap_or_default()
+    }))
+}
+
+fn is_test_code_symbol(symbol: &CodeSymbolRecord) -> bool {
+    let path = symbol.path.to_ascii_lowercase();
+    path.contains("/test/")
+        || path.starts_with("test/")
+        || path.contains("/tests/")
+        || path.starts_with("tests/")
+        || symbol.name.to_ascii_lowercase().starts_with("test")
+        || symbol
+            .container_chain
+            .iter()
+            .any(|container| container.to_ascii_lowercase().starts_with("test"))
+}
+
+fn context_symbol_json(
+    repo_id: &str,
+    base_revision: &str,
+    overlay: Option<&CodeWorkspaceOverlay>,
+    symbol: &CodeSymbolRecord,
+    relation: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "symbol",
+        "relation": relation,
+        "repository": repo_id,
+        "symbolKey": symbol.symbol_key,
+        "symbolId": symbol.symbol_id,
+        "name": symbol.name,
+        "symbolKind": symbol.kind,
+        "path": symbol.path,
+        "containerChain": symbol.container_chain,
+        "span": context_span_json_values(symbol.start_line, symbol.start_col, symbol.end_line, symbol.end_col),
+        "parserVersion": symbol.parser_version,
+        "queryPackVersion": symbol.query_pack_version,
+        "confidence": "exact",
+        "freshness": symbol.freshness,
+        "baseRevision": base_revision,
+        "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
+        "provenance": if overlay.is_some_and(|overlay| overlay.changed_paths.contains(&symbol.path)) { "workspace_overlay" } else { "indexed_baseline" },
+        "sourceRef": context_source_ref(&symbol.path, symbol.start_line, symbol.start_col, symbol.end_line, symbol.end_col)
+    })
+}
+
+fn context_edge_json(
+    repo_id: &str,
+    base_revision: &str,
+    overlay: Option<&CodeWorkspaceOverlay>,
+    edge: &CodeEdgeRecord,
+    related_symbol: Option<&CodeSymbolRecord>,
+    relation: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "edge",
+        "relation": relation,
+        "repository": repo_id,
+        "edgeKind": edge.edge_kind,
+        "sourceSymbolKey": edge.source_symbol_key,
+        "targetSymbolKey": edge.target_symbol_key,
+        "targetHint": edge.target_hint,
+        "path": edge.path,
+        "span": context_span_json_values(edge.start_line, edge.start_col, edge.end_line, edge.end_col),
+        "parserVersion": related_symbol.map(|symbol| symbol.parser_version.clone()),
+        "queryPackVersion": related_symbol.map(|symbol| symbol.query_pack_version.clone()),
+        "confidence": edge.confidence,
+        "freshness": edge.freshness,
+        "baseRevision": base_revision,
+        "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
+        "provenance": if overlay.is_some_and(|overlay| overlay.changed_paths.contains(&edge.path)) { "workspace_overlay" } else { "indexed_baseline" },
+        "sourceRef": context_source_ref(&edge.path, edge.start_line, edge.start_col, edge.end_line, edge.end_col)
+    })
+}
+
+fn context_span_json(span: &CodeSpan) -> serde_json::Value {
+    context_span_json_values(span.start_line, span.start_col, span.end_line, span.end_col)
+}
+
+fn context_span_json_values(
+    start_line: usize,
+    start_col: usize,
+    end_line: usize,
+    end_col: usize,
+) -> serde_json::Value {
+    serde_json::json!({
+        "startLine": start_line,
+        "startColumn": start_col,
+        "endLine": end_line,
+        "endColumn": end_col
+    })
+}
+
+fn context_source_ref(
+    path: &str,
+    start_line: usize,
+    start_col: usize,
+    end_line: usize,
+    end_col: usize,
+) -> String {
+    format!("{path}:{start_line}:{start_col}-{end_line}:{end_col}")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct WorkspaceDocumentCacheKey {
     repo_id: String,

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -66,6 +66,8 @@ pub struct CodeWorkspaceOverlay {
     pub tombstones: BTreeSet<String>,
     pub unanalyzed_files: Vec<String>,
     pub diagnostics: BTreeMap<String, Vec<CodeDiagnostic>>,
+    pub diagnostic_metadata: BTreeMap<String, (String, String)>,
+    pub retrieval_dropped: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,7 +164,7 @@ pub fn code_graph_context(
             })
             .cloned()
             .collect();
-        (symbols, edges, 0)
+        (symbols, edges, overlay.retrieval_dropped)
     } else {
         let Some(connection) = connection.as_ref() else {
             return Err(CodeGraphProjectionError::IndexUnavailable);
@@ -358,9 +360,73 @@ pub fn code_graph_context(
                 &options.repo_id,
                 &base_revision,
                 overlay,
-                symbol,
+                &symbol.path,
+                ContextDiagnosticMetadata {
+                    symbol_key: Some(&symbol.symbol_key),
+                    parser_version: &symbol.parser_version,
+                    query_pack_version: &symbol.query_pack_version,
+                    freshness: &symbol.freshness,
+                },
                 &diagnostic,
             ));
+        }
+    }
+
+    if selected.is_empty() {
+        if let Some(overlay) = overlay {
+            for path in overlay.diagnostics.keys().filter(|candidate| {
+                path.as_deref().is_some_and(|path| {
+                    *candidate == path || candidate.starts_with(&format!("{path}/"))
+                }) || query.as_deref().is_some_and(|query| {
+                    candidate.to_ascii_lowercase().contains(query)
+                })
+            }) {
+                let (parser_version, query_pack_version) = overlay
+                    .diagnostic_metadata
+                    .get(path)
+                    .cloned()
+                    .unwrap_or_default();
+                for diagnostic in overlay.diagnostics.get(path).into_iter().flatten() {
+                    evidence.push(context_diagnostic_json(
+                        &options.repo_id,
+                        &base_revision,
+                        Some(overlay),
+                        path,
+                        ContextDiagnosticMetadata {
+                            symbol_key: None,
+                            parser_version: &parser_version,
+                            query_pack_version: &query_pack_version,
+                            freshness: "current",
+                        },
+                        diagnostic,
+                    ));
+                }
+            }
+        } else if let (Some(connection), Some(path)) = (connection.as_ref(), path.as_deref()) {
+            let (diagnostics, dropped) = query_context_diagnostics_for_path(
+                config,
+                connection,
+                &options.repo_id,
+                &base_revision,
+                path,
+                limit,
+            )?;
+            query_dropped = query_dropped.saturating_add(usize::from(dropped));
+            for diagnostic in diagnostics {
+                evidence.push(context_diagnostic_json(
+                    &options.repo_id,
+                    &base_revision,
+                    None,
+                    &diagnostic.path,
+                    ContextDiagnosticMetadata {
+                        symbol_key: None,
+                        parser_version: &diagnostic.parser_version,
+                        query_pack_version: &diagnostic.query_pack_version,
+                        freshness: &diagnostic.freshness,
+                    },
+                    &diagnostic.diagnostic,
+                ));
+            }
         }
     }
 
@@ -387,23 +453,31 @@ fn context_diagnostic_json(
     repo_id: &str,
     base_revision: &str,
     overlay: Option<&CodeWorkspaceOverlay>,
-    symbol: &CodeSymbolRecord,
+    path: &str,
+    metadata: ContextDiagnosticMetadata<'_>,
     diagnostic: &CodeDiagnostic,
 ) -> serde_json::Value {
     serde_json::json!({
         "kind": "diagnostic",
         "repository": repo_id,
-        "path": symbol.path,
-        "symbolKey": symbol.symbol_key,
+        "path": path,
+        "symbolKey": metadata.symbol_key,
         "span": context_span_json(&diagnostic.span),
         "message": diagnostic.message,
         "diagnosticKind": diagnostic.kind,
         "severity": diagnostic.severity,
+        "parserVersion": metadata.parser_version,
+        "queryPackVersion": metadata.query_pack_version,
         "baseRevision": base_revision,
         "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
-        "freshness": symbol.freshness,
+        "provenance": if is_live_overlay_path(overlay, path) {
+            "workspace_overlay"
+        } else {
+            "indexed_baseline"
+        },
+        "freshness": metadata.freshness,
         "sourceRef": context_source_ref(
-            &symbol.path,
+            path,
             diagnostic.span.start_line,
             diagnostic.span.start_col,
             diagnostic.span.end_line,
@@ -421,6 +495,119 @@ struct CodeGraphContextSelectors<'a> {
 struct CodeGraphContextBounds {
     depth: usize,
     limit: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ContextDiagnostic {
+    path: String,
+    diagnostic: CodeDiagnostic,
+    parser_version: String,
+    query_pack_version: String,
+    freshness: String,
+}
+
+struct ContextDiagnosticMetadata<'a> {
+    symbol_key: Option<&'a str>,
+    parser_version: &'a str,
+    query_pack_version: &'a str,
+    freshness: &'a str,
+}
+
+fn query_context_diagnostics_for_path(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    path: &str,
+    limit: usize,
+) -> Result<(Vec<ContextDiagnostic>, bool), MemoryError> {
+    let path_prefix = format!("{path}/%");
+    let fetch_limit = limit.saturating_add(1) as i64;
+    let rows = if code_diagnostic_revisions_read_model_ready(connection, &config.index_path)? {
+        let mut statement = connection
+            .prepare(
+                "SELECT path, kind, severity, message, start_line, start_col, end_line, end_col, parser_version, query_pack_version, freshness FROM code_diagnostic_revisions WHERE repo_id = ? AND commit_sha = ? AND freshness = 'current' AND NOT worktree_dirty AND (path = ? OR path LIKE ?) ORDER BY path, start_line, start_col, diagnostic_id LIMIT ?",
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        statement
+            .query_map(
+                params![repo_id, revision, path, path_prefix, fetch_limit],
+                |row| {
+                    Ok(ContextDiagnostic {
+                        path: row.get(0)?,
+                        diagnostic: CodeDiagnostic {
+                            kind: row.get(1)?,
+                            severity: row.get(2)?,
+                            message: row.get(3)?,
+                            span: CodeSpan {
+                                start_line: row.get::<_, i64>(4)? as usize,
+                                start_col: row.get::<_, i64>(5)? as usize,
+                                end_line: row.get::<_, i64>(6)? as usize,
+                                end_col: row.get::<_, i64>(7)? as usize,
+                            },
+                        },
+                        parser_version: row.get(8)?,
+                        query_pack_version: row.get(9)?,
+                        freshness: row.get(10)?,
+                    })
+                },
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    } else {
+        let mut statement = connection
+            .prepare(
+                "SELECT path, kind, severity, message, start_line, start_col, end_line, end_col, parser_version, query_pack_version, freshness FROM code_diagnostics WHERE repo_id = ? AND commit_sha = ? AND freshness = 'current' AND NOT worktree_dirty AND (path = ? OR path LIKE ?) ORDER BY path, start_line, start_col, diagnostic_id LIMIT ?",
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?;
+        statement
+            .query_map(
+                params![repo_id, revision, path, path_prefix, fetch_limit],
+                |row| {
+                    Ok(ContextDiagnostic {
+                        path: row.get(0)?,
+                        diagnostic: CodeDiagnostic {
+                            kind: row.get(1)?,
+                            severity: row.get(2)?,
+                            message: row.get(3)?,
+                            span: CodeSpan {
+                                start_line: row.get::<_, i64>(4)? as usize,
+                                start_col: row.get::<_, i64>(5)? as usize,
+                                end_line: row.get::<_, i64>(6)? as usize,
+                                end_col: row.get::<_, i64>(7)? as usize,
+                            },
+                        },
+                        parser_version: row.get(8)?,
+                        query_pack_version: row.get(9)?,
+                        freshness: row.get(10)?,
+                    })
+                },
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    };
+    let dropped = rows.len() > limit;
+    Ok((rows.into_iter().take(limit).collect(), dropped))
 }
 
 fn query_context_symbols_for_revision(
@@ -868,6 +1055,8 @@ struct WorkspaceDocumentRecords {
     symbols: Vec<CodeSymbolRecord>,
     edges: Vec<CodeEdgeRecord>,
     diagnostics: Vec<CodeDiagnostic>,
+    parser_version: String,
+    query_pack_version: String,
 }
 
 type WorkspaceLiveChangedRecords = (
@@ -1390,6 +1579,7 @@ pub fn code_graph_workspace_overlay(
         .map(|edge| (edge.edge_id.clone(), edge))
         .collect::<BTreeMap<_, _>>();
     let mut diagnostics = BTreeMap::<String, Vec<CodeDiagnostic>>::new();
+    let mut diagnostic_metadata = BTreeMap::<String, (String, String)>::new();
     let mut unanalyzed_files = BTreeSet::new();
     let mut remaining_files = config.code_intel.ast.max_files_per_request;
 
@@ -1426,6 +1616,10 @@ pub fn code_graph_workspace_overlay(
         symbols.retain(|_, symbol| symbol.path != *path);
         edges.retain(|_, edge| edge.path != *path);
         diagnostics.insert(path.clone(), records.diagnostics);
+        diagnostic_metadata.insert(
+            path.clone(),
+            (records.parser_version.clone(), records.query_pack_version.clone()),
+        );
         for symbol in records.symbols {
             symbols.insert(symbol.symbol_key.clone(), symbol);
         }
@@ -1449,6 +1643,155 @@ pub fn code_graph_workspace_overlay(
         tombstones,
         unanalyzed_files: unanalyzed_files.into_iter().collect(),
         diagnostics,
+        diagnostic_metadata,
+        retrieval_dropped: 0,
+    })
+}
+
+pub fn code_graph_workspace_context_overlay(
+    config: &MemoryConfig,
+    repo_id: &str,
+    workspace_path: &Path,
+    run_id: &str,
+    base_revision: &str,
+    options: &CodeGraphContextQuery,
+) -> Result<CodeWorkspaceOverlay, CodeGraphProjectionError> {
+    let connection = open_workspace_graph_connection(config, repo_id, workspace_path, base_revision)?;
+    let path = options
+        .path
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(normalize_code_path)
+        .transpose()
+        .map_err(CodeGraphProjectionError::InvalidRequest)?;
+    let query = options
+        .query
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_ascii_lowercase());
+    let symbol_selector = options
+        .symbol
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_ascii_lowercase());
+    let depth = options.depth.min(8);
+    let limit = options.limit.clamp(1, CODE_GRAPH_MAX_RECORDS);
+    let (mut base_symbols, mut retrieval_dropped) = query_context_symbols_for_revision(
+        config,
+        &connection,
+        repo_id,
+        base_revision,
+        CodeGraphContextSelectors {
+            path: path.as_deref(),
+            query: query.as_deref(),
+            symbol: symbol_selector.as_deref(),
+        },
+        limit,
+    )?;
+    let seed_keys = base_symbols.keys().cloned().collect::<BTreeSet<_>>();
+    let (base_edges, dropped) = query_context_edges_and_neighbors(
+        config,
+        &connection,
+        repo_id,
+        base_revision,
+        &mut base_symbols,
+        &seed_keys,
+        CodeGraphContextBounds { depth, limit },
+    )?;
+    retrieval_dropped = retrieval_dropped.saturating_add(dropped);
+
+    let head_revision = workspace_head_revision(workspace_path)?;
+    let (changed_paths, tombstones, workspace_content_digest) = workspace_changed_paths(
+        workspace_path,
+        base_revision,
+        config.code_intel.ast.max_file_bytes,
+    )?;
+    let mut symbols = base_symbols.clone();
+    let mut edges = base_edges
+        .iter()
+        .cloned()
+        .map(|edge| (edge.edge_id.clone(), edge))
+        .collect::<BTreeMap<_, _>>();
+    let mut diagnostics = BTreeMap::<String, Vec<CodeDiagnostic>>::new();
+    let mut diagnostic_metadata = BTreeMap::<String, (String, String)>::new();
+    let mut unanalyzed_files = BTreeSet::new();
+    let mut remaining_files = config.code_intel.ast.max_files_per_request;
+    let path_matches = |candidate: &str| {
+        path.as_deref().is_none_or(|selector| {
+            candidate == selector || candidate.starts_with(&format!("{selector}/"))
+        })
+    };
+
+    for changed_path in changed_paths.iter().filter(|candidate| path_matches(candidate)) {
+        if tombstones.contains(changed_path) {
+            symbols.retain(|_, symbol| symbol.path != *changed_path);
+            edges.retain(|_, edge| edge.path != *changed_path);
+            continue;
+        }
+        let has_baseline_record = symbols.values().any(|symbol| symbol.path == *changed_path);
+        if remaining_files == 0 {
+            if has_baseline_record || path.is_some() {
+                unanalyzed_files.insert(changed_path.clone());
+            }
+            continue;
+        }
+        let Some(file_path) = workspace_file_path(workspace_path, changed_path)? else {
+            if has_baseline_record || path.is_some() {
+                unanalyzed_files.insert(changed_path.clone());
+            }
+            continue;
+        };
+        let Some(records) = workspace_document_records(
+            config,
+            repo_id,
+            changed_path,
+            &file_path,
+        )? else {
+            if has_baseline_record || path.is_some() {
+                unanalyzed_files.insert(changed_path.clone());
+            }
+            continue;
+        };
+        remaining_files = remaining_files.saturating_sub(1);
+        symbols.retain(|_, symbol| symbol.path != *changed_path);
+        edges.retain(|_, edge| edge.path != *changed_path);
+        let WorkspaceDocumentRecords {
+            symbols: live_symbols,
+            edges: live_edges,
+            diagnostics: live_diagnostics,
+            parser_version,
+            query_pack_version,
+        } = records;
+        diagnostics.insert(changed_path.clone(), live_diagnostics);
+        diagnostic_metadata.insert(
+            changed_path.clone(),
+            (parser_version, query_pack_version),
+        );
+        for symbol in live_symbols {
+            symbols.insert(symbol.symbol_key.clone(), symbol);
+        }
+        for edge in live_edges {
+            edges.insert(edge.edge_id.clone(), edge);
+        }
+    }
+
+    re_resolve_workspace_edges(&mut edges, &symbols);
+    Ok(CodeWorkspaceOverlay {
+        run_id: run_id.to_string(),
+        base_revision: base_revision.to_string(),
+        head_revision,
+        workspace_content_digest,
+        base_paths: base_symbols.values().map(|symbol| symbol.path.clone()).collect(),
+        base_symbols,
+        base_edges,
+        symbols,
+        edges: edges.into_values().collect(),
+        changed_paths,
+        tombstones,
+        unanalyzed_files: unanalyzed_files.into_iter().collect(),
+        diagnostics,
+        diagnostic_metadata,
+        retrieval_dropped,
     })
 }
 
@@ -1576,6 +1919,8 @@ fn code_graph_workspace_focused_overlay(
                 tombstones,
                 unanalyzed_files: unanalyzed_files.into_iter().collect(),
                 diagnostics: BTreeMap::new(),
+                diagnostic_metadata: BTreeMap::new(),
+                retrieval_dropped: 0,
             })
         }
         CodeGraphMode::Neighborhood => {
@@ -1771,6 +2116,8 @@ fn code_graph_workspace_focused_overlay(
                 tombstones,
                 unanalyzed_files,
                 diagnostics: BTreeMap::new(),
+                diagnostic_metadata: BTreeMap::new(),
+                retrieval_dropped: 0,
             })
         }
         CodeGraphMode::Atlas => unreachable!("focused overlay only handles file and neighborhood modes"),
@@ -2452,6 +2799,8 @@ fn workspace_document_records(
         symbols,
         edges,
         diagnostics,
+        parser_version: document.parser_version,
+        query_pack_version: document.query_pack_version,
     };
     let mut cache = WORKSPACE_DOCUMENT_CACHE
         .get_or_init(|| Mutex::new(BTreeMap::new()))

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -347,7 +347,7 @@ fn context_symbol_json(
         "freshness": symbol.freshness,
         "baseRevision": base_revision,
         "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
-        "provenance": if overlay.is_some_and(|overlay| overlay.changed_paths.contains(&symbol.path)) { "workspace_overlay" } else { "indexed_baseline" },
+        "provenance": if is_live_overlay_path(overlay, &symbol.path) { "workspace_overlay" } else { "indexed_baseline" },
         "sourceRef": context_source_ref(&symbol.path, symbol.start_line, symbol.start_col, symbol.end_line, symbol.end_col)
     })
 }
@@ -376,8 +376,15 @@ fn context_edge_json(
         "freshness": edge.freshness,
         "baseRevision": base_revision,
         "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
-        "provenance": if overlay.is_some_and(|overlay| overlay.changed_paths.contains(&edge.path)) { "workspace_overlay" } else { "indexed_baseline" },
+        "provenance": if is_live_overlay_path(overlay, &edge.path) { "workspace_overlay" } else { "indexed_baseline" },
         "sourceRef": context_source_ref(&edge.path, edge.start_line, edge.start_col, edge.end_line, edge.end_col)
+    })
+}
+
+fn is_live_overlay_path(overlay: Option<&CodeWorkspaceOverlay>, path: &str) -> bool {
+    overlay.is_some_and(|overlay| {
+        overlay.changed_paths.contains(path)
+            && !overlay.unanalyzed_files.iter().any(|candidate| candidate == path)
     })
 }
 
@@ -956,9 +963,6 @@ pub fn code_graph_workspace_overlay(
             continue;
         }
 
-        symbols.retain(|_, symbol| symbol.path != *path);
-        edges.retain(|_, edge| edge.path != *path);
-
         let Some(file_path) = workspace_file_path(workspace_path, path)? else {
             unanalyzed_files.insert(path.clone());
             continue;
@@ -979,6 +983,8 @@ pub fn code_graph_workspace_overlay(
             continue;
         };
         remaining_files = remaining_files.saturating_sub(1);
+        symbols.retain(|_, symbol| symbol.path != *path);
+        edges.retain(|_, edge| edge.path != *path);
         for symbol in records.symbols {
             symbols.insert(symbol.symbol_key.clone(), symbol);
         }

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -142,6 +142,7 @@ pub fn code_graph_context(
     let depth = options.depth.min(8);
     let limit = options.limit.clamp(1, CODE_GRAPH_MAX_RECORDS);
     let mut selected = BTreeMap::<String, (CodeSymbolRecord, &'static str)>::new();
+    let mut dropped_direct_matches = 0;
     for candidate in symbols.values().filter(|candidate| {
         let path_matches = path.as_deref().is_none_or(|path| {
             candidate.path == path || candidate.path.starts_with(&format!("{path}/"))
@@ -162,7 +163,8 @@ pub fn code_graph_context(
         path_matches && query_matches && symbol_matches
     }) {
         if selected.len() >= limit {
-            break;
+            dropped_direct_matches += 1;
+            continue;
         }
         selected.insert(candidate.symbol_key.clone(), (candidate.clone(), "match"));
     }
@@ -259,7 +261,14 @@ pub fn code_graph_context(
                 &base_revision,
                 overlay,
                 edge,
-                symbols.get(key),
+                edge.source_symbol_key
+                    .as_deref()
+                    .and_then(|source_key| symbols.get(source_key))
+                    .or_else(|| {
+                        edge.target_symbol_key
+                            .as_deref()
+                            .and_then(|target_key| symbols.get(target_key))
+                    }),
                 edge_relation,
             ));
         }
@@ -285,7 +294,7 @@ pub fn code_graph_context(
         }
     }
 
-    let dropped = dropped_neighbors + evidence.len().saturating_sub(limit);
+    let dropped = dropped_direct_matches + dropped_neighbors + evidence.len().saturating_sub(limit);
     evidence.truncate(limit);
     Ok(serde_json::json!({
         "repository": options.repo_id,
@@ -947,6 +956,9 @@ pub fn code_graph_workspace_overlay(
             continue;
         }
 
+        symbols.retain(|_, symbol| symbol.path != *path);
+        edges.retain(|_, edge| edge.path != *path);
+
         let Some(file_path) = workspace_file_path(workspace_path, path)? else {
             unanalyzed_files.insert(path.clone());
             continue;
@@ -967,8 +979,6 @@ pub fn code_graph_workspace_overlay(
             continue;
         };
         remaining_files = remaining_files.saturating_sub(1);
-        symbols.retain(|_, symbol| symbol.path != *path);
-        edges.retain(|_, edge| edge.path != *path);
         for symbol in records.symbols {
             symbols.insert(symbol.symbol_key.clone(), symbol);
         }

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -65,6 +65,7 @@ pub struct CodeWorkspaceOverlay {
     pub changed_paths: BTreeSet<String>,
     pub tombstones: BTreeSet<String>,
     pub unanalyzed_files: Vec<String>,
+    pub diagnostics: BTreeMap<String, Vec<CodeDiagnostic>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,20 +128,59 @@ pub fn code_graph_context(
             .and_then(|repo| repo.head_revision),
     }
     .ok_or(CodeGraphProjectionError::IndexUnavailable)?;
+    let depth = options.depth.min(8);
+    let limit = options.limit.clamp(1, CODE_GRAPH_MAX_RECORDS);
     let connection = open_existing_index_read_only(config)?;
-    let (symbols, edges) = if let Some(overlay) = overlay {
-        (overlay.symbols.clone(), overlay.edges.clone())
+    let baseline_query = overlay.is_none();
+    let (mut symbols, mut edges, mut query_dropped) = if let Some(overlay) = overlay {
+        let mut symbols = overlay.symbols.clone();
+        let unavailable_paths = overlay
+            .unanalyzed_files
+            .iter()
+            .filter(|path| overlay.changed_paths.contains(*path))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let unavailable_keys = symbols
+            .values()
+            .filter(|symbol| unavailable_paths.contains(&symbol.path))
+            .map(|symbol| symbol.symbol_key.clone())
+            .collect::<BTreeSet<_>>();
+        symbols.retain(|_, symbol| !unavailable_paths.contains(&symbol.path));
+        let edges = overlay
+            .edges
+            .iter()
+            .filter(|edge| {
+                !unavailable_paths.contains(&edge.path)
+                    && edge
+                        .source_symbol_key
+                        .as_ref()
+                        .is_none_or(|key| !unavailable_keys.contains(key))
+                    && edge
+                        .target_symbol_key
+                        .as_ref()
+                        .is_none_or(|key| !unavailable_keys.contains(key))
+            })
+            .cloned()
+            .collect();
+        (symbols, edges, 0)
     } else {
         let Some(connection) = connection.as_ref() else {
             return Err(CodeGraphProjectionError::IndexUnavailable);
         };
-        (
-            query_symbols_for_revision(config, connection, &options.repo_id, &base_revision)?,
-            query_code_edges_for_revision(connection, config, &options.repo_id, &base_revision)?,
-        )
+        let (symbols, dropped) = query_context_symbols_for_revision(
+            config,
+            connection,
+            &options.repo_id,
+            &base_revision,
+            CodeGraphContextSelectors {
+                path: path.as_deref(),
+                query: query.as_deref(),
+                symbol: symbol_selector.as_deref(),
+            },
+            limit,
+        )?;
+        (symbols, Vec::new(), dropped)
     };
-    let depth = options.depth.min(8);
-    let limit = options.limit.clamp(1, CODE_GRAPH_MAX_RECORDS);
     let mut selected = BTreeMap::<String, (CodeSymbolRecord, &'static str)>::new();
     let mut dropped_direct_matches = 0;
     for candidate in symbols.values().filter(|candidate| {
@@ -167,6 +207,24 @@ pub fn code_graph_context(
             continue;
         }
         selected.insert(candidate.symbol_key.clone(), (candidate.clone(), "match"));
+    }
+
+    if baseline_query && !selected.is_empty() {
+        let Some(connection) = connection.as_ref() else {
+            return Err(CodeGraphProjectionError::IndexUnavailable);
+        };
+        let seed_keys = selected.keys().cloned().collect::<BTreeSet<_>>();
+        let (context_edges, dropped) = query_context_edges_and_neighbors(
+            config,
+            connection,
+            &options.repo_id,
+            &base_revision,
+            &mut symbols,
+            &seed_keys,
+            CodeGraphContextBounds { depth, limit },
+        )?;
+        edges = context_edges;
+        query_dropped = query_dropped.saturating_add(dropped);
     }
 
     let mut frontier = selected.keys().cloned().collect::<BTreeSet<_>>();
@@ -272,29 +330,44 @@ pub fn code_graph_context(
                 edge_relation,
             ));
         }
-        if let Some(connection) = connection.as_ref()
-            && !overlay.is_some_and(|overlay| overlay.changed_paths.contains(&symbol.path))
-        {
-            for diagnostic in query_symbol_diagnostics(connection, config, symbol, false)? {
-                evidence.push(serde_json::json!({
-                    "kind": "diagnostic",
-                    "repository": options.repo_id,
-                    "path": symbol.path,
-                    "symbolKey": symbol.symbol_key,
-                    "span": context_span_json(&diagnostic.span),
-                    "message": diagnostic.message,
-                    "diagnosticKind": diagnostic.kind,
-                    "severity": diagnostic.severity,
-                    "baseRevision": base_revision,
-                    "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
-                    "freshness": symbol.freshness,
-                    "sourceRef": context_source_ref(&symbol.path, diagnostic.span.start_line, diagnostic.span.start_col, diagnostic.span.end_line, diagnostic.span.end_col)
-                }));
+        let diagnostics = if let Some(overlay) = overlay {
+            if is_live_overlay_path(Some(overlay), &symbol.path) {
+                overlay
+                    .diagnostics
+                    .get(&symbol.path)
+                    .into_iter()
+                    .flatten()
+                    .filter(|diagnostic| {
+                        diagnostic.span.start_line <= symbol.end_line
+                            && diagnostic.span.end_line >= symbol.start_line
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>()
+            } else if let Some(connection) = connection.as_ref() {
+                query_symbol_diagnostics(connection, config, symbol, false)?
+            } else {
+                Vec::new()
             }
+        } else if let Some(connection) = connection.as_ref() {
+            query_symbol_diagnostics(connection, config, symbol, false)?
+        } else {
+            Vec::new()
+        };
+        for diagnostic in diagnostics {
+            evidence.push(context_diagnostic_json(
+                &options.repo_id,
+                &base_revision,
+                overlay,
+                symbol,
+                &diagnostic,
+            ));
         }
     }
 
-    let dropped = dropped_direct_matches + dropped_neighbors + evidence.len().saturating_sub(limit);
+    let dropped = query_dropped
+        + dropped_direct_matches
+        + dropped_neighbors
+        + evidence.len().saturating_sub(limit);
     evidence.truncate(limit);
     Ok(serde_json::json!({
         "repository": options.repo_id,
@@ -308,6 +381,371 @@ pub fn code_graph_context(
         "evidence": evidence,
         "unanalyzedFiles": overlay.map(|overlay| overlay.unanalyzed_files.clone()).unwrap_or_default()
     }))
+}
+
+fn context_diagnostic_json(
+    repo_id: &str,
+    base_revision: &str,
+    overlay: Option<&CodeWorkspaceOverlay>,
+    symbol: &CodeSymbolRecord,
+    diagnostic: &CodeDiagnostic,
+) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "diagnostic",
+        "repository": repo_id,
+        "path": symbol.path,
+        "symbolKey": symbol.symbol_key,
+        "span": context_span_json(&diagnostic.span),
+        "message": diagnostic.message,
+        "diagnosticKind": diagnostic.kind,
+        "severity": diagnostic.severity,
+        "baseRevision": base_revision,
+        "overlayDigest": overlay.map(|overlay| overlay.workspace_content_digest.clone()),
+        "freshness": symbol.freshness,
+        "sourceRef": context_source_ref(
+            &symbol.path,
+            diagnostic.span.start_line,
+            diagnostic.span.start_col,
+            diagnostic.span.end_line,
+            diagnostic.span.end_col,
+        )
+    })
+}
+
+struct CodeGraphContextSelectors<'a> {
+    path: Option<&'a str>,
+    query: Option<&'a str>,
+    symbol: Option<&'a str>,
+}
+
+struct CodeGraphContextBounds {
+    depth: usize,
+    limit: usize,
+}
+
+fn query_context_symbols_for_revision(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    selectors: CodeGraphContextSelectors<'_>,
+    limit: usize,
+) -> Result<(BTreeMap<String, CodeSymbolRecord>, usize), MemoryError> {
+    let membership_ready = matches!(
+        code_snapshot_status(connection, config, repo_id, revision)?.as_deref(),
+        None | Some("completed")
+    ) && code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
+    let revision_predicate = if membership_ready {
+        "s.repo_id = ? AND s.symbol_key != '' AND s.freshness <> 'staged' AND NOT s.worktree_dirty AND (s.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = s.repo_id AND m.commit_sha = ? AND m.path = s.path AND m.content_sha256 = s.content_sha256 AND m.parser_version = s.parser_version AND m.query_pack_version = s.query_pack_version AND m.analyzed) )"
+    } else {
+        "s.repo_id = ? AND s.commit_sha = ? AND s.symbol_key != '' AND s.freshness <> 'staged' AND NOT s.worktree_dirty"
+    };
+    let selector_predicate = concat!(
+        "(? IS NULL OR s.path = ? OR s.path LIKE ?) ",
+        "AND (? IS NULL OR lower(s.name) LIKE ? OR lower(s.path) LIKE ? ",
+        "OR lower(s.container_chain) LIKE ?) ",
+        "AND (? IS NULL OR lower(s.symbol_key) = ? OR lower(s.name) = ? ",
+        "OR lower(s.name) LIKE ?)",
+    );
+    let from_where = format!(
+        "FROM code_symbols AS s WHERE {revision_predicate} AND {selector_predicate}"
+    );
+    let path_exact = selectors.path.map(str::to_string);
+    let path_prefix = selectors.path.map(|path| format!("{path}/%"));
+    let query_like = selectors.query.map(|query| format!("%{query}%"));
+    let symbol_exact = selectors.symbol.map(str::to_string);
+    let symbol_like = selectors.symbol.map(|selector| format!("%{selector}%"));
+    let count_query = format!("SELECT COUNT(DISTINCT s.symbol_key) {from_where}");
+    let total = if membership_ready {
+        connection.query_row(
+            &count_query,
+            params![
+                repo_id,
+                revision,
+                revision,
+                path_exact.as_deref(),
+                path_exact.as_deref(),
+                path_prefix.as_deref(),
+                query_like.as_deref(),
+                query_like.as_deref(),
+                query_like.as_deref(),
+                query_like.as_deref(),
+                symbol_exact.as_deref(),
+                symbol_exact.as_deref(),
+                symbol_exact.as_deref(),
+                symbol_like.as_deref(),
+            ],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?
+    } else {
+        connection.query_row(
+            &count_query,
+            params![
+                repo_id,
+                revision,
+                path_exact.as_deref(),
+                path_exact.as_deref(),
+                path_prefix.as_deref(),
+                query_like.as_deref(),
+                query_like.as_deref(),
+                query_like.as_deref(),
+                query_like.as_deref(),
+                symbol_exact.as_deref(),
+                symbol_exact.as_deref(),
+                symbol_exact.as_deref(),
+                symbol_like.as_deref(),
+            ],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|source| MemoryError::DuckDb {
+            path: config.index_path.clone(),
+            source,
+        })?
+    } as usize;
+
+    let query = format!(
+        "SELECT {CODE_SYMBOL_SELECT}, CASE WHEN s.worktree_dirty THEN 1 ELSE 0 END {from_where} QUALIFY ROW_NUMBER() OVER (PARTITION BY s.symbol_key ORDER BY s.indexed_at DESC, s.symbol_id) = 1 ORDER BY s.symbol_key, s.indexed_at DESC, s.symbol_id LIMIT ?"
+    );
+    let mut statement = connection.prepare(&query).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let rows = if membership_ready {
+        statement
+            .query_map(
+                params![
+                    repo_id,
+                    revision,
+                    revision,
+                    path_exact.as_deref(),
+                    path_exact.as_deref(),
+                    path_prefix.as_deref(),
+                    query_like.as_deref(),
+                    query_like.as_deref(),
+                    query_like.as_deref(),
+                    query_like.as_deref(),
+                    symbol_exact.as_deref(),
+                    symbol_exact.as_deref(),
+                    symbol_exact.as_deref(),
+                    symbol_like.as_deref(),
+                    limit as i64,
+                ],
+                |row| {
+                    let dirty = row.get::<_, i64>(25)?;
+                    if dirty != 0 {
+                        Ok(None)
+                    } else {
+                        code_symbol_from_row(row).map(Some)
+                    }
+                },
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })
+    } else {
+        statement
+            .query_map(
+                params![
+                    repo_id,
+                    revision,
+                    path_exact.as_deref(),
+                    path_exact.as_deref(),
+                    path_prefix.as_deref(),
+                    query_like.as_deref(),
+                    query_like.as_deref(),
+                    query_like.as_deref(),
+                    query_like.as_deref(),
+                    symbol_exact.as_deref(),
+                    symbol_exact.as_deref(),
+                    symbol_exact.as_deref(),
+                    symbol_like.as_deref(),
+                    limit as i64,
+                ],
+                |row| {
+                    let dirty = row.get::<_, i64>(25)?;
+                    if dirty != 0 {
+                        Ok(None)
+                    } else {
+                        code_symbol_from_row(row).map(Some)
+                    }
+                },
+            )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })
+    }?;
+    let mut symbols = BTreeMap::new();
+    for row in rows {
+        let Some(mut symbol) = row else {
+            continue;
+        };
+        if symbol.commit_sha.as_deref() != Some(revision) {
+            symbol.commit_sha = Some(revision.to_string());
+        }
+        fill_container_chain(connection, &mut symbol)?;
+        symbols.insert(symbol.symbol_key.clone(), symbol);
+    }
+    Ok((symbols, total.saturating_sub(limit)))
+}
+
+fn query_context_edges_and_neighbors(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    symbols: &mut BTreeMap<String, CodeSymbolRecord>,
+    seed_keys: &BTreeSet<String>,
+    bounds: CodeGraphContextBounds,
+) -> Result<(Vec<CodeEdgeRecord>, usize), MemoryError> {
+    let max_edges = bounds
+        .limit
+        .saturating_mul(bounds.depth.saturating_add(1))
+        .max(bounds.limit);
+    let mut edges = BTreeMap::new();
+    let mut frontier = seed_keys.clone();
+    let mut dropped = 0;
+
+    for layer in 0..=bounds.depth {
+        if frontier.is_empty() {
+            break;
+        }
+        let mut layer_edges = Vec::new();
+        let mut remaining_keys = frontier.len();
+        for key in &frontier {
+            let remaining_budget = max_edges.saturating_sub(edges.len());
+            if remaining_budget == 0 {
+                dropped += 1;
+                break;
+            }
+            let per_key_limit = remaining_budget
+                .div_ceil(remaining_keys.max(1))
+                .min(bounds.limit.max(1));
+            let (key_edges, truncated) = query_context_edges_for_key(
+                config,
+                connection,
+                repo_id,
+                revision,
+                key,
+                per_key_limit.min(bounds.limit.max(1)),
+            )?;
+            if truncated {
+                dropped += 1;
+            }
+            remaining_keys = remaining_keys.saturating_sub(1);
+            for edge in key_edges {
+                edges.insert(edge.edge_id.clone(), edge.clone());
+                layer_edges.push(edge);
+            }
+        }
+
+        let mut adjacent = BTreeSet::new();
+        for edge in layer_edges {
+            if edge
+                .source_symbol_key
+                .as_ref()
+                .is_some_and(|key| frontier.contains(key))
+                && let Some(key) = edge.target_symbol_key
+            {
+                adjacent.insert(key);
+            } else if edge
+                .target_symbol_key
+                .as_ref()
+                .is_some_and(|key| frontier.contains(key))
+                && let Some(key) = edge.source_symbol_key
+            {
+                adjacent.insert(key);
+            }
+        }
+        if adjacent.len() > bounds.limit {
+            dropped += adjacent.len() - bounds.limit;
+        }
+        let mut next_frontier = BTreeSet::new();
+        for key in adjacent.into_iter().take(bounds.limit) {
+            if !symbols.contains_key(&key)
+                && let Some(symbol) =
+                    query_revision_symbol_by_key(config, connection, repo_id, revision, &key)?
+            {
+                symbols.insert(key.clone(), symbol);
+            }
+            if symbols.contains_key(&key) {
+                next_frontier.insert(key);
+            }
+        }
+        if layer == bounds.depth {
+            break;
+        }
+        frontier = next_frontier;
+    }
+
+    Ok((edges.into_values().collect(), dropped))
+}
+
+fn query_context_edges_for_key(
+    config: &MemoryConfig,
+    connection: &Connection,
+    repo_id: &str,
+    revision: &str,
+    symbol_key: &str,
+    limit: usize,
+) -> Result<(Vec<CodeEdgeRecord>, bool), MemoryError> {
+    let membership_ready = matches!(
+        code_snapshot_status(connection, config, repo_id, revision)?.as_deref(),
+        None | Some("completed")
+    ) && code_snapshot_membership_read_model_ready(connection, &config.index_path)?;
+    let query = if membership_ready {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (e.commit_sha = ? OR EXISTS (SELECT 1 FROM code_snapshot_membership AS m WHERE m.repo_id = e.repo_id AND m.commit_sha = ? AND m.path = e.path AND m.content_sha256 = e.content_sha256 AND m.parser_version = e.parser_version AND m.query_pack_version = e.query_pack_version AND m.analyzed)) AND (e.source_symbol_key = ? OR e.target_symbol_key = ?) ORDER BY e.path, e.start_line, e.start_col, e.edge_id LIMIT ?"
+    } else {
+        "SELECT edge_id, edge_kind, source_symbol_key, target_symbol_key, target_hint, confidence, path, commit_sha, freshness, start_line, start_col, end_line, end_col FROM code_edges AS e WHERE e.repo_id = ? AND e.commit_sha = ? AND e.freshness <> 'staged' AND NOT e.worktree_dirty AND (e.source_symbol_key = ? OR e.target_symbol_key = ?) ORDER BY e.path, e.start_line, e.start_col, e.edge_id LIMIT ?"
+    };
+    let mut statement = connection.prepare(query).map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let fetch_limit = limit.saturating_add(1) as i64;
+    let rows = if membership_ready {
+        statement
+            .query_map(
+            params![repo_id, revision, revision, symbol_key, symbol_key, fetch_limit],
+            code_edge_from_row,
+        )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    } else {
+        statement
+            .query_map(
+            params![repo_id, revision, symbol_key, symbol_key, fetch_limit],
+            code_edge_from_row,
+        )
+            .map_err(|source| MemoryError::DuckDb {
+                path: config.index_path.clone(),
+                source,
+            })?
+    }
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|source| MemoryError::DuckDb {
+        path: config.index_path.clone(),
+        source,
+    })?;
+    let truncated = rows.len() > limit;
+    Ok((rows.into_iter().take(limit).collect(), truncated))
 }
 
 fn is_test_code_symbol(symbol: &CodeSymbolRecord) -> bool {
@@ -429,6 +867,7 @@ struct WorkspaceDocumentCacheKey {
 struct WorkspaceDocumentRecords {
     symbols: Vec<CodeSymbolRecord>,
     edges: Vec<CodeEdgeRecord>,
+    diagnostics: Vec<CodeDiagnostic>,
 }
 
 type WorkspaceLiveChangedRecords = (
@@ -950,6 +1389,7 @@ pub fn code_graph_workspace_overlay(
         .into_iter()
         .map(|edge| (edge.edge_id.clone(), edge))
         .collect::<BTreeMap<_, _>>();
+    let mut diagnostics = BTreeMap::<String, Vec<CodeDiagnostic>>::new();
     let mut unanalyzed_files = BTreeSet::new();
     let mut remaining_files = config.code_intel.ast.max_files_per_request;
 
@@ -985,6 +1425,7 @@ pub fn code_graph_workspace_overlay(
         remaining_files = remaining_files.saturating_sub(1);
         symbols.retain(|_, symbol| symbol.path != *path);
         edges.retain(|_, edge| edge.path != *path);
+        diagnostics.insert(path.clone(), records.diagnostics);
         for symbol in records.symbols {
             symbols.insert(symbol.symbol_key.clone(), symbol);
         }
@@ -1007,6 +1448,7 @@ pub fn code_graph_workspace_overlay(
         changed_paths,
         tombstones,
         unanalyzed_files: unanalyzed_files.into_iter().collect(),
+        diagnostics,
     })
 }
 
@@ -1133,6 +1575,7 @@ fn code_graph_workspace_focused_overlay(
                 changed_paths,
                 tombstones,
                 unanalyzed_files: unanalyzed_files.into_iter().collect(),
+                diagnostics: BTreeMap::new(),
             })
         }
         CodeGraphMode::Neighborhood => {
@@ -1327,6 +1770,7 @@ fn code_graph_workspace_focused_overlay(
                 changed_paths,
                 tombstones,
                 unanalyzed_files,
+                diagnostics: BTreeMap::new(),
             })
         }
         CodeGraphMode::Atlas => unreachable!("focused overlay only handles file and neighborhood modes"),
@@ -1989,7 +2433,26 @@ fn workspace_document_records(
         })
         .filter(|edge| edge.source_symbol_key.is_some())
         .collect::<Vec<_>>();
-    let records = WorkspaceDocumentRecords { symbols, edges };
+    let diagnostics = document
+        .diagnostics
+        .iter()
+        .map(|diagnostic| CodeDiagnostic {
+            kind: diagnostic.kind.clone(),
+            severity: diagnostic.severity.clone(),
+            message: diagnostic.message.clone(),
+            span: CodeSpan {
+                start_line: diagnostic.start_line,
+                start_col: diagnostic.start_col,
+                end_line: diagnostic.end_line,
+                end_col: diagnostic.end_col,
+            },
+        })
+        .collect();
+    let records = WorkspaceDocumentRecords {
+        symbols,
+        edges,
+        diagnostics,
+    };
     let mut cache = WORKSPACE_DOCUMENT_CACHE
         .get_or_init(|| Mutex::new(BTreeMap::new()))
         .lock()

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -1,9 +1,12 @@
 # Code Intelligence
 
-OpenSymphony code intelligence is local, read-only context for agents. It parses
-current source files with pinned Tree-sitter grammars, extracts symbols,
-diagnostics, references, and source-cited spans, then renders that evidence
-through `memory.context` and the read-only `code.ast.*` MCP tools.
+OpenSymphony code intelligence is local, read-only context for agents. The
+persistent code graph provides bounded discovery over the target-branch
+baseline and, for a run, its workspace overlay. Targeted current-file parsing
+with pinned Tree-sitter grammars remains the revalidation source of truth. The
+system extracts symbols, diagnostics, references, and source-cited spans, then
+renders that evidence through `memory.context`, `code.graph.context`, and the
+read-only `code.ast.*` MCP tools.
 
 Code intelligence does not replace source inspection or tests. Current files,
 repository docs, and test results remain authoritative.
@@ -103,17 +106,26 @@ watcher or second per-workspace DuckDB index.
 
 ## Agent Workflow
 
-Use memory first, then code-intelligence context after file discovery:
+Use memory first, indexed discovery when the exact files are not known, and
+live AST revalidation before edits:
 
 ```bash
 opensymphony memory context --issue COE-123
+# MCP: code.graph.context({repository, query|path|symbol, runId?, depth?, limit?})
 opensymphony memory context --issue COE-123 \
   --paths crates/opensymphony-cli/src/memory.rs \
   --include-code-intel
 ```
 
-Use the output to find likely symbols, diagnostics, and related tests. Then
-read the cited files and run the relevant tests before changing behavior.
+Use `code.graph.context` to find likely symbols, callers, references, related
+tests, and diagnostics without injecting the full repository graph into a
+prompt. It returns bounded source citations and provenance for either the
+indexed baseline or the supplied run's workspace overlay. The server resolves
+the repository and workspace; tool arguments cannot widen filesystem,
+visibility, or snippet policies. Then read the cited files and run targeted
+`memory.context --include-code-intel --paths ...` live scanning before changing
+behavior and again after touched-file changes. Current source files and tests
+remain authoritative over indexed evidence.
 
 Generated, vendor, build, and cache directories such as `node_modules`,
 `target`, `dist`, `build`, `.venv`, `.next`, `.turbo`, `vendor`, and
@@ -124,8 +136,9 @@ skipped with trace warnings rather than failing the whole request.
 
 ## MCP Tools
 
-When `code_intel.ast.enabled` is true, `tools/list` exposes these read-only
-tools:
+When `code_intel.enabled` is true, `tools/list` exposes the read-only
+`code.graph.context` indexed discovery tool. When `code_intel.ast.enabled` is
+also true, it exposes these AST tools:
 
 - `code.ast.status`
 - `code.ast.outline`
@@ -138,7 +151,9 @@ tools:
 `code.ast.query` accepts ad hoc Tree-sitter query text for local trusted use.
 When an admin token is configured, it is admin-gated. All tools enforce the
 configured file, match, and capture limits and run AST work off the async server
-thread.
+thread. `code.graph.context` is always read-only, bounded by depth and result
+limits, returns parser/query-pack and freshness metadata with source
+references, and never returns source snippets.
 
 ## Security
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -506,8 +506,12 @@ pass `--token` to require bearer-token access for read tools. Admin tools
 `memory.export_okf`, `memory.import_okf`, and `memory.ingest_code_intel`)
 require `OPENSYMPHONY_MEMORY_ADMIN_TOKEN` or `--admin-token`. When only the
 admin token is configured, it also gates read tools; do not inject that token
-into ordinary worker environments. When `code_intel.ast.enabled` is true,
-`tools/list` also exposes read-only `code.ast.*` inspection tools. The ad hoc
+into ordinary worker environments. When `code_intel.enabled` is true,
+`tools/list` exposes the read-only `code.graph.context` indexed discovery tool;
+when `code_intel.ast.enabled` is true, it also exposes `code.ast.*` inspection
+tools. The graph tool is bounded and can use the
+server-resolved run workspace overlay; it never accepts a client filesystem
+root or source-snippet override. The ad hoc
 `code.ast.query` tool is available for local trusted use without tokens, and is
 admin-gated when an admin token is configured. AST work runs off the async
 server thread, enforces configured file/match/capture limits, rejects paths and


### PR DESCRIPTION
## Summary

Add bounded, read-only indexed code discovery for agents through the memory MCP server, with server-resolved workspace overlays and live AST revalidation guidance.

## Changes

- Add `code.graph.context` schema, dispatcher, baseline symbol/edge/diagnostic retrieval, provenance, source citations, and depth/result bounds.
- Build run-scoped overlays from selector- and frontier-bounded records; validate workspace ownership manifests and reject direct workspace symlinks.
- Remove stale baseline records for unanalyzed changed files while preserving compatibility for other overlay consumers.
- Include parser/query-pack provenance on diagnostic evidence, including path-only diagnostics when no symbols are extracted.
- Update runtime/docs/workflow guidance and add direct plus HTTP MCP contract coverage.

## Evidence

### Test output

```text
cargo test-system-duckdb --lib                    842 passed, 0 failed
cargo test-system-duckdb --test memory             46 passed, 0 failed
cargo test-system-duckdb --lib code_graph_context  3 passed, 0 failed
cargo clippy-system-duckdb                         PASS
cargo fmt --all -- --check                         PASS
git diff --check                                   PASS
```

### Verification

The contract tests verify baseline symbol and caller discovery without a path, bounded truncation, zero-depth behavior, path traversal rejection, read-only/admin policy, run-overlay replacement and provenance, workspace ownership and symlink rejection, current-source revalidation after indexed discovery, diagnostic-only overlay evidence, and an actual `/mcp` HTTP round trip covering `tools/list`, `code.graph.context`, and `code.ast.context`. No source snippets, client filesystem roots, edit tools, or duplicate AST CLI family were added.

## Checklist

- [x] Tests pass
- [x] Code is formatted
- [x] Clippy is clean
- [x] Documentation updated
- [ ] `AGENTS.md` updated (no durable repository rule changed)
- [x] Evidence section filled out

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Breaking changes

None. The existing `memory.context --include-code-intel --paths ...` live revalidation path remains canonical.

## Related issues

Linear: https://linear.app/trilogy-ai-coe/issue/COE-544/indexed-agent-code-context-and-retrieval

## Additional notes

The operation uses logical indexed repository ids and server-owned roots. When a run is supplied, changed workspace files replace baseline records and the response labels `workspace_overlay` provenance with base revision and overlay digest.