### PR TITLE
Code Graph bootstrap indexing UX and E2E validation

### DIFF
--- a/apps/desktop/__tests__/app-shell-render.test.ts
+++ b/apps/desktop/__tests__/app-shell-render.test.ts
@@ -61,6 +61,11 @@ describe("desktop app shell render", () => {
       command: "code_symbol_detail",
       args: { repoId: "repo", symbolKey: "symbol", includeStale: null, visibility: "public" },
     });
+    await adapter.indexRepo("repo");
+    expect(calls[1]).toEqual({
+      command: "code_index_repo",
+      args: { repoId: "repo" },
+    });
     expect(() => adapter.getSymbolDetail("repo", "symbol", { visibility: "all_accessible" }))
       .toThrow('Code graph visibility "all_accessible" exceeds adapter policy "public"');
   });

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -21,6 +21,7 @@ import {
   memoryDeepLinkPrefix,
   codeDeepLinkFromLocationSearch,
   type CodeFileOutline,
+  type CodeIndexReport,
   type CodeGraphSnapshot,
   type CodeRepoList,
   type CodeSymbolDetail,
@@ -155,6 +156,7 @@ function createDesktopNativeGraphApi(invoke: TauriInvoke): NativeGraphApi {
 function createDesktopNativeCodeGraphApi(invoke: TauriInvoke): NativeCodeGraphApi {
   return {
     listRepos: (options) => invoke<CodeRepoList>("code_repos", { includeStale: options?.includeStale ?? null }),
+    indexRepo: (repoId) => invoke<CodeIndexReport>("code_index_repo", { repoId }),
     getGraphSnapshot: (repoId, options?: CodeGraphRequestOptions) =>
       invoke<CodeGraphSnapshot>("code_graph", {
         repoId,

--- a/crates/opensymphony-gateway-schema/src/code_graph.rs
+++ b/crates/opensymphony-gateway-schema/src/code_graph.rs
@@ -66,6 +66,8 @@ pub struct CodeRepoSummary {
     pub symbol_count: usize,
     pub edge_count: usize,
     pub freshness: CodeGraphFreshness,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub indexed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub indexed_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/opensymphony-gateway/src/lib.rs
+++ b/crates/opensymphony-gateway/src/lib.rs
@@ -2383,6 +2383,13 @@ fn code_repo_id_for_workspace(workspace_path: &StdPath) -> Option<String> {
         .ok()
         .as_deref()
         .and_then(repo_id_from_remote_url)
+        .or_else(|| {
+            workspace_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+        })
 }
 
 fn repo_id_from_remote_url(url: &str) -> Option<String> {

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2370,7 +2370,9 @@ async fn gateway_index_starts_target_branch_job_and_journals_completion() {
     assert_eq!(report.status, CodeIndexStatus::Accepted);
 
     let mut completed = false;
-    for _ in 0..200 {
+    // Target-branch indexing runs in a blocking worker; allow slower CI
+    // runners to finish the same deterministic completion assertion.
+    for _ in 0..600 {
         let events = journal.all_events().await;
         completed = events.iter().any(|event| {
             matches!(

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -38,9 +38,10 @@ use opensymphony::opensymphony_gateway_schema::model_settings::{
 use opensymphony::opensymphony_gateway_schema::run::DiffLine;
 use opensymphony::opensymphony_gateway_schema::validation::ValidationStatus;
 use opensymphony::opensymphony_memory::{
-    CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput, CodeIntelPersistBatch,
-    CodeIntelSkippedFileInput, CodeIntelSymbolInput, MemoryConfig, persist_code_intel_documents,
-    persist_code_intel_skipped_files, refresh_memory_index_from_okf,
+    CodeGraphContextQuery, CodeIntelDiagnosticInput, CodeIntelDocumentInput, CodeIntelEdgeInput,
+    CodeIntelPersistBatch, CodeIntelSkippedFileInput, CodeIntelSymbolInput, MemoryConfig,
+    code_graph_context, code_graph_workspace_context_overlay, code_graph_workspace_diff_overlay,
+    persist_code_intel_documents, persist_code_intel_skipped_files, refresh_memory_index_from_okf,
 };
 use tokio::net::TcpListener;
 use url::Url;
@@ -2410,6 +2411,232 @@ async fn gateway_index_starts_target_branch_job_and_journals_completion() {
             .and_then(|payload| payload.get("status"))
             == Some(&serde_json::json!("completed"))
     }));
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn gateway_code_graph_bootstraps_empty_store_and_dirty_workspace_flow() {
+    let repo = tempfile::tempdir().expect("target repository");
+    std::fs::create_dir_all(repo.path().join("src/services")).expect("source directories");
+    std::fs::write(
+        repo.path().join("WORKFLOW.md"),
+        "## Branch target\n\nTarget branch: `develop`\n",
+    )
+    .expect("workflow marker");
+    std::fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub mod app;\npub mod services { pub mod shared; }\n",
+    )
+    .expect("module root");
+    std::fs::write(repo.path().join("src/app.rs"), "pub fn run() {}\n")
+        .expect("application source");
+    std::fs::write(
+        repo.path().join("src/services/shared.rs"),
+        "pub fn helper() {}\n",
+    )
+    .expect("shared source");
+    run_git(repo.path(), &["init", "-b", "develop"]);
+    run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+    run_git(repo.path(), &["config", "user.name", "Test User"]);
+    run_git(repo.path(), &["add", "."]);
+    run_git(repo.path(), &["commit", "-m", "code graph baseline"]);
+    let base_revision = run_git(repo.path(), &["rev-parse", "HEAD"]);
+    let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+    let repo_id = repo
+        .path()
+        .file_name()
+        .expect("repository id")
+        .to_string_lossy()
+        .to_string();
+
+    let journal = opensymphony::opensymphony_domain::InMemoryEventJournal::new(100, 32);
+    let broker = opensymphony::opensymphony_domain::StreamBroker::new(journal.clone());
+    let server = GatewayServer::with_journal(
+        SnapshotStore::new(fixture_snapshot(0)),
+        journal.clone(),
+        broker,
+    )
+    .with_memory_config(Some(config.clone()));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+    let server_task = tokio::spawn(async move {
+        server.serve(listener).await.expect("gateway should serve");
+    });
+    let client = reqwest::Client::new();
+    let base = format!("http://{address}/api/v1/code");
+
+    let empty_repos = client
+        .get(format!("{base}/repos"))
+        .send()
+        .await
+        .expect("fetch empty code repos")
+        .json::<CodeRepoList>()
+        .await
+        .expect("decode empty code repos");
+    let empty_repo = empty_repos
+        .repos
+        .iter()
+        .find(|summary| summary.repo_id == repo_id)
+        .expect("configured repository should be discoverable before indexing");
+    assert_eq!(empty_repo.document_count, 0);
+
+    let accepted = client
+        .post(format!("{base}/repos/{repo_id}/index"))
+        .send()
+        .await
+        .expect("index empty code repo")
+        .json::<CodeIndexReport>()
+        .await
+        .expect("decode accepted index report");
+    assert_eq!(accepted.status, CodeIndexStatus::Accepted);
+    assert_eq!(accepted.repo_id, repo_id);
+
+    let mut completed = false;
+    for _ in 0..200 {
+        let events = journal.all_events().await;
+        completed = events.iter().any(|event| {
+            matches!(
+                event.kind,
+                opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeGraphUpdated { .. }
+            )
+        });
+        if completed {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(completed, "index completion should refresh the code graph");
+    let events = journal.all_events().await;
+    assert!(events.iter().any(|event| {
+        matches!(
+            event.kind,
+            opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeIndexProgress { .. }
+        ) && event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("status"))
+            == Some(&serde_json::json!("progress"))
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event.kind,
+            opensymphony::opensymphony_gateway_schema::event_journal::EventKind::CodeIndexProgress { .. }
+        ) && event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("status"))
+            == Some(&serde_json::json!("completed"))
+    }));
+
+    let indexed_repos = client
+        .get(format!("{base}/repos"))
+        .send()
+        .await
+        .expect("refresh indexed code repos")
+        .json::<CodeRepoList>()
+        .await
+        .expect("decode indexed code repos");
+    let indexed_repo = indexed_repos
+        .repos
+        .iter()
+        .find(|summary| summary.repo_id == repo_id)
+        .expect("indexed repository should remain discoverable");
+    assert_eq!(
+        indexed_repo.head_revision.as_deref(),
+        Some(base_revision.as_str())
+    );
+    assert!(indexed_repo.document_count > 0);
+
+    let snapshot = client
+        .get(format!("{base}/repos/{repo_id}/graph?mode=atlas"))
+        .send()
+        .await
+        .expect("fetch indexed graph")
+        .json::<CodeGraphSnapshot>()
+        .await
+        .expect("decode indexed graph");
+    assert!(
+        !snapshot.nodes.is_empty(),
+        "indexed graph should be nonempty"
+    );
+
+    let context_query = CodeGraphContextQuery {
+        repo_id: repo_id.clone(),
+        query: Some("run".to_string()),
+        path: None,
+        symbol: None,
+        depth: 1,
+        limit: 20,
+    };
+    let baseline_context = code_graph_context(&config, context_query.clone(), None)
+        .expect("indexed baseline should be available");
+    assert_eq!(
+        baseline_context.pointer("/provenance/kind"),
+        Some(&serde_json::json!("indexed_baseline"))
+    );
+    assert!(
+        baseline_context
+            .pointer("/evidence")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|evidence| !evidence.is_empty())
+    );
+
+    std::fs::write(
+        repo.path().join("src/app.rs"),
+        "pub fn run() { crate::services::shared::helper(); }\n",
+    )
+    .expect("dirty cross-module edit");
+    let overlay = code_graph_workspace_context_overlay(
+        &config,
+        &repo_id,
+        repo.path(),
+        "COE-546",
+        &base_revision,
+        &context_query,
+    )
+    .expect("workspace context overlay");
+    let overlay_context = code_graph_context(&config, context_query, Some(&overlay))
+        .expect("dirty workspace context should be available");
+    assert_eq!(
+        overlay_context.pointer("/provenance/kind"),
+        Some(&serde_json::json!("workspace_overlay"))
+    );
+    assert!(
+        overlay_context
+            .pointer("/evidence")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|evidence| evidence.iter().any(|entry| {
+                entry.pointer("/provenance") == Some(&serde_json::json!("workspace_overlay"))
+            }))
+    );
+
+    let diff = code_graph_workspace_diff_overlay(
+        &config,
+        &repo_id,
+        repo.path(),
+        "COE-546",
+        &base_revision,
+        500,
+    )
+    .expect("workspace topology diff");
+    assert!(
+        diff.modified_symbols
+            .iter()
+            .any(|symbol| symbol.after.as_ref().is_some_and(|side| side.name == "run"))
+    );
+    assert!(
+        diff.edge_deltas
+            .iter()
+            .any(|edge| edge.status == CodeDiffEdgeStatus::Added)
+    );
+    assert!(
+        diff.module_connection_deltas
+            .iter()
+            .any(|connection| connection.status == CodeDiffEdgeStatus::Added)
+    );
+
     server_task.abort();
 }
 

--- a/crates/opensymphony-gateway/tests/gateway.rs
+++ b/crates/opensymphony-gateway/tests/gateway.rs
@@ -2481,6 +2481,7 @@ async fn gateway_code_graph_bootstraps_empty_store_and_dirty_workspace_flow() {
         .find(|summary| summary.repo_id == repo_id)
         .expect("configured repository should be discoverable before indexing");
     assert_eq!(empty_repo.document_count, 0);
+    assert!(!empty_repo.indexed);
 
     let accepted = client
         .post(format!("{base}/repos/{repo_id}/index"))
@@ -2547,6 +2548,7 @@ async fn gateway_code_graph_bootstraps_empty_store_and_dirty_workspace_flow() {
         indexed_repo.head_revision.as_deref(),
         Some(base_revision.as_str())
     );
+    assert!(indexed_repo.indexed);
     assert!(indexed_repo.document_count > 0);
 
     let snapshot = client

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1077,16 +1077,10 @@ pub fn code_graph_repos(
     include_stale: bool,
 ) -> Result<CodeRepoList, CodeGraphProjectionError> {
     let Some(connection) = open_existing_index_read_only(config)? else {
-        return Ok(CodeRepoList {
-            schema_version: SchemaVersion::v1(),
-            repos: Vec::new(),
-        });
+        return Ok(unindexed_code_repo_list(config));
     };
     if !code_documents_read_model_ready(&connection, &config.index_path)? {
-        return Ok(CodeRepoList {
-            schema_version: SchemaVersion::v1(),
-            repos: Vec::new(),
-        });
+        return Ok(unindexed_code_repo_list(config));
     }
 
     let freshness = code_freshness_filter(include_stale);
@@ -1239,10 +1233,43 @@ pub fn code_graph_repos(
         summaries.push(entry.into_summary());
     }
 
+    if summaries.is_empty() {
+        summaries.push(unindexed_code_repo_summary(config));
+    }
+
     Ok(CodeRepoList {
         schema_version: SchemaVersion::v1(),
         repos: summaries,
     })
+}
+
+fn unindexed_code_repo_list(config: &MemoryConfig) -> CodeRepoList {
+    CodeRepoList {
+        schema_version: SchemaVersion::v1(),
+        repos: vec![unindexed_code_repo_summary(config)],
+    }
+}
+
+fn unindexed_code_repo_summary(config: &MemoryConfig) -> CodeRepoSummary {
+    let repo_id = config
+        .repo_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("repository")
+        .to_string();
+    CodeRepoSummary {
+        repo_id: repo_id.clone(),
+        display_root: repo_id,
+        languages: Vec::new(),
+        document_count: 0,
+        symbol_count: 0,
+        edge_count: 0,
+        freshness: CodeGraphFreshness::Unknown,
+        indexed_at: None,
+        head_revision: None,
+        worktree_dirty: false,
+    }
 }
 
 pub fn code_graph_snapshot(

--- a/crates/opensymphony-memory/src/code_graph.rs
+++ b/crates/opensymphony-memory/src/code_graph.rs
@@ -1251,13 +1251,7 @@ fn unindexed_code_repo_list(config: &MemoryConfig) -> CodeRepoList {
 }
 
 fn unindexed_code_repo_summary(config: &MemoryConfig) -> CodeRepoSummary {
-    let repo_id = config
-        .repo_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .unwrap_or("repository")
-        .to_string();
+    let repo_id = configured_code_repo_id(config);
     CodeRepoSummary {
         repo_id: repo_id.clone(),
         display_root: repo_id,
@@ -1266,10 +1260,41 @@ fn unindexed_code_repo_summary(config: &MemoryConfig) -> CodeRepoSummary {
         symbol_count: 0,
         edge_count: 0,
         freshness: CodeGraphFreshness::Unknown,
+        indexed: false,
         indexed_at: None,
         head_revision: None,
         worktree_dirty: false,
     }
+}
+
+fn configured_code_repo_id(config: &MemoryConfig) -> String {
+    let remote = Command::new("git")
+        .args(["-C"])
+        .arg(&config.repo_root)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| repo_id_from_remote_url(&String::from_utf8_lossy(&output.stdout)));
+    remote.unwrap_or_else(|| {
+        config
+            .repo_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or("repository")
+            .to_string()
+    })
+}
+
+fn repo_id_from_remote_url(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches(".git").trim_end_matches('/');
+    let name = trimmed
+        .rsplit(['/', ':'])
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())?;
+    Some(name.to_string())
 }
 
 pub fn code_graph_snapshot(
@@ -3734,12 +3759,13 @@ pub fn code_graph_index_report(
         .repos
         .into_iter()
         .find(|repo| repo.repo_id == repo_id);
-    let status = if repo.is_some() {
+    let indexed = repo.as_ref().is_some_and(|repo| repo.indexed);
+    let status = if indexed {
         CodeIndexStatus::Completed
     } else {
         CodeIndexStatus::Unavailable
     };
-    let head_revision = repo.and_then(|repo| repo.head_revision);
+    let head_revision = repo.as_ref().and_then(|repo| repo.head_revision.clone());
     let counts = code_index_counts(config, repo_id)?;
     Ok(CodeIndexReport {
         schema_version: SchemaVersion::v1(),
@@ -3753,7 +3779,11 @@ pub fn code_graph_index_report(
         persisted_diagnostics: counts.diagnostics,
         stale_rows: counts.stale_rows,
         skipped_files: Vec::new(),
-        diagnostics: Vec::new(),
+        diagnostics: if indexed {
+            Vec::new()
+        } else {
+            vec!["configured repository has not been indexed".to_string()]
+        },
         cursor: code_graph_cursor(repo_id, indexed_at),
         indexed_at,
     })
@@ -5465,6 +5495,7 @@ impl CodeRepoAccumulator {
             } else {
                 CodeGraphFreshness::Unknown
             },
+            indexed: self.indexed_at.is_some() || self.head_revision.is_some(),
             indexed_at: self.indexed_at,
             head_revision: self.head_revision,
             worktree_dirty: self.worktree_dirty,
@@ -7394,7 +7425,7 @@ mod code_graph_tests {
 
     use super::{
         code_citation_matches_symbol, code_file_outline_from_workspace, code_graph_diff_overlay,
-        code_graph_repos, code_graph_snapshot, code_graph_workspace_diff_overlay,
+        code_graph_index_report, code_graph_repos, code_graph_snapshot, code_graph_workspace_diff_overlay,
         code_graph_workspace_overlay,
         code_graph_workspace_snapshot,
         assign_edge_keys, code_index_document, code_symbol_span_matches,
@@ -9088,6 +9119,31 @@ mod code_graph_tests {
             .expect("skipped-only repo summary");
         assert_eq!(summary.document_count, 0);
         assert!(summary.languages.is_empty());
+    }
+
+    #[test]
+    fn empty_repo_discovery_uses_origin_id_and_stays_unavailable() {
+        let repo = TempDir::new().expect("repository tempdir");
+        git(repo.path(), &["init", "-b", "develop"]);
+        git(
+            repo.path(),
+            &["remote", "add", "origin", "git@github.com:example/canonical.git"],
+        );
+        let config = MemoryConfig::load(repo.path(), None).expect("memory config");
+
+        let repos = code_graph_repos(&config, false).expect("empty repo discovery");
+        assert_eq!(repos.repos[0].repo_id, "canonical");
+        assert!(!repos.repos[0].indexed);
+
+        let report = code_graph_index_report(&config, "canonical").expect("index report");
+        assert_eq!(
+            report.status,
+            crate::opensymphony_gateway_schema::code_graph::CodeIndexStatus::Unavailable
+        );
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("has not been indexed")));
     }
 
     #[test]

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -86,7 +86,9 @@ operator can choose `Index repository` without an admin MCP call. Progress
 reports include parsed and persisted coverage; skipped files and diagnostics
 remain visible in the empty-state panel; failures are retryable. After
 `code_graph_updated`, the client reloads the repository summary and baseline
-snapshot, retaining the selected target revision in the provenance strip.
+snapshot, retaining the selected target revision in the provenance strip. If an
+accepted/progress job completes while the event stream is unavailable, the
+client polls repository summaries and recognizes the indexed baseline directly.
 
 ## Workspace overlays
 

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -80,6 +80,14 @@ after completion. This shared target-branch baseline is not the live truth for
 an issue workspace; workspace-specific code belongs to the overlay/composite
 graph path.
 
+The web and desktop Code Graph surfaces expose this operation for an empty
+store. The configured repository is discoverable before the first index, so an
+operator can choose `Index repository` without an admin MCP call. Progress
+reports include parsed and persisted coverage; skipped files and diagnostics
+remain visible in the empty-state panel; failures are retryable. After
+`code_graph_updated`, the client reloads the repository summary and baseline
+snapshot, retaining the selected target revision in the provenance strip.
+
 ## Workspace overlays
 
 Run-scoped code reads compose the pinned target-branch merge-base snapshot with

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -99,6 +99,24 @@ in one terminal and `cargo run` from `apps/desktop/src-tauri` in another.
 Plain `cargo run` rebuilds and reads the current `apps/desktop/dist` bundle; it
 does not start Vite.
 
+## Code Graph production smoke
+
+For an empty Code Graph store, launch the normal desktop shell, open Graph, and
+choose the configured repository's `Index repository` action. The status panel
+shows target-branch progress, parsed/persisted coverage, skipped files, and
+retry diagnostics; completion is driven by `code_graph_updated`. This path
+uses the production Tauri command, not fixture data. The equivalent web smoke
+uses the production HTTP adapter. A packaged parity check is:
+
+```bash
+npm run build --workspace=@opensymphony/desktop
+npm run package:release --workspace=@opensymphony/desktop -- --dry-run
+```
+
+The installed bundle must contain the same shared shell and production adapter
+selection as the local Tauri launch; `?fixtures` is reserved for the graph
+visualization workbench.
+
 ## Release Bundle
 
 The first release asset format is a tarball consumed by the lazy CLI launcher.

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -104,9 +104,11 @@ does not start Vite.
 For an empty Code Graph store, launch the normal desktop shell, open Graph, and
 choose the configured repository's `Index repository` action. The status panel
 shows target-branch progress, parsed/persisted coverage, skipped files, and
-retry diagnostics; completion is driven by `code_graph_updated`. This path
-uses the production Tauri command, not fixture data. The equivalent web smoke
-uses the production HTTP adapter. A packaged parity check is:
+retry diagnostics; completion is driven by `code_graph_updated`, with a
+repository-summary polling fallback while accepted/progress jobs have no event
+delivery. This path uses the production Tauri command, not fixture data. The
+equivalent web smoke uses the production HTTP adapter. A packaged parity check
+is:
 
 ```bash
 npm run build --workspace=@opensymphony/desktop

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -279,10 +279,13 @@ empty target instead of showing a dead-end placeholder. `Index repository`
 starts the target-branch job; accepted/progress reports update the accessible
 status and coverage counts, failed or unavailable reports show diagnostics and
 enable `Retry indexing`, and the completed `code_graph_updated` event refreshes
-the graph. The provenance strip identifies the target revision and labels the
-current view as baseline, workspace-composed, stale, truncated, or partially
-covered. Web uses the production HTTP adapter and packaged Tauri uses the
-production native command; `?fixtures` remains a deterministic workbench only.
+the graph. While an accepted/progress job has no event delivery, the shell
+polls repository summaries and promotes an observed indexed baseline so the
+surface cannot remain stuck on the empty state. The provenance strip identifies
+the target revision and labels the current view as baseline, workspace-composed,
+stale, truncated, or partially covered. Web uses the production HTTP adapter
+and packaged Tauri uses the production native command; `?fixtures` remains a
+deterministic workbench only.
 
 ### Tests that gate this area
 

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -274,6 +274,16 @@ gateway-schema DTOs as HTTP, including the hosted default-deny snippet policy;
 paths exposed to clients remain workspace-relative and stale/unsupported
 records stay visible only when explicitly requested.
 
+When the configured repository has no indexed rows, the surface lists it as an
+empty target instead of showing a dead-end placeholder. `Index repository`
+starts the target-branch job; accepted/progress reports update the accessible
+status and coverage counts, failed or unavailable reports show diagnostics and
+enable `Retry indexing`, and the completed `code_graph_updated` event refreshes
+the graph. The provenance strip identifies the target revision and labels the
+current view as baseline, workspace-composed, stale, truncated, or partially
+covered. Web uses the production HTTP adapter and packaged Tauri uses the
+production native command; `?fixtures` remains a deterministic workbench only.
+
 ### Tests that gate this area
 
 - `packages/ui-core/__tests__/knowledge-graph-scene.test.ts` — projector ↔

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -256,9 +256,10 @@ An empty DuckDB is a supported starting state. The gateway advertises the
 configured repository with zero coverage, allowing the web or desktop Code
 Graph surface to start indexing directly. The surface renders accepted and
 progress coverage, skipped-file diagnostics, retryable failures, and refreshes
-from `code_graph_updated`; production web requests use HTTP and packaged
-desktop requests use the Tauri-native `code_index_repo` command against the
-same report contract.
+from `code_graph_updated`; during accepted/progress work with no event delivery,
+the shell polls repository summaries and recognizes a newly indexed baseline.
+Production web requests use HTTP and packaged desktop requests use the
+Tauri-native `code_index_repo` command against the same report contract.
 
 Initialize the shared memory policy and learned ontology file once:
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -252,6 +252,14 @@ only after a completed snapshot is available.
 This index is a shared target-branch baseline. It must not be treated as the
 live code state of an issue workspace; workspace overlays provide that view.
 
+An empty DuckDB is a supported starting state. The gateway advertises the
+configured repository with zero coverage, allowing the web or desktop Code
+Graph surface to start indexing directly. The surface renders accepted and
+progress coverage, skipped-file diagnostics, retryable failures, and refreshes
+from `code_graph_updated`; production web requests use HTTP and packaged
+desktop requests use the Tauri-native `code_index_repo` command against the
+same report contract.
+
 Initialize the shared memory policy and learned ontology file once:
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -318,6 +318,24 @@ removing older revisions. Requests return an accepted report; inspect the event
 journal for progress and the terminal completion/failure event. Concurrent
 requests are serialized by the index writer.
 
+The operator-facing equivalent is the Code Graph empty state: select the
+configured repository and choose `Index repository`. It is safe to start from
+an empty `.opensymphony/memory/memory.duckdb`; the repository row is exposed
+with zero counts until the job begins. `accepted` and `progress` reports show
+coverage, `failed` and `unavailable` reports show diagnostics with a retry
+action, and `code_graph_updated` causes the shell to refresh the baseline.
+The provenance strip should show the configured target revision and whether a
+view is baseline, workspace-composed, stale, truncated, or partially analyzed.
+
+For a production transport smoke, use the gateway endpoint rather than the
+fixture workbench:
+
+```bash
+curl http://127.0.0.1:2468/api/v1/code/repos
+curl -X POST http://127.0.0.1:2468/api/v1/code/repos/<repo-id>/index
+curl 'http://127.0.0.1:2468/api/v1/code/repos/<repo-id>/graph?mode=atlas'
+```
+
 ## 4.1 Subscription Credential Operations
 
 OpenAI ChatGPT/Codex subscription mode is explicit and feature-gated. Build or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -323,7 +323,9 @@ configured repository and choose `Index repository`. It is safe to start from
 an empty `.opensymphony/memory/memory.duckdb`; the repository row is exposed
 with zero counts until the job begins. `accepted` and `progress` reports show
 coverage, `failed` and `unavailable` reports show diagnostics with a retry
-action, and `code_graph_updated` causes the shell to refresh the baseline.
+action, and `code_graph_updated` causes the shell to refresh the baseline. If
+the event stream is silent during an accepted/progress job, the shell polls the
+repository summary and refreshes as soon as an indexed baseline is visible.
 The provenance strip should show the configured target revision and whether a
 view is baseline, workspace-composed, stale, truncated, or partially analyzed.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,3 +56,27 @@ last_memory_sync: 2026-07-04T03:35:18.210566+00:00
 - COE-541
 
 <!-- END OPENSYMPHONY MANAGED MEMORY SYNC -->
+
+## M12.9 Code Graph desktop release gate
+
+The Code Graph follow-on is release-ready only when the web and packaged
+desktop shells use the production HTTP/native adapters and the empty-database
+index action is present in the installed bundle. Before publishing, verify
+that the root crate and desktop metadata remain in lock-step across
+`Cargo.toml`, `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`,
+`apps/desktop/src-tauri/Cargo.lock`, `apps/desktop/src-tauri/tauri.conf.json`,
+and the root `package-lock.json`.
+
+Use the default bundled-mode checks plus the package parity guard:
+
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo test
+npm run build --workspace=@opensymphony/desktop
+npm run package:release --workspace=@opensymphony/desktop -- --dry-run
+```
+
+The dry run must pass without creating a release archive. The desktop smoke
+must launch the packaged bundle against a real gateway and verify repository
+indexing, progress/error/retry rendering, completion refresh, and target
+revision provenance; fixture mode is only a visualization-workbench check.

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -198,6 +198,13 @@ and login -> Enable device code authorization for Codex before retrying.
 
 ## 3.1.1 Code Graph repository indexing
 
+- exercise the empty-DuckDB gateway flow: repository discovery, target-branch
+  index, accepted/progress/completed events, nonempty snapshot, baseline
+  `code.graph.context`, dirty workspace overlay, and cleanup
+- verify a dirty cross-module call produces an added edge and module-connection
+  delta against the configured target branch
+- assert the fixture, production HTTP, and Tauri-native adapters return the same
+  index-report and graph DTO shapes
 - bootstrap an empty DuckDB index from the configured target branch and assert
   nonzero documents, symbols, and edges for supported source
 - keep base and later commits independently queryable, including identical
@@ -320,6 +327,23 @@ The web and desktop clients both mount the shared `OpenSymphonyApp` shell from `
 - auth-aware placeholder states (`packages/ui-core/__tests__/auth-states.test.ts`): unauthenticated (sign-in), unauthorized (access denied), forbidden (access forbidden), organization/project selection placeholders, and local `auth_modes:["none"]` gateways rendering the dashboard with no login gate; recovery when the gateway later permits a read
 - remote web/desktop parity (`packages/ui-core/__tests__/remote-parity.test.ts`): the shell renders the same core dashboard metrics, task graph nodes, run detail, planning workspace, and stream events in both `mode:"web"` and `mode:"desktop"` against an identical fixture transport
 - gateway error classification (`packages/api-client/__tests__/gateway-errors.test.ts`): `HttpGatewayTransport` maps HTTP 401/403 (including a 403 with an explicit `error_code:"unauthorized"` body signal) to a classified `GatewayRequestError`, and `authStateFromError` maps it to an `AuthState` from `@opensymphony/gateway-schema`
+
+Code Graph UI validation also covers the real empty-state interaction: the
+keyboard-accessible index button, disabled progress state, skipped-file
+coverage, retry diagnostics, target-revision/provenance labels, stale and
+truncated status, and refresh after `code_graph_updated`. The packaged desktop
+smoke must use production adapters; passing only `?fixtures` is insufficient.
+
+Release-sensitive evidence for this surface includes:
+
+```bash
+cargo clippy-system-duckdb
+npm run type-check
+npm run package:release --workspace=@opensymphony/desktop -- --dry-run
+```
+
+Run the corresponding bundled-mode `cargo clippy --all-targets -- -D warnings`
+and `cargo test` checks before publishing a release bundle.
 
 ### Evidence for UI/shell changes
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -331,7 +331,8 @@ The web and desktop clients both mount the shared `OpenSymphonyApp` shell from `
 Code Graph UI validation also covers the real empty-state interaction: the
 keyboard-accessible index button, disabled progress state, skipped-file
 coverage, retry diagnostics, target-revision/provenance labels, stale and
-truncated status, and refresh after `code_graph_updated`. The packaged desktop
+truncated status, refresh after `code_graph_updated`, and recovery when an
+accepted/progress job completes without event delivery. The packaged desktop
 smoke must use production adapters; passing only `?fixtures` is insufficient.
 
 Release-sensitive evidence for this surface includes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "apps/desktop": {
       "name": "@opensymphony/desktop",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "dependencies": {
         "@opensymphony/api-client": "*",
         "@opensymphony/gateway-schema": "*",

--- a/packages/gateway-schema/src/code_graph.ts
+++ b/packages/gateway-schema/src/code_graph.ts
@@ -27,6 +27,7 @@ export interface CodeRepoSummary {
   symbol_count: number;
   edge_count: number;
   freshness: CodeGraphFreshness;
+  indexed?: boolean;
   indexed_at?: string | null;
   head_revision?: string | null;
   worktree_dirty?: boolean;

--- a/packages/graph/__tests__/code-graph.test.ts
+++ b/packages/graph/__tests__/code-graph.test.ts
@@ -523,6 +523,47 @@ describe("Code Graph adapters and state", () => {
     expect(fetchMock).toHaveBeenCalledTimes(9);
   });
 
+  it("ignores stale index reports while allowing terminal status at a shared cursor", () => {
+    const repos = {
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      repos: [{
+        repo_id: "opensymphony",
+        display_root: "OpenSymphony",
+        languages: [],
+        document_count: 0,
+        symbol_count: 0,
+        edge_count: 0,
+        freshness: "unknown" as const,
+        indexed_at: null,
+        head_revision: null,
+      }],
+    };
+    const report = (status: "accepted" | "progress" | "failed", sequence = 7) => ({
+      schema_version: { major: 1, minor: 0, patch: 0 },
+      repo_id: "opensymphony",
+      status,
+      head_revision: null,
+      parsed_files: 0,
+      persisted_documents: 0,
+      persisted_symbols: 0,
+      persisted_edges: 0,
+      persisted_diagnostics: status === "failed" ? 1 : 0,
+      stale_rows: 0,
+      skipped_files: [],
+      diagnostics: status === "failed" ? ["failed"] : [],
+      cursor: { sequence, partition: "code-graph:opensymphony" },
+      indexed_at: "2026-07-13T00:00:00Z",
+    });
+    let state = codeGraphReducer(createInitialCodeGraphState(), { type: "REPOS_LOADED", repos });
+    state = codeGraphReducer(state, { type: "INDEX_REPORT", report: report("accepted") });
+    state = codeGraphReducer(state, { type: "INDEX_REPORT", report: report("progress") });
+    state = codeGraphReducer(state, { type: "INDEX_REPORT", report: report("failed") });
+    expect(state.indexReport?.status).toBe("failed");
+    state = codeGraphReducer(state, { type: "INDEX_REPORT", report: report("accepted", 6) });
+    expect(state.indexReport?.status).toBe("failed");
+    expect(state.indexError).toBe("failed");
+  });
+
   it("normalizes legacy diff payloads before graph materialization", async () => {
     const fetchMock = jest.fn(async () => ({
       ok: true,

--- a/packages/graph/__tests__/code-graph.test.ts
+++ b/packages/graph/__tests__/code-graph.test.ts
@@ -491,6 +491,11 @@ describe("Code Graph adapters and state", () => {
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/code/repos");
     await http.listRepos({ includeStale: true });
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/code/repos?include_stale=true");
+    await http.indexRepo("opensymphony");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:2468/api/v1/code/repos/opensymphony/index",
+      { method: "POST" },
+    );
     await http.getGraphSnapshot("opensymphony", { mode: "atlas", includeStale: true });
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:2468/api/v1/code/repos/opensymphony/graph?mode=atlas&include_stale=true");
     await http.getRunGraphSnapshot!("COE-543", "opensymphony", { mode: "file", path: "src/lib.rs", depth: 1 });
@@ -515,7 +520,7 @@ describe("Code Graph adapters and state", () => {
     expect(() => publicNative.getSymbolDetail("opensymphony", "privateSymbol", { visibility: "all_accessible" }))
       .toThrow('Code graph visibility "all_accessible" exceeds adapter policy "public"');
     await native.listRepos();
-    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(fetchMock).toHaveBeenCalledTimes(9);
   });
 
   it("normalizes legacy diff payloads before graph materialization", async () => {
@@ -577,6 +582,8 @@ describe("Code Graph adapters and state", () => {
       .resolves.toEqual(await fixture.getGraphSnapshot("opensymphony", { mode: "neighborhood" }));
     await expect(native.getDiffOverlay("opensymphony", "base-rev", "head-rev"))
       .resolves.toEqual(await fixture.getDiffOverlay("opensymphony", "base-rev", "head-rev"));
+    await expect(native.indexRepo("opensymphony"))
+      .resolves.toEqual(await fixture.indexRepo("opensymphony"));
   });
 
   it("keeps base/head diff fixtures aligned for ghosts and blast radius", () => {

--- a/packages/graph/src/code-graph.ts
+++ b/packages/graph/src/code-graph.ts
@@ -11,6 +11,7 @@ import type {
   CodeGraphMode as SnapshotMode,
   CodeGraphNode,
   CodeGraphSnapshot,
+  CodeIndexReport,
   CodeRepoList,
   CodeSymbolDetail,
   MemoryGraphEdgeKind,
@@ -97,6 +98,7 @@ export interface CodeGraphAdapterPolicy {
 
 export interface CodeGraphAdapter {
   listRepos(options?: CodeRepoListRequestOptions): Promise<CodeRepoList>;
+  indexRepo(repoId: string): Promise<CodeIndexReport>;
   getGraphSnapshot(repoId: string, options?: CodeGraphRequestOptions): Promise<CodeGraphSnapshot>;
   getRunGraphSnapshot?(runId: string, repoId?: string, options?: CodeGraphRequestOptions): Promise<CodeGraphSnapshot>;
   getSymbolDetail(repoId: string, symbolKey: string, options?: CodeSymbolDetailRequestOptions): Promise<CodeSymbolDetail>;
@@ -136,6 +138,9 @@ export interface CodeGraphHistoryState {
 
 export interface CodeGraphState extends CodeGraphHistoryState {
   repos: CodeRepoList | null;
+  indexReport: CodeIndexReport | null;
+  indexing: boolean;
+  indexError: string | null;
   snapshot: CodeGraphSnapshot | null;
   symbolDetails: Record<string, CodeSymbolDetail>;
   diffOverlay: CodeDiffOverlay | null;
@@ -149,6 +154,9 @@ export interface CodeGraphState extends CodeGraphHistoryState {
 export type CodeGraphAction =
   | { type: "REPOS_LOADED"; repos: CodeRepoList }
   | { type: "REPOS_INVALIDATED" }
+  | { type: "INDEX_STARTED"; repoId: string }
+  | { type: "INDEX_REPORT"; report: CodeIndexReport }
+  | { type: "INDEX_REQUEST_FAILED"; repoId: string; error: string }
   | { type: "LOAD_FAILED"; error: string }
   | { type: "SNAPSHOT_LOADED"; snapshot: CodeGraphSnapshot }
   | { type: "SYMBOL_DETAIL_LOADED"; detail: CodeSymbolDetail }
@@ -197,6 +205,9 @@ export const initialCodeGraphFilters = createInitialCodeGraphFilters();
 export function createInitialCodeGraphState(): CodeGraphState {
   return {
     repos: null,
+    indexReport: null,
+    indexing: false,
+    indexError: null,
     snapshot: null,
     symbolDetails: {},
     diffOverlay: null,
@@ -243,6 +254,25 @@ export function codeGraphReducer(state: CodeGraphState, action: CodeGraphAction)
     }
     case "REPOS_INVALIDATED":
       return { ...state, repos: null };
+    case "INDEX_STARTED":
+      return state.repoId === action.repoId
+        ? { ...state, indexing: true, indexError: null }
+        : state;
+    case "INDEX_REPORT":
+      return state.repoId === action.report.repo_id
+        ? {
+            ...state,
+            indexReport: action.report,
+            indexing: action.report.status === "accepted" || action.report.status === "progress",
+            indexError: action.report.status === "failed" || action.report.status === "unavailable"
+              ? action.report.diagnostics[0] ?? `Code Graph index ${action.report.status}`
+              : null,
+          }
+        : state;
+    case "INDEX_REQUEST_FAILED":
+      return state.repoId === action.repoId
+        ? { ...state, indexing: false, indexError: action.error }
+        : state;
     case "LOAD_FAILED":
       return {
         ...state,
@@ -413,6 +443,9 @@ function selectCodeGraphRepo(state: CodeGraphState, repoId: string | null): Code
   return {
     ...state,
     repoId,
+    indexReport: null,
+    indexing: false,
+    indexError: null,
     mode: "atlas",
     snapshot: repoId === state.snapshot?.repo_id ? state.snapshot : null,
     symbolKey: null,
@@ -681,6 +714,13 @@ export function createHttpCodeGraphAdapter(
       if (options?.includeStale !== undefined) params.set("include_stale", String(options.includeStale));
       return read<CodeRepoList>("/api/v1/code/repos", params);
     },
+    indexRepo: async (repoId) => {
+      const response = await fetchFn(`${base}/api/v1/code/repos/${encodeURIComponent(repoId)}/index`, {
+        method: "POST",
+      });
+      if (!response.ok) throw new Error(`Code graph request failed: HTTP ${response.status}`);
+      return await response.json() as CodeIndexReport;
+    },
     getGraphSnapshot: (repoId, options) => {
       const params = codeGraphRequestParams(options);
       return read<CodeGraphSnapshot>(`/api/v1/code/repos/${encodeURIComponent(repoId)}/graph`, params);
@@ -753,6 +793,8 @@ export function createTauriNativeCodeGraphAdapter(
 
 export interface CodeGraphFixtures {
   repos?: CodeRepoList;
+  indexReports?: readonly CodeIndexReport[];
+  indexRepo?: (repoId: string) => Promise<CodeIndexReport>;
   snapshots?: CodeGraphSnapshot | readonly CodeGraphSnapshot[];
   symbolDetails?: readonly CodeSymbolDetail[];
   fileOutlines?: readonly CodeFileOutline[];
@@ -761,6 +803,7 @@ export interface CodeGraphFixtures {
 
 export function createFixtureCodeGraphAdapter(fixtures: CodeGraphFixtures = {}): CodeGraphAdapter {
   const repos = fixtures.repos ?? codeGraphFixtureRepos;
+  const indexReports = fixtures.indexReports ?? [];
   const snapshots: readonly CodeGraphSnapshot[] = Array.isArray(fixtures.snapshots)
     ? fixtures.snapshots
     : fixtures.snapshots
@@ -771,6 +814,29 @@ export function createFixtureCodeGraphAdapter(fixtures: CodeGraphFixtures = {}):
   const overlays = fixtures.diffOverlays ?? codeGraphFixtureDiffOverlays;
   return {
     listRepos: async () => repos,
+    indexRepo: async (repoId) => {
+      if (fixtures.indexRepo) return fixtures.indexRepo(repoId);
+      const report = indexReports.find((candidate) => candidate.repo_id === repoId)
+        ?? repos.repos.find((candidate) => candidate.repo_id === repoId);
+      if (!report) throw new Error(`Code graph index target not found: ${repoId}`);
+      if ("status" in report) return report;
+      return {
+        schema_version: { major: 1, minor: 0, patch: 0 },
+        repo_id: repoId,
+        status: "completed",
+        head_revision: report.head_revision ?? null,
+        parsed_files: report.document_count,
+        persisted_documents: report.document_count,
+        persisted_symbols: report.symbol_count,
+        persisted_edges: report.edge_count,
+        persisted_diagnostics: 0,
+        stale_rows: 0,
+        skipped_files: [],
+        diagnostics: [],
+        cursor: { sequence: 1, partition: `code-graph:${repoId}` },
+        indexed_at: report.indexed_at ?? new Date().toISOString(),
+      };
+    },
     getGraphSnapshot: async (repoId, options) => {
       const mode = options?.mode ?? "atlas";
       const snapshot = snapshots.find((candidate) =>

--- a/packages/graph/src/code-graph.ts
+++ b/packages/graph/src/code-graph.ts
@@ -260,6 +260,7 @@ export function codeGraphReducer(state: CodeGraphState, action: CodeGraphAction)
         : state;
     case "INDEX_REPORT":
       return state.repoId === action.report.repo_id
+        && !isStaleCodeIndexReport(state.indexReport, action.report)
         ? {
             ...state,
             indexReport: action.report,
@@ -461,6 +462,31 @@ function selectCodeGraphRepo(state: CodeGraphState, repoId: string | null): Code
     layoutStatus: "idle",
     layoutError: null,
   };
+}
+
+function isStaleCodeIndexReport(
+  current: CodeIndexReport | null,
+  candidate: CodeIndexReport,
+): boolean {
+  if (!current || current.repo_id !== candidate.repo_id) return false;
+  if (current.cursor.partition !== candidate.cursor.partition) return false;
+  if (candidate.cursor.sequence < current.cursor.sequence) return true;
+  if (candidate.cursor.sequence > current.cursor.sequence) return false;
+  return codeIndexStatusRank(candidate.status) <= codeIndexStatusRank(current.status);
+}
+
+function codeIndexStatusRank(status: CodeIndexReport["status"]): number {
+  switch (status) {
+    case "accepted":
+      return 0;
+    case "progress":
+      return 1;
+    case "failed":
+    case "unavailable":
+      return 2;
+    case "completed":
+      return 3;
+  }
 }
 
 export function currentCodeGraphSnapshot(state: CodeGraphState): CodeGraphSnapshot | null {

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -29,6 +29,7 @@ export type {
   CodeFileOutline,
   CodeGraphNode,
   CodeGraphSnapshot,
+  CodeIndexReport,
   CodeRepoList,
   CodeSymbolDetail,
   MemoryBundleList,

--- a/packages/ui-core/__tests__/app-shell.test.ts
+++ b/packages/ui-core/__tests__/app-shell.test.ts
@@ -1576,6 +1576,118 @@ describe("OpenSymphonyApp mount", () => {
     }
   });
 
+  it("indexes an empty repository from the Code Graph surface and refreshes on events", async () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const transport = new LiveEventTransport({
+      baseUri: "http://127.0.0.1:2468",
+      health: capabilities,
+      snapshot: dashboard,
+      taskGraph,
+      runDetails: [runDetail],
+    });
+    const fixtureAdapter = createFixtureCodeGraphAdapter();
+    const indexedRepos = await fixtureAdapter.listRepos();
+    const emptyRepos: CodeRepoList = {
+      ...indexedRepos,
+      repos: indexedRepos.repos.map((repo) => ({
+        ...repo,
+        document_count: 0,
+        symbol_count: 0,
+        edge_count: 0,
+        freshness: "unknown" as const,
+        indexed_at: null,
+        head_revision: null,
+      })),
+    };
+    let indexed = false;
+    let indexCalls = 0;
+    const codeGraphAdapter = {
+      ...fixtureAdapter,
+      async listRepos() {
+        return indexed ? indexedRepos : emptyRepos;
+      },
+      async indexRepo(repoId: string) {
+        indexCalls += 1;
+        expect(repoId).toBe("opensymphony");
+        return {
+          schema_version: schemaVersionV1(),
+          repo_id: repoId,
+          status: "accepted" as const,
+          head_revision: "head-rev",
+          parsed_files: 0,
+          persisted_documents: 0,
+          persisted_symbols: 0,
+          persisted_edges: 0,
+          persisted_diagnostics: 0,
+          stale_rows: 0,
+          skipped_files: [],
+          diagnostics: ["index accepted"],
+          cursor: { sequence: 1, partition: "code-graph:opensymphony" },
+          indexed_at: "2026-07-13T00:00:00Z",
+        };
+      },
+    };
+    const handle = renderOpenSymphonyApp({ root, mode: "desktop", transport, codeGraphAdapter });
+
+    try {
+      await flushUntil(() => root.querySelector("[data-graph-view='code']") !== null);
+      (root.querySelector("[data-graph-view='code']") as HTMLButtonElement).click();
+      await flushUntil(() => root.querySelector("[data-testid='code-graph-index']") !== null);
+      (root.querySelector("[data-testid='code-graph-index']") as HTMLButtonElement).click();
+      await flushUntil(() => indexCalls === 1);
+      const app = handle as unknown as { state: { codeGraph: { indexing: boolean; indexReport: { status: string } | null } } };
+      await flushUntil(() => app.state.codeGraph.indexReport?.status === "accepted");
+      expect(root.querySelector("[data-testid='code-graph-index-empty']")?.textContent).toContain("Indexing repository");
+
+      transport.emit({
+        schema_version: schemaVersionV1(),
+        cursor: { sequence: 91, partition: "events" },
+        entity_ref: { kind: "repository", id: "opensymphony" },
+        event_kind: "code_index_progress",
+        emitted_at: "2026-07-13T19:10:00Z",
+        payload: {
+          schema_version: schemaVersionV1(),
+          repo_id: "opensymphony",
+          status: "progress",
+          head_revision: "head-rev",
+          parsed_files: 4,
+          persisted_documents: 4,
+          persisted_symbols: 8,
+          persisted_edges: 6,
+          persisted_diagnostics: 0,
+          stale_rows: 0,
+          skipped_files: ["src/generated.rs"],
+          diagnostics: ["one generated file skipped"],
+          cursor: { sequence: 2, partition: "code-graph:opensymphony" },
+          indexed_at: "2026-07-13T19:10:00Z",
+        },
+      });
+      await flushUntil(() => root.querySelector("[data-testid='code-graph-index-coverage']")?.textContent?.includes("4 files") ?? false);
+      indexed = true;
+      transport.emit({
+        schema_version: schemaVersionV1(),
+        cursor: { sequence: 92, partition: "events" },
+        entity_ref: { kind: "repository", id: "opensymphony" },
+        event_kind: "code_graph_updated",
+        emitted_at: "2026-07-13T19:11:00Z",
+        payload: {
+          schema_version: schemaVersionV1(),
+          repo_id: "opensymphony",
+          head_revision: "head-rev",
+          topology_delta_available: true,
+          cursor: { sequence: 3, partition: "code-graph:opensymphony" },
+          updated_at: "2026-07-13T19:11:00Z",
+        },
+      });
+      await flushUntil(() => root.querySelector("[data-testid='code-graph-canvas']") !== null);
+      expect(indexCalls).toBe(1);
+      expect(app.state.codeGraph.stale).toBe(false);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("recomputes Code Graph layout after the stage resizes", async () => {
     const root = document.createElement("div");
     document.body.appendChild(root);

--- a/packages/ui-core/__tests__/code-graph.test.ts
+++ b/packages/ui-core/__tests__/code-graph.test.ts
@@ -3,6 +3,7 @@
 import {
   codeEdgeVisualStyle,
   codeGraphFixtureSnapshots,
+  codeGraphFixtureRepos,
   codeGraphFixtureSymbolDetails,
   codeGraphFixtureDiffOverlays,
   codeGraphReducer,
@@ -26,6 +27,97 @@ import { createKnowledgeGraphViewState } from "../src/knowledge-graph-scene.js";
 
 describe("Code Graph renderer surface", () => {
   const snapshot = codeGraphFixtureSnapshots.find((candidate) => candidate.mode === "file")!;
+
+  it("renders an accessible empty-state index action with progress and retry diagnostics", () => {
+    const repo = {
+      ...codeGraphFixtureRepos.repos[0],
+      document_count: 0,
+      symbol_count: 0,
+      edge_count: 0,
+      freshness: "unknown" as const,
+      indexed_at: null,
+      head_revision: null,
+    };
+    let state = codeGraphReducer(createInitialCodeGraphState(), {
+      type: "REPOS_LOADED",
+      repos: { ...codeGraphFixtureRepos, repos: [repo] },
+    });
+    const root = document.createElement("div");
+    root.innerHTML = renderCodeGraphSurface({ snapshot: null, layout: null, state });
+    expect(root.querySelector("[data-testid='code-graph-index']")?.textContent).toContain("Index repository");
+    expect(root.querySelector("[data-testid='code-graph-index']")?.getAttribute("type")).toBe("button");
+    expect(root.querySelector("[data-testid='code-graph-index-empty']")?.textContent).toContain("Repository is not indexed");
+
+    state = codeGraphReducer(state, { type: "INDEX_STARTED", repoId: "opensymphony" });
+    root.innerHTML = renderCodeGraphSurface({ snapshot: null, layout: null, state });
+    expect(root.querySelector("[data-testid='code-graph-index']")?.hasAttribute("disabled")).toBe(true);
+    expect(root.querySelector("[data-testid='code-graph-index-empty']")?.textContent).toContain("Indexing repository");
+
+    state = codeGraphReducer(state, {
+      type: "INDEX_REPORT",
+      report: {
+        schema_version: { major: 1, minor: 0, patch: 0 },
+        repo_id: "opensymphony",
+        status: "failed",
+        head_revision: null,
+        parsed_files: 2,
+        persisted_documents: 1,
+        persisted_symbols: 3,
+        persisted_edges: 1,
+        persisted_diagnostics: 1,
+        stale_rows: 0,
+        skipped_files: ["vendor/generated.rs"],
+        diagnostics: ["parser limit reached"],
+        cursor: { sequence: 2, partition: "code-graph:opensymphony" },
+        indexed_at: "2026-07-13T00:00:00Z",
+      },
+    });
+    root.innerHTML = renderCodeGraphSurface({ snapshot: null, layout: null, state });
+    expect(root.querySelector("[data-testid='code-graph-index']")?.textContent).toContain("Retry indexing");
+    expect(root.querySelector("[data-testid='code-graph-index-diagnostics']")?.textContent).toContain("parser limit reached");
+    expect(root.querySelector("[data-testid='code-graph-index-coverage']")?.textContent).toContain("1 skipped");
+  });
+
+  it("shows revision, workspace provenance, stale, truncated, and partial coverage status", () => {
+    let state = codeGraphReducer(createInitialCodeGraphState(), {
+      type: "REPOS_LOADED",
+      repos: codeGraphFixtureRepos,
+    });
+    state = codeGraphReducer(state, { type: "SNAPSHOT_LOADED", snapshot });
+    state = codeGraphReducer(state, { type: "TARGET_SET", runId: "COE-546" });
+    state = codeGraphReducer(state, { type: "GRAPH_UPDATED", repoId: "opensymphony", updatedAt: "2026-07-13T00:00:00Z" });
+    state = codeGraphReducer(state, {
+      type: "INDEX_REPORT",
+      report: {
+        schema_version: { major: 1, minor: 0, patch: 0 },
+        repo_id: "opensymphony",
+        status: "completed",
+        head_revision: "target-revision",
+        parsed_files: 4,
+        persisted_documents: 4,
+        persisted_symbols: 8,
+        persisted_edges: 6,
+        persisted_diagnostics: 0,
+        stale_rows: 0,
+        skipped_files: ["src/generated.rs"],
+        diagnostics: [],
+        cursor: { sequence: 3, partition: "code-graph:opensymphony" },
+        indexed_at: "2026-07-13T00:00:00Z",
+      },
+    });
+    const truncated = { ...snapshot, truncation: { nodes_dropped: 2, edges_dropped: 1, reason: "bounded" } };
+    const root = document.createElement("div");
+    root.innerHTML = renderCodeGraphSurface({ snapshot: truncated, layout: null, state });
+    expect(root.querySelector("[data-testid='code-graph-target-revision']")?.textContent).toBe("target-revision");
+    expect(root.querySelector("[data-testid='code-graph-view-provenance']")?.textContent)
+      .toContain("Workspace-composed");
+    expect(root.querySelector("[data-testid='code-graph-view-provenance']")?.textContent)
+      .toContain("Stale");
+    expect(root.querySelector("[data-testid='code-graph-view-provenance']")?.textContent)
+      .toContain("Truncated");
+    expect(root.querySelector("[data-testid='code-graph-view-provenance']")?.textContent)
+      .toContain("Partial coverage");
+  });
 
   it("renders modes, structure fallback, freshness, diagnostics, and raw detail", () => {
     let state = codeGraphReducer(createInitialCodeGraphState(), { type: "SNAPSHOT_LOADED", snapshot });

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -23,6 +23,7 @@ import type {
   ModelCredentialMode,
   MemoryGraphUpdatedEvent,
   CodeGraphUpdatedEvent,
+  CodeIndexReport,
   CodeGraphNode,
   CodeGraphSnapshot,
   CodeDiffOverlay,
@@ -1134,6 +1135,34 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     return completion;
   }
 
+  private async startCodeGraphIndex(): Promise<void> {
+    const adapter = this.codeGraphAdapter;
+    const repoId = this.state.codeGraph.repoId
+      ?? this.state.codeGraph.repos?.repos[0]?.repo_id
+      ?? null;
+    if (!adapter || !repoId || this.state.codeGraph.indexing) return;
+    this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "INDEX_STARTED", repoId });
+    this.render();
+    try {
+      const report = await adapter.indexRepo(repoId);
+      if (this.destroyed) return;
+      this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "INDEX_REPORT", report });
+      this.render();
+      if (report.status === "completed") {
+        this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "REPOS_INVALIDATED" });
+        await this.loadCodeGraph();
+      }
+    } catch (error) {
+      if (this.destroyed) return;
+      this.state.codeGraph = codeGraphReducer(this.state.codeGraph, {
+        type: "INDEX_REQUEST_FAILED",
+        repoId,
+        error: errorMessage(error),
+      });
+      this.render();
+    }
+  }
+
   private async loadCodeGraphOnce(): Promise<void> {
     const navigationVersion = this.codeGraphNavigationVersion;
     let requestKey: string | null = null;
@@ -1160,6 +1189,18 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       }
       if (this.state.codeGraph.repoId !== repoId) {
         this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "REPO_SELECTED", repoId });
+      }
+      const repo = this.state.codeGraph.repos?.repos.find((candidate) => candidate.repo_id === repoId);
+      const hasIndexedBaseline = Boolean(
+        repo?.indexed_at
+          || repo?.head_revision
+          || (this.state.codeGraph.indexReport?.repo_id === repoId
+            && this.state.codeGraph.indexReport.status === "completed"),
+      );
+      if (repo && repo.document_count === 0 && !hasIndexedBaseline) {
+        this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "LAYOUT_STATUS_SET", status: "ready" });
+        this.render();
+        return;
       }
       requestKey = this.codeGraphRequestKey();
       await this.refreshCodeGraphSnapshot(repoId, requestKey, navigationVersion);
@@ -1560,6 +1601,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private async onGatewayEvent(envelope: GatewayEnvelope): Promise<void> {
     let handledMemoryGraphUpdate = false;
     let handledCodeGraphUpdate = false;
+    let handledCodeIndexStatus = false;
     if (envelope.event_kind === "memory_graph_updated") {
       if (isMemoryGraphUpdatedEvent(envelope.payload)) {
         handledMemoryGraphUpdate = true;
@@ -1597,9 +1639,20 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       }
       this.render();
     }
+    if ((envelope.event_kind === "code_index_progress" || envelope.event_kind === "code_index_failed")
+      && isCodeIndexReport(envelope.payload)) {
+      handledCodeIndexStatus = true;
+      this.state.codeGraph = codeGraphReducer(this.state.codeGraph, {
+        type: "INDEX_REPORT",
+        report: envelope.payload,
+      });
+      this.render();
+    }
     if (!handledMemoryGraphUpdate && !handledCodeGraphUpdate && !this.eventAffectsCurrentView(envelope)) {
+      if (handledCodeIndexStatus) return;
       return;
     }
+    if (handledCodeIndexStatus && !handledMemoryGraphUpdate && !handledCodeGraphUpdate) return;
     await this.requestLiveRefresh();
   }
 
@@ -4450,6 +4503,9 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         }
       });
     });
+    this.listen(this.options.root.querySelector("[data-code-index]"), "code-index", "click", () => {
+      void this.startCodeGraphIndex();
+    });
     this.options.root.querySelectorAll<HTMLElement>("[data-code-filter]").forEach((control) => {
       const eventType = control instanceof HTMLInputElement && control.type === "text" ? "input" : "change";
       this.listen(control, "code-filter", eventType, () => this.onCodeGraphFilterChange(control));
@@ -5532,6 +5588,27 @@ function isCodeGraphUpdatedEvent(value: unknown): value is CodeGraphUpdatedEvent
     && typeof candidate.updated_at === "string"
     && typeof candidate.cursor?.sequence === "number"
     && typeof candidate.cursor.partition === "string";
+}
+
+function isCodeIndexReport(value: unknown): value is CodeIndexReport {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<CodeIndexReport>;
+  const cursor = candidate.cursor as { sequence?: unknown; partition?: unknown } | undefined;
+  return typeof candidate.repo_id === "string"
+    && (candidate.status === "accepted"
+      || candidate.status === "progress"
+      || candidate.status === "completed"
+      || candidate.status === "unavailable"
+      || candidate.status === "failed")
+    && typeof candidate.parsed_files === "number"
+    && typeof candidate.persisted_documents === "number"
+    && typeof candidate.persisted_symbols === "number"
+    && typeof candidate.persisted_edges === "number"
+    && Array.isArray(candidate.skipped_files)
+    && Array.isArray(candidate.diagnostics)
+    && !!cursor
+    && typeof cursor.sequence === "number"
+    && typeof cursor.partition === "string";
 }
 
 function sameCodeGraphTopology(a: CodeGraphSnapshot, b: CodeGraphSnapshot): boolean {
@@ -7034,6 +7111,18 @@ function appShellStyles(): string {
     .os-knowledge-toolbar span { color: #667788; font-size: 12px; }
     .os-kg-reset { flex: 0 0 auto; border-color: #39708f; color: #23566f; background: #e7f1f5; font-weight: 600; }
     .os-kg-status { flex: 0 0 auto; border: 1px solid #cbd5df; border-radius: 999px; padding: 3px 8px; color: #23566f; background: #e7f1f5; font-size: 11px; }
+    .os-code-provenance { display: flex; flex-wrap: wrap; gap: 8px 16px; margin: 0; padding: 7px 9px; border: 1px solid #d8dee4; border-radius: 6px; background: #f8fafc; font-size: 11px; }
+    .os-code-provenance div { display: flex; gap: 5px; min-width: 0; }
+    .os-code-provenance dt { color: #667788; font-weight: 700; }
+    .os-code-provenance dd { margin: 0; color: #23566f; overflow-wrap: anywhere; }
+    .os-code-index-empty { display: grid; gap: 8px; padding: 18px; border: 1px dashed #cbd5df; border-radius: 8px; background: #f8fafc; }
+    .os-code-index-empty h3, .os-code-index-empty p { margin: 0; }
+    .os-code-index-empty h3 { color: #23566f; font-size: 15px; }
+    .os-code-index-empty p { color: #536170; font-size: 12px; }
+    .os-code-index-coverage { font-variant-numeric: tabular-nums; }
+    .os-code-index-diagnostics { padding: 8px 10px; border: 1px solid #fecaca; border-radius: 6px; background: #fef2f2; color: #991b1b; font-size: 12px; }
+    .os-code-index-diagnostics strong { display: block; margin-bottom: 4px; }
+    .os-code-index-diagnostics ul { margin: 0; padding-left: 18px; }
     .os-kg-status-failed { color: #991b1b; background: #fee2e2; border-color: #fecaca; }
     .os-code-filters { border: 1px solid #d8dee4; border-radius: 6px; padding: 5px 8px; background: #f8fafc; }
     .os-code-filters summary { cursor: pointer; color: #23566f; font-size: 11px; font-weight: 700; }

--- a/packages/ui-core/src/app-shell.ts
+++ b/packages/ui-core/src/app-shell.ts
@@ -24,6 +24,7 @@ import type {
   MemoryGraphUpdatedEvent,
   CodeGraphUpdatedEvent,
   CodeIndexReport,
+  CodeRepoSummary,
   CodeGraphNode,
   CodeGraphSnapshot,
   CodeDiffOverlay,
@@ -359,6 +360,7 @@ const schemaVersion = { major: 1, minor: 0, patch: 0 };
 // Two consecutive failures avoid noisy transient warnings while still surfacing stale live data.
 const liveRefreshFailureThreshold = 2;
 const liveRefreshPollIntervalMs = 5_000;
+const codeGraphIndexPollIntervalMs = 1_000;
 const defaultWorkspacePaneSizes: WorkspacePaneSizes = { left: 50, right: 50 };
 const minWorkspacePaneSizes: WorkspacePaneSizes = { left: 30, right: 30 };
 type TaskSidePane = "done" | "backlog";
@@ -411,6 +413,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
   private codeGraphLayoutSize: { width: number; height: number } | null = null;
   private codeGraphLoadInFlight: Promise<void> | null = null;
   private codeGraphLoadQueued = false;
+  private codeGraphIndexPollTimer: ReturnType<typeof setTimeout> | null = null;
   private codeGraphLayoutRun = 0;
   private codeGraphNavigationVersion = 0;
   private codeGraphView: KnowledgeGraphViewState = createKnowledgeGraphViewState();
@@ -680,6 +683,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       clearTimeout(this.completedTasksSearchTimer);
       this.completedTasksSearchTimer = null;
     }
+    this.clearCodeGraphIndexPoll();
     this.stopLiveRefreshTimer();
     this.stopEventSubscription();
     this.graphLayoutAdapter.dispose();
@@ -852,6 +856,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
 
   private resetCodeGraph(): void {
     const shouldReload = this.state.graphPaneView === "code" && !this.destroyed;
+    this.clearCodeGraphIndexPoll();
     this.state.codeGraph = createInitialCodeGraphState();
     this.codeGraphLayout = null;
     this.codeGraphLayoutSize = null;
@@ -1147,9 +1152,16 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       const report = await adapter.indexRepo(repoId);
       if (this.destroyed) return;
       this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "INDEX_REPORT", report });
-      this.render();
-      if (report.status === "completed") {
+      if (report.status === "accepted" || report.status === "progress" || report.status === "completed") {
         this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "REPOS_INVALIDATED" });
+      }
+      if (report.status === "accepted" || report.status === "progress") {
+        this.scheduleCodeGraphIndexPoll();
+      } else {
+        this.clearCodeGraphIndexPoll();
+      }
+      this.render();
+      if (report.status === "accepted" || report.status === "progress" || report.status === "completed") {
         await this.loadCodeGraph();
       }
     } catch (error) {
@@ -1159,8 +1171,51 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
         repoId,
         error: errorMessage(error),
       });
+      this.clearCodeGraphIndexPoll();
       this.render();
     }
+  }
+
+  private clearCodeGraphIndexPoll(): void {
+    if (this.codeGraphIndexPollTimer === null) return;
+    clearTimeout(this.codeGraphIndexPollTimer);
+    this.codeGraphIndexPollTimer = null;
+  }
+
+  private scheduleCodeGraphIndexPoll(): void {
+    if (this.destroyed || this.codeGraphIndexPollTimer !== null) return;
+    this.codeGraphIndexPollTimer = setTimeout(() => {
+      this.codeGraphIndexPollTimer = null;
+      void this.pollCodeGraphIndex();
+    }, codeGraphIndexPollIntervalMs);
+  }
+
+  private async pollCodeGraphIndex(): Promise<void> {
+    if (this.destroyed) return;
+    const report = this.state.codeGraph.indexReport;
+    if (!report || (report.status !== "accepted" && report.status !== "progress")) return;
+    if (this.state.graphPaneView === "code") {
+      try {
+        await this.loadCodeGraph();
+      } catch {
+        // The normal load path records UI diagnostics; keep the fallback alive
+        // so a transient repository read failure does not strand the job.
+      }
+    }
+    if (this.destroyed) return;
+    const currentReport = this.state.codeGraph.indexReport;
+    if (!currentReport || (currentReport.status !== "accepted" && currentReport.status !== "progress")) return;
+    const repo = this.state.codeGraph.repos?.repos.find((candidate) => candidate.repo_id === currentReport.repo_id);
+    if (repo && codeRepoMatchesIndexTarget(repo, currentReport)) {
+      this.state.codeGraph = codeGraphReducer(this.state.codeGraph, {
+        type: "INDEX_REPORT",
+        report: completedCodeIndexReport(currentReport, repo),
+      });
+      this.clearCodeGraphIndexPoll();
+      this.render();
+      return;
+    }
+    this.scheduleCodeGraphIndexPoll();
   }
 
   private async loadCodeGraphOnce(): Promise<void> {
@@ -1171,7 +1226,10 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       return;
     }
     try {
-      if (!this.state.codeGraph.repos) {
+      const indexIsInFlight = this.state.codeGraph.indexing
+        || this.state.codeGraph.indexReport?.status === "accepted"
+        || this.state.codeGraph.indexReport?.status === "progress";
+      if (!this.state.codeGraph.repos || indexIsInFlight) {
         const includeStale = codeGraphNeedsBroadFreshness(this.state.codeGraph.filters);
         const repos = await this.codeGraphAdapter.listRepos({
           includeStale,
@@ -1192,8 +1250,7 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
       }
       const repo = this.state.codeGraph.repos?.repos.find((candidate) => candidate.repo_id === repoId);
       const hasIndexedBaseline = Boolean(
-        repo?.indexed_at
-          || repo?.head_revision
+        (repo && codeRepoHasIndexedBaseline(repo))
           || (this.state.codeGraph.indexReport?.repo_id === repoId
             && this.state.codeGraph.indexReport.status === "completed"),
       );
@@ -1642,10 +1699,25 @@ class OpenSymphonyApp implements OpenSymphonyAppHandle {
     if ((envelope.event_kind === "code_index_progress" || envelope.event_kind === "code_index_failed")
       && isCodeIndexReport(envelope.payload)) {
       handledCodeIndexStatus = true;
+      const previousReport = this.state.codeGraph.indexReport;
+      const report = envelope.payload;
       this.state.codeGraph = codeGraphReducer(this.state.codeGraph, {
         type: "INDEX_REPORT",
-        report: envelope.payload,
+        report,
       });
+      if (this.state.codeGraph.indexReport !== previousReport) {
+        if (report.status === "accepted" || report.status === "progress") {
+          this.scheduleCodeGraphIndexPoll();
+        } else {
+          this.clearCodeGraphIndexPoll();
+          if (report.status === "completed") {
+            this.state.codeGraph = codeGraphReducer(this.state.codeGraph, { type: "REPOS_INVALIDATED" });
+            if (this.state.graphPaneView === "code") {
+              void this.loadCodeGraph();
+            }
+          }
+        }
+      }
       this.render();
     }
     if (!handledMemoryGraphUpdate && !handledCodeGraphUpdate && !this.eventAffectsCurrentView(envelope)) {
@@ -5609,6 +5681,32 @@ function isCodeIndexReport(value: unknown): value is CodeIndexReport {
     && !!cursor
     && typeof cursor.sequence === "number"
     && typeof cursor.partition === "string";
+}
+
+function codeRepoHasIndexedBaseline(repo: CodeRepoSummary): boolean {
+  return repo.indexed === true || Boolean(repo.indexed_at || repo.head_revision);
+}
+
+function codeRepoMatchesIndexTarget(repo: CodeRepoSummary, report: CodeIndexReport): boolean {
+  if (!codeRepoHasIndexedBaseline(repo)) return false;
+  return !report.head_revision
+    || !repo.head_revision
+    || repo.head_revision === report.head_revision;
+}
+
+function completedCodeIndexReport(report: CodeIndexReport, repo: CodeRepoSummary): CodeIndexReport {
+  return {
+    ...report,
+    status: "completed",
+    head_revision: repo.head_revision ?? report.head_revision,
+    parsed_files: repo.document_count,
+    persisted_documents: repo.document_count,
+    persisted_symbols: repo.symbol_count,
+    persisted_edges: repo.edge_count,
+    persisted_diagnostics: 0,
+    diagnostics: [],
+    indexed_at: repo.indexed_at ?? report.indexed_at,
+  };
 }
 
 function sameCodeGraphTopology(a: CodeGraphSnapshot, b: CodeGraphSnapshot): boolean {

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -150,7 +150,10 @@ export function renderCodeGraphSurface(surface: CodeGraphSurface): string {
       || diffOverlay?.unanalyzed_files.length,
   );
   const repositoryHasNoBaseline = !selectedRepo
-    || (selectedRepo.document_count === 0 && !selectedRepo.indexed_at && !selectedRepo.head_revision);
+    || (selectedRepo.indexed !== true
+      && selectedRepo.document_count === 0
+      && !selectedRepo.indexed_at
+      && !selectedRepo.head_revision);
   const emptySnapshot = repositoryHasNoBaseline && (!snapshot || snapshot.nodes.length === 0);
   const truncationSummary = hasTruncation
     ? ` Truncated ${formatCount(truncation.nodes_dropped)} nodes and ${formatCount(truncation.edges_dropped)} edges${truncation.reason ? `: ${truncation.reason}` : "."}`

--- a/packages/ui-core/src/knowledge-graph-renderer.ts
+++ b/packages/ui-core/src/knowledge-graph-renderer.ts
@@ -131,6 +131,8 @@ export function renderKnowledgeGraphSurface(surface: KnowledgeGraphSurface): str
 
 export function renderCodeGraphSurface(surface: CodeGraphSurface): string {
   const { snapshot, state } = surface;
+  const selectedRepo = state.repos?.repos.find((repo) => repo.repo_id === state.repoId) ?? null;
+  const indexReport = state.indexReport?.repo_id === state.repoId ? state.indexReport : null;
   const diffOverlay = state.mode === "diff" && state.diffOverlay
     ? normalizeCodeDiffOverlay(state.diffOverlay)
     : null;
@@ -143,6 +145,13 @@ export function renderCodeGraphSurface(surface: CodeGraphSurface): string {
     reason: [snapshotTruncation?.reason, diffTruncation?.reason].filter((reason): reason is string => Boolean(reason)).join("; ") || null,
   };
   const hasTruncation = truncation.nodes_dropped > 0 || truncation.edges_dropped > 0;
+  const hasPartialCoverage = Boolean(
+    indexReport?.skipped_files.length
+      || diffOverlay?.unanalyzed_files.length,
+  );
+  const repositoryHasNoBaseline = !selectedRepo
+    || (selectedRepo.document_count === 0 && !selectedRepo.indexed_at && !selectedRepo.head_revision);
+  const emptySnapshot = repositoryHasNoBaseline && (!snapshot || snapshot.nodes.length === 0);
   const truncationSummary = hasTruncation
     ? ` Truncated ${formatCount(truncation.nodes_dropped)} nodes and ${formatCount(truncation.edges_dropped)} edges${truncation.reason ? `: ${truncation.reason}` : "."}`
     : " No records were truncated.";
@@ -150,8 +159,8 @@ export function renderCodeGraphSurface(surface: CodeGraphSurface): string {
     ? `${formatCount(snapshot.nodes.length)} nodes / ${formatCount(snapshot.edges.length)} edges${hasTruncation ? ` / ${formatCount(truncation.nodes_dropped)} nodes + ${formatCount(truncation.edges_dropped)} edges truncated${truncation.reason ? `: ${truncation.reason}` : ""}` : ""}`
     : "No code graph snapshot";
   const accessibleSummary = snapshot
-    ? `Code Graph ${state.mode} mode for ${snapshot.repo_id}: ${snapshot.nodes.length} nodes and ${snapshot.edges.length} edges.${truncationSummary} ${diffOverlay ? `${diffOverlay.edge_deltas.length} topology edge changes and ${diffOverlay.module_connection_deltas.length} module connection changes. ${diffOverlay.blast_radius.reduce((count, entry) => count + entry.inbound.length + entry.outbound.length, 0)} detailed blast-radius relationships. ` : ""}${state.stale ? "Refreshing." : ""}`
-    : "Code Graph has no loaded snapshot.";
+    ? `Code Graph ${state.mode} mode for ${snapshot.repo_id}: ${snapshot.nodes.length} nodes and ${snapshot.edges.length} edges.${truncationSummary} ${diffOverlay ? `${diffOverlay.edge_deltas.length} topology edge changes and ${diffOverlay.module_connection_deltas.length} module connection changes. ${diffOverlay.blast_radius.reduce((count, entry) => count + entry.inbound.length + entry.outbound.length, 0)} detailed blast-radius relationships. ` : ""}${state.runId ? "Workspace-composed view. " : "Baseline view. "}${hasPartialCoverage ? "Partial coverage. " : ""}${state.stale ? "Refreshing." : ""}`
+    : `Code Graph has no loaded snapshot. ${state.repoId ? "Index the configured repository to begin." : "No configured repository is available."}`;
   const narrowed = state.mode !== "atlas" || state.selectedNodeIds.length > 0 || state.path !== null || state.symbolKey !== null;
   const diffUnavailable = !state.baseRevision || !state.headRevision;
   return `
@@ -163,22 +172,77 @@ export function renderCodeGraphSurface(surface: CodeGraphSurface): string {
         </div>
         <div class="os-segmented" data-testid="code-graph-mode-toggle">
           ${(["atlas", "file", "neighborhood", "diff"] as const).map((mode) =>
-            `<button type="button" class="${state.mode === mode ? "is-selected" : ""}" data-code-mode="${mode}"${mode === "diff" && diffUnavailable ? " disabled" : ""}>${mode[0].toUpperCase()}${mode.slice(1)}</button>`).join("")}
+            `<button type="button" class="${state.mode === mode ? "is-selected" : ""}" data-code-mode="${mode}"${(mode === "diff" && diffUnavailable) || emptySnapshot ? " disabled" : ""}>${mode[0].toUpperCase()}${mode.slice(1)}</button>`).join("")}
         </div>
         ${narrowed ? `<button type="button" class="os-icon-button os-kg-reset" data-code-reset data-testid="code-graph-reset">Show full graph</button>` : ""}
         <span class="os-kg-status" data-testid="code-graph-status">${escapeHtml(state.layoutStatus === "failed" ? state.layoutError ?? "Unavailable" : state.stale ? "Refreshing" : state.layoutStatus === "ready" ? "Ready" : "Idle")}</span>
       </div>
-      ${renderCodeGraphFilters(surface)}
+      ${renderCodeGraphProvenance(surface, hasTruncation, hasPartialCoverage)}
+      ${emptySnapshot ? renderCodeGraphIndexState(surface) : renderCodeGraphFilters(surface)}
       ${renderCodeBreadcrumb(state)}
-      ${renderCodeGraphTopologySummary(state)}
+      ${emptySnapshot ? "" : renderCodeGraphTopologySummary(state)}
       <p id="code-graph-screen-reader-summary" class="os-sr-only" data-testid="code-graph-screen-reader-summary" role="status" aria-live="polite">${escapeHtml(accessibleSummary)}</p>
-      <div class="os-knowledge-stage" data-kg-stage>
+      ${emptySnapshot ? "" : `<div class="os-knowledge-stage" data-kg-stage>
         <canvas class="os-knowledge-canvas os-code-graph-canvas" data-testid="code-graph-canvas" role="img" aria-label="Code Graph canvas" aria-describedby="code-graph-screen-reader-summary"></canvas>
         <div class="os-knowledge-labels" data-kg-labels data-morph-ignore-children></div>
         <span class="os-kg-controls-hint" aria-hidden="true">drag pan &middot; &#8997;-drag orbit &middot; scroll zoom &middot; double-click neighborhood &middot; esc to back out</span>
-      </div>
+      </div>`}
     </div>
   `;
+}
+
+function renderCodeGraphProvenance(
+  surface: CodeGraphSurface,
+  hasTruncation: boolean,
+  hasPartialCoverage: boolean,
+): string {
+  const { state } = surface;
+  const repo = state.repos?.repos.find((candidate) => candidate.repo_id === state.repoId);
+  const revision = state.indexReport?.head_revision
+    ?? state.headRevision
+    ?? repo?.head_revision
+    ?? "Not indexed";
+  const statuses = [
+    state.runId ? "Workspace-composed" : "Baseline",
+    state.stale ? "Stale" : null,
+    hasTruncation ? "Truncated" : null,
+    hasPartialCoverage ? "Partial coverage" : null,
+  ].filter((value): value is string => Boolean(value));
+  return `<dl class="os-code-provenance" data-testid="code-graph-provenance">
+    <div><dt>Target revision</dt><dd data-testid="code-graph-target-revision">${escapeHtml(revision)}</dd></div>
+    <div><dt>View</dt><dd data-testid="code-graph-view-provenance">${escapeHtml(statuses.join(" · "))}</dd></div>
+  </dl>`;
+}
+
+function renderCodeGraphIndexState(surface: CodeGraphSurface): string {
+  const { state } = surface;
+  const report = state.indexReport?.repo_id === state.repoId ? state.indexReport : null;
+  const repo = state.repos?.repos.find((candidate) => candidate.repo_id === state.repoId);
+  const repoLabel = repo?.display_root ?? state.repoId ?? "configured repository";
+  const running = state.indexing || report?.status === "accepted" || report?.status === "progress";
+  const failed = report?.status === "failed" || report?.status === "unavailable" || Boolean(state.indexError);
+  const coverage = report
+    ? `${report.parsed_files.toLocaleString("en-US")} files parsed · ${report.persisted_documents.toLocaleString("en-US")} documents · ${report.persisted_symbols.toLocaleString("en-US")} symbols · ${report.persisted_edges.toLocaleString("en-US")} edges`
+    : "No indexed files yet";
+  const diagnostics = [...new Set([
+    ...(state.indexError ? [state.indexError] : []),
+    ...(report?.diagnostics ?? []),
+  ])];
+  const skipped = report?.skipped_files ?? [];
+  const status = running
+    ? "Indexing repository…"
+    : failed
+      ? "Indexing failed"
+      : report?.status === "completed"
+        ? skipped.length > 0 ? "Indexed with partial coverage" : "Index complete; refresh the graph"
+        : "Repository is not indexed";
+  return `<section class="os-code-index-empty" data-testid="code-graph-index-empty" aria-labelledby="code-graph-index-title">
+    <h3 id="code-graph-index-title">${escapeHtml(status)}</h3>
+    <p>Build the target-branch Code Graph for <strong>${escapeHtml(repoLabel)}</strong>.</p>
+    <p class="os-code-index-coverage" data-testid="code-graph-index-coverage">${escapeHtml(coverage)}${skipped.length > 0 ? ` · ${skipped.length.toLocaleString("en-US")} skipped` : ""}</p>
+    ${diagnostics.length > 0 ? `<div class="os-code-index-diagnostics" role="alert"><strong>Diagnostics</strong><ul data-testid="code-graph-index-diagnostics">${diagnostics.map((diagnostic) => `<li>${escapeHtml(diagnostic)}</li>`).join("")}</ul></div>` : ""}
+    <button type="button" data-code-index data-testid="code-graph-index"${running ? " disabled aria-busy=\"true\"" : ""}>${failed ? "Retry indexing" : "Index repository"}</button>
+  </section>`;
 }
 
 export function renderCodeGraphFilters(surface: CodeGraphSurface): string {


### PR DESCRIPTION
## Summary

Adds the product-facing Code Graph bootstrap flow from an empty DuckDB through indexed baseline, dirty workspace overlays, topology deltas, and a packaged desktop build.

## Changes

- Add `indexRepo` to the shared Code Graph adapter with fixture, HTTP, and Tauri-native implementations.
- Expose configured repositories from an empty read model and render index/progress/coverage/failure/retry/provenance states with event refresh.
- Add deterministic gateway E2E coverage plus web/desktop adapter, UI, production-build, and release documentation.

## Evidence

### Test output

```text
cargo test --quiet
847 unit tests passed; all integration suites passed.

cargo test-system-duckdb --test gateway
72 passed

cargo test-system-duckdb --test memory
46 passed

Focused Jest suites
4 suites, 146 tests passed

apps/desktop/__tests__/build-smoke.test.ts
2 tests passed

npm run package:release --workspace=@opensymphony/desktop -- --dry-run
version 2.9.5; platform macos; architecture aarch64

npm run package:release --workspace=@opensymphony/desktop
Wrote opensymphony-desktop-v2.9.5-macos-aarch64.tar.gz
```

### Verification

The new gateway E2E starts with an empty DuckDB and a target-branch fixture repository, indexes it through the production route, observes progress/completion journal events, verifies baseline `code.graph.context`, edits a workspace to add a cross-module call, and verifies workspace provenance, changed symbols, an added topology edge, and an added module connection.

The shared shell tests cover the keyboard-accessible empty-state action, disabled progress state, skipped-file coverage, retry diagnostics, stale/truncated/partial provenance, and `code_graph_updated` refresh. The real desktop archive manifest was checked against the streamed executable SHA-256. The production desktop bundle smoke asserts the shared app shell is present and the old placeholder strings are absent.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Breaking changes

None. The shared adapter gains a required `indexRepo` operation, implemented by all production and fixture adapters.

## Related issues

- Linear: https://linear.app/trilogy-ai-coe/issue/COE-546/code-graph-bootstrap-ux-and-end-to-end-validation

## Additional notes

The desktop release metadata remains at 2.9.5 across workspace, npm lockfile, Tauri Cargo metadata, and Tauri configuration. The frontend builds emit existing Vite chunk-size and browser `crypto` externalization warnings only.
