### PR TITLE
Add parent execution roots and shared child worktrees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ uuid.workspace = true
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
 [workspace.package]
 edition = "2024"
 license = "MIT"

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -14117,6 +14117,7 @@ Public memory concept.
             workspace_path: workspace.clone(),
             repository_binding: None,
             runtime_envelope: Some(runtime_envelope),
+            parent_runtime_envelope: None,
             attempt: 2,
             normal_retry_count: 0,
             pending_retry: false,

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -2,6 +2,7 @@
 
 use futures_util::{StreamExt, stream};
 use serde::de::DeserializeOwned;
+use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     env, io,
@@ -48,9 +49,10 @@ use crate::opensymphony_orchestrator::{
 use crate::opensymphony_workflow::{Environment, ProcessEnvironment, ResolvedWorkflow};
 use crate::opensymphony_workspace::{
     CheckoutRepository, CleanupConfig, HookConfig, HookDefinition, IssueDescriptor,
-    IssueLifecycleState, RunDescriptor, RunManifest, RunStatus, TerminalRuntimeEnvelope,
-    WorkspaceError, WorkspaceHandle, WorkspaceManager, WorkspaceManagerConfig,
-    checkout_credential_environment_variables, compose_terminal_prompt,
+    IssueLifecycleState, ParentCheckoutRequest, ParentRuntimeDescriptor, ParentRuntimeEnvelope,
+    RunDescriptor, RunManifest, RunStatus, TerminalRuntimeEnvelope, WorkspaceError,
+    WorkspaceHandle, WorkspaceManager, WorkspaceManagerConfig,
+    checkout_credential_environment_variables, compose_parent_prompt, compose_terminal_prompt,
     environment_variable_names_equal,
 };
 use async_trait::async_trait;
@@ -66,8 +68,9 @@ use tokio::{
 use url::Url;
 
 use super::{
-    RunCommandError, RuntimeMemoryEnv, config::RunRuntimeConfig, datetime_to_timestamp_ms,
-    now_timestamp, timestamp_to_datetime,
+    RunCommandError, RuntimeMemoryEnv,
+    config::{ResolvedIntegrationInstructions, RunRuntimeConfig},
+    datetime_to_timestamp_ms, now_timestamp, timestamp_to_datetime,
 };
 
 const DEFAULT_WORKER_LAUNCH_TIMEOUT: Duration = Duration::from_secs(60);
@@ -187,6 +190,7 @@ pub(super) struct RuntimeWorkerBackend {
     workpad_comment_source: Option<Arc<dyn WorkpadCommentSource>>,
     worker_env: BTreeMap<String, String>,
     checkout_credential_envs: BTreeSet<String>,
+    integration_instructions: Option<ResolvedIntegrationInstructions>,
     codex_bin: String,
     codex_schema_validators: CodexSchemaValidatorCache,
     codex_interrupts: CodexInterruptRegistry,
@@ -2353,6 +2357,99 @@ impl GitHubRepository {
     }
 }
 
+fn parent_checkout_requests(
+    state: &DurableOrchestratorState,
+    parent_id: &IssueId,
+    snapshot: &HierarchySnapshot,
+) -> Result<Vec<ParentCheckoutRequest>, CliWorkspaceError> {
+    let resources = state.descendant_resources_for(parent_id);
+    for edge in snapshot
+        .required_child_edges
+        .iter()
+        .filter(|edge| edge.required)
+    {
+        let mut subtree = BTreeSet::from([edge.child_id.clone()]);
+        let mut pending = vec![edge.child_id.clone()];
+        while let Some(issue_id) = pending.pop() {
+            if let Some(child_snapshot) = state.hierarchy.get(&issue_id) {
+                for child in child_snapshot
+                    .required_child_edges
+                    .iter()
+                    .filter(|child| child.required)
+                {
+                    if subtree.insert(child.child_id.clone()) {
+                        pending.push(child.child_id.clone());
+                    }
+                }
+            }
+        }
+        if !resources
+            .iter()
+            .any(|resource| subtree.contains(&resource.issue_id))
+        {
+            return Err(CliWorkspaceError::RetryState(format!(
+                "required child {} has no active generation-bound ancestor lease",
+                edge.child_identifier
+            )));
+        }
+    }
+    let repository_ids = resources
+        .iter()
+        .map(|resource| resource.repository_id.clone())
+        .collect::<BTreeSet<_>>();
+    if snapshot
+        .dispatch_required_merge_commits
+        .iter()
+        .any(|commit| commit.repository_id.is_none())
+        && repository_ids.len() != 1
+    {
+        return Err(CliWorkspaceError::RetryState(
+            "repository-neutral merge evidence is ambiguous for a multi-repository parent"
+                .to_owned(),
+        ));
+    }
+    let owner = crate::opensymphony_orchestrator::LeaseOwner::ancestor(parent_id);
+    resources
+        .into_iter()
+        .map(|resource| {
+            let lease = state
+                .leases
+                .iter()
+                .find(|lease| {
+                    lease.active()
+                        && lease.owner == owner
+                        && lease.hierarchy_generation == snapshot.generation
+                        && lease.resource == resource
+                })
+                .ok_or_else(|| {
+                    CliWorkspaceError::RetryState(format!(
+                        "parent checkout {} has no active ancestor lease",
+                        resource.checkout_generation
+                    ))
+                })?;
+            let required_merge_commits = snapshot
+                .dispatch_required_merge_commits
+                .iter()
+                .filter(|commit| {
+                    commit
+                        .repository_id
+                        .as_ref()
+                        .is_some_and(|repository_id| repository_id == &resource.repository_id)
+                        || (commit.repository_id.is_none() && repository_ids.len() == 1)
+                })
+                .map(|commit| commit.commit.clone())
+                .collect();
+            Ok(ParentCheckoutRequest {
+                issue_id: resource.issue_id.to_string(),
+                repository_id: resource.repository_id.to_string(),
+                checkout_generation: resource.checkout_generation,
+                lease_owner: lease.owner.id.clone(),
+                required_merge_commits,
+            })
+        })
+        .collect()
+}
+
 impl RuntimeWorkspaceBackend {
     #[cfg(test)]
     pub(super) fn new(manager: Arc<WorkspaceManager>, workflow: &ResolvedWorkflow) -> Self {
@@ -2652,6 +2749,52 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         issue: &NormalizedIssue,
         _observed_at: TimestampMs,
     ) -> Result<crate::opensymphony_domain::WorkspaceRecord, Self::Error> {
+        if !issue.sub_issues.is_empty() {
+            let raw = self
+                .manager
+                .load_orchestrator_state::<serde_json::Value>()
+                .await?
+                .ok_or_else(|| {
+                    CliWorkspaceError::RetryState(
+                        "parent preparation requires durable hierarchy state".to_owned(),
+                    )
+                })?;
+            let state: DurableOrchestratorState = serde_json::from_value(raw).map_err(|error| {
+                CliWorkspaceError::RetryState(format!(
+                    "invalid durable hierarchy state during parent preparation: {error}"
+                ))
+            })?;
+            state.validate().map_err(CliWorkspaceError::RetryState)?;
+            let snapshot = state.hierarchy.get(&issue.id).ok_or_else(|| {
+                CliWorkspaceError::RetryState(
+                    "parent preparation requires a pinned hierarchy snapshot".to_owned(),
+                )
+            })?;
+            if !snapshot.dispatch_intended() {
+                return Err(CliWorkspaceError::RetryState(
+                    "parent preparation requires a persisted dispatch intent".to_owned(),
+                ));
+            }
+            let requests = parent_checkout_requests(&state, &issue.id, snapshot)?;
+            let parent = self
+                .manager
+                .prepare_parent_execution_root(
+                    &issue_descriptor(issue),
+                    snapshot.generation,
+                    requests,
+                )
+                .await?;
+            self.terminal_cleanup_paths
+                .remove(parent.handle.workspace_path());
+            return Ok(crate::opensymphony_domain::WorkspaceRecord {
+                path: parent.handle.workspace_path().to_path_buf(),
+                workspace_key: WorkspaceKey::new(parent.handle.workspace_key().to_owned())?,
+                created_now: parent.created,
+                created_at: Some(datetime_to_timestamp_ms(parent.manifest.created_at)),
+                updated_at: Some(datetime_to_timestamp_ms(parent.manifest.updated_at)),
+                last_seen_tracker_refresh_at: issue.updated_at,
+            });
+        }
         let ensured = self
             .manager
             .ensure_with_checkout_timeout(&issue_descriptor(issue), DEFAULT_WORKER_LAUNCH_TIMEOUT)
@@ -3634,6 +3777,7 @@ impl RuntimeWorkerBackend {
             workpad_comment_source,
             worker_env,
             checkout_credential_envs: BTreeSet::new(),
+            integration_instructions: None,
             codex_bin: env::var("OPENSYMPHONY_CODEX_BIN").unwrap_or_else(|_| "codex".into()),
             codex_schema_validators: Arc::new(AsyncMutex::new(HashMap::new())),
             codex_interrupts: Arc::new(Mutex::new(HashMap::new())),
@@ -3647,6 +3791,14 @@ impl RuntimeWorkerBackend {
 
     pub(super) fn with_checkout_credential_envs(mut self, variables: BTreeSet<String>) -> Self {
         self.checkout_credential_envs = variables;
+        self
+    }
+
+    pub(super) fn with_integration_instructions(
+        mut self,
+        instructions: Option<ResolvedIntegrationInstructions>,
+    ) -> Self {
+        self.integration_instructions = instructions;
         self
     }
 
@@ -3719,6 +3871,7 @@ impl RuntimeWorkerBackend {
         let memory_env = self.memory_env.clone();
         let workpad_comment_source = self.workpad_comment_source.clone();
         let workspace_manager = self.workspace_manager.clone();
+        let integration_instructions = self.integration_instructions.clone();
         let openhands_conversation_store = self.openhands_conversation_store.clone();
         let workflow = self.workflow.clone();
         let updates_tx = self.updates_tx.clone();
@@ -3751,17 +3904,62 @@ impl RuntimeWorkerBackend {
                 workspace_issue.repository_binding =
                     Some(RepositoryBindingOutcome::Resolved(binding));
             }
-            let ensured = match workspace_manager
-                .ensure_with_run_id(&workspace_issue, Some(&run_id))
-                .await
-            {
-                Ok(ensured) => ensured,
-                Err(error) => {
-                    report_launch_failure(
-                        &mut launch_tx,
-                        format!("failed to ensure workspace: {error}"),
-                    );
-                    return;
+            let (ensured, parent_execution) = if issue.sub_issues.is_empty() {
+                match workspace_manager
+                    .ensure_with_run_id(&workspace_issue, Some(&run_id))
+                    .await
+                {
+                    Ok(ensured) => (ensured, None),
+                    Err(error) => {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            format!("failed to ensure workspace: {error}"),
+                        );
+                        return;
+                    }
+                }
+            } else {
+                match workspace_manager
+                    .open_parent_execution_root_at(&workspace_issue, &run.workspace_path)
+                    .await
+                {
+                    Ok(parent) => {
+                        let issue_manifest =
+                            match workspace_manager.load_issue_manifest(&parent.handle).await {
+                                Ok(Some(manifest)) => manifest,
+                                Ok(None) => {
+                                    report_launch_failure(
+                                        &mut launch_tx,
+                                        "parent execution root is missing its issue manifest"
+                                            .to_owned(),
+                                    );
+                                    return;
+                                }
+                                Err(error) => {
+                                    report_launch_failure(
+                                        &mut launch_tx,
+                                        format!("failed to load parent issue manifest: {error}"),
+                                    );
+                                    return;
+                                }
+                            };
+                        (
+                            crate::opensymphony_workspace::EnsureWorkspaceResult {
+                                handle: parent.handle.clone(),
+                                issue_manifest,
+                                created: false,
+                                after_create: None,
+                            },
+                            Some(parent),
+                        )
+                    }
+                    Err(error) => {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            format!("failed to open parent execution root: {error}"),
+                        );
+                        return;
+                    }
                 }
             };
             let scheduler_workspace_path = match fs::canonicalize(&run.workspace_path).await {
@@ -3850,16 +4048,34 @@ impl RuntimeWorkerBackend {
             let persisted_conversation_binding = recovered_conversation
                 .as_ref()
                 .filter(|_| !switching_harness)
-                .and_then(|manifest| manifest.runtime_envelope.as_ref())
-                .and_then(|envelope| envelope.conversation_binding.clone())
+                .and_then(|manifest| {
+                    manifest
+                        .runtime_envelope
+                        .as_ref()
+                        .and_then(|envelope| envelope.conversation_binding.clone())
+                        .or_else(|| {
+                            manifest
+                                .parent_runtime_envelope
+                                .as_ref()
+                                .and_then(|envelope| envelope.conversation_binding.clone())
+                        })
+                })
                 .or_else(|| {
                     if switching_harness {
                         None
                     } else {
-                        prior_run_manifest
-                            .as_ref()
-                            .and_then(|manifest| manifest.runtime_envelope.as_ref())
-                            .and_then(|envelope| envelope.conversation_binding.clone())
+                        prior_run_manifest.as_ref().and_then(|manifest| {
+                            manifest
+                                .runtime_envelope
+                                .as_ref()
+                                .and_then(|envelope| envelope.conversation_binding.clone())
+                                .or_else(|| {
+                                    manifest
+                                        .parent_runtime_envelope
+                                        .as_ref()
+                                        .and_then(|envelope| envelope.conversation_binding.clone())
+                                })
+                        })
                     }
                 });
             let attempt = run.attempt.map(|attempt| attempt.get()).unwrap_or(1);
@@ -3918,7 +4134,7 @@ impl RuntimeWorkerBackend {
                             }),
                             requested_execution_scope: "single_checkout".to_owned(),
                             effective_containment: "trusted_host_process_cwd".to_owned(),
-                            conversation_binding: persisted_conversation_binding,
+                            conversation_binding: persisted_conversation_binding.clone(),
                             cleanup_intent: "workspace_manager_owned".to_owned(),
                         })
                     }
@@ -3933,62 +4149,143 @@ impl RuntimeWorkerBackend {
             } else {
                 None
             };
-            let mut memory_grant_requires_fresh_conversation = false;
-            let worker_memory_env = memory_env.as_ref().map(|memory| {
-                let mut scoped = memory.clone();
-                scoped.project = worker_memory_project(&issue, &memory.project);
-                scoped.execution_repo = runtime_envelope
-                    .as_ref()
-                    .map(|envelope| envelope.repository_binding.repository.id.to_string())
-                    .unwrap_or_else(|| memory.execution_repo.clone());
-                scoped.run_id = runtime_envelope
-                    .as_ref()
-                    .map(|envelope| envelope.run_id.clone());
-                scoped.attempt = runtime_envelope.as_ref().map(|envelope| envelope.attempt);
-                scoped.target_commit = runtime_envelope
-                    .as_ref()
-                    .map(|envelope| envelope.target_commit.clone());
-                scoped.checkout_head = initially_verified_checkout
-                    .as_ref()
-                    .map(|checkout| checkout.head.clone());
-                let authorized_repositories = scoped
-                    .authorized_repositories_by_project
-                    .get(&scoped.project)
-                    .cloned()
-                    .or_else(|| {
-                        scoped
-                            .authorized_repositories_by_project
-                            .iter()
-                            .find(|(project, _)| project.eq_ignore_ascii_case(&scoped.project))
-                            .map(|(_, repositories)| repositories.clone())
-                    })
-                    .filter(|repositories| !repositories.is_empty())
-                    .unwrap_or_else(|| BTreeSet::from([scoped.execution_repo.clone()]));
-                scoped.authorized_repositories = authorized_repositories.clone();
-                if let Some(grants) = &scoped.scope_grants {
-                    let (token, requires_fresh_conversation) =
-                        grants.issue_or_refresh_with_claims(MemoryScopeGrant {
-                            project: scoped.project.clone(),
-                            project_set: scoped.project_set.clone(),
-                            execution_repo: scoped.execution_repo.clone(),
-                            authorized_repositories,
-                            issue: issue.identifier.to_string(),
-                            run_id: scoped.run_id.clone(),
-                            attempt: scoped.attempt,
-                            checkout_generation: runtime_envelope
-                                .as_ref()
-                                .map(|envelope| envelope.checkout_generation.clone()),
-                            target_commit: scoped.target_commit.clone(),
-                            checkout_head: scoped.checkout_head.clone(),
-                            visibility: scoped.visibility,
-                            capabilities: BTreeSet::new(),
-                        });
-                    memory_grant_requires_fresh_conversation = requires_fresh_conversation;
-                    scoped.token = Some(token.clone());
+            let (parent_runtime_envelope, parent_integration_instructions) = if let Some(parent) =
+                parent_execution.as_ref()
+            {
+                let integration_content = match integration_instructions.as_ref() {
+                    Some(instructions) => match fs::read(&instructions.path).await {
+                        Ok(content) => {
+                            let mut hasher = Sha256::new();
+                            hasher.update(&content);
+                            let actual = format!("sha256:{:x}", hasher.finalize());
+                            if actual != instructions.content_hash {
+                                report_launch_failure(
+                                        &mut launch_tx,
+                                        "project-set integration instructions changed after configuration was resolved"
+                                            .to_owned(),
+                                    );
+                                return;
+                            }
+                            Some(String::from_utf8_lossy(&content).into_owned())
+                        }
+                        Err(error) => {
+                            report_launch_failure(
+                                &mut launch_tx,
+                                format!(
+                                    "failed to read project-set integration instructions: {error}"
+                                ),
+                            );
+                            return;
+                        }
+                    },
+                    None => None,
+                };
+                let mut envelope = workspace_manager.parent_runtime_envelope(
+                    parent,
+                    ParentRuntimeDescriptor {
+                        run_id: run_id.clone(),
+                        attempt,
+                        integration_instruction: integration_instructions.as_ref().map(
+                            |instructions| {
+                                (instructions.path.clone(), instructions.content_hash.clone())
+                            },
+                        ),
+                        harness: route.harness_kind.clone(),
+                        model_profile: route
+                            .model_profile
+                            .clone()
+                            .unwrap_or_else(|| "default".to_owned()),
+                        model: route.model.clone().or_else(|| {
+                            if route.harness_kind == OPENHANDS_AGENT_SERVER_KIND {
+                                workflow
+                                    .extensions
+                                    .openhands
+                                    .conversation
+                                    .agent
+                                    .llm
+                                    .as_ref()
+                                    .and_then(|llm| llm.model.clone())
+                            } else {
+                                None
+                            }
+                        }),
+                        effective_containment: "trusted_host".to_owned(),
+                    },
+                );
+                envelope.conversation_binding = persisted_conversation_binding.clone();
+                if let Err(error) = workspace_manager
+                    .write_parent_runtime_envelope(parent, &envelope)
+                    .await
+                {
+                    report_launch_failure(
+                        &mut launch_tx,
+                        format!("failed to persist parent runtime envelope: {error}"),
+                    );
+                    return;
                 }
-                scoped.authorized_repositories_by_project.clear();
-                scoped
-            });
+                (Some(envelope), integration_content)
+            } else {
+                (None, None)
+            };
+            let mut memory_grant_requires_fresh_conversation = false;
+            let worker_memory_env = memory_env
+                .as_ref()
+                .filter(|_| parent_execution.is_none())
+                .map(|memory| {
+                    let mut scoped = memory.clone();
+                    scoped.project = worker_memory_project(&issue, &memory.project);
+                    scoped.execution_repo = runtime_envelope
+                        .as_ref()
+                        .map(|envelope| envelope.repository_binding.repository.id.to_string())
+                        .unwrap_or_else(|| memory.execution_repo.clone());
+                    scoped.run_id = runtime_envelope
+                        .as_ref()
+                        .map(|envelope| envelope.run_id.clone());
+                    scoped.attempt = runtime_envelope.as_ref().map(|envelope| envelope.attempt);
+                    scoped.target_commit = runtime_envelope
+                        .as_ref()
+                        .map(|envelope| envelope.target_commit.clone());
+                    scoped.checkout_head = initially_verified_checkout
+                        .as_ref()
+                        .map(|checkout| checkout.head.clone());
+                    let authorized_repositories = scoped
+                        .authorized_repositories_by_project
+                        .get(&scoped.project)
+                        .cloned()
+                        .or_else(|| {
+                            scoped
+                                .authorized_repositories_by_project
+                                .iter()
+                                .find(|(project, _)| project.eq_ignore_ascii_case(&scoped.project))
+                                .map(|(_, repositories)| repositories.clone())
+                        })
+                        .filter(|repositories| !repositories.is_empty())
+                        .unwrap_or_else(|| BTreeSet::from([scoped.execution_repo.clone()]));
+                    scoped.authorized_repositories = authorized_repositories.clone();
+                    if let Some(grants) = &scoped.scope_grants {
+                        let (token, requires_fresh_conversation) = grants
+                            .issue_or_refresh_with_claims(MemoryScopeGrant {
+                                project: scoped.project.clone(),
+                                project_set: scoped.project_set.clone(),
+                                execution_repo: scoped.execution_repo.clone(),
+                                authorized_repositories,
+                                issue: issue.identifier.to_string(),
+                                run_id: scoped.run_id.clone(),
+                                attempt: scoped.attempt,
+                                checkout_generation: runtime_envelope
+                                    .as_ref()
+                                    .map(|envelope| envelope.checkout_generation.clone()),
+                                target_commit: scoped.target_commit.clone(),
+                                checkout_head: scoped.checkout_head.clone(),
+                                visibility: scoped.visibility,
+                                capabilities: BTreeSet::new(),
+                            });
+                        memory_grant_requires_fresh_conversation = requires_fresh_conversation;
+                        scoped.token = Some(token.clone());
+                    }
+                    scoped.authorized_repositories_by_project.clear();
+                    scoped
+                });
             let memory_grant_requires_fresh_conversation = memory_grant_requires_fresh_conversation
                 || (memory_grant_registry_recovered
                     && worker_memory_env
@@ -4049,10 +4346,27 @@ impl RuntimeWorkerBackend {
             } else {
                 None
             };
-            let terminal_prompt = if let Some(checkout) = runtime_envelope.as_ref() {
-                let central_procedure = match workflow
-                    .render_prompt(&issue, run.attempt.map(|attempt| attempt.get()))
+            let parent_repository_instructions = if let Some(parent) = parent_execution.as_ref() {
+                match workspace_manager
+                    .parent_repository_instructions(parent)
+                    .await
                 {
+                    Ok(instructions) => instructions,
+                    Err(error) => {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            format!("failed to load parent repository instructions: {error}"),
+                        );
+                        return;
+                    }
+                }
+            } else {
+                BTreeMap::new()
+            };
+            let central_procedure =
+                || workflow.render_prompt(&issue, run.attempt.map(|attempt| attempt.get()));
+            let terminal_prompt = if let Some(checkout) = runtime_envelope.as_ref() {
+                let central_procedure = match central_procedure() {
                     Ok(prompt) => prompt,
                     Err(error) => {
                         report_launch_failure(
@@ -4094,6 +4408,34 @@ impl RuntimeWorkerBackend {
                         checkout.effective_containment
                     ),
                 ))
+            } else if let Some(parent_envelope) = parent_runtime_envelope.as_ref() {
+                let central_procedure = match central_procedure() {
+                    Ok(prompt) => prompt,
+                    Err(error) => {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            format!("failed to render workflow prompt: {error}"),
+                        );
+                        return;
+                    }
+                };
+                Some(compose_parent_prompt(
+                    &central_procedure,
+                    &format!(
+                        "Issue: {}\nTitle: {}\nAttempt: {}\nAcceptance and task description:\n{}",
+                        issue.identifier,
+                        issue.title,
+                        attempt,
+                        issue
+                            .description
+                            .as_deref()
+                            .filter(|description| !description.trim().is_empty())
+                            .unwrap_or("No tracker description provided."),
+                    ),
+                    parent_envelope,
+                    parent_integration_instructions.as_deref(),
+                    &parent_repository_instructions,
+                ))
             } else {
                 None
             };
@@ -4101,7 +4443,8 @@ impl RuntimeWorkerBackend {
             let run_descriptor = RunDescriptor::new(run_id, attempt)
                 .with_normal_retry_count(run.normal_retry_count)
                 .with_repository_binding(run.repository_binding.clone())
-                .with_runtime_envelope(runtime_envelope.clone());
+                .with_runtime_envelope(runtime_envelope.clone())
+                .with_parent_runtime_envelope(parent_runtime_envelope.clone());
             let mut initialize_fresh_conversation = false;
             let mut run_manifest = if recovered {
                 match workspace_manager.load_run_manifest(&ensured.handle).await {
@@ -5226,6 +5569,7 @@ async fn try_run_codex_stdio_issue(
                 &conversation_id,
                 route,
                 run_manifest.runtime_envelope.clone(),
+                run_manifest.parent_runtime_envelope.clone(),
             )
             .await
             {
@@ -5277,8 +5621,9 @@ async fn try_run_codex_stdio_issue(
                     ));
                 }
             };
-            if manifest.runtime_envelope.is_some() {
+            if manifest.runtime_envelope.is_some() || manifest.parent_runtime_envelope.is_some() {
                 run_manifest.runtime_envelope = manifest.runtime_envelope.clone();
+                run_manifest.parent_runtime_envelope = manifest.parent_runtime_envelope.clone();
                 workspace_manager
                     .write_run_manifest(workspace, run_manifest)
                     .await
@@ -6744,6 +7089,7 @@ async fn write_codex_conversation_manifest(
     thread_id: &str,
     route: &crate::opensymphony_orchestrator::HarnessRouteDecision,
     runtime_envelope: Option<TerminalRuntimeEnvelope>,
+    parent_runtime_envelope: Option<ParentRuntimeEnvelope>,
 ) -> Result<IssueConversationManifest, String> {
     let now = chrono::Utc::now();
     let conversation_id = ConversationId::new(thread_id.to_string())
@@ -6769,6 +7115,7 @@ async fn write_codex_conversation_manifest(
         reset_reason: None,
         runtime_contract_version: Some(CODEX_APP_SERVER_CONTRACT.to_string()),
         runtime_envelope,
+        parent_runtime_envelope,
         codex_archive_state: Some("active".to_string()),
         last_turn_id: None,
         active_run_id: None,
@@ -6788,6 +7135,9 @@ async fn write_codex_conversation_manifest(
         last_token_accumulation_at: None,
     };
     if let Some(envelope) = manifest.runtime_envelope.as_mut() {
+        envelope.conversation_binding = Some(manifest.conversation_id.to_string());
+    }
+    if let Some(envelope) = manifest.parent_runtime_envelope.as_mut() {
         envelope.conversation_binding = Some(manifest.conversation_id.to_string());
     }
     workspace_manager
@@ -7442,9 +7792,13 @@ mod tests {
     };
 
     use crate::opensymphony_domain::{
-        ConversationId, HarnessInterruptCommand, HarnessInterruptExpectedNextState,
-        HarnessInterruptReason, IssueId, IssueIdentifier, IssueState, IssueStateCategory,
-        RetryAttempt, RunAttempt, TrackerIssueStateKind, WorkerId, WorkspaceKey,
+        CanonicalRepositoryId, ConversationId, HarnessInterruptCommand,
+        HarnessInterruptExpectedNextState, HarnessInterruptReason, IssueId, IssueIdentifier,
+        IssueState, IssueStateCategory, RetryAttempt, RunAttempt, TrackerIssueStateKind, WorkerId,
+        WorkspaceKey,
+    };
+    use crate::opensymphony_orchestrator::{
+        HierarchyChildEdge, LeaseKind, LeaseOwner, LeaseRecord,
     };
     use crate::opensymphony_workflow::WorkflowDefinition;
     use tempfile::TempDir;
@@ -7460,6 +7814,106 @@ mod tests {
             None
         );
         assert!(parse_superseded_harness_manifests("{not-json").is_err());
+    }
+
+    #[test]
+    fn parent_checkout_requests_require_generation_bound_leases_and_scoped_merges() {
+        let parent_id = IssueId::new("parent-id").expect("parent id");
+        let child_a = IssueId::new("child-a").expect("child id");
+        let child_b = IssueId::new("child-b").expect("child id");
+        let repository_a = CanonicalRepositoryId::new("github:repository:a").expect("repo id");
+        let repository_b = CanonicalRepositoryId::new("github:repository:b").expect("repo id");
+        let mut snapshot = HierarchySnapshot {
+            parent_id: parent_id.clone(),
+            generation: 7,
+            required_child_edges: vec![
+                HierarchyChildEdge {
+                    child_id: child_a.clone(),
+                    child_identifier: IssueIdentifier::new("COE-A").expect("identifier"),
+                    required: true,
+                },
+                HierarchyChildEdge {
+                    child_id: child_b.clone(),
+                    child_identifier: IssueIdentifier::new("COE-B").expect("identifier"),
+                    required: true,
+                },
+            ],
+            frozen: true,
+            blocked_reason: None,
+            eligibility_blocked_reason: None,
+            dispatched_generation: None,
+            dispatch_intent_generation: Some(7),
+            in_flight_generation: None,
+            dispatch_required_merge_commits: vec![
+                RequiredMergeCommit {
+                    repository_id: Some(repository_a.clone()),
+                    commit: "merge-a".to_owned(),
+                },
+                RequiredMergeCommit {
+                    repository_id: Some(repository_b.clone()),
+                    commit: "merge-b".to_owned(),
+                },
+            ],
+        };
+        let owner = LeaseOwner::ancestor(&parent_id);
+        let resources = [
+            LeaseResource {
+                issue_id: child_a,
+                repository_id: repository_a,
+                checkout_generation: "generation-a".to_owned(),
+            },
+            LeaseResource {
+                issue_id: child_b,
+                repository_id: repository_b,
+                checkout_generation: "generation-b".to_owned(),
+            },
+        ];
+        let mut state = DurableOrchestratorState::default();
+        state.hierarchy.insert(parent_id.clone(), snapshot.clone());
+        state.leases = resources
+            .iter()
+            .cloned()
+            .map(|resource| LeaseRecord {
+                kind: LeaseKind::AncestorIntegration,
+                resource,
+                owner: owner.clone(),
+                hierarchy_generation: 7,
+                acquired_at: 1,
+                expires_at: None,
+                released_at: None,
+            })
+            .collect();
+
+        let requests = parent_checkout_requests(&state, &parent_id, &snapshot)
+            .expect("leased requests should resolve");
+        assert_eq!(requests.len(), 2);
+        assert!(requests.iter().any(|request| {
+            request.checkout_generation == "generation-a"
+                && request.required_merge_commits == ["merge-a"]
+        }));
+        state.leases.pop();
+        assert!(matches!(
+            parent_checkout_requests(&state, &parent_id, &snapshot),
+            Err(CliWorkspaceError::RetryState(reason)) if reason.contains("no active generation-bound ancestor lease")
+        ));
+
+        state.leases.push(LeaseRecord {
+            kind: LeaseKind::AncestorIntegration,
+            resource: resources[1].clone(),
+            owner,
+            hierarchy_generation: 7,
+            acquired_at: 1,
+            expires_at: None,
+            released_at: None,
+        });
+        snapshot.dispatch_required_merge_commits = vec![RequiredMergeCommit {
+            repository_id: None,
+            commit: "ambiguous-merge".to_owned(),
+        }];
+        assert!(matches!(
+            parent_checkout_requests(&state, &parent_id, &snapshot),
+            Err(CliWorkspaceError::RetryState(reason)) if reason.contains("ambiguous")
+        ));
     }
 
     fn empty_codex_schema_cache() -> CodexSchemaValidatorCache {
@@ -7543,6 +7997,7 @@ mod tests {
             reset_reason: None,
             runtime_contract_version: None,
             runtime_envelope: None,
+            parent_runtime_envelope: None,
             codex_archive_state: None,
             last_turn_id: None,
             active_run_id: None,
@@ -7787,6 +8242,7 @@ mod tests {
             workspace_path: PathBuf::from("/workspace/COE-479"),
             repository_binding: None,
             runtime_envelope: None,
+            parent_runtime_envelope: None,
             attempt: 1,
             normal_retry_count: 0,
             pending_retry: false,
@@ -7861,6 +8317,7 @@ mod tests {
             workspace_path: PathBuf::from("/workspace/COE-479--generation-1"),
             repository_binding: None,
             runtime_envelope: Some(runtime_envelope.clone()),
+            parent_runtime_envelope: None,
             attempt: 1,
             normal_retry_count: 0,
             pending_retry: false,
@@ -7943,6 +8400,7 @@ mod tests {
             workspace_path: PathBuf::from("/workspace/COE-479--generation-1"),
             repository_binding: None,
             runtime_envelope: Some(runtime_envelope.clone()),
+            parent_runtime_envelope: None,
             attempt: 1,
             normal_retry_count: 0,
             pending_retry: false,
@@ -11387,6 +11845,7 @@ Run the scheduler.
             state_root: None,
             memory_catalog_root: None,
             memory_sources: std::collections::BTreeMap::new(),
+            integration_instructions: None,
             project_set_id: None,
             retain_failed: true,
             preserve_terminal_workspaces: true,
@@ -12132,6 +12591,64 @@ Run the scheduler.
         }
     }
 
+    #[tokio::test]
+    async fn codex_manifest_binds_the_same_parent_execution_scope() {
+        let root = TempDir::new().expect("temporary root should exist");
+        let manager = WorkspaceManager::new(WorkspaceManagerConfig {
+            root: root.path().join("workspaces"),
+            hooks: HookConfig::default(),
+            cleanup: CleanupConfig::default(),
+        })
+        .expect("workspace manager should build");
+        let issue = sample_issue();
+        let workspace = manager
+            .ensure(&issue_descriptor(&issue))
+            .await
+            .expect("workspace should exist");
+        let envelope: ParentRuntimeEnvelope = serde_json::from_value(serde_json::json!({
+            "parent_issue_id": issue.id.as_str(),
+            "parent_identifier": issue.identifier.as_str(),
+            "run_id": "run-parent-codex",
+            "attempt": 1,
+            "hierarchy_generation": 7,
+            "workspace_path": workspace.handle.workspace_path(),
+            "checkouts": {},
+            "harness": "codex_app_server",
+            "model_profile": "codex-chatgpt-local-keychain",
+            "requested_execution_scope": "parent_multi_checkout",
+            "effective_containment": "trusted_host"
+        }))
+        .expect("parent envelope should decode");
+
+        let manifest = write_codex_conversation_manifest(
+            &manager,
+            &workspace.handle,
+            &issue,
+            "thread-parent-codex",
+            &codex_test_route(false),
+            None,
+            Some(envelope),
+        )
+        .await
+        .expect("Codex manifest should persist");
+
+        assert!(manifest.runtime_envelope.is_none());
+        assert_eq!(
+            manifest
+                .parent_runtime_envelope
+                .as_ref()
+                .and_then(|envelope| envelope.conversation_binding.as_deref()),
+            Some("thread-parent-codex")
+        );
+        assert_eq!(
+            manifest
+                .parent_runtime_envelope
+                .as_ref()
+                .map(|envelope| envelope.requested_execution_scope.as_str()),
+            Some("parent_multi_checkout")
+        );
+    }
+
     const FAKE_CODEX_SCHEMA: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","definitions":{"ClientRequest":{"type":"object","required":["jsonrpc","id","method","params"],"properties":{"jsonrpc":{"const":"2.0"},"id":{"type":"integer"},"method":{"enum":["initialize","thread/start","thread/resume","thread/list","thread/archive","thread/unarchive","turn/start","turn/interrupt"]},"params":{"type":"object"}}}}}"#;
 
     #[cfg(unix)]
@@ -12627,6 +13144,7 @@ exit 64
             reset_reason: None,
             runtime_contract_version: None,
             runtime_envelope: None,
+            parent_runtime_envelope: None,
             codex_archive_state: None,
             last_turn_id: None,
             active_run_id: None,

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -4358,9 +4358,7 @@ impl RuntimeWorkerBackend {
             } else {
                 None
             };
-            let parent_repository_instructions = if let Some(parent) = parent_execution.as_ref()
-                && persisted_conversation_binding.is_none()
-            {
+            let parent_repository_instructions = if let Some(parent) = parent_execution.as_ref() {
                 match workspace_manager
                     .parent_repository_instructions(parent)
                     .await
@@ -4658,30 +4656,27 @@ impl RuntimeWorkerBackend {
                     );
                     return;
                 }
-                if persisted_conversation_binding.is_none() {
-                    let final_instructions = match workspace_manager
-                        .parent_repository_instructions(&verified_parent)
-                        .await
-                    {
-                        Ok(instructions) => instructions,
-                        Err(error) => {
-                            report_launch_failure(
-                                &mut launch_tx,
-                                format!(
-                                    "parent repository instructions changed before harness attach: {error}"
-                                ),
-                            );
-                            return;
-                        }
-                    };
-                    if parent_repository_instructions != final_instructions {
+                let final_instructions = match workspace_manager
+                    .parent_repository_instructions(&verified_parent)
+                    .await
+                {
+                    Ok(instructions) => instructions,
+                    Err(error) => {
                         report_launch_failure(
                             &mut launch_tx,
-                            "parent repository instructions changed before harness attach"
-                                .to_owned(),
+                            format!(
+                                "parent repository instructions changed before harness attach: {error}"
+                            ),
                         );
                         return;
                     }
+                };
+                if parent_repository_instructions != final_instructions {
+                    report_launch_failure(
+                        &mut launch_tx,
+                        "parent repository instructions changed before harness attach".to_owned(),
+                    );
+                    return;
                 }
             }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -4359,7 +4359,7 @@ impl RuntimeWorkerBackend {
                 None
             };
             let parent_repository_instructions = if let Some(parent) = parent_execution.as_ref()
-                && !is_parent_retry
+                && persisted_conversation_binding.is_none()
             {
                 match workspace_manager
                     .parent_repository_instructions(parent)
@@ -4620,6 +4620,68 @@ impl RuntimeWorkerBackend {
                         "verified checkout envelope changed before harness attach".to_owned(),
                     );
                     return;
+                }
+            }
+
+            if let Some(parent) = parent_execution.as_ref() {
+                let verified_parent = match if is_parent_retry {
+                    workspace_manager
+                        .open_parent_execution_root_at_for_retry(
+                            &workspace_issue,
+                            parent.handle.workspace_path(),
+                        )
+                        .await
+                } else {
+                    workspace_manager
+                        .open_parent_execution_root_at(
+                            &workspace_issue,
+                            parent.handle.workspace_path(),
+                        )
+                        .await
+                } {
+                    Ok(parent) => parent,
+                    Err(error) => {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            format!("parent execution root changed before harness attach: {error}"),
+                        );
+                        return;
+                    }
+                };
+                if let Some(expected) = parent_runtime_envelope.as_ref()
+                    && let Err(error) =
+                        workspace_manager.verify_parent_runtime_envelope(&verified_parent, expected)
+                {
+                    report_launch_failure(
+                        &mut launch_tx,
+                        format!("parent runtime envelope changed before harness attach: {error}"),
+                    );
+                    return;
+                }
+                if persisted_conversation_binding.is_none() {
+                    let final_instructions = match workspace_manager
+                        .parent_repository_instructions(&verified_parent)
+                        .await
+                    {
+                        Ok(instructions) => instructions,
+                        Err(error) => {
+                            report_launch_failure(
+                                &mut launch_tx,
+                                format!(
+                                    "parent repository instructions changed before harness attach: {error}"
+                                ),
+                            );
+                            return;
+                        }
+                    };
+                    if parent_repository_instructions != final_instructions {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            "parent repository instructions changed before harness attach"
+                                .to_owned(),
+                        );
+                        return;
+                    }
                 }
             }
 

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -3904,6 +3904,9 @@ impl RuntimeWorkerBackend {
                 workspace_issue.repository_binding =
                     Some(RepositoryBindingOutcome::Resolved(binding));
             }
+            let is_parent_retry = recovered
+                || run.normal_retry_count > 0
+                || run.attempt.is_some_and(|attempt| attempt.get() > 1);
             let (ensured, parent_execution) = if issue.sub_issues.is_empty() {
                 match workspace_manager
                     .ensure_with_run_id(&workspace_issue, Some(&run_id))
@@ -3919,10 +3922,19 @@ impl RuntimeWorkerBackend {
                     }
                 }
             } else {
-                match workspace_manager
-                    .open_parent_execution_root_at(&workspace_issue, &run.workspace_path)
-                    .await
-                {
+                let parent = if is_parent_retry {
+                    workspace_manager
+                        .open_parent_execution_root_at_for_retry(
+                            &workspace_issue,
+                            &run.workspace_path,
+                        )
+                        .await
+                } else {
+                    workspace_manager
+                        .open_parent_execution_root_at(&workspace_issue, &run.workspace_path)
+                        .await
+                };
+                match parent {
                     Ok(parent) => {
                         let issue_manifest =
                             match workspace_manager.load_issue_manifest(&parent.handle).await {
@@ -4346,7 +4358,9 @@ impl RuntimeWorkerBackend {
             } else {
                 None
             };
-            let parent_repository_instructions = if let Some(parent) = parent_execution.as_ref() {
+            let parent_repository_instructions = if let Some(parent) = parent_execution.as_ref()
+                && !is_parent_retry
+            {
                 match workspace_manager
                     .parent_repository_instructions(parent)
                     .await
@@ -7914,6 +7928,15 @@ mod tests {
             parent_checkout_requests(&state, &parent_id, &snapshot),
             Err(CliWorkspaceError::RetryState(reason)) if reason.contains("ambiguous")
         ));
+
+        snapshot.required_child_edges.clear();
+        snapshot.dispatch_required_merge_commits.clear();
+        state.leases.clear();
+        assert!(
+            parent_checkout_requests(&state, &parent_id, &snapshot)
+                .expect("a parent with no required children should need no checkouts")
+                .is_empty()
+        );
     }
 
     fn empty_codex_schema_cache() -> CodexSchemaValidatorCache {

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -4161,37 +4161,7 @@ impl RuntimeWorkerBackend {
             } else {
                 None
             };
-            let (parent_runtime_envelope, parent_integration_instructions) = if let Some(parent) =
-                parent_execution.as_ref()
-            {
-                let integration_content = match integration_instructions.as_ref() {
-                    Some(instructions) => match fs::read(&instructions.path).await {
-                        Ok(content) => {
-                            let mut hasher = Sha256::new();
-                            hasher.update(&content);
-                            let actual = format!("sha256:{:x}", hasher.finalize());
-                            if actual != instructions.content_hash {
-                                report_launch_failure(
-                                        &mut launch_tx,
-                                        "project-set integration instructions changed after configuration was resolved"
-                                            .to_owned(),
-                                    );
-                                return;
-                            }
-                            Some(String::from_utf8_lossy(&content).into_owned())
-                        }
-                        Err(error) => {
-                            report_launch_failure(
-                                &mut launch_tx,
-                                format!(
-                                    "failed to read project-set integration instructions: {error}"
-                                ),
-                            );
-                            return;
-                        }
-                    },
-                    None => None,
-                };
+            let parent_runtime_envelope = if let Some(parent) = parent_execution.as_ref() {
                 let mut envelope = workspace_manager.parent_runtime_envelope(
                     parent,
                     ParentRuntimeDescriptor {
@@ -4235,9 +4205,9 @@ impl RuntimeWorkerBackend {
                     );
                     return;
                 }
-                (Some(envelope), integration_content)
+                Some(envelope)
             } else {
-                (None, None)
+                None
             };
             let mut memory_grant_requires_fresh_conversation = false;
             let worker_memory_env = memory_env
@@ -4377,7 +4347,7 @@ impl RuntimeWorkerBackend {
             };
             let central_procedure =
                 || workflow.render_prompt(&issue, run.attempt.map(|attempt| attempt.get()));
-            let terminal_prompt = if let Some(checkout) = runtime_envelope.as_ref() {
+            let mut terminal_prompt = if let Some(checkout) = runtime_envelope.as_ref() {
                 let central_procedure = match central_procedure() {
                     Ok(prompt) => prompt,
                     Err(error) => {
@@ -4420,38 +4390,9 @@ impl RuntimeWorkerBackend {
                         checkout.effective_containment
                     ),
                 ))
-            } else if let Some(parent_envelope) = parent_runtime_envelope.as_ref() {
-                let central_procedure = match central_procedure() {
-                    Ok(prompt) => prompt,
-                    Err(error) => {
-                        report_launch_failure(
-                            &mut launch_tx,
-                            format!("failed to render workflow prompt: {error}"),
-                        );
-                        return;
-                    }
-                };
-                Some(compose_parent_prompt(
-                    &central_procedure,
-                    &format!(
-                        "Issue: {}\nTitle: {}\nAttempt: {}\nAcceptance and task description:\n{}",
-                        issue.identifier,
-                        issue.title,
-                        attempt,
-                        issue
-                            .description
-                            .as_deref()
-                            .filter(|description| !description.trim().is_empty())
-                            .unwrap_or("No tracker description provided."),
-                    ),
-                    parent_envelope,
-                    parent_integration_instructions.as_deref(),
-                    &parent_repository_instructions,
-                ))
             } else {
                 None
             };
-            runner = runner.with_terminal_prompt(terminal_prompt.clone());
             let run_descriptor = RunDescriptor::new(run_id, attempt)
                 .with_normal_retry_count(run.normal_retry_count)
                 .with_repository_binding(run.repository_binding.clone())
@@ -4678,7 +4619,48 @@ impl RuntimeWorkerBackend {
                     );
                     return;
                 }
+                let parent_integration_instructions =
+                    match read_verified_integration_instructions(integration_instructions.as_ref())
+                        .await
+                    {
+                        Ok(instructions) => instructions,
+                        Err(error) => {
+                            report_launch_failure(&mut launch_tx, error);
+                            return;
+                        }
+                    };
+                let central_procedure = match central_procedure() {
+                    Ok(prompt) => prompt,
+                    Err(error) => {
+                        report_launch_failure(
+                            &mut launch_tx,
+                            format!("failed to render workflow prompt: {error}"),
+                        );
+                        return;
+                    }
+                };
+                let parent_envelope = parent_runtime_envelope
+                    .as_ref()
+                    .expect("parent execution always creates a runtime envelope");
+                terminal_prompt = Some(compose_parent_prompt(
+                    &central_procedure,
+                    &format!(
+                        "Issue: {}\nTitle: {}\nAttempt: {}\nAcceptance and task description:\n{}",
+                        issue.identifier,
+                        issue.title,
+                        attempt,
+                        issue
+                            .description
+                            .as_deref()
+                            .filter(|description| !description.trim().is_empty())
+                            .unwrap_or("No tracker description provided."),
+                    ),
+                    parent_envelope,
+                    parent_integration_instructions.as_deref(),
+                    &parent_repository_instructions,
+                ));
             }
+            runner = runner.with_terminal_prompt(terminal_prompt.clone());
 
             if route.dry_run {
                 if let Some(sender) = launch_tx.take() {
@@ -7489,6 +7471,28 @@ fn report_launch_failure(
     }
 }
 
+async fn read_verified_integration_instructions(
+    instructions: Option<&ResolvedIntegrationInstructions>,
+) -> Result<Option<String>, String> {
+    let Some(instructions) = instructions else {
+        return Ok(None);
+    };
+    let content = fs::read(&instructions.path).await.map_err(|error| {
+        format!(
+            "failed to read project-set integration instructions before harness attach: {error}"
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(&content);
+    let actual = format!("sha256:{:x}", hasher.finalize());
+    if actual != instructions.content_hash {
+        return Err(
+            "project-set integration instructions changed before harness attach".to_owned(),
+        );
+    }
+    Ok(Some(String::from_utf8_lossy(&content).into_owned()))
+}
+
 fn pending_launch_failure_detail(result: &Result<IssueSessionResult, IssueSessionError>) -> String {
     match result {
         Ok(result) => {
@@ -7876,6 +7880,37 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[tokio::test]
+    async fn integration_instructions_are_revalidated_from_current_bytes_before_attach() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let path = tempdir.path().join("integration.md");
+        fs::write(&path, "verified integration instructions\n")
+            .expect("integration instructions should be written");
+        let mut hasher = Sha256::new();
+        hasher.update(fs::read(&path).expect("instruction bytes should be readable"));
+        let instructions = ResolvedIntegrationInstructions {
+            path: path.clone(),
+            content_hash: format!("sha256:{:x}", hasher.finalize()),
+        };
+
+        assert_eq!(
+            read_verified_integration_instructions(Some(&instructions))
+                .await
+                .expect("current instruction bytes should verify")
+                .as_deref(),
+            Some("verified integration instructions\n")
+        );
+
+        fs::write(&path, "changed by before_run\n")
+            .expect("integration instructions should be changed");
+        assert!(
+            read_verified_integration_instructions(Some(&instructions))
+                .await
+                .expect_err("post-hook instruction drift must fail before attach")
+                .contains("changed before harness attach")
+        );
+    }
 
     #[test]
     fn cleared_superseded_harness_evidence_is_an_empty_sentinel() {

--- a/crates/opensymphony-cli/src/orchestrator_run/config.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/config.rs
@@ -483,6 +483,7 @@ pub(super) struct RunRuntimeConfig {
     pub(super) memory_catalog_root: Option<PathBuf>,
     pub(super) memory_sources: BTreeMap<String, ResolvedMemorySource>,
     pub(super) project_set_id: Option<String>,
+    pub(super) integration_instructions: Option<ResolvedIntegrationInstructions>,
     pub(super) retain_failed: bool,
     pub(super) preserve_terminal_workspaces: bool,
     pub(super) memory: RunMemoryConfig,
@@ -503,6 +504,7 @@ pub(super) async fn resolve_runtime_config(
         central_memory_catalog_root,
         central_memory_sources,
         central_project_set_id,
+        central_integration_instructions,
         central_repository_instruction_path,
         central_workflow_front_matter,
         retry_max_attempts,
@@ -530,6 +532,7 @@ pub(super) async fn resolve_runtime_config(
                     central.memory_catalog_root,
                     central.memory_sources,
                     central.project_set_id,
+                    central.integration_instructions,
                     central.repository_instruction_path,
                     Some(central.workflow_front_matter),
                     central.retry_max_attempts,
@@ -552,6 +555,7 @@ pub(super) async fn resolve_runtime_config(
                     None,
                     None,
                     None,
+                    None,
                 )
             }
         }
@@ -564,6 +568,7 @@ pub(super) async fn resolve_runtime_config(
             None,
             None,
             BTreeMap::new(),
+            None,
             None,
             None,
             None,
@@ -711,6 +716,7 @@ pub(super) async fn resolve_runtime_config(
         memory_catalog_root: central_memory_catalog_root,
         memory_sources: central_memory_sources,
         project_set_id: central_project_set_id,
+        integration_instructions: central_integration_instructions,
         retain_failed: central_retain_failed.unwrap_or(true),
         preserve_terminal_workspaces: central_preserve_terminal_workspaces.unwrap_or(true),
         memory,

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -1127,6 +1127,7 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
         linear_worker_env,
     )
     .with_openhands_conversation_store(runtime.openhands_conversation_store.clone())
+    .with_integration_instructions(runtime.integration_instructions.clone())
     .with_checkout_credential_envs(
         runtime
             .repository_checkouts
@@ -2043,6 +2044,7 @@ mod tests {
             state_root: Some(state.clone()),
             memory_catalog_root: Some(memory),
             memory_sources: BTreeMap::new(),
+            integration_instructions: None,
             project_set_id: None,
             retain_failed: true,
             preserve_terminal_workspaces: true,

--- a/crates/opensymphony-cli/tests/run.rs
+++ b/crates/opensymphony-cli/tests/run.rs
@@ -509,6 +509,7 @@ async fn seed_recovered_human_review_workspace(
         reset_reason: None,
         runtime_contract_version: Some("openhands-sdk-agent-server-v1".to_string()),
         runtime_envelope: None,
+        parent_runtime_envelope: None,
         codex_archive_state: None,
         last_turn_id: None,
         active_run_id: None,

--- a/crates/opensymphony-openhands/src/session.rs
+++ b/crates/opensymphony-openhands/src/session.rs
@@ -23,8 +23,8 @@ use crate::opensymphony_workflow::{
     Environment, OpenHandsConversationToolConfig, ProcessEnvironment, ResolvedWorkflow,
 };
 use crate::opensymphony_workspace::{
-    RunManifest, RunStatus, TerminalRuntimeEnvelope, WorkspaceError, WorkspaceHandle,
-    WorkspaceManager, compose_terminal_prompt,
+    ParentRuntimeEnvelope, RunManifest, RunStatus, TerminalRuntimeEnvelope, WorkspaceError,
+    WorkspaceHandle, WorkspaceManager, compose_terminal_prompt,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -802,6 +802,8 @@ pub struct IssueConversationManifest {
     pub runtime_contract_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_envelope: Option<TerminalRuntimeEnvelope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_runtime_envelope: Option<ParentRuntimeEnvelope>,
     /// Codex-only archive state. Missing values from older manifests mean active.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_archive_state: Option<String>,
@@ -885,6 +887,7 @@ impl IssueConversationManifest {
             reset_reason,
             runtime_contract_version: Some(RUNTIME_CONTRACT_VERSION.to_string()),
             runtime_envelope: None,
+            parent_runtime_envelope: None,
             codex_archive_state: None,
             last_turn_id: None,
             active_run_id: None,
@@ -1009,6 +1012,22 @@ impl IssueConversationManifest {
             next_activity_sequence: 0,
         }
     }
+}
+
+fn bind_runtime_envelopes(
+    manifest: &mut IssueConversationManifest,
+    run_manifest: &mut RunManifest,
+) {
+    manifest.runtime_envelope = run_manifest.runtime_envelope.clone();
+    if let Some(envelope) = manifest.runtime_envelope.as_mut() {
+        envelope.conversation_binding = Some(manifest.conversation_id.to_string());
+    }
+    run_manifest.runtime_envelope = manifest.runtime_envelope.clone();
+    manifest.parent_runtime_envelope = run_manifest.parent_runtime_envelope.clone();
+    if let Some(envelope) = manifest.parent_runtime_envelope.as_mut() {
+        envelope.conversation_binding = Some(manifest.conversation_id.to_string());
+    }
+    run_manifest.parent_runtime_envelope = manifest.parent_runtime_envelope.clone();
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2951,11 +2970,7 @@ impl IssueSessionRunner {
         );
         manifest.llm_config_fingerprint =
             Some(LlmConfigFingerprint::from_llm_config(&request.agent.llm));
-        manifest.runtime_envelope = run_manifest.runtime_envelope.clone();
-        if let Some(envelope) = manifest.runtime_envelope.as_mut() {
-            envelope.conversation_binding = Some(manifest.conversation_id.to_string());
-        }
-        run_manifest.runtime_envelope = manifest.runtime_envelope.clone();
+        bind_runtime_envelopes(&mut manifest, run_manifest);
         let pending_manifest_path = pending_conversation_manifest_path(workspace);
         if let Err(error) = workspace_manager
             .write_json_artifact_atomically(workspace, &pending_manifest_path, &Some(&manifest))
@@ -3131,6 +3146,10 @@ impl IssueSessionRunner {
         );
         failed_manifest.runtime_envelope = run_manifest.runtime_envelope.clone();
         if let Some(envelope) = failed_manifest.runtime_envelope.as_mut() {
+            envelope.conversation_binding = Some(failed_manifest.conversation_id.to_string());
+        }
+        failed_manifest.parent_runtime_envelope = run_manifest.parent_runtime_envelope.clone();
+        if let Some(envelope) = failed_manifest.parent_runtime_envelope.as_mut() {
             envelope.conversation_binding = Some(failed_manifest.conversation_id.to_string());
         }
         failed_manifest.apply_transport_diagnostics(
@@ -4726,7 +4745,7 @@ mod tests {
 
     use crate::opensymphony_domain::{
         BlockerRef, ConversationId, HarnessInterruptExpectedNextState, HarnessInterruptReason,
-        IssueRef, IssueState, IssueStateCategory, WorkerOutcomeKind,
+        IssueIdentifier, IssueRef, IssueState, IssueStateCategory, WorkerOutcomeKind,
     };
     use crate::opensymphony_testkit::{FakeOpenHandsConfig, FakeOpenHandsServer};
     use axum::{Json, Router, extract::State, routing::post};
@@ -4740,6 +4759,77 @@ mod tests {
             Ok(value) => value,
             Err(error) => panic!("{error}"),
         }
+    }
+
+    #[test]
+    fn openhands_binds_parent_scope_without_creating_a_leaf_envelope() {
+        let root = tempfile::tempdir().expect("temporary workspace root");
+        let path = root.path().join("parent-root");
+        std::fs::create_dir_all(&path).expect("parent root should exist");
+        let workspace =
+            WorkspaceHandle::new("parent-id", "COE-PARENT", "parent-COE-PARENT", path.clone());
+        let parent_envelope: ParentRuntimeEnvelope = serde_json::from_value(json!({
+            "parent_issue_id": "parent-id",
+            "parent_identifier": "COE-PARENT",
+            "run_id": "run-parent",
+            "attempt": 1,
+            "hierarchy_generation": 7,
+            "workspace_path": path,
+            "checkouts": {},
+            "harness": "openhands_agent_server",
+            "model_profile": "default",
+            "requested_execution_scope": "parent_multi_checkout",
+            "effective_containment": "trusted_host"
+        }))
+        .expect("parent envelope should decode");
+        let mut run_manifest = RunManifest::new(
+            &workspace,
+            &crate::opensymphony_workspace::RunDescriptor::new("run-parent", 1)
+                .with_parent_runtime_envelope(Some(parent_envelope)),
+        );
+        let profile = ConversationLaunchProfile {
+            workspace_kind: "LocalWorkspace".to_owned(),
+            confirmation_policy_kind: "NeverConfirm".to_owned(),
+            agent_kind: "Agent".to_owned(),
+            llm_model: "test-model".to_owned(),
+            llm_credential_mode: "api_key".to_owned(),
+            llm_api_key_env: None,
+            llm_base_url_env: None,
+            llm_subscription: None,
+            condenser: None,
+            agent_tools: None,
+            agent_include_default_tools: None,
+            max_iterations: 10,
+            stuck_detection: true,
+            llm_api_key_fingerprint: None,
+        };
+        let conversation_id = must(ConversationId::new("conversation-parent"));
+        let mut manifest = IssueConversationManifest::new(
+            must(IssueId::new("parent-id")),
+            must(IssueIdentifier::new("COE-PARENT")),
+            conversation_id.clone(),
+            "per_issue",
+            workspace.openhands_dir(),
+            Utc::now(),
+            None,
+            profile,
+            &BTreeMap::new(),
+        );
+
+        bind_runtime_envelopes(&mut manifest, &mut run_manifest);
+
+        assert!(manifest.runtime_envelope.is_none());
+        assert_eq!(
+            manifest
+                .parent_runtime_envelope
+                .as_ref()
+                .and_then(|envelope| envelope.conversation_binding.as_deref()),
+            Some(conversation_id.as_str())
+        );
+        assert_eq!(
+            manifest.parent_runtime_envelope,
+            run_manifest.parent_runtime_envelope
+        );
     }
 
     #[test]
@@ -5343,6 +5433,7 @@ mod tests {
             reset_reason: None,
             runtime_contract_version: None,
             runtime_envelope: None,
+            parent_runtime_envelope: None,
             codex_archive_state: None,
             last_turn_id: None,
             active_run_id: None,

--- a/crates/opensymphony-workspace/src/lib.rs
+++ b/crates/opensymphony-workspace/src/lib.rs
@@ -18,6 +18,6 @@ pub use models::{
     environment_variable_names_equal, redact_runtime_diagnostic,
 };
 pub use paths::{
-    checkout_workspace_key, resolve_path_within_root, sanitize_workspace_key,
+    checkout_workspace_key, parent_workspace_key, resolve_path_within_root, sanitize_workspace_key,
     workspace_path_for_root,
 };

--- a/crates/opensymphony-workspace/src/lib.rs
+++ b/crates/opensymphony-workspace/src/lib.rs
@@ -4,16 +4,18 @@ mod models;
 mod paths;
 
 pub use error::{WorkspaceError, WorkspaceOwnershipConflictDetails};
-pub use manager::{WorkspaceManager, compose_terminal_prompt};
+pub use manager::{WorkspaceManager, compose_parent_prompt, compose_terminal_prompt};
 pub use models::{
     CheckoutManifest, CheckoutRepository, CleanupConfig, CleanupDecision, CleanupOutcome,
     ConversationManifest, EnsureWorkspaceResult, HookConfig, HookDefinition, HookExecutionRecord,
     HookExecutionStatus, HookKind, InstructionProvenance, IssueContextArtifact, IssueDescriptor,
-    IssueLifecycleState, IssueManifest, PromptCaptureDescriptor, PromptCaptureManifest, PromptKind,
-    RunDescriptor, RunManifest, RunStatus, SSH_AUTH_SOCK_ENV, SessionContextArtifact,
-    TerminalRuntimeEnvelope, WorkspaceHandle, WorkspaceManagerConfig,
-    checkout_credential_environment_variables, environment_variable_names_equal,
-    redact_runtime_diagnostic,
+    IssueLifecycleState, IssueManifest, ParentCheckoutRequest, ParentChildCheckoutMap,
+    ParentExecutionManifest, ParentExecutionRoot, ParentIntegrationCheckout,
+    ParentRetainedCheckout, ParentRuntimeCheckout, ParentRuntimeDescriptor, ParentRuntimeEnvelope,
+    PromptCaptureDescriptor, PromptCaptureManifest, PromptKind, RunDescriptor, RunManifest,
+    RunStatus, SSH_AUTH_SOCK_ENV, SessionContextArtifact, TerminalRuntimeEnvelope, WorkspaceHandle,
+    WorkspaceManagerConfig, checkout_credential_environment_variables,
+    environment_variable_names_equal, redact_runtime_diagnostic,
 };
 pub use paths::{
     checkout_workspace_key, resolve_path_within_root, sanitize_workspace_key,

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -42,8 +42,8 @@ use super::{
         redact_runtime_diagnostic,
     },
     paths::{
-        checkout_workspace_key, normalize_absolute_path, resolve_path_within_root,
-        sanitize_workspace_key,
+        checkout_workspace_key, normalize_absolute_path, parent_workspace_key,
+        resolve_path_within_root, sanitize_workspace_key,
     },
 };
 use crate::opensymphony_domain::{RepositoryBinding, SafeRemoteFingerprint};
@@ -286,7 +286,7 @@ impl WorkspaceManager {
                 "parent preparation requires a repository-neutral issue and a hierarchy generation",
             ));
         }
-        let workspace_key = format!("parent-{}", sanitize_workspace_key(&issue.identifier)?);
+        let workspace_key = parent_workspace_key(&issue.identifier, &issue.issue_id)?;
         let parent_relative = PathBuf::from("parents").join(&workspace_key);
         self.reject_symlinked_path_components(&self.config.root, &parent_relative)
             .await?;
@@ -318,6 +318,12 @@ impl WorkspaceManager {
                 Ok(Some(_)) => self.write_after_create_receipt(issue, &handle).await?,
                 Ok(None) => {}
                 Err(failure) => return Err(failure.error),
+            }
+            if path_exists(&handle.workspace_path().join(".git")).await? {
+                return Err(checkout_verification(
+                    handle.workspace_path(),
+                    "parent after_create hook created a root-level Git repository",
+                ));
             }
             self.bootstrap_workspace_layout(&handle).await?;
             self.create_managed_directory(&handle, &handle.workspace_path().join("evidence"))
@@ -484,8 +490,15 @@ impl WorkspaceManager {
             checkout_operation_with_timeout(
                 checkout_time_remaining(integration_deadline),
                 source_handle.workspace_path(),
+                "validate parent worktree process-filter configuration",
+                self.reject_checkout_controlled_process_filters(source_handle.workspace_path()),
+            )
+            .await?;
+            checkout_operation_with_timeout(
+                checkout_time_remaining(integration_deadline),
+                source_handle.workspace_path(),
                 "create parent integration worktree",
-                self.git(
+                self.git_with_isolated_hooks_and_global_config(
                     source_handle.workspace_path(),
                     &[
                         "worktree",
@@ -602,10 +615,7 @@ impl WorkspaceManager {
         self.reject_symlinked_path_components(
             &self.config.root,
             &PathBuf::from("parents")
-                .join(format!(
-                    "parent-{}",
-                    sanitize_workspace_key(&issue.identifier)?
-                ))
+                .join(parent_workspace_key(&issue.identifier, &issue.issue_id)?)
                 .join(hierarchy_generation.to_string()),
         )
         .await?;
@@ -617,7 +627,7 @@ impl WorkspaceManager {
         let handle = WorkspaceHandle::new(
             issue.issue_id.clone(),
             issue.identifier.clone(),
-            format!("parent-{}", sanitize_workspace_key(&issue.identifier)?),
+            parent_workspace_key(&issue.identifier, &issue.issue_id)?,
             canonical_root,
         );
         let expected_root = self
@@ -716,7 +726,7 @@ impl WorkspaceManager {
         let handle = WorkspaceHandle::new(
             issue.issue_id.clone(),
             issue.identifier.clone(),
-            format!("parent-{}", sanitize_workspace_key(&issue.identifier)?),
+            parent_workspace_key(&issue.identifier, &issue.issue_id)?,
             canonical_root,
         );
         let manifest = self
@@ -738,7 +748,7 @@ impl WorkspaceManager {
         let handle = WorkspaceHandle::new(
             issue.issue_id.clone(),
             issue.identifier.clone(),
-            format!("parent-{}", sanitize_workspace_key(&issue.identifier)?),
+            parent_workspace_key(&issue.identifier, &issue.issue_id)?,
             canonical_root,
         );
         let manifest = self
@@ -1056,6 +1066,53 @@ impl WorkspaceManager {
         &self,
         checkout: &Path,
     ) -> Result<(), WorkspaceError> {
+        let names = self.checkout_controlled_config_names(checkout).await?;
+        if let Some(name) = names.iter().find(|name| {
+            let name = name.trim().to_ascii_lowercase();
+            name.starts_with("http.")
+                || name.starts_with("credential.")
+                || name == "core.gitproxy"
+                || name == "core.sshcommand"
+                || name == "ssh.variant"
+                || name.starts_with("protocol.")
+                || (name.starts_with("url.")
+                    && (name.ends_with(".insteadof") || name.ends_with(".pushinsteadof")))
+        }) {
+            return Err(checkout_verification(
+                checkout,
+                &format!(
+                    "checkout-controlled Git transport configuration `{}` is not allowed for authenticated parent fetches",
+                    name.trim()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn reject_checkout_controlled_process_filters(
+        &self,
+        checkout: &Path,
+    ) -> Result<(), WorkspaceError> {
+        let names = self.checkout_controlled_config_names(checkout).await?;
+        if let Some(name) = names
+            .iter()
+            .find(|name| name.trim().to_ascii_lowercase().starts_with("filter."))
+        {
+            return Err(checkout_verification(
+                checkout,
+                &format!(
+                    "checkout-controlled Git process-filter configuration `{}` is not allowed for parent worktree creation",
+                    name.trim()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn checkout_controlled_config_names(
+        &self,
+        checkout: &Path,
+    ) -> Result<Vec<String>, WorkspaceError> {
         let local_names = self
             .git(
                 checkout,
@@ -1085,10 +1142,9 @@ impl WorkspaceManager {
         } else {
             false
         };
-        let mut scopes = vec![("--local", local_names)];
+        let mut names = local_names.lines().map(str::to_owned).collect::<Vec<_>>();
         if worktree_config_enabled {
-            scopes.push((
-                "--worktree",
+            names.extend(
                 self.git(
                     checkout,
                     &[
@@ -1099,31 +1155,12 @@ impl WorkspaceManager {
                         "--list",
                     ],
                 )
-                .await?,
-            ));
+                .await?
+                .lines()
+                .map(str::to_owned),
+            );
         }
-        for (_, names) in scopes {
-            if let Some(name) = names.lines().find(|name| {
-                let name = name.trim().to_ascii_lowercase();
-                name.starts_with("http.")
-                    || name.starts_with("credential.")
-                    || name == "core.gitproxy"
-                    || name == "core.sshcommand"
-                    || name == "ssh.variant"
-                    || name.starts_with("protocol.")
-                    || (name.starts_with("url.")
-                        && (name.ends_with(".insteadof") || name.ends_with(".pushinsteadof")))
-            }) {
-                return Err(checkout_verification(
-                    checkout,
-                    &format!(
-                        "checkout-controlled Git transport configuration `{}` is not allowed for authenticated parent fetches",
-                        name.trim()
-                    ),
-                ));
-            }
-        }
-        Ok(())
+        Ok(names)
     }
 
     async fn run_authenticated_git(
@@ -1240,7 +1277,7 @@ impl WorkspaceManager {
         configure_process_group(&mut command);
         command.kill_on_drop(true);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
-        let child = match command.spawn() {
+        let mut child = match command.spawn() {
             Ok(child) => child,
             Err(source) => {
                 if let Some(path) = askpass_path.as_ref() {
@@ -1256,34 +1293,83 @@ impl WorkspaceManager {
         let process_id = child.id();
         #[cfg(unix)]
         let mut process_group_guard = ProcessGroupGuard::new(process_id);
-        let output = timeout(
-            RETAINED_CHECKOUT_VERIFICATION_TIMEOUT,
-            child.wait_with_output(),
-        )
-        .await;
-        if let Some(path) = askpass_path.as_ref() {
-            let _ = fs::remove_file(path).await;
-        }
-        let output = output
-            .map_err(|_| WorkspaceError::CheckoutOperation {
-                operation: args.first().copied().unwrap_or("git").to_owned(),
-                path: checkout.to_path_buf(),
-                detail: format!(
-                    "operation timed out after {:?}",
-                    RETAINED_CHECKOUT_VERIFICATION_TIMEOUT
-                ),
-            })?
-            .map_err(|source| WorkspaceError::CheckoutOperation {
+        let stdout_task = tokio::spawn(read_child_pipe(child.stdout.take()));
+        let stderr_task = tokio::spawn(read_child_pipe(child.stderr.take()));
+        let status = match timeout(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT, child.wait()).await {
+            Ok(Ok(status)) => status,
+            Ok(Err(source)) => {
+                let terminate = terminate_process_tree(&mut child, process_id).await;
+                let _ = child.wait().await;
+                #[cfg(unix)]
+                process_group_guard.disarm();
+                let _ = join_child_pipe(stdout_task).await;
+                let _ = join_child_pipe(stderr_task).await;
+                if let Some(path) = askpass_path.as_ref() {
+                    let _ = fs::remove_file(path).await;
+                }
+                if let Err(error) = terminate {
+                    return Err(WorkspaceError::CheckoutOperation {
+                        operation: "terminate authenticated Git process tree".to_owned(),
+                        path: checkout.to_path_buf(),
+                        detail: error.to_string(),
+                    });
+                }
+                return Err(WorkspaceError::CheckoutOperation {
+                    operation: args.first().copied().unwrap_or("git").to_owned(),
+                    path: checkout.to_path_buf(),
+                    detail: source.to_string(),
+                });
+            }
+            Err(_) => {
+                let terminate = terminate_process_tree(&mut child, process_id).await;
+                let _ = child.wait().await;
+                #[cfg(unix)]
+                process_group_guard.disarm();
+                let _ = join_child_pipe(stdout_task).await;
+                let _ = join_child_pipe(stderr_task).await;
+                if let Some(path) = askpass_path.as_ref() {
+                    let _ = fs::remove_file(path).await;
+                }
+                if let Err(error) = terminate {
+                    return Err(WorkspaceError::CheckoutOperation {
+                        operation: "terminate authenticated Git process tree".to_owned(),
+                        path: checkout.to_path_buf(),
+                        detail: error.to_string(),
+                    });
+                }
+                return Err(WorkspaceError::CheckoutOperation {
+                    operation: args.first().copied().unwrap_or("git").to_owned(),
+                    path: checkout.to_path_buf(),
+                    detail: format!(
+                        "operation timed out after {:?}",
+                        RETAINED_CHECKOUT_VERIFICATION_TIMEOUT
+                    ),
+                });
+            }
+        };
+        #[cfg(unix)]
+        process_group_guard.disarm();
+        let _stdout = join_child_pipe(stdout_task).await.map_err(|source| {
+            WorkspaceError::CheckoutOperation {
                 operation: args.first().copied().unwrap_or("git").to_owned(),
                 path: checkout.to_path_buf(),
                 detail: source.to_string(),
-            })?;
-        #[cfg(unix)]
-        process_group_guard.disarm();
-        if output.status.success() {
+            }
+        })?;
+        let stderr = join_child_pipe(stderr_task).await.map_err(|source| {
+            WorkspaceError::CheckoutOperation {
+                operation: args.first().copied().unwrap_or("git").to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            }
+        })?;
+        if let Some(path) = askpass_path.as_ref() {
+            let _ = fs::remove_file(path).await;
+        }
+        if status.success() {
             return Ok(());
         }
-        let mut detail = redact_runtime_diagnostic(&String::from_utf8_lossy(&output.stderr));
+        let mut detail = redact_runtime_diagnostic(&String::from_utf8_lossy(&stderr));
         if let Some(value) = environment_credential_value.as_deref() {
             detail = detail.replace(value, "<redacted>");
         }
@@ -3497,6 +3583,75 @@ impl WorkspaceManager {
             }
         }
         Ok(())
+    }
+
+    async fn git_with_isolated_hooks_and_global_config(
+        &self,
+        checkout: &Path,
+        args: &[&str],
+    ) -> Result<String, WorkspaceError> {
+        let isolated_config = tempfile::Builder::new()
+            .prefix("opensymphony-isolated-git-")
+            .tempdir()
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: "isolate Git worktree creation".to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        let mut hooks_config = OsString::from("core.hooksPath=");
+        hooks_config.push(isolated_config.path());
+        let mut command = Command::new("git");
+        command
+            .arg("-c")
+            .arg(hooks_config)
+            .arg("-C")
+            .arg(checkout)
+            .args(args);
+        for variable in &self.checkout_credential_envs {
+            command.env_remove(variable);
+        }
+        sanitize_git_environment(&mut command);
+        command
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env(
+                "GIT_CONFIG_GLOBAL",
+                isolated_config.path().join("global.gitconfig"),
+            )
+            .env("GIT_NO_REPLACE_OBJECTS", "1");
+        configure_process_group(&mut command);
+        command
+            .kill_on_drop(true)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = command
+            .spawn()
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: args.first().copied().unwrap_or("git").to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        let process_id = child.id();
+        #[cfg(unix)]
+        let mut process_group_guard = ProcessGroupGuard::new(process_id);
+        let output =
+            child
+                .wait_with_output()
+                .await
+                .map_err(|source| WorkspaceError::CheckoutOperation {
+                    operation: args.first().copied().unwrap_or("git").to_owned(),
+                    path: checkout.to_path_buf(),
+                    detail: source.to_string(),
+                })?;
+        #[cfg(unix)]
+        process_group_guard.disarm();
+        if !output.status.success() {
+            return Err(WorkspaceError::CheckoutOperation {
+                operation: args.first().copied().unwrap_or("git").to_owned(),
+                path: checkout.to_path_buf(),
+                detail: redact_runtime_diagnostic(&String::from_utf8_lossy(&output.stderr)),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
     }
 
     async fn git(&self, checkout: &Path, args: &[&str]) -> Result<String, WorkspaceError> {

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -396,6 +396,15 @@ impl WorkspaceManager {
                         )
                     })?;
                 let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
+                checkout_operation_with_timeout(
+                    checkout_time_remaining(deadline),
+                    child_handle.workspace_path(),
+                    "validate retained child process configuration",
+                    self.reject_checkout_controlled_process_filters(
+                        child_handle.workspace_path(),
+                    ),
+                )
+                .await?;
                 let checkout = self
                     .verify_checkout_with_worker_changes_timeout(
                         &child_handle,
@@ -1094,14 +1103,17 @@ impl WorkspaceManager {
         checkout: &Path,
     ) -> Result<(), WorkspaceError> {
         let names = self.checkout_controlled_config_names(checkout).await?;
-        if let Some(name) = names
-            .iter()
-            .find(|name| name.trim().to_ascii_lowercase().starts_with("filter."))
-        {
+        if let Some(name) = names.iter().find(|name| {
+            let name = name.trim().to_ascii_lowercase();
+            name.starts_with("filter.")
+                || name == "core.fsmonitor"
+                || name == "core.hookspath"
+                || name.starts_with("includeif.")
+        }) {
             return Err(checkout_verification(
                 checkout,
                 &format!(
-                    "checkout-controlled Git process-filter configuration `{}` is not allowed for parent worktree creation",
+                    "checkout-controlled Git process configuration or conditional include `{}` is not allowed for parent worktree creation or verification",
                     name.trim()
                 ),
             ));
@@ -1144,21 +1156,32 @@ impl WorkspaceManager {
         };
         let mut names = local_names.lines().map(str::to_owned).collect::<Vec<_>>();
         if worktree_config_enabled {
-            names.extend(
-                self.git(
-                    checkout,
-                    &[
-                        "config",
-                        "--worktree",
-                        "--includes",
-                        "--name-only",
-                        "--list",
-                    ],
-                )
-                .await?
-                .lines()
-                .map(str::to_owned),
-            );
+            let worktree_config_path = self
+                .git(checkout, &["rev-parse", "--git-path", "config.worktree"])
+                .await?;
+            let worktree_config_path = PathBuf::from(worktree_config_path);
+            let worktree_config_path = if worktree_config_path.is_absolute() {
+                worktree_config_path
+            } else {
+                checkout.join(worktree_config_path)
+            };
+            if path_exists(&worktree_config_path).await? {
+                names.extend(
+                    self.git(
+                        checkout,
+                        &[
+                            "config",
+                            "--worktree",
+                            "--includes",
+                            "--name-only",
+                            "--list",
+                        ],
+                    )
+                    .await?
+                    .lines()
+                    .map(str::to_owned),
+                );
+            }
         }
         Ok(names)
     }
@@ -1236,6 +1259,8 @@ impl WorkspaceManager {
         command
             .arg("-c")
             .arg("credential.helper=")
+            .arg("-c")
+            .arg("core.fsmonitor=")
             .arg("-c")
             .arg(hooks_config)
             .arg("-C")
@@ -1404,6 +1429,8 @@ impl WorkspaceManager {
                 "integration checkout path does not match its opaque handle",
             ));
         }
+        self.reject_checkout_controlled_process_filters(&integration)
+            .await?;
         let worktree_root = self
             .git(&integration, &["rev-parse", "--show-toplevel"])
             .await?;
@@ -1585,6 +1612,13 @@ impl WorkspaceManager {
                     Some(&retained.issue_id),
                 )
                 .await?;
+            checkout_operation_with_timeout(
+                checkout_time_remaining(deadline),
+                child.workspace_path(),
+                "validate retained child process configuration",
+                self.reject_checkout_controlled_process_filters(child.workspace_path()),
+            )
+            .await?;
             self.verify_checkout_with_worker_changes_timeout(&child, true, true, deadline)
                 .await?;
             let status = checkout_operation_with_timeout(
@@ -3603,6 +3637,8 @@ impl WorkspaceManager {
         let mut command = Command::new("git");
         command
             .arg("-c")
+            .arg("core.fsmonitor=")
+            .arg("-c")
             .arg(hooks_config)
             .arg("-C")
             .arg(checkout)
@@ -3655,8 +3691,25 @@ impl WorkspaceManager {
     }
 
     async fn git(&self, checkout: &Path, args: &[&str]) -> Result<String, WorkspaceError> {
+        let hooks_directory = tempfile::Builder::new()
+            .prefix("opensymphony-empty-git-hooks-")
+            .tempdir()
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: "isolate Git verification hooks".to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        let mut hooks_config = OsString::from("core.hooksPath=");
+        hooks_config.push(hooks_directory.path());
         let mut command = Command::new("git");
-        command.arg("-C").arg(checkout).args(args);
+        command
+            .arg("-c")
+            .arg("core.fsmonitor=")
+            .arg("-c")
+            .arg(hooks_config)
+            .arg("-C")
+            .arg(checkout)
+            .args(args);
         for variable in &self.checkout_credential_envs {
             command.env_remove(variable);
         }
@@ -3699,8 +3752,22 @@ impl WorkspaceManager {
     }
 
     async fn git_fsck(&self, checkout: &Path) -> Result<(), WorkspaceError> {
+        let hooks_directory = tempfile::Builder::new()
+            .prefix("opensymphony-empty-git-hooks-")
+            .tempdir()
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: "isolate Git integrity-check hooks".to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        let mut hooks_config = OsString::from("core.hooksPath=");
+        hooks_config.push(hooks_directory.path());
         let mut command = Command::new("git");
         command
+            .arg("-c")
+            .arg("core.fsmonitor=")
+            .arg("-c")
+            .arg(hooks_config)
             .arg("-C")
             .arg(checkout)
             .args(["fsck", "--no-dangling"]);
@@ -3759,8 +3826,25 @@ impl WorkspaceManager {
         checkout: &Path,
         args: &[&str],
     ) -> Result<bool, WorkspaceError> {
+        let hooks_directory = tempfile::Builder::new()
+            .prefix("opensymphony-empty-git-hooks-")
+            .tempdir()
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: "isolate Git ancestry-check hooks".to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        let mut hooks_config = OsString::from("core.hooksPath=");
+        hooks_config.push(hooks_directory.path());
         let mut command = Command::new("git");
-        command.arg("-C").arg(checkout).args(args);
+        command
+            .arg("-c")
+            .arg("core.fsmonitor=")
+            .arg("-c")
+            .arg(hooks_config)
+            .arg("-C")
+            .arg(checkout)
+            .args(args);
         for variable in &self.checkout_credential_envs {
             command.env_remove(variable);
         }
@@ -6202,8 +6286,18 @@ async fn tracked_instruction_paths(
 ) -> Result<Vec<PathBuf>, WorkspaceError> {
     const MAX_TRACKED_INSTRUCTION_PATHS: usize = 10_000;
     const MAX_TRACKED_INSTRUCTION_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+    let hooks_directory = tempfile::Builder::new()
+        .prefix("opensymphony-empty-git-hooks-")
+        .tempdir()
+        .map_err(|_| checkout_verification(root, "tracked instruction probe failed"))?;
+    let mut hooks_config = OsString::from("core.hooksPath=");
+    hooks_config.push(hooks_directory.path());
     let mut command = Command::new("git");
     command
+        .arg("-c")
+        .arg("core.fsmonitor=")
+        .arg("-c")
+        .arg(hooks_config)
         .arg("-C")
         .arg(root)
         .args(["ls-files", "--cached", "-z", "--", ":(glob)**/AGENTS.md"]);
@@ -7129,6 +7223,99 @@ mod tests {
                 )
             )
         }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn orchestrator_git_probe_disables_checkout_fsmonitor() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().expect("checkout root should exist");
+        let checkout = root.path().join("checkout");
+        std::fs::create_dir(&checkout).expect("checkout should exist");
+        for args in [
+            vec!["init", "--quiet"],
+            vec!["config", "user.name", "Test User"],
+            vec!["config", "user.email", "test@example.com"],
+        ] {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&checkout)
+                .args(args)
+                .status()
+                .expect("git setup should launch");
+            assert!(status.success(), "git setup should succeed");
+        }
+        std::fs::write(checkout.join("tracked.txt"), "tracked\n")
+            .expect("tracked file should exist");
+        for args in [vec!["add", "tracked.txt"], vec!["commit", "-m", "initial"]] {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&checkout)
+                .args(args)
+                .status()
+                .expect("git setup should launch");
+            assert!(status.success(), "git setup should succeed");
+        }
+
+        let marker = root.path().join("fsmonitor-ran.txt");
+        let hook_marker = root.path().join("post-index-change-ran.txt");
+        let fsmonitor = root.path().join("fsmonitor.sh");
+        std::fs::write(
+            &fsmonitor,
+            format!(
+                "#!/bin/sh\nprintf invoked > {}\n",
+                shell_single_quote(&marker.to_string_lossy())
+            ),
+        )
+        .expect("fsmonitor should be written");
+        std::fs::set_permissions(&fsmonitor, std::fs::Permissions::from_mode(0o755))
+            .expect("fsmonitor should be executable");
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&checkout)
+            .args(["config", "core.fsmonitor"])
+            .arg(&fsmonitor)
+            .status()
+            .expect("git config should launch");
+        assert!(status.success(), "git config should succeed");
+        let hook = checkout.join(".git/hooks/post-index-change");
+        std::fs::write(
+            &hook,
+            format!(
+                "#!/bin/sh\nprintf invoked > {}\n",
+                shell_single_quote(&hook_marker.to_string_lossy())
+            ),
+        )
+        .expect("post-index-change hook should be written");
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+            .expect("post-index-change hook should be executable");
+        std::thread::sleep(std::time::Duration::from_millis(1_100));
+        std::fs::write(checkout.join("tracked.txt"), "tracked\n")
+            .expect("tracked file timestamp should change");
+
+        let manager = WorkspaceManager::new(WorkspaceManagerConfig {
+            root: root.path().join("workspaces"),
+            hooks: HookConfig::default(),
+            cleanup: CleanupConfig::default(),
+        })
+        .expect("workspace manager should be constructed");
+        manager
+            .git(&checkout, &["status", "--porcelain"])
+            .await
+            .expect("orchestrator Git probe should succeed");
+        super::tracked_instruction_paths(&checkout, &std::collections::BTreeSet::new())
+            .await
+            .expect("tracked instruction probe should succeed");
+
+        assert!(
+            !marker.exists(),
+            "checkout-controlled fsmonitor must be disabled on the Git command itself"
+        );
+        assert!(
+            !hook_marker.exists(),
+            "default checkout hooks must be disabled on the Git command itself"
+        );
     }
 
     #[test]

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -1025,6 +1025,13 @@ impl WorkspaceManager {
         source: &WorkspaceHandle,
         repository: &CheckoutRepository,
     ) -> Result<(), WorkspaceError> {
+        checkout_operation_with_timeout(
+            Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT),
+            source.workspace_path(),
+            "validate parent fetch transport configuration",
+            self.reject_checkout_controlled_transport_config(source.workspace_path()),
+        )
+        .await?;
         let shallow = self
             .git(
                 source.workspace_path(),
@@ -1040,9 +1047,83 @@ impl WorkspaceManager {
             "+refs/heads/{0}:refs/remotes/origin/{0}",
             repository.target_branch
         );
-        args.extend(["origin", refspec.as_str()]);
+        args.extend([repository.remote.as_str(), refspec.as_str()]);
         self.run_authenticated_git(source.workspace_path(), repository, &args)
             .await
+    }
+
+    async fn reject_checkout_controlled_transport_config(
+        &self,
+        checkout: &Path,
+    ) -> Result<(), WorkspaceError> {
+        let local_names = self
+            .git(
+                checkout,
+                &["config", "--local", "--includes", "--name-only", "--list"],
+            )
+            .await?;
+        let worktree_config_enabled = if local_names.lines().any(|name| {
+            name.trim()
+                .eq_ignore_ascii_case("extensions.worktreeConfig")
+        }) {
+            matches!(
+                self.git(
+                    checkout,
+                    &[
+                        "config",
+                        "--local",
+                        "--includes",
+                        "--bool",
+                        "--get",
+                        "extensions.worktreeConfig",
+                    ],
+                )
+                .await?
+                .as_str(),
+                "true"
+            )
+        } else {
+            false
+        };
+        let mut scopes = vec![("--local", local_names)];
+        if worktree_config_enabled {
+            scopes.push((
+                "--worktree",
+                self.git(
+                    checkout,
+                    &[
+                        "config",
+                        "--worktree",
+                        "--includes",
+                        "--name-only",
+                        "--list",
+                    ],
+                )
+                .await?,
+            ));
+        }
+        for (_, names) in scopes {
+            if let Some(name) = names.lines().find(|name| {
+                let name = name.trim().to_ascii_lowercase();
+                name.starts_with("http.")
+                    || name.starts_with("credential.")
+                    || name == "core.gitproxy"
+                    || name == "core.sshcommand"
+                    || name == "ssh.variant"
+                    || name.starts_with("protocol.")
+                    || (name.starts_with("url.")
+                        && (name.ends_with(".insteadof") || name.ends_with(".pushinsteadof")))
+            }) {
+                return Err(checkout_verification(
+                    checkout,
+                    &format!(
+                        "checkout-controlled Git transport configuration `{}` is not allowed for authenticated parent fetches",
+                        name.trim()
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 
     async fn run_authenticated_git(

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -810,6 +810,20 @@ impl WorkspaceManager {
         parent: &ParentExecutionRoot,
         envelope: &ParentRuntimeEnvelope,
     ) -> Result<(), WorkspaceError> {
+        self.verify_parent_runtime_envelope(parent, envelope)?;
+        self.write_manifest_atomically(
+            &parent.handle,
+            &parent.handle.parent_runtime_envelope_path(),
+            envelope,
+        )
+        .await
+    }
+
+    pub fn verify_parent_runtime_envelope(
+        &self,
+        parent: &ParentExecutionRoot,
+        envelope: &ParentRuntimeEnvelope,
+    ) -> Result<(), WorkspaceError> {
         if envelope.parent_issue_id != parent.manifest.parent_issue_id
             || envelope.parent_identifier != parent.manifest.parent_identifier
             || envelope.hierarchy_generation != parent.manifest.hierarchy_generation
@@ -843,12 +857,7 @@ impl WorkspaceManager {
                 "parent runtime envelope does not match the prepared execution root",
             ));
         }
-        self.write_manifest_atomically(
-            &parent.handle,
-            &parent.handle.parent_runtime_envelope_path(),
-            envelope,
-        )
-        .await
+        Ok(())
     }
 
     pub fn parent_runtime_envelope(
@@ -1249,6 +1258,7 @@ impl WorkspaceManager {
         &self,
         record: &ParentIntegrationCheckout,
     ) -> Result<WorkspaceHandle, WorkspaceError> {
+        let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
         let mut source = None;
         for retained in &record.retained_checkouts {
             let child = self
@@ -1258,25 +1268,38 @@ impl WorkspaceManager {
                     Some(&retained.issue_id),
                 )
                 .await?;
-            self.verify_checkout_for_parent(&child).await?;
-            let status = self
-                .git(
+            self.verify_checkout_with_worker_changes_timeout(&child, true, true, deadline)
+                .await?;
+            let status = checkout_operation_with_timeout(
+                checkout_time_remaining(deadline),
+                child.workspace_path(),
+                "verify retained child cleanliness",
+                self.git(
                     child.workspace_path(),
                     &["status", "--porcelain", "--untracked-files=all"],
-                )
-                .await?;
+                ),
+            )
+            .await?;
             if !status.is_empty() {
                 return Err(checkout_verification(
                     child.workspace_path(),
                     "retained child checkout is dirty",
                 ));
             }
-            let child_head = self
-                .git(child.workspace_path(), &["rev-parse", "HEAD"])
-                .await?;
-            let child_branch = self
-                .git(child.workspace_path(), &["branch", "--show-current"])
-                .await?;
+            let child_head = checkout_operation_with_timeout(
+                checkout_time_remaining(deadline),
+                child.workspace_path(),
+                "verify retained child head",
+                self.git(child.workspace_path(), &["rev-parse", "HEAD"]),
+            )
+            .await?;
+            let child_branch = checkout_operation_with_timeout(
+                checkout_time_remaining(deadline),
+                child.workspace_path(),
+                "verify retained child branch",
+                self.git(child.workspace_path(), &["branch", "--show-current"]),
+            )
+            .await?;
             if child_head != retained.child_head || child_branch != retained.child_branch {
                 return Err(checkout_verification(
                     child.workspace_path(),
@@ -1953,8 +1976,8 @@ impl WorkspaceManager {
                 reason: "checkout manifest provenance is inconsistent".to_owned(),
             });
         }
-        let shallow_state_matches = facts.shallow == manifest.shallow
-            || (allow_shallow && manifest.shallow && !facts.shallow);
+        let shallow_state_matches =
+            facts.shallow == manifest.shallow || (manifest.shallow && !facts.shallow);
         if (!allow_worker_changes && facts.head != manifest.head)
             || (!allow_worker_changes && facts.branch != manifest.current_branch)
             || !shallow_state_matches

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
     future::Future,
     io,
     path::{Path, PathBuf},
@@ -380,31 +381,51 @@ impl WorkspaceManager {
                             "retained child checkout generation is unavailable",
                         )
                     })?;
-                let checkout = self.verify_checkout_for_parent(&child_handle).await?;
+                let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
+                let checkout = self
+                    .verify_checkout_with_worker_changes_timeout(
+                        &child_handle,
+                        true,
+                        true,
+                        deadline,
+                    )
+                    .await?;
                 if checkout.repository_binding.repository_id().as_str() != repository_id {
                     return Err(checkout_verification(
                         child_handle.workspace_path(),
                         "retained child checkout has the wrong canonical repository",
                     ));
                 }
-                let status = self
-                    .git(
+                let status = checkout_operation_with_timeout(
+                    checkout_time_remaining(deadline),
+                    child_handle.workspace_path(),
+                    "verify retained child cleanliness",
+                    self.git(
                         child_handle.workspace_path(),
                         &["status", "--porcelain", "--untracked-files=all"],
-                    )
-                    .await?;
+                    ),
+                )
+                .await?;
                 if !status.is_empty() {
                     return Err(checkout_verification(
                         child_handle.workspace_path(),
                         "retained child checkout is dirty",
                     ));
                 }
-                let child_branch = self
-                    .git(child_handle.workspace_path(), &["branch", "--show-current"])
-                    .await?;
-                let child_head = self
-                    .git(child_handle.workspace_path(), &["rev-parse", "HEAD"])
-                    .await?;
+                let child_branch = checkout_operation_with_timeout(
+                    checkout_time_remaining(deadline),
+                    child_handle.workspace_path(),
+                    "verify retained child branch",
+                    self.git(child_handle.workspace_path(), &["branch", "--show-current"]),
+                )
+                .await?;
+                let child_head = checkout_operation_with_timeout(
+                    checkout_time_remaining(deadline),
+                    child_handle.workspace_path(),
+                    "verify retained child head",
+                    self.git(child_handle.workspace_path(), &["rev-parse", "HEAD"]),
+                )
+                .await?;
                 source.get_or_insert((child_handle.clone(), checkout.clone()));
                 required_merge_commits.extend(
                     request
@@ -784,19 +805,20 @@ impl WorkspaceManager {
                 })?;
             self.reject_symlinked_path_components(parent.handle.workspace_path(), relative)
                 .await?;
-            let (hash, bytes) =
+            let (hash, mut bytes) =
                 read_bounded_instruction_file(&path, &mut total_bytes, true).await?;
+            let hash = if is_workflow_instruction_path(&record.instruction.path) {
+                bytes = workflow_body(&bytes);
+                hash_bytes(&bytes)
+            } else {
+                hash
+            };
             if hash != record.instruction.content_hash {
                 return Err(checkout_verification(
                     &path,
                     "repository instruction hash does not match the parent checkout map",
                 ));
             }
-            let bytes = if is_workflow_instruction_path(&record.instruction.path) {
-                workflow_body(&bytes)
-            } else {
-                bytes
-            };
             instructions.insert(
                 record.repository_id.clone(),
                 String::from_utf8_lossy(&bytes).into_owned(),
@@ -1019,10 +1041,22 @@ impl WorkspaceManager {
             None
         };
 
+        let hooks_directory = tempfile::Builder::new()
+            .prefix("opensymphony-empty-git-hooks-")
+            .tempdir()
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: "isolate Git hooks".to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        let mut hooks_config = OsString::from("core.hooksPath=");
+        hooks_config.push(hooks_directory.path());
         let mut command = Command::new("git");
         command
             .arg("-c")
             .arg("credential.helper=")
+            .arg("-c")
+            .arg(hooks_config)
             .arg("-C")
             .arg(checkout)
             .args(args);
@@ -2081,15 +2115,6 @@ impl WorkspaceManager {
     ) -> Result<CheckoutManifest, WorkspaceError> {
         let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
         self.verify_checkout_with_worker_changes_timeout(workspace, true, false, deadline)
-            .await
-    }
-
-    async fn verify_checkout_for_parent(
-        &self,
-        workspace: &WorkspaceHandle,
-    ) -> Result<CheckoutManifest, WorkspaceError> {
-        let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
-        self.verify_checkout_with_worker_changes_timeout(workspace, true, true, deadline)
             .await
     }
 
@@ -5889,7 +5914,7 @@ async fn tracked_instruction_paths(
 fn path_from_git_bytes(bytes: &[u8]) -> PathBuf {
     use std::os::unix::ffi::OsStringExt;
 
-    PathBuf::from(std::ffi::OsString::from_vec(bytes.to_vec()))
+    PathBuf::from(OsString::from_vec(bytes.to_vec()))
 }
 
 #[cfg(not(unix))]

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -1214,30 +1214,62 @@ impl WorkspaceManager {
             &repository.remote,
         )
         .map_err(|error| checkout_verification(&integration, &error.to_string()))?;
-        for args in [
-            ["remote", "get-url", "--all", "origin"].as_slice(),
-            ["remote", "get-url", "--all", "--push", "origin"].as_slice(),
+        let expected_locator = SafeRemoteFingerprint::from_remote(
+            &repository.provider,
+            None,
+            &repository.remote_locator,
+        )
+        .map_err(|error| checkout_verification(&integration, &error.to_string()))?;
+        for (kind, args) in [
+            ("fetch", ["remote", "get-url", "--all", "origin"].as_slice()),
+            (
+                "push",
+                ["remote", "get-url", "--all", "--push", "origin"].as_slice(),
+            ),
         ] {
-            let remotes = self.git(&integration, args).await?;
-            if remotes.lines().all(|remote| remote.trim().is_empty()) {
-                return Err(checkout_verification(
+            let remotes = self.git(&integration, args).await.map_err(|_| {
+                checkout_verification(
                     &integration,
-                    "origin remote is unavailable",
-                ));
-            }
-            for remote in remotes.lines() {
+                    &format!("origin {kind} remote is unavailable"),
+                )
+            })?;
+            let mut found = false;
+            for remote in remotes
+                .lines()
+                .map(str::trim)
+                .filter(|remote| !remote.is_empty())
+            {
+                found = true;
+                if remote_contains_credentials(remote) {
+                    return Err(checkout_verification(
+                        &integration,
+                        "observed remote contains credentials",
+                    ));
+                }
                 let actual = SafeRemoteFingerprint::from_remote(
                     &repository.provider,
                     repository.provider_id.as_deref(),
                     remote,
                 )
                 .map_err(|error| checkout_verification(&integration, &error.to_string()))?;
-                if actual != expected || actual.as_str() != record.safe_remote_fingerprint {
+                let actual_locator =
+                    SafeRemoteFingerprint::from_remote(&repository.provider, None, remote)
+                        .map_err(|error| checkout_verification(&integration, &error.to_string()))?;
+                if actual != expected
+                    || actual.as_str() != record.safe_remote_fingerprint
+                    || actual_locator != expected_locator
+                {
                     return Err(checkout_verification(
                         &integration,
                         "origin remote fingerprint mismatch",
                     ));
                 }
+            }
+            if !found {
+                return Err(checkout_verification(
+                    &integration,
+                    &format!("origin {kind} remote is unavailable"),
+                ));
             }
         }
         if !allow_worker_changes {

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -293,6 +293,9 @@ impl WorkspaceManager {
         let parent_base = resolve_path_within_root(&self.config.root, &parent_relative)?;
         self.create_directory(&parent_base).await?;
         let root = parent_base.join(hierarchy_generation.to_string());
+        let parent_pin_path = self
+            .parent_child_checkout_pin_path(&workspace_key, hierarchy_generation)
+            .await?;
         self.reject_symlinked_workspace_root(&root).await?;
         if path_exists(&root).await? {
             let parent = self
@@ -311,6 +314,11 @@ impl WorkspaceManager {
                 workspace_key,
                 root,
             );
+            match self.execute_hook(HookKind::AfterCreate, &handle).await {
+                Ok(Some(_)) => self.write_after_create_receipt(issue, &handle).await?,
+                Ok(None) => {}
+                Err(failure) => return Err(failure.error),
+            }
             self.bootstrap_workspace_layout(&handle).await?;
             self.create_managed_directory(&handle, &handle.workspace_path().join("evidence"))
                 .await?;
@@ -468,11 +476,13 @@ impl WorkspaceManager {
             let checkout_handle = parent_checkout_handle(&repository_id, hierarchy_generation);
             let relative_path = PathBuf::from("repositories").join(&checkout_handle);
             let integration_path = handle.workspace_path().join(&relative_path);
+            let integration_deadline =
+                checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
             let integration_path_text = integration_path.to_str().ok_or_else(|| {
                 checkout_verification(&integration_path, "integration checkout path is not UTF-8")
             })?;
             checkout_operation_with_timeout(
-                Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT),
+                checkout_time_remaining(integration_deadline),
                 source_handle.workspace_path(),
                 "create parent integration worktree",
                 self.git(
@@ -487,9 +497,13 @@ impl WorkspaceManager {
                 ),
             )
             .await?;
-            let instruction = self
-                .load_instruction_provenance(&integration_path, repository, &target_commit)
-                .await?;
+            let instruction = checkout_operation_with_timeout(
+                checkout_time_remaining(integration_deadline),
+                &integration_path,
+                "load parent integration instructions",
+                self.load_instruction_provenance(&integration_path, repository, &target_commit),
+            )
+            .await?;
             let record = ParentIntegrationCheckout {
                 checkout_handle: checkout_handle.clone(),
                 repository_id: repository_id.clone(),
@@ -502,8 +516,13 @@ impl WorkspaceManager {
                 required_merge_commits: required_merge_commits.into_iter().collect(),
                 instruction,
             };
-            self.verify_parent_integration_checkout(&handle, &record, &source_handle, false)
-                .await?;
+            checkout_operation_with_timeout(
+                checkout_time_remaining(integration_deadline),
+                &integration_path,
+                "verify parent integration worktree",
+                self.verify_parent_integration_checkout(&handle, &record, &source_handle, false),
+            )
+            .await?;
                 repositories.insert(repository_id, record);
             }
 
@@ -532,6 +551,11 @@ impl WorkspaceManager {
             &child_checkout_map,
         )
             .await?;
+            self.write_parent_child_checkout_pin(
+                &parent_pin_path,
+                &child_checkout_map,
+            )
+            .await?;
             self.write_bytes_artifact_atomically(
             &handle,
             &handle.workspace_path().join("integration-plan.md"),
@@ -552,6 +576,8 @@ impl WorkspaceManager {
         .await;
         if result.is_err() {
             self.rollback_parent_preparation(&root).await;
+            self.remove_parent_child_checkout_pin(&parent_pin_path)
+                .await;
         }
         result
     }
@@ -618,6 +644,15 @@ impl WorkspaceManager {
             .ok_or_else(|| {
                 checkout_verification(handle.workspace_path(), "child checkout map is missing")
             })?;
+        let pinned_child_checkout_map = self
+            .load_parent_child_checkout_pin(handle.workspace_key(), hierarchy_generation)
+            .await?
+            .ok_or_else(|| {
+                checkout_verification(
+                    handle.workspace_path(),
+                    "orchestrator-owned parent checkout pin is missing",
+                )
+            })?;
         if manifest.schema_version != 1
             || manifest.parent_issue_id != issue.issue_id
             || manifest.parent_identifier != issue.identifier
@@ -629,6 +664,7 @@ impl WorkspaceManager {
             || manifest.repositories_directory != Path::new("repositories")
             || child_checkout_map.schema_version != 1
             || child_checkout_map.hierarchy_generation != hierarchy_generation
+            || child_checkout_map != pinned_child_checkout_map
             || path_exists(&handle.workspace_path().join(".git")).await?
         {
             return Err(checkout_verification(
@@ -636,10 +672,32 @@ impl WorkspaceManager {
                 "parent execution root identity is inconsistent",
             ));
         }
+        if self.config.hooks.after_create.is_some()
+            && !matches!(
+                self.inspect_after_create_receipt_state(issue, &handle)
+                    .await?,
+                ExistingReceiptState::Owned
+            )
+        {
+            return Err(checkout_verification(
+                handle.workspace_path(),
+                "parent after_create hook completion receipt is missing or invalid",
+            ));
+        }
         for record in child_checkout_map.repositories.values() {
             let source = self.validate_parent_retained_checkouts(record).await?;
-            self.verify_parent_integration_checkout(&handle, record, &source, allow_worker_changes)
-                .await?;
+            checkout_operation_with_timeout(
+                Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT),
+                handle.workspace_path(),
+                "verify retained parent integration worktree",
+                self.verify_parent_integration_checkout(
+                    &handle,
+                    record,
+                    &source,
+                    allow_worker_changes,
+                ),
+            )
+            .await?;
         }
         Ok(ParentExecutionRoot {
             handle,
@@ -715,8 +773,13 @@ impl WorkspaceManager {
                 )
             })?;
         let source = self.validate_parent_retained_checkouts(record).await?;
-        self.verify_parent_integration_checkout(&parent.handle, record, &source, true)
-            .await?;
+        checkout_operation_with_timeout(
+            Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT),
+            parent.handle.workspace_path(),
+            "verify resolved parent integration worktree",
+            self.verify_parent_integration_checkout(&parent.handle, record, &source, true),
+        )
+        .await?;
         Ok(parent.handle.workspace_path().join(&record.relative_path))
     }
 
@@ -1208,6 +1271,27 @@ impl WorkspaceManager {
             ));
         }
         let head = self.git(&integration, &["rev-parse", "HEAD"]).await?;
+        for required in &record.required_merge_commits {
+            if !self
+                .git_is_ancestor(
+                    &integration,
+                    &[
+                        "merge-base",
+                        "--is-ancestor",
+                        required,
+                        &record.target_commit,
+                    ],
+                )
+                .await?
+            {
+                return Err(checkout_verification(
+                    &integration,
+                    &format!(
+                        "provider merge result {required} is not reachable from the pinned target commit"
+                    ),
+                ));
+            }
+        }
         if (!allow_worker_changes && head != record.target_commit)
             || (allow_worker_changes
                 && !self
@@ -1324,9 +1408,9 @@ impl WorkspaceManager {
         &self,
         record: &ParentIntegrationCheckout,
     ) -> Result<WorkspaceHandle, WorkspaceError> {
-        let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
         let mut source = None;
         for retained in &record.retained_checkouts {
+            let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
             let child = self
                 .find_retained_checkout(
                     &record.repository_id,
@@ -4246,6 +4330,54 @@ impl WorkspaceManager {
 
     fn orchestrator_state_path(&self, canonical_root: &Path) -> PathBuf {
         canonical_root.join(".opensymphony-orchestrator-state.json")
+    }
+
+    async fn parent_child_checkout_pin_path(
+        &self,
+        workspace_key: &str,
+        hierarchy_generation: u64,
+    ) -> Result<PathBuf, WorkspaceError> {
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        Ok(canonical_root
+            .join(".opensymphony-parent-pins")
+            .join(workspace_key)
+            .join(format!("{hierarchy_generation}.json")))
+    }
+
+    async fn write_parent_child_checkout_pin(
+        &self,
+        path: &Path,
+        map: &ParentChildCheckoutMap,
+    ) -> Result<(), WorkspaceError> {
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let handle = self.orchestrator_state_handle(canonical_root);
+        self.write_json_artifact_atomically(&handle, path, map)
+            .await
+    }
+
+    async fn load_parent_child_checkout_pin(
+        &self,
+        workspace_key: &str,
+        hierarchy_generation: u64,
+    ) -> Result<Option<ParentChildCheckoutMap>, WorkspaceError> {
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let handle = self.orchestrator_state_handle(canonical_root);
+        let path = self
+            .parent_child_checkout_pin_path(workspace_key, hierarchy_generation)
+            .await?;
+        self.load_manifest(&handle, &path).await
+    }
+
+    async fn remove_parent_child_checkout_pin(&self, path: &Path) {
+        if let Err(error) = fs::remove_file(path).await
+            && error.kind() != io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                path = %path.display(),
+                error = %error,
+                "failed to remove incomplete parent checkout pin"
+            );
+        }
     }
 
     pub async fn load_conversation_manifest(

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -279,10 +279,10 @@ impl WorkspaceManager {
         hierarchy_generation: u64,
         requests: Vec<ParentCheckoutRequest>,
     ) -> Result<ParentExecutionRoot, WorkspaceError> {
-        if hierarchy_generation == 0 || requests.is_empty() || issue.repository_binding.is_some() {
+        if hierarchy_generation == 0 || issue.repository_binding.is_some() {
             return Err(checkout_verification(
                 &self.config.root,
-                "parent preparation requires a repository-neutral issue, a hierarchy generation, and retained checkout requests",
+                "parent preparation requires a repository-neutral issue and a hierarchy generation",
             ));
         }
         let workspace_key = format!("parent-{}", sanitize_workspace_key(&issue.identifier)?);
@@ -301,24 +301,25 @@ impl WorkspaceManager {
             return Ok(parent);
         }
         self.create_directory(&root).await?;
-        let root = self.canonicalize_path(&root).await?;
-        ensure_descendant(&self.canonicalize_path(&self.config.root).await?, &root)?;
-        let handle = WorkspaceHandle::new(
-            issue.issue_id.clone(),
-            issue.identifier.clone(),
-            workspace_key,
-            root,
-        );
-        self.bootstrap_workspace_layout(&handle).await?;
-        self.create_managed_directory(&handle, &handle.workspace_path().join("evidence"))
-            .await?;
-        self.create_managed_directory(&handle, &handle.workspace_path().join("repositories"))
-            .await?;
+        let result = async {
+            let root = self.canonicalize_path(&root).await?;
+            ensure_descendant(&self.canonicalize_path(&self.config.root).await?, &root)?;
+            let handle = WorkspaceHandle::new(
+                issue.issue_id.clone(),
+                issue.identifier.clone(),
+                workspace_key,
+                root,
+            );
+            self.bootstrap_workspace_layout(&handle).await?;
+            self.create_managed_directory(&handle, &handle.workspace_path().join("evidence"))
+                .await?;
+            self.create_managed_directory(&handle, &handle.workspace_path().join("repositories"))
+                .await?;
 
-        let retained = self.list_all_workspaces().await?;
-        let mut grouped = BTreeMap::<String, Vec<ParentCheckoutRequest>>::new();
-        let mut request_keys = BTreeSet::new();
-        for request in requests {
+            let retained = self.list_all_workspaces().await?;
+            let mut grouped = BTreeMap::<String, Vec<ParentCheckoutRequest>>::new();
+            let mut request_keys = BTreeSet::new();
+            for request in requests {
             if request.issue_id.trim().is_empty()
                 || request.repository_id.trim().is_empty()
                 || request.checkout_generation.trim().is_empty()
@@ -339,14 +340,14 @@ impl WorkspaceManager {
                     "parent checkout requests contain a duplicate generation-bound handle",
                 ));
             }
-            grouped
-                .entry(request.repository_id.clone())
-                .or_default()
-                .push(request);
-        }
+                grouped
+                    .entry(request.repository_id.clone())
+                    .or_default()
+                    .push(request);
+            }
 
-        let mut repositories = BTreeMap::new();
-        for (repository_id, mut repository_requests) in grouped {
+            let mut repositories = BTreeMap::new();
+            for (repository_id, mut repository_requests) in grouped {
             repository_requests.sort_by(|left, right| {
                 left.issue_id
                     .cmp(&right.issue_id)
@@ -449,15 +450,20 @@ impl WorkspaceManager {
             let integration_path_text = integration_path.to_str().ok_or_else(|| {
                 checkout_verification(&integration_path, "integration checkout path is not UTF-8")
             })?;
-            self.git(
+            checkout_operation_with_timeout(
+                Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT),
                 source_handle.workspace_path(),
-                &[
-                    "worktree",
-                    "add",
-                    "--detach",
-                    integration_path_text,
-                    &target_commit,
-                ],
+                "create parent integration worktree",
+                self.git(
+                    source_handle.workspace_path(),
+                    &[
+                        "worktree",
+                        "add",
+                        "--detach",
+                        integration_path_text,
+                        &target_commit,
+                    ],
+                ),
             )
             .await?;
             let instruction = self
@@ -475,18 +481,18 @@ impl WorkspaceManager {
                 required_merge_commits: required_merge_commits.into_iter().collect(),
                 instruction,
             };
-            self.verify_parent_integration_checkout(&handle, &record, &source_handle)
+            self.verify_parent_integration_checkout(&handle, &record, &source_handle, false)
                 .await?;
-            repositories.insert(repository_id, record);
-        }
+                repositories.insert(repository_id, record);
+            }
 
-        let now = Utc::now();
-        let child_checkout_map = ParentChildCheckoutMap {
+            let now = Utc::now();
+            let child_checkout_map = ParentChildCheckoutMap {
             schema_version: 1,
             hierarchy_generation,
             repositories,
-        };
-        let manifest = ParentExecutionManifest {
+            };
+            let manifest = ParentExecutionManifest {
             schema_version: 1,
             parent_issue_id: issue.issue_id.clone(),
             parent_identifier: issue.identifier.clone(),
@@ -498,29 +504,35 @@ impl WorkspaceManager {
             repositories_directory: PathBuf::from("repositories"),
             created_at: now,
             updated_at: now,
-        };
-        self.write_manifest_atomically(
+            };
+            self.write_manifest_atomically(
             &handle,
             &handle.child_checkouts_path(),
             &child_checkout_map,
         )
-        .await?;
-        self.write_bytes_artifact_atomically(
+            .await?;
+            self.write_bytes_artifact_atomically(
             &handle,
             &handle.workspace_path().join("integration-plan.md"),
             render_parent_integration_plan(&child_checkout_map).as_bytes(),
         )
-        .await?;
-        self.write_manifest_atomically(&handle, &handle.parent_manifest_path(), &manifest)
             .await?;
-        let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
-        debug_assert_eq!(issue_manifest.workspace_path, handle.workspace_path());
-        Ok(ParentExecutionRoot {
-            handle,
-            manifest,
-            child_checkout_map,
-            created: true,
-        })
+            self.write_manifest_atomically(&handle, &handle.parent_manifest_path(), &manifest)
+                .await?;
+            let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
+            debug_assert_eq!(issue_manifest.workspace_path, handle.workspace_path());
+            Ok(ParentExecutionRoot {
+                handle,
+                manifest,
+                child_checkout_map,
+                created: true,
+            })
+        }
+        .await;
+        if result.is_err() {
+            self.rollback_parent_preparation(&root).await;
+        }
+        result
     }
 
     pub async fn open_parent_execution_root(
@@ -528,6 +540,17 @@ impl WorkspaceManager {
         issue: &IssueDescriptor,
         hierarchy_generation: u64,
         root: &Path,
+    ) -> Result<ParentExecutionRoot, WorkspaceError> {
+        self.open_parent_execution_root_with_changes(issue, hierarchy_generation, root, false)
+            .await
+    }
+
+    async fn open_parent_execution_root_with_changes(
+        &self,
+        issue: &IssueDescriptor,
+        hierarchy_generation: u64,
+        root: &Path,
+        allow_worker_changes: bool,
     ) -> Result<ParentExecutionRoot, WorkspaceError> {
         self.reject_symlinked_path_components(
             &self.config.root,
@@ -593,14 +616,8 @@ impl WorkspaceManager {
             ));
         }
         for record in child_checkout_map.repositories.values() {
-            let source = self
-                .find_retained_checkout(
-                    &record.repository_id,
-                    &record.storage_source_generation,
-                    None,
-                )
-                .await?;
-            self.verify_parent_integration_checkout(&handle, record, &source)
+            let source = self.validate_parent_retained_checkouts(record).await?;
+            self.verify_parent_integration_checkout(&handle, record, &source, allow_worker_changes)
                 .await?;
         }
         Ok(ParentExecutionRoot {
@@ -633,6 +650,33 @@ impl WorkspaceManager {
             .await
     }
 
+    pub async fn open_parent_execution_root_at_for_retry(
+        &self,
+        issue: &IssueDescriptor,
+        root: &Path,
+    ) -> Result<ParentExecutionRoot, WorkspaceError> {
+        let canonical_root = self.canonicalize_path(root).await?;
+        let handle = WorkspaceHandle::new(
+            issue.issue_id.clone(),
+            issue.identifier.clone(),
+            format!("parent-{}", sanitize_workspace_key(&issue.identifier)?),
+            canonical_root,
+        );
+        let manifest = self
+            .load_manifest::<ParentExecutionManifest>(&handle, &handle.parent_manifest_path())
+            .await?
+            .ok_or_else(|| {
+                checkout_verification(handle.workspace_path(), "parent manifest is missing")
+            })?;
+        self.open_parent_execution_root_with_changes(
+            issue,
+            manifest.hierarchy_generation,
+            root,
+            true,
+        )
+        .await
+    }
+
     pub async fn resolve_parent_checkout(
         &self,
         parent: &ParentExecutionRoot,
@@ -649,14 +693,8 @@ impl WorkspaceManager {
                     "checkout handle is not present in the pinned parent map",
                 )
             })?;
-        let source = self
-            .find_retained_checkout(
-                &record.repository_id,
-                &record.storage_source_generation,
-                None,
-            )
-            .await?;
-        self.verify_parent_integration_checkout(&parent.handle, record, &source)
+        let source = self.validate_parent_retained_checkouts(record).await?;
+        self.verify_parent_integration_checkout(&parent.handle, record, &source, true)
             .await?;
         Ok(parent.handle.workspace_path().join(&record.relative_path))
     }
@@ -730,6 +768,7 @@ impl WorkspaceManager {
         parent: &ParentExecutionRoot,
     ) -> Result<BTreeMap<String, String>, WorkspaceError> {
         let mut instructions = BTreeMap::new();
+        let mut total_bytes = 0;
         for record in parent.child_checkout_map.repositories.values() {
             let checkout = self
                 .resolve_parent_checkout(parent, &record.checkout_handle)
@@ -745,7 +784,6 @@ impl WorkspaceManager {
                 })?;
             self.reject_symlinked_path_components(parent.handle.workspace_path(), relative)
                 .await?;
-            let mut total_bytes = 0;
             let (hash, bytes) =
                 read_bounded_instruction_file(&path, &mut total_bytes, true).await?;
             if hash != record.instruction.content_hash {
@@ -973,7 +1011,12 @@ impl WorkspaceManager {
         };
 
         let mut command = Command::new("git");
-        command.arg("-C").arg(checkout).args(args);
+        command
+            .arg("-c")
+            .arg("credential.helper=")
+            .arg("-C")
+            .arg(checkout)
+            .args(args);
         for variable in &self.checkout_credential_envs {
             command.env_remove(variable);
         }
@@ -1009,7 +1052,28 @@ impl WorkspaceManager {
         }
         configure_process_group(&mut command);
         command.kill_on_drop(true);
-        let output = timeout(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT, command.output()).await;
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let child = match command.spawn() {
+            Ok(child) => child,
+            Err(source) => {
+                if let Some(path) = askpass_path.as_ref() {
+                    let _ = fs::remove_file(path).await;
+                }
+                return Err(WorkspaceError::CheckoutOperation {
+                    operation: args.first().copied().unwrap_or("git").to_owned(),
+                    path: checkout.to_path_buf(),
+                    detail: source.to_string(),
+                });
+            }
+        };
+        let process_id = child.id();
+        #[cfg(unix)]
+        let mut process_group_guard = ProcessGroupGuard::new(process_id);
+        let output = timeout(
+            RETAINED_CHECKOUT_VERIFICATION_TIMEOUT,
+            child.wait_with_output(),
+        )
+        .await;
         if let Some(path) = askpass_path.as_ref() {
             let _ = fs::remove_file(path).await;
         }
@@ -1027,6 +1091,8 @@ impl WorkspaceManager {
                 path: checkout.to_path_buf(),
                 detail: source.to_string(),
             })?;
+        #[cfg(unix)]
+        process_group_guard.disarm();
         if output.status.success() {
             return Ok(());
         }
@@ -1046,10 +1112,15 @@ impl WorkspaceManager {
         parent: &WorkspaceHandle,
         record: &ParentIntegrationCheckout,
         source: &WorkspaceHandle,
+        allow_worker_changes: bool,
     ) -> Result<(), WorkspaceError> {
         let integration = resolve_path_within_root(parent.workspace_path(), &record.relative_path)?;
         let repositories = parent.workspace_path().join("repositories");
+        self.reject_symlinked_path_components(parent.workspace_path(), Path::new("repositories"))
+            .await?;
+        let canonical_parent = self.canonicalize_path(parent.workspace_path()).await?;
         let canonical_repositories = self.canonicalize_path(&repositories).await?;
+        ensure_descendant(&canonical_parent, &canonical_repositories)?;
         let canonical_integration = self.canonicalize_path(&integration).await?;
         ensure_descendant(&canonical_repositories, &canonical_integration)?;
         if integration.file_name().and_then(|name| name.to_str())
@@ -1093,19 +1164,29 @@ impl WorkspaceManager {
                 "integration checkout does not share retained child Git storage",
             ));
         }
-        if self.git(&integration, &["rev-parse", "HEAD"]).await? != record.target_commit {
+        let head = self.git(&integration, &["rev-parse", "HEAD"]).await?;
+        if (!allow_worker_changes && head != record.target_commit)
+            || (allow_worker_changes
+                && !self
+                    .git_is_ancestor(
+                        &integration,
+                        &["merge-base", "--is-ancestor", &record.target_commit, &head],
+                    )
+                    .await?)
+        {
             return Err(checkout_verification(
                 &integration,
-                "integration checkout is not at its recorded target commit",
+                "integration checkout does not retain its recorded target commit",
             ));
         }
-        if !self
-            .git(
-                &integration,
-                &["status", "--porcelain", "--untracked-files=all"],
-            )
-            .await?
-            .is_empty()
+        if !allow_worker_changes
+            && !self
+                .git(
+                    &integration,
+                    &["status", "--porcelain", "--untracked-files=all"],
+                )
+                .await?
+                .is_empty()
         {
             return Err(checkout_verification(
                 &integration,
@@ -1150,16 +1231,99 @@ impl WorkspaceManager {
                 }
             }
         }
-        let instruction = self
-            .load_instruction_provenance(&integration, repository, &record.target_commit)
-            .await?;
-        if instruction != record.instruction {
-            return Err(checkout_verification(
-                &integration,
-                "repository instruction provenance does not match the parent checkout map",
-            ));
+        if !allow_worker_changes {
+            let instruction = self
+                .load_instruction_provenance(&integration, repository, &record.target_commit)
+                .await?;
+            if instruction != record.instruction {
+                return Err(checkout_verification(
+                    &integration,
+                    "repository instruction provenance does not match the parent checkout map",
+                ));
+            }
         }
         Ok(())
+    }
+
+    async fn validate_parent_retained_checkouts(
+        &self,
+        record: &ParentIntegrationCheckout,
+    ) -> Result<WorkspaceHandle, WorkspaceError> {
+        let mut source = None;
+        for retained in &record.retained_checkouts {
+            let child = self
+                .find_retained_checkout(
+                    &record.repository_id,
+                    &retained.checkout_generation,
+                    Some(&retained.issue_id),
+                )
+                .await?;
+            let child_manifest = self.verify_checkout_for_parent(&child).await?;
+            let status = self
+                .git(
+                    child.workspace_path(),
+                    &["status", "--porcelain", "--untracked-files=all"],
+                )
+                .await?;
+            if !status.is_empty() {
+                return Err(checkout_verification(
+                    child.workspace_path(),
+                    "retained child checkout is dirty",
+                ));
+            }
+            if child_manifest.head != retained.child_head
+                || child_manifest.current_branch != retained.child_branch
+            {
+                return Err(checkout_verification(
+                    child.workspace_path(),
+                    "retained child evidence no longer matches the pinned parent map",
+                ));
+            }
+            if retained.checkout_generation == record.storage_source_generation {
+                source = Some(child);
+            }
+        }
+        source.ok_or_else(|| {
+            checkout_verification(
+                &self.config.root,
+                "parent checkout map has no retained storage source",
+            )
+        })
+    }
+
+    async fn rollback_parent_preparation(&self, root: &Path) {
+        let repositories = root.join("repositories");
+        if let Ok(mut entries) = fs::read_dir(&repositories).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let integration = entry.path();
+                if entry
+                    .file_type()
+                    .await
+                    .is_ok_and(|file_type| file_type.is_dir() && !file_type.is_symlink())
+                    && let Some(integration_text) = integration.to_str()
+                {
+                    let _ = checkout_operation_with_timeout(
+                        Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT),
+                        &integration,
+                        "roll back parent integration worktree",
+                        self.git(
+                            &integration,
+                            &["worktree", "remove", "--force", integration_text],
+                        ),
+                    )
+                    .await;
+                }
+            }
+        }
+        if let Err(error) = fs::remove_dir_all(root).await
+            && error.kind() != io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                path = %root.display(),
+                %error,
+                "failed to roll back incomplete parent execution root"
+            );
+        }
     }
 
     pub async fn ensure(
@@ -1785,9 +1949,11 @@ impl WorkspaceManager {
                 reason: "checkout manifest provenance is inconsistent".to_owned(),
             });
         }
+        let shallow_state_matches = facts.shallow == manifest.shallow
+            || (allow_shallow && manifest.shallow && !facts.shallow);
         if (!allow_worker_changes && facts.head != manifest.head)
             || (!allow_worker_changes && facts.branch != manifest.current_branch)
-            || facts.shallow != manifest.shallow
+            || !shallow_state_matches
             || (!allow_worker_changes && (!facts.clean || manifest.clean != facts.clean))
         {
             return Err(WorkspaceError::CheckoutVerification {

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -295,7 +295,7 @@ impl WorkspaceManager {
         self.reject_symlinked_workspace_root(&root).await?;
         if path_exists(&root).await? {
             let parent = self
-                .open_parent_execution_root(issue, hierarchy_generation, &root)
+                .open_parent_execution_root_with_changes(issue, hierarchy_generation, &root, true)
                 .await?;
             self.verify_parent_requests(&parent, &requests)?;
             return Ok(parent);
@@ -1258,7 +1258,7 @@ impl WorkspaceManager {
                     Some(&retained.issue_id),
                 )
                 .await?;
-            let child_manifest = self.verify_checkout_for_parent(&child).await?;
+            self.verify_checkout_for_parent(&child).await?;
             let status = self
                 .git(
                     child.workspace_path(),
@@ -1271,9 +1271,13 @@ impl WorkspaceManager {
                     "retained child checkout is dirty",
                 ));
             }
-            if child_manifest.head != retained.child_head
-                || child_manifest.current_branch != retained.child_branch
-            {
+            let child_head = self
+                .git(child.workspace_path(), &["rev-parse", "HEAD"])
+                .await?;
+            let child_branch = self
+                .git(child.workspace_path(), &["branch", "--show-current"])
+                .await?;
+            if child_head != retained.child_head || child_branch != retained.child_branch {
                 return Err(checkout_verification(
                     child.workspace_path(),
                     "retained child evidence no longer matches the pinned parent map",

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -31,9 +31,11 @@ use super::{
     CheckoutManifest, CheckoutRepository, CleanupDecision, CleanupOutcome, ConversationManifest,
     EnsureWorkspaceResult, HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind,
     IssueContextArtifact, IssueDescriptor, IssueLifecycleState, IssueManifest,
-    PromptCaptureDescriptor, PromptCaptureManifest, RunDescriptor, RunManifest, RunStatus,
-    SessionContextArtifact, TerminalRuntimeEnvelope, WorkspaceError, WorkspaceHandle,
-    WorkspaceManagerConfig, WorkspaceOwnershipConflictDetails,
+    ParentCheckoutRequest, ParentChildCheckoutMap, ParentExecutionManifest, ParentExecutionRoot,
+    ParentIntegrationCheckout, ParentRetainedCheckout, ParentRuntimeCheckout,
+    ParentRuntimeDescriptor, ParentRuntimeEnvelope, PromptCaptureDescriptor, PromptCaptureManifest,
+    RunDescriptor, RunManifest, RunStatus, SessionContextArtifact, TerminalRuntimeEnvelope,
+    WorkspaceError, WorkspaceHandle, WorkspaceManagerConfig, WorkspaceOwnershipConflictDetails,
     models::{
         AfterCreateBootstrapReceipt, InstructionProvenance, SSH_AUTH_SOCK_ENV,
         redact_runtime_diagnostic,
@@ -269,6 +271,895 @@ impl WorkspaceManager {
 
     pub fn workspace_path_for(&self, issue_identifier: &str) -> Result<PathBuf, WorkspaceError> {
         super::workspace_path_for_root(&self.config.root, issue_identifier)
+    }
+
+    pub async fn prepare_parent_execution_root(
+        &self,
+        issue: &IssueDescriptor,
+        hierarchy_generation: u64,
+        requests: Vec<ParentCheckoutRequest>,
+    ) -> Result<ParentExecutionRoot, WorkspaceError> {
+        if hierarchy_generation == 0 || requests.is_empty() || issue.repository_binding.is_some() {
+            return Err(checkout_verification(
+                &self.config.root,
+                "parent preparation requires a repository-neutral issue, a hierarchy generation, and retained checkout requests",
+            ));
+        }
+        let workspace_key = format!("parent-{}", sanitize_workspace_key(&issue.identifier)?);
+        let parent_relative = PathBuf::from("parents").join(&workspace_key);
+        self.reject_symlinked_path_components(&self.config.root, &parent_relative)
+            .await?;
+        let parent_base = resolve_path_within_root(&self.config.root, &parent_relative)?;
+        self.create_directory(&parent_base).await?;
+        let root = parent_base.join(hierarchy_generation.to_string());
+        self.reject_symlinked_workspace_root(&root).await?;
+        if path_exists(&root).await? {
+            let parent = self
+                .open_parent_execution_root(issue, hierarchy_generation, &root)
+                .await?;
+            self.verify_parent_requests(&parent, &requests)?;
+            return Ok(parent);
+        }
+        self.create_directory(&root).await?;
+        let root = self.canonicalize_path(&root).await?;
+        ensure_descendant(&self.canonicalize_path(&self.config.root).await?, &root)?;
+        let handle = WorkspaceHandle::new(
+            issue.issue_id.clone(),
+            issue.identifier.clone(),
+            workspace_key,
+            root,
+        );
+        self.bootstrap_workspace_layout(&handle).await?;
+        self.create_managed_directory(&handle, &handle.workspace_path().join("evidence"))
+            .await?;
+        self.create_managed_directory(&handle, &handle.workspace_path().join("repositories"))
+            .await?;
+
+        let retained = self.list_all_workspaces().await?;
+        let mut grouped = BTreeMap::<String, Vec<ParentCheckoutRequest>>::new();
+        let mut request_keys = BTreeSet::new();
+        for request in requests {
+            if request.issue_id.trim().is_empty()
+                || request.repository_id.trim().is_empty()
+                || request.checkout_generation.trim().is_empty()
+                || request.lease_owner.trim().is_empty()
+            {
+                return Err(checkout_verification(
+                    handle.workspace_path(),
+                    "parent checkout request is missing a generation-bound identity or lease owner",
+                ));
+            }
+            if !request_keys.insert((
+                request.repository_id.clone(),
+                request.issue_id.clone(),
+                request.checkout_generation.clone(),
+            )) {
+                return Err(checkout_verification(
+                    handle.workspace_path(),
+                    "parent checkout requests contain a duplicate generation-bound handle",
+                ));
+            }
+            grouped
+                .entry(request.repository_id.clone())
+                .or_default()
+                .push(request);
+        }
+
+        let mut repositories = BTreeMap::new();
+        for (repository_id, mut repository_requests) in grouped {
+            repository_requests.sort_by(|left, right| {
+                left.issue_id
+                    .cmp(&right.issue_id)
+                    .then_with(|| left.checkout_generation.cmp(&right.checkout_generation))
+            });
+            let repository = self
+                .checkout_repositories
+                .get(&repository_id)
+                .ok_or_else(|| {
+                    checkout_verification(
+                        handle.workspace_path(),
+                        "parent checkout repository policy is unavailable",
+                    )
+                })?;
+            let mut retained_checkouts = Vec::with_capacity(repository_requests.len());
+            let mut source = None;
+            let mut required_merge_commits = BTreeSet::new();
+            for request in repository_requests {
+                let (child_handle, child_issue) = retained
+                    .iter()
+                    .find(|(candidate, manifest)| {
+                        manifest.issue_id == request.issue_id
+                            && candidate.checkout_generation()
+                                == Some(request.checkout_generation.as_str())
+                    })
+                    .cloned()
+                    .ok_or_else(|| {
+                        checkout_verification(
+                            handle.workspace_path(),
+                            "retained child checkout generation is unavailable",
+                        )
+                    })?;
+                let checkout = self.verify_checkout_for_parent(&child_handle).await?;
+                if checkout.repository_binding.repository_id().as_str() != repository_id {
+                    return Err(checkout_verification(
+                        child_handle.workspace_path(),
+                        "retained child checkout has the wrong canonical repository",
+                    ));
+                }
+                let status = self
+                    .git(
+                        child_handle.workspace_path(),
+                        &["status", "--porcelain", "--untracked-files=all"],
+                    )
+                    .await?;
+                if !status.is_empty() {
+                    return Err(checkout_verification(
+                        child_handle.workspace_path(),
+                        "retained child checkout is dirty",
+                    ));
+                }
+                let child_branch = self
+                    .git(child_handle.workspace_path(), &["branch", "--show-current"])
+                    .await?;
+                let child_head = self
+                    .git(child_handle.workspace_path(), &["rev-parse", "HEAD"])
+                    .await?;
+                source.get_or_insert((child_handle.clone(), checkout.clone()));
+                required_merge_commits.extend(
+                    request
+                        .required_merge_commits
+                        .into_iter()
+                        .filter(|commit| !commit.trim().is_empty()),
+                );
+                retained_checkouts.push(ParentRetainedCheckout {
+                    issue_id: request.issue_id,
+                    identifier: child_issue.identifier,
+                    checkout_generation: request.checkout_generation,
+                    lease_owner: request.lease_owner,
+                    child_branch,
+                    child_head,
+                });
+            }
+            let (source_handle, source_manifest) = source.expect("non-empty repository group");
+            self.fetch_parent_target(&source_handle, repository).await?;
+            let target_ref = format!("refs/remotes/origin/{}", repository.target_branch);
+            let target_commit = self
+                .git(source_handle.workspace_path(), &["rev-parse", &target_ref])
+                .await?;
+            for required in &required_merge_commits {
+                if !self
+                    .git_is_ancestor(
+                        source_handle.workspace_path(),
+                        &["merge-base", "--is-ancestor", required, &target_commit],
+                    )
+                    .await?
+                {
+                    return Err(checkout_verification(
+                        source_handle.workspace_path(),
+                        &format!(
+                            "provider merge result {required} is not reachable from target commit {target_commit}"
+                        ),
+                    ));
+                }
+            }
+
+            let checkout_handle = parent_checkout_handle(&repository_id, hierarchy_generation);
+            let relative_path = PathBuf::from("repositories").join(&checkout_handle);
+            let integration_path = handle.workspace_path().join(&relative_path);
+            let integration_path_text = integration_path.to_str().ok_or_else(|| {
+                checkout_verification(&integration_path, "integration checkout path is not UTF-8")
+            })?;
+            self.git(
+                source_handle.workspace_path(),
+                &[
+                    "worktree",
+                    "add",
+                    "--detach",
+                    integration_path_text,
+                    &target_commit,
+                ],
+            )
+            .await?;
+            let instruction = self
+                .load_instruction_provenance(&integration_path, repository, &target_commit)
+                .await?;
+            let record = ParentIntegrationCheckout {
+                checkout_handle: checkout_handle.clone(),
+                repository_id: repository_id.clone(),
+                safe_remote_fingerprint: source_manifest.remote_fingerprint.clone(),
+                relative_path,
+                target_branch: repository.target_branch.clone(),
+                target_commit,
+                storage_source_generation: source_manifest.generation,
+                retained_checkouts,
+                required_merge_commits: required_merge_commits.into_iter().collect(),
+                instruction,
+            };
+            self.verify_parent_integration_checkout(&handle, &record, &source_handle)
+                .await?;
+            repositories.insert(repository_id, record);
+        }
+
+        let now = Utc::now();
+        let child_checkout_map = ParentChildCheckoutMap {
+            schema_version: 1,
+            hierarchy_generation,
+            repositories,
+        };
+        let manifest = ParentExecutionManifest {
+            schema_version: 1,
+            parent_issue_id: issue.issue_id.clone(),
+            parent_identifier: issue.identifier.clone(),
+            hierarchy_generation,
+            workspace_path: handle.workspace_path().to_path_buf(),
+            child_checkout_map: PathBuf::from("child-checkouts.json"),
+            integration_plan: PathBuf::from("integration-plan.md"),
+            evidence_directory: PathBuf::from("evidence"),
+            repositories_directory: PathBuf::from("repositories"),
+            created_at: now,
+            updated_at: now,
+        };
+        self.write_manifest_atomically(
+            &handle,
+            &handle.child_checkouts_path(),
+            &child_checkout_map,
+        )
+        .await?;
+        self.write_bytes_artifact_atomically(
+            &handle,
+            &handle.workspace_path().join("integration-plan.md"),
+            render_parent_integration_plan(&child_checkout_map).as_bytes(),
+        )
+        .await?;
+        self.write_manifest_atomically(&handle, &handle.parent_manifest_path(), &manifest)
+            .await?;
+        let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
+        debug_assert_eq!(issue_manifest.workspace_path, handle.workspace_path());
+        Ok(ParentExecutionRoot {
+            handle,
+            manifest,
+            child_checkout_map,
+            created: true,
+        })
+    }
+
+    pub async fn open_parent_execution_root(
+        &self,
+        issue: &IssueDescriptor,
+        hierarchy_generation: u64,
+        root: &Path,
+    ) -> Result<ParentExecutionRoot, WorkspaceError> {
+        self.reject_symlinked_path_components(
+            &self.config.root,
+            &PathBuf::from("parents")
+                .join(format!(
+                    "parent-{}",
+                    sanitize_workspace_key(&issue.identifier)?
+                ))
+                .join(hierarchy_generation.to_string()),
+        )
+        .await?;
+        let canonical_root = self.canonicalize_path(root).await?;
+        ensure_descendant(
+            &self.canonicalize_path(&self.config.root).await?,
+            &canonical_root,
+        )?;
+        let handle = WorkspaceHandle::new(
+            issue.issue_id.clone(),
+            issue.identifier.clone(),
+            format!("parent-{}", sanitize_workspace_key(&issue.identifier)?),
+            canonical_root,
+        );
+        let expected_root = self
+            .config
+            .root
+            .join("parents")
+            .join(handle.workspace_key())
+            .join(hierarchy_generation.to_string());
+        if self.canonicalize_path(&expected_root).await? != handle.workspace_path() {
+            return Err(checkout_verification(
+                handle.workspace_path(),
+                "parent execution root is not the generation-bound managed path",
+            ));
+        }
+        let manifest = self
+            .load_manifest::<ParentExecutionManifest>(&handle, &handle.parent_manifest_path())
+            .await?
+            .ok_or_else(|| {
+                checkout_verification(handle.workspace_path(), "parent manifest is missing")
+            })?;
+        let child_checkout_map = self
+            .load_manifest::<ParentChildCheckoutMap>(&handle, &handle.child_checkouts_path())
+            .await?
+            .ok_or_else(|| {
+                checkout_verification(handle.workspace_path(), "child checkout map is missing")
+            })?;
+        if manifest.schema_version != 1
+            || manifest.parent_issue_id != issue.issue_id
+            || manifest.parent_identifier != issue.identifier
+            || manifest.hierarchy_generation != hierarchy_generation
+            || manifest.workspace_path != handle.workspace_path()
+            || manifest.child_checkout_map != Path::new("child-checkouts.json")
+            || manifest.integration_plan != Path::new("integration-plan.md")
+            || manifest.evidence_directory != Path::new("evidence")
+            || manifest.repositories_directory != Path::new("repositories")
+            || child_checkout_map.schema_version != 1
+            || child_checkout_map.hierarchy_generation != hierarchy_generation
+            || path_exists(&handle.workspace_path().join(".git")).await?
+        {
+            return Err(checkout_verification(
+                handle.workspace_path(),
+                "parent execution root identity is inconsistent",
+            ));
+        }
+        for record in child_checkout_map.repositories.values() {
+            let source = self
+                .find_retained_checkout(
+                    &record.repository_id,
+                    &record.storage_source_generation,
+                    None,
+                )
+                .await?;
+            self.verify_parent_integration_checkout(&handle, record, &source)
+                .await?;
+        }
+        Ok(ParentExecutionRoot {
+            handle,
+            manifest,
+            child_checkout_map,
+            created: false,
+        })
+    }
+
+    pub async fn open_parent_execution_root_at(
+        &self,
+        issue: &IssueDescriptor,
+        root: &Path,
+    ) -> Result<ParentExecutionRoot, WorkspaceError> {
+        let canonical_root = self.canonicalize_path(root).await?;
+        let handle = WorkspaceHandle::new(
+            issue.issue_id.clone(),
+            issue.identifier.clone(),
+            format!("parent-{}", sanitize_workspace_key(&issue.identifier)?),
+            canonical_root,
+        );
+        let manifest = self
+            .load_manifest::<ParentExecutionManifest>(&handle, &handle.parent_manifest_path())
+            .await?
+            .ok_or_else(|| {
+                checkout_verification(handle.workspace_path(), "parent manifest is missing")
+            })?;
+        self.open_parent_execution_root(issue, manifest.hierarchy_generation, root)
+            .await
+    }
+
+    pub async fn resolve_parent_checkout(
+        &self,
+        parent: &ParentExecutionRoot,
+        checkout_handle: &str,
+    ) -> Result<PathBuf, WorkspaceError> {
+        let record = parent
+            .child_checkout_map
+            .repositories
+            .values()
+            .find(|record| record.checkout_handle == checkout_handle)
+            .ok_or_else(|| {
+                checkout_verification(
+                    parent.handle.workspace_path(),
+                    "checkout handle is not present in the pinned parent map",
+                )
+            })?;
+        let source = self
+            .find_retained_checkout(
+                &record.repository_id,
+                &record.storage_source_generation,
+                None,
+            )
+            .await?;
+        self.verify_parent_integration_checkout(&parent.handle, record, &source)
+            .await?;
+        Ok(parent.handle.workspace_path().join(&record.relative_path))
+    }
+
+    fn verify_parent_requests(
+        &self,
+        parent: &ParentExecutionRoot,
+        requests: &[ParentCheckoutRequest],
+    ) -> Result<(), WorkspaceError> {
+        let expected = requests
+            .iter()
+            .map(|request| {
+                (
+                    request.repository_id.as_str(),
+                    request.issue_id.as_str(),
+                    request.checkout_generation.as_str(),
+                    request.lease_owner.as_str(),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        let observed = parent
+            .child_checkout_map
+            .repositories
+            .values()
+            .flat_map(|repository| {
+                repository.retained_checkouts.iter().map(|checkout| {
+                    (
+                        repository.repository_id.as_str(),
+                        checkout.issue_id.as_str(),
+                        checkout.checkout_generation.as_str(),
+                        checkout.lease_owner.as_str(),
+                    )
+                })
+            })
+            .collect::<BTreeSet<_>>();
+        let expected_merges = requests
+            .iter()
+            .flat_map(|request| {
+                request
+                    .required_merge_commits
+                    .iter()
+                    .map(|commit| (request.repository_id.as_str(), commit.as_str()))
+            })
+            .filter(|(_, commit)| !commit.trim().is_empty())
+            .collect::<BTreeSet<_>>();
+        let observed_merges = parent
+            .child_checkout_map
+            .repositories
+            .values()
+            .flat_map(|repository| {
+                repository
+                    .required_merge_commits
+                    .iter()
+                    .map(|commit| (repository.repository_id.as_str(), commit.as_str()))
+            })
+            .collect::<BTreeSet<_>>();
+        if expected.len() != requests.len()
+            || expected != observed
+            || expected_merges != observed_merges
+        {
+            return Err(checkout_verification(
+                parent.handle.workspace_path(),
+                "existing parent checkout map does not match the generation-bound preparation request",
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn parent_repository_instructions(
+        &self,
+        parent: &ParentExecutionRoot,
+    ) -> Result<BTreeMap<String, String>, WorkspaceError> {
+        let mut instructions = BTreeMap::new();
+        for record in parent.child_checkout_map.repositories.values() {
+            let checkout = self
+                .resolve_parent_checkout(parent, &record.checkout_handle)
+                .await?;
+            if record.instruction.path.as_os_str().is_empty() {
+                continue;
+            }
+            let path = resolve_path_within_root(&checkout, &record.instruction.path)?;
+            let relative = path
+                .strip_prefix(parent.handle.workspace_path())
+                .map_err(|_| {
+                    checkout_verification(&path, "repository instruction path escapes parent root")
+                })?;
+            self.reject_symlinked_path_components(parent.handle.workspace_path(), relative)
+                .await?;
+            let mut total_bytes = 0;
+            let (hash, bytes) =
+                read_bounded_instruction_file(&path, &mut total_bytes, true).await?;
+            if hash != record.instruction.content_hash {
+                return Err(checkout_verification(
+                    &path,
+                    "repository instruction hash does not match the parent checkout map",
+                ));
+            }
+            let bytes = if is_workflow_instruction_path(&record.instruction.path) {
+                workflow_body(&bytes)
+            } else {
+                bytes
+            };
+            instructions.insert(
+                record.repository_id.clone(),
+                String::from_utf8_lossy(&bytes).into_owned(),
+            );
+        }
+        Ok(instructions)
+    }
+
+    pub async fn write_parent_runtime_envelope(
+        &self,
+        parent: &ParentExecutionRoot,
+        envelope: &ParentRuntimeEnvelope,
+    ) -> Result<(), WorkspaceError> {
+        if envelope.parent_issue_id != parent.manifest.parent_issue_id
+            || envelope.parent_identifier != parent.manifest.parent_identifier
+            || envelope.hierarchy_generation != parent.manifest.hierarchy_generation
+            || envelope.workspace_path != parent.handle.workspace_path()
+            || envelope.checkouts.len() != parent.child_checkout_map.repositories.len()
+            || envelope.requested_execution_scope != "parent_multi_checkout"
+            || !matches!(
+                envelope.effective_containment.as_str(),
+                "trusted_host" | "workspace_confined"
+            )
+            || parent
+                .child_checkout_map
+                .repositories
+                .values()
+                .any(|record| {
+                    envelope
+                        .checkouts
+                        .get(&record.checkout_handle)
+                        .is_none_or(|checkout| {
+                            checkout.repository_id != record.repository_id
+                                || checkout.relative_path != record.relative_path
+                                || checkout.target_branch != record.target_branch
+                                || checkout.target_commit != record.target_commit
+                                || checkout.instruction_path != record.instruction.path
+                                || checkout.instruction_hash != record.instruction.content_hash
+                        })
+                })
+        {
+            return Err(checkout_verification(
+                parent.handle.workspace_path(),
+                "parent runtime envelope does not match the prepared execution root",
+            ));
+        }
+        self.write_manifest_atomically(
+            &parent.handle,
+            &parent.handle.parent_runtime_envelope_path(),
+            envelope,
+        )
+        .await
+    }
+
+    pub fn parent_runtime_envelope(
+        &self,
+        parent: &ParentExecutionRoot,
+        descriptor: ParentRuntimeDescriptor,
+    ) -> ParentRuntimeEnvelope {
+        let checkouts = parent
+            .child_checkout_map
+            .repositories
+            .values()
+            .map(|record| {
+                (
+                    record.checkout_handle.clone(),
+                    ParentRuntimeCheckout {
+                        repository_id: record.repository_id.clone(),
+                        checkout_handle: record.checkout_handle.clone(),
+                        relative_path: record.relative_path.clone(),
+                        target_branch: record.target_branch.clone(),
+                        target_commit: record.target_commit.clone(),
+                        instruction_path: record.instruction.path.clone(),
+                        instruction_hash: record.instruction.content_hash.clone(),
+                    },
+                )
+            })
+            .collect();
+        let (integration_instruction_path, integration_instruction_hash) = descriptor
+            .integration_instruction
+            .map_or((None, None), |(path, hash)| (Some(path), Some(hash)));
+        ParentRuntimeEnvelope {
+            parent_issue_id: parent.manifest.parent_issue_id.clone(),
+            parent_identifier: parent.manifest.parent_identifier.clone(),
+            run_id: descriptor.run_id,
+            attempt: descriptor.attempt,
+            hierarchy_generation: parent.manifest.hierarchy_generation,
+            workspace_path: parent.handle.workspace_path().to_path_buf(),
+            checkouts,
+            integration_instruction_path,
+            integration_instruction_hash,
+            harness: descriptor.harness,
+            model_profile: descriptor.model_profile,
+            model: descriptor.model,
+            requested_execution_scope: "parent_multi_checkout".to_owned(),
+            effective_containment: descriptor.effective_containment,
+            conversation_binding: None,
+        }
+    }
+
+    async fn find_retained_checkout(
+        &self,
+        repository_id: &str,
+        generation: &str,
+        issue_id: Option<&str>,
+    ) -> Result<WorkspaceHandle, WorkspaceError> {
+        self.list_all_workspaces()
+            .await?
+            .into_iter()
+            .find_map(|(handle, manifest)| {
+                (handle.checkout_generation() == Some(generation)
+                    && issue_id.is_none_or(|issue_id| manifest.issue_id == issue_id)
+                    && manifest
+                        .repository_binding
+                        .as_ref()
+                        .and_then(
+                            crate::opensymphony_domain::RepositoryBindingOutcome::repository_id,
+                        )
+                        .is_some_and(|candidate| candidate.as_str() == repository_id))
+                .then_some(handle)
+            })
+            .ok_or_else(|| {
+                checkout_verification(
+                    &self.config.root,
+                    "generation-bound retained checkout handle is stale",
+                )
+            })
+    }
+
+    async fn fetch_parent_target(
+        &self,
+        source: &WorkspaceHandle,
+        repository: &CheckoutRepository,
+    ) -> Result<(), WorkspaceError> {
+        let shallow = self
+            .git(
+                source.workspace_path(),
+                &["rev-parse", "--is-shallow-repository"],
+            )
+            .await?
+            == "true";
+        let mut args = vec!["fetch", "--prune"];
+        if shallow {
+            args.push("--unshallow");
+        }
+        let refspec = format!(
+            "+refs/heads/{0}:refs/remotes/origin/{0}",
+            repository.target_branch
+        );
+        args.extend(["origin", refspec.as_str()]);
+        self.run_authenticated_git(source.workspace_path(), repository, &args)
+            .await
+    }
+
+    async fn run_authenticated_git(
+        &self,
+        checkout: &Path,
+        repository: &CheckoutRepository,
+        args: &[&str],
+    ) -> Result<(), WorkspaceError> {
+        let environment_credential = repository.credential_kind == "environment";
+        let ssh_agent_credential = repository.credential_kind == "ssh-agent";
+        let environment_credential_value = environment_credential
+            .then_some(repository.credential_env.as_deref())
+            .flatten()
+            .and_then(std::env::var_os)
+            .map(|value| value.to_string_lossy().into_owned());
+        if (environment_credential && environment_credential_value.is_none())
+            || (ssh_agent_credential && !ssh_agent_socket_is_usable())
+            || (!environment_credential && !ssh_agent_credential)
+        {
+            return Err(WorkspaceError::CheckoutOperation {
+                operation: "resolve repository credential provider".to_owned(),
+                path: checkout.to_path_buf(),
+                detail: if ssh_agent_credential {
+                    "SSH_AUTH_SOCK is unset or does not point to a usable SSH agent socket"
+                        .to_owned()
+                } else {
+                    "repository credential provider is unavailable".to_owned()
+                },
+            });
+        }
+
+        let askpass_path = if environment_credential {
+            let path = checkout
+                .join(".opensymphony")
+                .join(format!("askpass-{}", Uuid::new_v4().simple()));
+            fs::write(
+                &path,
+                b"#!/bin/sh\ncase \"$1\" in\n  *Username*) printf '%s\\n' \"$OPENSYMPHONY_CHECKOUT_USERNAME\" ;;\n  *) printf '%s\\n' \"$OPENSYMPHONY_CHECKOUT_CREDENTIAL\" ;;\nesac\n",
+            )
+            .await
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: "prepare Git credential helper".to_owned(),
+                path: path.clone(),
+                detail: source.to_string(),
+            })?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))
+                    .await
+                    .map_err(|source| WorkspaceError::CheckoutOperation {
+                        operation: "prepare Git credential helper".to_owned(),
+                        path: path.clone(),
+                        detail: source.to_string(),
+                    })?;
+            }
+            Some(path)
+        } else {
+            None
+        };
+
+        let mut command = Command::new("git");
+        command.arg("-C").arg(checkout).args(args);
+        for variable in &self.checkout_credential_envs {
+            command.env_remove(variable);
+        }
+        sanitize_git_environment(&mut command);
+        command
+            .env_remove("OPENSYMPHONY_CHECKOUT_CREDENTIAL")
+            .env_remove("GIT_SSH_COMMAND")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+            .env("GIT_NO_REPLACE_OBJECTS", "1");
+        if ssh_agent_credential {
+            let value = std::env::var_os(SSH_AUTH_SOCK_ENV)
+                .expect("usable SSH agent socket was validated above");
+            command.env(SSH_AUTH_SOCK_ENV, &value).env(
+                "GIT_SSH_COMMAND",
+                format!(
+                    "ssh -o IdentityAgent={}",
+                    shell_single_quote(&value.to_string_lossy())
+                ),
+            );
+        }
+        if let Some(value) = environment_credential_value.as_deref() {
+            command.env("OPENSYMPHONY_CHECKOUT_CREDENTIAL", value);
+        }
+        command.env(
+            "OPENSYMPHONY_CHECKOUT_USERNAME",
+            git_askpass_username(&repository.provider),
+        );
+        if let Some(path) = askpass_path.as_ref() {
+            command
+                .env("GIT_ASKPASS", path)
+                .env("GIT_TERMINAL_PROMPT", "0");
+        }
+        configure_process_group(&mut command);
+        command.kill_on_drop(true);
+        let output = timeout(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT, command.output()).await;
+        if let Some(path) = askpass_path.as_ref() {
+            let _ = fs::remove_file(path).await;
+        }
+        let output = output
+            .map_err(|_| WorkspaceError::CheckoutOperation {
+                operation: args.first().copied().unwrap_or("git").to_owned(),
+                path: checkout.to_path_buf(),
+                detail: format!(
+                    "operation timed out after {:?}",
+                    RETAINED_CHECKOUT_VERIFICATION_TIMEOUT
+                ),
+            })?
+            .map_err(|source| WorkspaceError::CheckoutOperation {
+                operation: args.first().copied().unwrap_or("git").to_owned(),
+                path: checkout.to_path_buf(),
+                detail: source.to_string(),
+            })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let mut detail = redact_runtime_diagnostic(&String::from_utf8_lossy(&output.stderr));
+        if let Some(value) = environment_credential_value.as_deref() {
+            detail = detail.replace(value, "<redacted>");
+        }
+        Err(WorkspaceError::CheckoutOperation {
+            operation: args.first().copied().unwrap_or("git").to_owned(),
+            path: checkout.to_path_buf(),
+            detail,
+        })
+    }
+
+    async fn verify_parent_integration_checkout(
+        &self,
+        parent: &WorkspaceHandle,
+        record: &ParentIntegrationCheckout,
+        source: &WorkspaceHandle,
+    ) -> Result<(), WorkspaceError> {
+        let integration = resolve_path_within_root(parent.workspace_path(), &record.relative_path)?;
+        let repositories = parent.workspace_path().join("repositories");
+        let canonical_repositories = self.canonicalize_path(&repositories).await?;
+        let canonical_integration = self.canonicalize_path(&integration).await?;
+        ensure_descendant(&canonical_repositories, &canonical_integration)?;
+        if integration.file_name().and_then(|name| name.to_str())
+            != Some(record.checkout_handle.as_str())
+        {
+            return Err(checkout_verification(
+                &integration,
+                "integration checkout path does not match its opaque handle",
+            ));
+        }
+        let worktree_root = self
+            .git(&integration, &["rev-parse", "--show-toplevel"])
+            .await?;
+        if self.canonicalize_path(Path::new(&worktree_root)).await? != canonical_integration {
+            return Err(checkout_verification(
+                &integration,
+                "integration checkout Git root is inconsistent",
+            ));
+        }
+        let common = self
+            .git(&integration, &["rev-parse", "--git-common-dir"])
+            .await?;
+        let common = PathBuf::from(common);
+        let common = if common.is_absolute() {
+            common
+        } else {
+            integration.join(common)
+        };
+        let source_common = self
+            .git(source.workspace_path(), &["rev-parse", "--git-common-dir"])
+            .await?;
+        let source_common = PathBuf::from(source_common);
+        let source_common = if source_common.is_absolute() {
+            source_common
+        } else {
+            source.workspace_path().join(source_common)
+        };
+        if self.canonicalize_path(&common).await? != self.canonicalize_path(&source_common).await? {
+            return Err(checkout_verification(
+                &integration,
+                "integration checkout does not share retained child Git storage",
+            ));
+        }
+        if self.git(&integration, &["rev-parse", "HEAD"]).await? != record.target_commit {
+            return Err(checkout_verification(
+                &integration,
+                "integration checkout is not at its recorded target commit",
+            ));
+        }
+        if !self
+            .git(
+                &integration,
+                &["status", "--porcelain", "--untracked-files=all"],
+            )
+            .await?
+            .is_empty()
+        {
+            return Err(checkout_verification(
+                &integration,
+                "integration checkout is dirty",
+            ));
+        }
+        let repository = self
+            .checkout_repositories
+            .get(&record.repository_id)
+            .ok_or_else(|| {
+                checkout_verification(&integration, "repository policy is unavailable")
+            })?;
+        let expected = SafeRemoteFingerprint::from_remote(
+            &repository.provider,
+            repository.provider_id.as_deref(),
+            &repository.remote,
+        )
+        .map_err(|error| checkout_verification(&integration, &error.to_string()))?;
+        for args in [
+            ["remote", "get-url", "--all", "origin"].as_slice(),
+            ["remote", "get-url", "--all", "--push", "origin"].as_slice(),
+        ] {
+            let remotes = self.git(&integration, args).await?;
+            if remotes.lines().all(|remote| remote.trim().is_empty()) {
+                return Err(checkout_verification(
+                    &integration,
+                    "origin remote is unavailable",
+                ));
+            }
+            for remote in remotes.lines() {
+                let actual = SafeRemoteFingerprint::from_remote(
+                    &repository.provider,
+                    repository.provider_id.as_deref(),
+                    remote,
+                )
+                .map_err(|error| checkout_verification(&integration, &error.to_string()))?;
+                if actual != expected || actual.as_str() != record.safe_remote_fingerprint {
+                    return Err(checkout_verification(
+                        &integration,
+                        "origin remote fingerprint mismatch",
+                    ));
+                }
+            }
+        }
+        let instruction = self
+            .load_instruction_provenance(&integration, repository, &record.target_commit)
+            .await?;
+        if instruction != record.instruction {
+            return Err(checkout_verification(
+                &integration,
+                "repository instruction provenance does not match the parent checkout map",
+            ));
+        }
+        Ok(())
     }
 
     pub async fn ensure(
@@ -539,7 +1430,7 @@ impl WorkspaceManager {
             checkout_time_remaining(checkout_deadline),
             &staging_path,
             "verify acquired checkout",
-            self.verify_git_checkout(&staging_path, binding, repository, true, true),
+            self.verify_git_checkout(&staging_path, binding, repository, true, true, false),
         )
         .await
         {
@@ -632,7 +1523,14 @@ impl WorkspaceManager {
             checkout_time_remaining(checkout_deadline),
             workspace.workspace_path(),
             "verify checkout after creation hook",
-            self.verify_git_checkout(workspace.workspace_path(), binding, repository, true, true),
+            self.verify_git_checkout(
+                workspace.workspace_path(),
+                binding,
+                repository,
+                true,
+                true,
+                false,
+            ),
         )
         .await
         {
@@ -743,7 +1641,7 @@ impl WorkspaceManager {
     ) -> Result<CheckoutManifest, WorkspaceError> {
         let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
         let manifest = self
-            .verify_checkout_with_worker_changes_timeout(workspace, true, deadline)
+            .verify_checkout_with_worker_changes_timeout(workspace, true, false, deadline)
             .await?;
         if manifest.repository_binding != expected.repository_binding
             || manifest.policy_generation != expected.policy_generation
@@ -799,14 +1697,20 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
         allow_worker_changes: bool,
     ) -> Result<CheckoutManifest, WorkspaceError> {
-        self.verify_checkout_with_worker_changes_timeout(workspace, allow_worker_changes, None)
-            .await
+        self.verify_checkout_with_worker_changes_timeout(
+            workspace,
+            allow_worker_changes,
+            false,
+            None,
+        )
+        .await
     }
 
     async fn verify_checkout_with_worker_changes_timeout(
         &self,
         workspace: &WorkspaceHandle,
         allow_worker_changes: bool,
+        allow_shallow: bool,
         checkout_deadline: Option<Instant>,
     ) -> Result<CheckoutManifest, WorkspaceError> {
         self.validate_workspace_handle(workspace).await?;
@@ -856,6 +1760,7 @@ impl WorkspaceManager {
                 repository,
                 !allow_worker_changes,
                 false,
+                allow_shallow,
             ),
         )
         .await?;
@@ -950,7 +1855,16 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
     ) -> Result<CheckoutManifest, WorkspaceError> {
         let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
-        self.verify_checkout_with_worker_changes_timeout(workspace, true, deadline)
+        self.verify_checkout_with_worker_changes_timeout(workspace, true, false, deadline)
+            .await
+    }
+
+    async fn verify_checkout_for_parent(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<CheckoutManifest, WorkspaceError> {
+        let deadline = checkout_deadline(Some(RETAINED_CHECKOUT_VERIFICATION_TIMEOUT));
+        self.verify_checkout_with_worker_changes_timeout(workspace, true, true, deadline)
             .await
     }
 
@@ -1178,6 +2092,7 @@ impl WorkspaceManager {
                             repository,
                             true,
                             true,
+                            false,
                         )
                         .await
                     {
@@ -1296,6 +2211,7 @@ impl WorkspaceManager {
                 .verify_checkout_with_worker_changes_timeout(
                     &handle,
                     allow_worker_changes,
+                    false,
                     checkout_deadline,
                 )
                 .await
@@ -1925,6 +2841,7 @@ impl WorkspaceManager {
         repository: &CheckoutRepository,
         enforce_worktree_state: bool,
         require_remote_head: bool,
+        allow_shallow: bool,
     ) -> Result<GitFacts, WorkspaceError> {
         let inside = self
             .git(checkout, &["rev-parse", "--is-inside-work-tree"])
@@ -2073,7 +2990,7 @@ impl WorkspaceManager {
             .git(checkout, &["rev-parse", "--is-shallow-repository"])
             .await?
             == "true";
-        if shallow {
+        if shallow && !allow_shallow {
             return Err(checkout_verification(checkout, "history is shallow"));
         }
         let status = self
@@ -4192,6 +5109,83 @@ pub fn compose_terminal_prompt(
         .unwrap_or("No repository-specific instructions were selected.");
     format!(
         "## Central Execution Procedure\n\n{central_procedure}\n\n## Task Facts\n\n{task_facts}\n\n## Verified Checkout\n\n{checkout_facts}\n\n## Repository Instructions\n\n{repository_section}\n\n## Runtime Capabilities\n\n{capabilities}\n"
+    )
+}
+
+pub fn compose_parent_prompt(
+    central_procedure: &str,
+    task_facts: &str,
+    envelope: &ParentRuntimeEnvelope,
+    integration_instructions: Option<&str>,
+    repository_instructions: &BTreeMap<String, String>,
+) -> String {
+    let checkout_map = envelope
+        .checkouts
+        .values()
+        .map(|checkout| {
+            format!(
+                "- handle={} repository={} path={} branch={} commit={}",
+                checkout.checkout_handle,
+                checkout.repository_id,
+                checkout.relative_path.display(),
+                checkout.target_branch,
+                checkout.target_commit
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let integration = integration_instructions
+        .filter(|instructions| !instructions.trim().is_empty())
+        .unwrap_or("No project-set integration instructions were configured.");
+    let repositories = repository_instructions
+        .iter()
+        .map(|(repository_id, instructions)| {
+            format!("### Repository `{repository_id}`\n\n{instructions}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let repositories = if repositories.is_empty() {
+        "No repository-specific instructions were selected.".to_owned()
+    } else {
+        repositories
+    };
+    format!(
+        "## Central Execution Procedure\n\n{central_procedure}\n\n## Parent Task Facts\n\n{task_facts}\n\n## Verified Child Checkout Map\n\nParent root: {}\nHierarchy generation: {}\n{}\n\n## Project-set Integration Instructions\n\n{}\n\n## Repository Instructions by Canonical ID\n\n{}\n\n## Runtime Capabilities\n\nharness={} cwd={} requested_scope={} containment={}\n",
+        envelope.workspace_path.display(),
+        envelope.hierarchy_generation,
+        checkout_map,
+        integration,
+        repositories,
+        envelope.harness,
+        envelope.workspace_path.display(),
+        envelope.requested_execution_scope,
+        envelope.effective_containment,
+    )
+}
+
+fn parent_checkout_handle(repository_id: &str, hierarchy_generation: u64) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(repository_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(hierarchy_generation.to_le_bytes());
+    format!("checkout-{}", &format!("{:x}", hasher.finalize())[..16])
+}
+
+fn render_parent_integration_plan(map: &ParentChildCheckoutMap) -> String {
+    let repositories = map
+        .repositories
+        .values()
+        .map(|checkout| {
+            format!(
+                "- `{}` via `{}` at `{}`",
+                checkout.repository_id, checkout.checkout_handle, checkout.target_commit
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "# Parent Integration Plan\n\nHierarchy generation: {}\n\n{}\n",
+        map.hierarchy_generation, repositories
     )
 }
 

--- a/crates/opensymphony-workspace/src/models.rs
+++ b/crates/opensymphony-workspace/src/models.rs
@@ -124,6 +124,115 @@ pub struct TerminalRuntimeEnvelope {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentCheckoutRequest {
+    pub issue_id: String,
+    pub repository_id: String,
+    pub checkout_generation: String,
+    pub lease_owner: String,
+    #[serde(default)]
+    pub required_merge_commits: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentRetainedCheckout {
+    pub issue_id: String,
+    pub identifier: String,
+    pub checkout_generation: String,
+    pub lease_owner: String,
+    pub child_branch: String,
+    pub child_head: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentIntegrationCheckout {
+    pub checkout_handle: String,
+    pub repository_id: String,
+    pub safe_remote_fingerprint: String,
+    pub relative_path: PathBuf,
+    pub target_branch: String,
+    pub target_commit: String,
+    pub storage_source_generation: String,
+    pub retained_checkouts: Vec<ParentRetainedCheckout>,
+    pub required_merge_commits: Vec<String>,
+    pub instruction: InstructionProvenance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentChildCheckoutMap {
+    pub schema_version: u32,
+    pub hierarchy_generation: u64,
+    pub repositories: BTreeMap<String, ParentIntegrationCheckout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentExecutionManifest {
+    pub schema_version: u32,
+    pub parent_issue_id: String,
+    pub parent_identifier: String,
+    pub hierarchy_generation: u64,
+    pub workspace_path: PathBuf,
+    pub child_checkout_map: PathBuf,
+    pub integration_plan: PathBuf,
+    pub evidence_directory: PathBuf,
+    pub repositories_directory: PathBuf,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentRuntimeCheckout {
+    pub repository_id: String,
+    pub checkout_handle: String,
+    pub relative_path: PathBuf,
+    pub target_branch: String,
+    pub target_commit: String,
+    pub instruction_path: PathBuf,
+    pub instruction_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentRuntimeEnvelope {
+    pub parent_issue_id: String,
+    pub parent_identifier: String,
+    pub run_id: String,
+    pub attempt: u32,
+    pub hierarchy_generation: u64,
+    pub workspace_path: PathBuf,
+    pub checkouts: BTreeMap<String, ParentRuntimeCheckout>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integration_instruction_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integration_instruction_hash: Option<String>,
+    pub harness: String,
+    pub model_profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub requested_execution_scope: String,
+    pub effective_containment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation_binding: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentRuntimeDescriptor {
+    pub run_id: String,
+    pub attempt: u32,
+    pub integration_instruction: Option<(PathBuf, String)>,
+    pub harness: String,
+    pub model_profile: String,
+    pub model: Option<String>,
+    pub effective_containment: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentExecutionRoot {
+    pub handle: WorkspaceHandle,
+    pub manifest: ParentExecutionManifest,
+    pub child_checkout_map: ParentChildCheckoutMap,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckoutManifest {
     pub schema_version: u32,
     pub generation: String,
@@ -528,6 +637,7 @@ pub struct RunDescriptor {
     pub normal_retry_count: u32,
     pub repository_binding: Option<RepositoryBinding>,
     pub runtime_envelope: Option<TerminalRuntimeEnvelope>,
+    pub parent_runtime_envelope: Option<ParentRuntimeEnvelope>,
 }
 
 impl RunDescriptor {
@@ -538,6 +648,7 @@ impl RunDescriptor {
             normal_retry_count: 0,
             repository_binding: None,
             runtime_envelope: None,
+            parent_runtime_envelope: None,
         }
     }
 
@@ -559,6 +670,14 @@ impl RunDescriptor {
         runtime_envelope: Option<TerminalRuntimeEnvelope>,
     ) -> Self {
         self.runtime_envelope = runtime_envelope;
+        self
+    }
+
+    pub fn with_parent_runtime_envelope(
+        mut self,
+        parent_runtime_envelope: Option<ParentRuntimeEnvelope>,
+    ) -> Self {
+        self.parent_runtime_envelope = parent_runtime_envelope;
         self
     }
 }
@@ -688,6 +807,18 @@ impl WorkspaceHandle {
 
     pub fn checkout_manifest_path(&self) -> PathBuf {
         self.metadata_dir().join("checkout.json")
+    }
+
+    pub fn parent_manifest_path(&self) -> PathBuf {
+        self.workspace_path.join("parent-manifest.json")
+    }
+
+    pub fn child_checkouts_path(&self) -> PathBuf {
+        self.workspace_path.join("child-checkouts.json")
+    }
+
+    pub fn parent_runtime_envelope_path(&self) -> PathBuf {
+        self.metadata_dir().join("parent-runtime.json")
     }
 
     pub fn logs_dir(&self) -> PathBuf {
@@ -913,6 +1044,8 @@ pub struct RunManifest {
     pub repository_binding: Option<RepositoryBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_envelope: Option<TerminalRuntimeEnvelope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_runtime_envelope: Option<ParentRuntimeEnvelope>,
     pub attempt: u32,
     #[serde(default)]
     pub normal_retry_count: u32,
@@ -951,6 +1084,7 @@ impl RunManifest {
             workspace_path: workspace.workspace_path().to_path_buf(),
             repository_binding: run.repository_binding.clone(),
             runtime_envelope: run.runtime_envelope.clone(),
+            parent_runtime_envelope: run.parent_runtime_envelope.clone(),
             attempt: run.attempt,
             normal_retry_count: run.normal_retry_count,
             pending_retry: false,

--- a/crates/opensymphony-workspace/src/paths.rs
+++ b/crates/opensymphony-workspace/src/paths.rs
@@ -62,6 +62,20 @@ pub fn checkout_workspace_key(
     Ok(format!("{display}-{}", &digest[..16]))
 }
 
+/// Derive a collision-resistant key for a repository-neutral parent workspace.
+pub fn parent_workspace_key(
+    issue_identifier: &str,
+    issue_id: &str,
+) -> Result<String, WorkspaceError> {
+    let display = sanitize_workspace_key(issue_identifier)?;
+    let mut hasher = Sha256::new();
+    hasher.update(issue_identifier.as_bytes());
+    hasher.update([0]);
+    hasher.update(issue_id.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    Ok(format!("parent-{display}-{}", &digest[..16]))
+}
+
 pub fn resolve_path_within_root(
     root: impl AsRef<Path>,
     candidate: impl AsRef<Path>,
@@ -111,7 +125,10 @@ mod tests {
     use std::path::PathBuf;
 
     use super::WorkspaceError;
-    use super::{checkout_workspace_key, resolve_path_within_root, sanitize_workspace_key};
+    use super::{
+        checkout_workspace_key, parent_workspace_key, resolve_path_within_root,
+        sanitize_workspace_key,
+    };
 
     #[test]
     fn sanitizes_documented_examples() {
@@ -176,5 +193,15 @@ mod tests {
         assert_ne!(slash, colon);
         assert_ne!(slash, unicode);
         assert_ne!(colon, unicode);
+    }
+
+    #[test]
+    fn parent_keys_keep_sanitized_collisions_distinct() {
+        let slash = parent_workspace_key("TEAM/A", "parent-one").expect("slash key");
+        let underscore = parent_workspace_key("TEAM_A", "parent-two").expect("underscore key");
+
+        assert!(slash.starts_with("parent-TEAM_A-"));
+        assert!(underscore.starts_with("parent-TEAM_A-"));
+        assert_ne!(slash, underscore);
     }
 }

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -200,7 +200,8 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     let temp_dir = TempDir::new().expect("temp dir should exist");
     let (source_a, mut binding_a, mut repository_a) =
         repository_fixture(temp_dir.path(), "repository-a");
-    let (source_b, binding_b, repository_b) = repository_fixture(temp_dir.path(), "repository-b");
+    let (source_b, binding_b, mut repository_b) =
+        repository_fixture(temp_dir.path(), "repository-b");
     let (source_c, binding_c, repository_c) = repository_fixture(temp_dir.path(), "repository-c");
     repository_a.provider_id = Some("repository-a-native-id".to_owned());
     binding_a.repository.safe_remote_fingerprint = SafeRemoteFingerprint::from_remote(
@@ -209,6 +210,13 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         &repository_a.remote,
     )
     .expect("native repository fingerprint should be valid");
+    repository_b.instructions_path = "WORKFLOW.md".into();
+    commit_file(
+        &source_b,
+        "WORKFLOW.md",
+        "---\nname: repository-b\n---\nrepository workflow instructions\n",
+        "add repository workflow instructions",
+    );
     let merge_a1 = squash_merge_fixture(&source_a);
     let manager = WorkspaceManager::new(manager_config(
         &temp_dir.path().join("workspaces"),
@@ -242,6 +250,27 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         child_a1.handle.workspace_path(),
         &["commit", "-m", "retain child feature commit"],
     );
+    #[cfg(unix)]
+    let credential_exfil_path = {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_dir.path().join("retained-hook-credential.txt");
+        let hook = child_a1
+            .handle
+            .workspace_path()
+            .join(".git/hooks/reference-transaction");
+        std::fs::write(
+            &hook,
+            format!(
+                "#!/bin/sh\nif [ -n \"$OPENSYMPHONY_CHECKOUT_CREDENTIAL\" ]; then printf '%s' \"$OPENSYMPHONY_CHECKOUT_CREDENTIAL\" > {}; fi\n",
+                shell_quote(&path)
+            ),
+        )
+        .expect("retained checkout hook should be written");
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+            .expect("retained checkout hook should be executable");
+        path
+    };
     let child_a1_head = git(child_a1.handle.workspace_path(), &["rev-parse", "HEAD"]);
     let merge_a2 = rebase_merge_fixture(&source_a);
 
@@ -411,6 +440,12 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .prepare_parent_execution_root(&parent, 5, requests)
         .await
         .expect("same generation should retry after incomplete preparation is rolled back");
+
+    #[cfg(unix)]
+    assert!(
+        !credential_exfil_path.exists(),
+        "authenticated parent fetches must not run retained-checkout hooks"
+    );
 
     assert!(!prepared.handle.workspace_path().join(".git").exists());
     assert_eq!(prepared.child_checkout_map.repositories.len(), 3);
@@ -625,6 +660,12 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .parent_repository_instructions(&prepared)
         .await
         .expect("repository instructions should load");
+    assert_eq!(
+        repository_instructions
+            .get(binding_b.repository_id().as_str())
+            .map(String::as_str),
+        Some("repository workflow instructions\n")
+    );
     let openhands = manager.parent_runtime_envelope(
         &prepared,
         ParentRuntimeDescriptor {

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -501,7 +501,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     assert!(matches!(
         manager.prepare_parent_execution_root(&parent, 7, requests.clone()).await,
         Err(WorkspaceError::CheckoutVerification { reason, .. })
-            if reason.contains("process-filter configuration")
+            if reason.contains("process configuration")
     ));
     assert!(!parent_generation_path(&manager, &parent, 7).exists());
     git(
@@ -678,6 +678,45 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
             "remote.origin.pushurl",
         ],
     );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let marker = temp_dir.path().join("integration-fsmonitor-ran.txt");
+        let fsmonitor = temp_dir.path().join("integration-fsmonitor.sh");
+        std::fs::write(
+            &fsmonitor,
+            format!("#!/bin/sh\nprintf invoked > {}\n", shell_quote(&marker)),
+        )
+        .expect("integration fsmonitor should be written");
+        std::fs::set_permissions(&fsmonitor, std::fs::Permissions::from_mode(0o755))
+            .expect("integration fsmonitor should be executable");
+        git(
+            &integration,
+            &[
+                "config",
+                "--worktree",
+                "core.fsmonitor",
+                fsmonitor.to_str().expect("fsmonitor path"),
+            ],
+        );
+        let fsmonitor_error = manager
+            .open_parent_execution_root_at(&parent, prepared.handle.workspace_path())
+            .await
+            .expect_err("worktree-specific fsmonitor must invalidate the parent root");
+        assert!(
+            fsmonitor_error.to_string().contains("core.fsmonitor"),
+            "unexpected integration fsmonitor error: {fsmonitor_error}"
+        );
+        assert!(
+            !marker.exists(),
+            "integration fsmonitor must not run during parent probes"
+        );
+        git(
+            &integration,
+            &["config", "--worktree", "--unset-all", "core.fsmonitor"],
+        );
+    }
     std::fs::write(
         integration.join("parent-change.txt"),
         "preserve across retry\n",
@@ -982,8 +1021,8 @@ async fn parent_execution_root_rolls_back_when_after_create_initializes_git() {
 }
 
 #[cfg(unix)]
-#[tokio::test(start_paused = true)]
-async fn parent_preparation_times_out_stalled_integration_verification() {
+#[tokio::test]
+async fn parent_preparation_rejects_child_controlled_fsmonitor_before_execution() {
     use std::os::unix::fs::PermissionsExt;
 
     let temp_dir = TempDir::new().expect("temp dir should exist");
@@ -1003,12 +1042,11 @@ async fn parent_preparation_times_out_stalled_integration_verification() {
     child.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding.clone()));
     let child = manager.ensure(&child).await.expect("child should exist");
 
-    let fsmonitor = temp_dir
-        .path()
-        .join("stall-parent-integration-fsmonitor.sh");
+    let fsmonitor = temp_dir.path().join("capture-parent-probe-env.sh");
+    let marker = temp_dir.path().join("parent-probe-fsmonitor-ran.txt");
     std::fs::write(
         &fsmonitor,
-        "#!/bin/sh\ncase \"$PWD\" in */parents/*/repositories/*) sleep 300 ;; esac\nexit 0\n",
+        format!("#!/bin/sh\nprintf invoked > {}\n", shell_quote(&marker)),
     )
     .expect("fsmonitor hook should be written");
     std::fs::set_permissions(&fsmonitor, std::fs::Permissions::from_mode(0o755))
@@ -1041,11 +1079,98 @@ async fn parent_preparation_times_out_stalled_integration_verification() {
             }],
         )
         .await
-        .expect_err("stalled integration verification must time out");
+        .expect_err("child-controlled fsmonitor must be rejected");
 
     assert!(
-        error.to_string().contains("timed out"),
-        "unexpected integration timeout error: {error}"
+        error.to_string().contains("core.fsmonitor"),
+        "unexpected process-configuration error: {error}"
+    );
+    assert!(
+        !marker.exists(),
+        "fsmonitor must not run during parent probes"
+    );
+    assert!(!parent_generation_path(&manager, &parent, 1).exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn parent_preparation_rejects_worktree_conditional_fsmonitor_before_execution() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let (source, binding, repository) =
+        repository_fixture(temp_dir.path(), "conditional-fsmonitor-repository");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build")
+    .with_repository_checkouts(BTreeMap::from([(
+        binding.repository_id().to_string(),
+        repository,
+    )]));
+    let mut child = sample_issue("COE-CONDITIONAL-FSMONITOR-CHILD");
+    child.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding.clone()));
+    let child = manager.ensure(&child).await.expect("child should exist");
+
+    let fsmonitor = temp_dir.path().join("conditional-fsmonitor.sh");
+    let marker = temp_dir.path().join("conditional-fsmonitor-ran.txt");
+    std::fs::write(
+        &fsmonitor,
+        format!("#!/bin/sh\nprintf invoked > {}\n", shell_quote(&marker)),
+    )
+    .expect("fsmonitor hook should be written");
+    std::fs::set_permissions(&fsmonitor, std::fs::Permissions::from_mode(0o755))
+        .expect("fsmonitor hook should be executable");
+    let included_config = temp_dir.path().join("worktree-conditional.gitconfig");
+    std::fs::write(
+        &included_config,
+        format!(
+            "[core]\n\tfsmonitor = {}\n",
+            fsmonitor.to_str().expect("fsmonitor path")
+        ),
+    )
+    .expect("conditional config should be written");
+    git(
+        child.handle.workspace_path(),
+        &[
+            "config",
+            "--local",
+            "includeIf.gitdir:**/worktrees/*.path",
+            included_config.to_str().expect("conditional config path"),
+        ],
+    );
+
+    let mut parent = sample_issue("COE-CONDITIONAL-FSMONITOR-PARENT");
+    parent.issue_id = "conditional-fsmonitor-parent-id".to_owned();
+    let error = manager
+        .prepare_parent_execution_root(
+            &parent,
+            1,
+            vec![ParentCheckoutRequest {
+                issue_id: child.handle.issue_id().to_owned(),
+                repository_id: binding.repository_id().to_string(),
+                checkout_generation: child
+                    .handle
+                    .checkout_generation()
+                    .expect("generation")
+                    .to_owned(),
+                lease_owner: "ancestor-integration:conditional-fsmonitor-parent-id".to_owned(),
+                required_merge_commits: vec![git(&source, &["rev-parse", "HEAD"])],
+            }],
+        )
+        .await
+        .expect_err("worktree-conditional fsmonitor must be rejected");
+
+    assert!(
+        error.to_string().contains("includeif.gitdir"),
+        "unexpected conditional-configuration error: {error}"
+    );
+    assert!(
+        !marker.exists(),
+        "worktree-conditional fsmonitor must not run during parent preparation"
     );
     assert!(!parent_generation_path(&manager, &parent, 1).exists());
 }

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -57,6 +57,11 @@ fn git(path: &std::path::Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_owned()
 }
 
+fn configure_git_identity(path: &std::path::Path) {
+    git(path, &["config", "user.email", "test@example.invalid"]);
+    git(path, &["config", "user.name", "OpenSymphony Test"]);
+}
+
 #[test]
 fn terminal_prompt_keeps_repository_instructions_in_one_section() {
     let prompt = compose_terminal_prompt(
@@ -193,9 +198,17 @@ fn rebase_merge_fixture(source: &std::path::Path) -> String {
 #[tokio::test]
 async fn parent_execution_root_reuses_three_repositories_and_preserves_children() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
-    let (source_a, binding_a, repository_a) = repository_fixture(temp_dir.path(), "repository-a");
+    let (source_a, mut binding_a, mut repository_a) =
+        repository_fixture(temp_dir.path(), "repository-a");
     let (source_b, binding_b, repository_b) = repository_fixture(temp_dir.path(), "repository-b");
     let (source_c, binding_c, repository_c) = repository_fixture(temp_dir.path(), "repository-c");
+    repository_a.provider_id = Some("repository-a-native-id".to_owned());
+    binding_a.repository.safe_remote_fingerprint = SafeRemoteFingerprint::from_remote(
+        &repository_a.provider,
+        repository_a.provider_id.as_deref(),
+        &repository_a.remote,
+    )
+    .expect("native repository fingerprint should be valid");
     let merge_a1 = squash_merge_fixture(&source_a);
     let manager = WorkspaceManager::new(manager_config(
         &temp_dir.path().join("workspaces"),
@@ -215,6 +228,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .ensure(&child_a1)
         .await
         .expect("first repository-a child should exist");
+    configure_git_identity(child_a1.handle.workspace_path());
     std::fs::write(
         child_a1.handle.workspace_path().join("child-a1-work.txt"),
         "retained child feature commit\n",
@@ -237,6 +251,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .ensure(&child_a2)
         .await
         .expect("second repository-a child should exist");
+    configure_git_identity(child_a2.handle.workspace_path());
     let mut child_b = sample_issue("COE-B");
     child_b.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding_b.clone()));
     let child_b = manager
@@ -517,6 +532,38 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .handle
         .workspace_path()
         .join(&repository_a.relative_path);
+    git(
+        &integration,
+        &["config", "extensions.worktreeConfig", "true"],
+    );
+    git(
+        &integration,
+        &[
+            "config",
+            "--worktree",
+            "remote.origin.pushurl",
+            source_b.to_str().expect("wrong push remote path"),
+        ],
+    );
+    let remote_drift_error = manager
+        .open_parent_execution_root_at(&parent, prepared.handle.workspace_path())
+        .await
+        .expect_err("a worktree-specific wrong push remote must invalidate the parent root");
+    assert!(
+        remote_drift_error
+            .to_string()
+            .contains("remote fingerprint"),
+        "unexpected integration remote error: {remote_drift_error}"
+    );
+    git(
+        &integration,
+        &[
+            "config",
+            "--worktree",
+            "--unset-all",
+            "remote.origin.pushurl",
+        ],
+    );
     std::fs::write(
         integration.join("parent-change.txt"),
         "preserve across retry\n",

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -444,6 +444,10 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         "false"
     );
     manager
+        .verify_checkout_for_retry(&child_c.handle)
+        .await
+        .expect("a parent-deepened child should remain reusable for its own retry");
+    manager
         .prepare_parent_execution_root(&parent, 8, repeat_requests.clone())
         .await
         .expect("a deepened retained child should support a later parent generation");

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -632,6 +632,37 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     std::fs::remove_file(integration.join("parent-change.txt"))
         .expect("parent change should be removed before manifest mismatch validation");
 
+    let child_checkout_map_path = prepared.handle.child_checkouts_path();
+    let original_child_checkout_map =
+        std::fs::read(&child_checkout_map_path).expect("child checkout map should remain readable");
+    let mut tampered_child_checkout_map: serde_json::Value =
+        serde_json::from_slice(&original_child_checkout_map)
+            .expect("child checkout map should decode");
+    let older_target = git(&integration, &["rev-parse", "HEAD^"]);
+    tampered_child_checkout_map["repositories"][binding_a.repository_id().as_str()]["target_commit"] =
+        serde_json::Value::String(older_target.clone());
+    std::fs::write(
+        &child_checkout_map_path,
+        serde_json::to_vec_pretty(&tampered_child_checkout_map)
+            .expect("tampered child checkout map should encode"),
+    )
+    .expect("tampered child checkout map should be writable");
+    git(&integration, &["reset", "--hard", &older_target]);
+    let repin_error = manager
+        .open_parent_execution_root_at_for_retry(&parent, prepared.handle.workspace_path())
+        .await
+        .expect_err("an agent-writable target pin must not authorize an older integration head");
+    assert!(
+        repin_error.to_string().contains("identity is inconsistent"),
+        "unexpected parent-map repin error: {repin_error}"
+    );
+    std::fs::write(&child_checkout_map_path, original_child_checkout_map)
+        .expect("trusted child checkout map should be restored");
+    git(
+        &integration,
+        &["reset", "--hard", &repository_a.target_commit],
+    );
+
     let mut changed_requests = prepared
         .child_checkout_map
         .repositories
@@ -729,7 +760,10 @@ async fn parent_execution_root_supports_no_required_child_checkouts() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
     let manager = WorkspaceManager::new(manager_config(
         &temp_dir.path().join("workspaces"),
-        HookConfig::default(),
+        HookConfig {
+            after_create: Some(HookDefinition::shell(parent_after_create_once_command())),
+            ..HookConfig::default()
+        },
         CleanupConfig::default(),
     ))
     .expect("manager should build");
@@ -749,6 +783,141 @@ async fn parent_execution_root_supports_no_required_child_checkouts() {
             .workspace_path()
             .join("repositories")
             .is_dir()
+    );
+    assert_eq!(
+        std::fs::read_to_string(
+            prepared
+                .handle
+                .workspace_path()
+                .join("parent-after-create.txt")
+        )
+        .expect("parent after_create output should exist")
+        .trim(),
+        "created"
+    );
+    let after_create_receipt = prepared
+        .handle
+        .workspace_path()
+        .join(".opensymphony.after_create.json");
+    assert!(after_create_receipt.is_file());
+
+    let reopened = manager
+        .prepare_parent_execution_root(&parent, 1, Vec::new())
+        .await
+        .expect("a completed parent after_create hook must not rerun on reuse");
+    assert!(!reopened.created);
+
+    std::fs::remove_file(after_create_receipt)
+        .expect("parent after_create receipt should be removable for validation");
+    assert!(matches!(
+        manager
+            .open_parent_execution_root_at(&parent, prepared.handle.workspace_path())
+            .await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("after_create")
+    ));
+}
+
+#[tokio::test]
+async fn parent_execution_root_rolls_back_after_create_failure() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let manager = WorkspaceManager::new(manager_config(
+        &temp_dir.path().join("workspaces"),
+        HookConfig {
+            after_create: Some(HookDefinition::shell(failing_parent_after_create_command())),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let mut parent = sample_issue("COE-FAILED-PARENT");
+    parent.issue_id = "failed-parent-id".to_owned();
+
+    assert!(matches!(
+        manager
+            .prepare_parent_execution_root(&parent, 1, Vec::new())
+            .await,
+        Err(WorkspaceError::HookFailed { .. })
+    ));
+    assert!(
+        !manager
+            .config()
+            .root
+            .join("parents/parent-COE-FAILED-PARENT/1")
+            .exists()
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test(start_paused = true)]
+async fn parent_preparation_times_out_stalled_integration_verification() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let (source, binding, repository) = repository_fixture(temp_dir.path(), "timeout-repository");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build")
+    .with_repository_checkouts(BTreeMap::from([(
+        binding.repository_id().to_string(),
+        repository,
+    )]));
+    let mut child = sample_issue("COE-TIMEOUT-CHILD");
+    child.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding.clone()));
+    let child = manager.ensure(&child).await.expect("child should exist");
+
+    let fsmonitor = temp_dir
+        .path()
+        .join("stall-parent-integration-fsmonitor.sh");
+    std::fs::write(
+        &fsmonitor,
+        "#!/bin/sh\ncase \"$PWD\" in */parents/*/repositories/*) sleep 300 ;; esac\nexit 0\n",
+    )
+    .expect("fsmonitor hook should be written");
+    std::fs::set_permissions(&fsmonitor, std::fs::Permissions::from_mode(0o755))
+        .expect("fsmonitor hook should be executable");
+    git(
+        child.handle.workspace_path(),
+        &[
+            "config",
+            "core.fsmonitor",
+            fsmonitor.to_str().expect("fsmonitor path"),
+        ],
+    );
+
+    let mut parent = sample_issue("COE-TIMEOUT-PARENT");
+    parent.issue_id = "timeout-parent-id".to_owned();
+    let error = manager
+        .prepare_parent_execution_root(
+            &parent,
+            1,
+            vec![ParentCheckoutRequest {
+                issue_id: child.handle.issue_id().to_owned(),
+                repository_id: binding.repository_id().to_string(),
+                checkout_generation: child
+                    .handle
+                    .checkout_generation()
+                    .expect("generation")
+                    .to_owned(),
+                lease_owner: "ancestor-integration:timeout-parent-id".to_owned(),
+                required_merge_commits: vec![git(&source, &["rev-parse", "HEAD"])],
+            }],
+        )
+        .await
+        .expect_err("stalled integration verification must time out");
+
+    assert!(
+        error.to_string().contains("timed out"),
+        "unexpected integration timeout error: {error}"
+    );
+    assert!(
+        !workspace_root
+            .join("parents/parent-COE-TIMEOUT-PARENT/1")
+            .exists()
     );
 }
 
@@ -801,6 +970,26 @@ fn current_dir_command(output_path: &str) -> String {
 #[cfg(windows)]
 fn current_dir_command(output_path: &str) -> String {
     format!("cd > {output_path}")
+}
+
+#[cfg(unix)]
+fn parent_after_create_once_command() -> &'static str {
+    "if [ -e parent-after-create.txt ]; then exit 41; fi; echo created > parent-after-create.txt"
+}
+
+#[cfg(windows)]
+fn parent_after_create_once_command() -> &'static str {
+    "if exist parent-after-create.txt (exit /b 41) else (echo created> parent-after-create.txt)"
+}
+
+#[cfg(unix)]
+fn failing_parent_after_create_command() -> &'static str {
+    "exit 23"
+}
+
+#[cfg(windows)]
+fn failing_parent_after_create_command() -> &'static str {
+    "exit /b 23"
 }
 
 #[cfg(unix)]

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -435,6 +435,41 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         &["remote", "set-url", "origin", &expected_remote],
     );
 
+    git(
+        child_a1.handle.workspace_path(),
+        &["config", "http.proxy", "http://127.0.0.1:9"],
+    );
+    git(
+        child_a1.handle.workspace_path(),
+        &["config", "http.sslVerify", "false"],
+    );
+    assert!(matches!(
+        manager.prepare_parent_execution_root(&parent, 7, requests.clone()).await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("checkout-controlled Git transport configuration")
+    ));
+    assert!(
+        !manager
+            .config()
+            .root
+            .join("parents/parent-COE-PARENT/7")
+            .exists(),
+        "a rejected transport configuration must roll back the partial parent root"
+    );
+    #[cfg(unix)]
+    assert!(
+        !credential_exfil_path.exists(),
+        "checkout-controlled transport configuration must be rejected before credential exposure"
+    );
+    git(
+        child_a1.handle.workspace_path(),
+        &["config", "--unset-all", "http.proxy"],
+    );
+    git(
+        child_a1.handle.workspace_path(),
+        &["config", "--unset-all", "http.sslVerify"],
+    );
+
     let repeat_requests = requests.clone();
     let prepared = manager
         .prepare_parent_execution_root(&parent, 5, requests)

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -215,6 +215,19 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .ensure(&child_a1)
         .await
         .expect("first repository-a child should exist");
+    std::fs::write(
+        child_a1.handle.workspace_path().join("child-a1-work.txt"),
+        "retained child feature commit\n",
+    )
+    .expect("retained child feature should be written");
+    git(
+        child_a1.handle.workspace_path(),
+        &["add", "child-a1-work.txt"],
+    );
+    git(
+        child_a1.handle.workspace_path(),
+        &["commit", "-m", "retain child feature commit"],
+    );
     let child_a1_head = git(child_a1.handle.workspace_path(), &["rev-parse", "HEAD"]);
     let merge_a2 = rebase_merge_fixture(&source_a);
 
@@ -431,7 +444,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         "false"
     );
     manager
-        .prepare_parent_execution_root(&parent, 8, repeat_requests)
+        .prepare_parent_execution_root(&parent, 8, repeat_requests.clone())
         .await
         .expect("a deepened retained child should support a later parent generation");
     assert!(matches!(
@@ -464,6 +477,38 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     )
     .expect("late child drift marker should be removed");
 
+    let child_a2_head = git(child_a2.handle.workspace_path(), &["rev-parse", "HEAD"]);
+    std::fs::write(
+        child_a2
+            .handle
+            .workspace_path()
+            .join("late-child-commit.txt"),
+        "committed drift must be detected\n",
+    )
+    .expect("late child commit should be written");
+    git(
+        child_a2.handle.workspace_path(),
+        &["add", "late-child-commit.txt"],
+    );
+    git(
+        child_a2.handle.workspace_path(),
+        &["commit", "-m", "late child drift"],
+    );
+    let child_commit_drift_error = manager
+        .open_parent_execution_root_at(&parent, prepared.handle.workspace_path())
+        .await
+        .expect_err("committed non-source child drift must invalidate the parent root");
+    assert!(
+        child_commit_drift_error
+            .to_string()
+            .contains("pinned parent map"),
+        "unexpected child-commit-drift error: {child_commit_drift_error}"
+    );
+    git(
+        child_a2.handle.workspace_path(),
+        &["reset", "--hard", &child_a2_head],
+    );
+
     let integration = prepared
         .handle
         .workspace_path()
@@ -485,6 +530,12 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .open_parent_execution_root_at_for_retry(&parent, prepared.handle.workspace_path())
         .await
         .expect("retry attachment should preserve parent integration changes");
+    let retried_preparation = manager
+        .prepare_parent_execution_root(&parent, 5, repeat_requests.clone())
+        .await
+        .expect("scheduler preparation should preserve parent integration changes on retry");
+    assert!(!retried_preparation.created);
+    assert!(integration.join("parent-change.txt").exists());
     assert_eq!(
         manager
             .resolve_parent_checkout(&prepared, &repository_a.checkout_handle)

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -10,7 +10,7 @@ use crate::opensymphony_workspace::{
     IssueContextArtifact, IssueDescriptor, IssueLifecycleState, ParentCheckoutRequest,
     ParentRuntimeDescriptor, PromptCaptureDescriptor, PromptKind, RunDescriptor, RunManifest,
     RunStatus, SessionContextArtifact, WorkspaceError, WorkspaceManager, WorkspaceManagerConfig,
-    compose_parent_prompt, compose_terminal_prompt,
+    compose_parent_prompt, compose_terminal_prompt, parent_workspace_key,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -39,6 +39,22 @@ fn manager_config(
         hooks,
         cleanup,
     }
+}
+
+fn parent_generation_path(
+    manager: &WorkspaceManager,
+    parent: &IssueDescriptor,
+    generation: u64,
+) -> std::path::PathBuf {
+    manager
+        .config()
+        .root
+        .join("parents")
+        .join(
+            parent_workspace_key(&parent.identifier, &parent.issue_id)
+                .expect("parent workspace key should be valid"),
+        )
+        .join(generation.to_string())
 }
 
 fn git(path: &std::path::Path, args: &[&str]) -> String {
@@ -251,25 +267,40 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         &["commit", "-m", "retain child feature commit"],
     );
     #[cfg(unix)]
-    let credential_exfil_path = {
+    let (credential_exfil_path, worktree_hook_exfil_path) = {
         use std::os::unix::fs::PermissionsExt;
 
-        let path = temp_dir.path().join("retained-hook-credential.txt");
-        let hook = child_a1
+        let credential_path = temp_dir.path().join("retained-hook-credential.txt");
+        let reference_hook = child_a1
             .handle
             .workspace_path()
             .join(".git/hooks/reference-transaction");
         std::fs::write(
-            &hook,
+            &reference_hook,
             format!(
                 "#!/bin/sh\nif [ -n \"$OPENSYMPHONY_CHECKOUT_CREDENTIAL\" ]; then printf '%s' \"$OPENSYMPHONY_CHECKOUT_CREDENTIAL\" > {}; fi\n",
-                shell_quote(&path)
+                shell_quote(&credential_path)
             ),
         )
         .expect("retained checkout hook should be written");
-        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+        std::fs::set_permissions(&reference_hook, std::fs::Permissions::from_mode(0o755))
             .expect("retained checkout hook should be executable");
-        path
+        let worktree_path = temp_dir.path().join("retained-worktree-hook.txt");
+        let post_checkout_hook = child_a1
+            .handle
+            .workspace_path()
+            .join(".git/hooks/post-checkout");
+        std::fs::write(
+            &post_checkout_hook,
+            format!(
+                "#!/bin/sh\nprintf invoked > {}\n",
+                shell_quote(&worktree_path)
+            ),
+        )
+        .expect("retained post-checkout hook should be written");
+        std::fs::set_permissions(&post_checkout_hook, std::fs::Permissions::from_mode(0o755))
+            .expect("retained post-checkout hook should be executable");
+        (credential_path, worktree_path)
     };
     let child_a1_head = git(child_a1.handle.workspace_path(), &["rev-parse", "HEAD"]);
     let merge_a2 = rebase_merge_fixture(&source_a);
@@ -404,13 +435,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     ));
     std::fs::remove_file(child_b.handle.workspace_path().join("dirty.txt"))
         .expect("dirty marker should be removed");
-    assert!(
-        !manager
-            .config()
-            .root
-            .join("parents/parent-COE-PARENT/5")
-            .exists()
-    );
+    assert!(!parent_generation_path(&manager, &parent, 5).exists());
 
     let expected_remote = git(
         child_c.handle.workspace_path(),
@@ -449,11 +474,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
             if reason.contains("checkout-controlled Git transport configuration")
     ));
     assert!(
-        !manager
-            .config()
-            .root
-            .join("parents/parent-COE-PARENT/7")
-            .exists(),
+        !parent_generation_path(&manager, &parent, 7).exists(),
         "a rejected transport configuration must roll back the partial parent root"
     );
     #[cfg(unix)]
@@ -469,6 +490,24 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         child_a1.handle.workspace_path(),
         &["config", "--unset-all", "http.sslVerify"],
     );
+    git(
+        child_a1.handle.workspace_path(),
+        &[
+            "config",
+            "filter.opensymphony-test.process",
+            "unused-process-filter",
+        ],
+    );
+    assert!(matches!(
+        manager.prepare_parent_execution_root(&parent, 7, requests.clone()).await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("process-filter configuration")
+    ));
+    assert!(!parent_generation_path(&manager, &parent, 7).exists());
+    git(
+        child_a1.handle.workspace_path(),
+        &["config", "--unset-all", "filter.opensymphony-test.process"],
+    );
 
     let repeat_requests = requests.clone();
     let prepared = manager
@@ -480,6 +519,11 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     assert!(
         !credential_exfil_path.exists(),
         "authenticated parent fetches must not run retained-checkout hooks"
+    );
+    #[cfg(unix)]
+    assert!(
+        !worktree_hook_exfil_path.exists(),
+        "parent worktree creation must not run retained-checkout hooks"
     );
 
     assert!(!prepared.handle.workspace_path().join(".git").exists());
@@ -854,6 +898,41 @@ async fn parent_execution_root_supports_no_required_child_checkouts() {
 }
 
 #[tokio::test]
+async fn parent_execution_roots_keep_colliding_sanitized_identifiers_distinct() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let manager = WorkspaceManager::new(manager_config(
+        &temp_dir.path().join("workspaces"),
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let mut slash_parent = sample_issue("TEAM/A");
+    slash_parent.issue_id = "parent-one".to_owned();
+    let mut underscore_parent = sample_issue("TEAM_A");
+    underscore_parent.issue_id = "parent-two".to_owned();
+
+    let slash = manager
+        .prepare_parent_execution_root(&slash_parent, 1, Vec::new())
+        .await
+        .expect("slash parent should prepare");
+    let underscore = manager
+        .prepare_parent_execution_root(&underscore_parent, 1, Vec::new())
+        .await
+        .expect("underscore parent should prepare independently");
+
+    assert_ne!(
+        slash.handle.workspace_key(),
+        underscore.handle.workspace_key()
+    );
+    assert_ne!(
+        slash.handle.workspace_path(),
+        underscore.handle.workspace_path()
+    );
+    assert_eq!(slash.manifest.parent_issue_id, "parent-one");
+    assert_eq!(underscore.manifest.parent_issue_id, "parent-two");
+}
+
+#[tokio::test]
 async fn parent_execution_root_rolls_back_after_create_failure() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
     let manager = WorkspaceManager::new(manager_config(
@@ -874,13 +953,32 @@ async fn parent_execution_root_rolls_back_after_create_failure() {
             .await,
         Err(WorkspaceError::HookFailed { .. })
     ));
-    assert!(
-        !manager
-            .config()
-            .root
-            .join("parents/parent-COE-FAILED-PARENT/1")
-            .exists()
-    );
+    assert!(!parent_generation_path(&manager, &parent, 1).exists());
+}
+
+#[tokio::test]
+async fn parent_execution_root_rolls_back_when_after_create_initializes_git() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let manager = WorkspaceManager::new(manager_config(
+        &temp_dir.path().join("workspaces"),
+        HookConfig {
+            after_create: Some(HookDefinition::shell("git init -b parent-hook")),
+            ..HookConfig::default()
+        },
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let mut parent = sample_issue("COE-GIT-PARENT");
+    parent.issue_id = "git-parent-id".to_owned();
+
+    assert!(matches!(
+        manager
+            .prepare_parent_execution_root(&parent, 1, Vec::new())
+            .await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("root-level Git repository")
+    ));
+    assert!(!parent_generation_path(&manager, &parent, 1).exists());
 }
 
 #[cfg(unix)]
@@ -949,11 +1047,7 @@ async fn parent_preparation_times_out_stalled_integration_verification() {
         error.to_string().contains("timed out"),
         "unexpected integration timeout error: {error}"
     );
-    assert!(
-        !workspace_root
-            .join("parents/parent-COE-TIMEOUT-PARENT/1")
-            .exists()
-    );
+    assert!(!parent_generation_path(&manager, &parent, 1).exists());
 }
 
 #[cfg(unix)]

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -7,9 +7,10 @@ use crate::opensymphony_domain::{
 use crate::opensymphony_workspace::{
     CheckoutManifest, CheckoutRepository, CleanupConfig, CleanupDecision, ConversationManifest,
     HookConfig, HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind,
-    IssueContextArtifact, IssueDescriptor, IssueLifecycleState, PromptCaptureDescriptor,
-    PromptKind, RunDescriptor, RunManifest, RunStatus, SessionContextArtifact, WorkspaceError,
-    WorkspaceManager, WorkspaceManagerConfig, compose_terminal_prompt,
+    IssueContextArtifact, IssueDescriptor, IssueLifecycleState, ParentCheckoutRequest,
+    ParentRuntimeDescriptor, PromptCaptureDescriptor, PromptKind, RunDescriptor, RunManifest,
+    RunStatus, SessionContextArtifact, WorkspaceError, WorkspaceManager, WorkspaceManagerConfig,
+    compose_parent_prompt, compose_terminal_prompt,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -70,6 +71,491 @@ fn terminal_prompt_keeps_repository_instructions_in_one_section() {
     assert!(prompt.contains("Description:\nacceptance criteria"));
     assert!(prompt.contains("## Repository Instructions\n\nrepository-only instruction"));
     assert!(!prompt.contains("other repository"));
+}
+
+fn repository_fixture(
+    root: &std::path::Path,
+    name: &str,
+) -> (std::path::PathBuf, RepositoryBinding, CheckoutRepository) {
+    let source = root.join(format!("{name}-source"));
+    let origin = root.join(format!("{name}.git"));
+    std::fs::create_dir_all(&source).expect("source should exist");
+    std::fs::create_dir_all(&origin).expect("origin should exist");
+    git(&source, &["init", "-b", "main"]);
+    git(&source, &["config", "user.email", "test@example.invalid"]);
+    git(&source, &["config", "user.name", "OpenSymphony Test"]);
+    std::fs::write(
+        source.join("AGENTS.md"),
+        format!("instructions for {name}\n"),
+    )
+    .expect("instructions should be written");
+    std::fs::write(source.join("README.md"), format!("{name}\n"))
+        .expect("readme should be written");
+    git(&source, &["add", "."]);
+    git(&source, &["commit", "-m", "initial"]);
+    git(&origin, &["init", "--bare"]);
+    git(
+        &source,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.to_str().expect("origin path"),
+        ],
+    );
+    git(&source, &["push", "-u", "origin", "main"]);
+    let id =
+        CanonicalRepositoryId::from_remote("local", None, origin.to_str().expect("origin path"))
+            .expect("repository id should be valid");
+    let fingerprint =
+        SafeRemoteFingerprint::from_remote("local", None, origin.to_str().expect("origin path"))
+            .expect("fingerprint should be valid");
+    (
+        source,
+        RepositoryBinding {
+            alias: name.to_owned(),
+            repository: RepositoryIdentity {
+                id,
+                safe_remote_fingerprint: fingerprint,
+            },
+            config_generation: "config-1".to_owned(),
+            inventory_generation: "inventory-1".to_owned(),
+        },
+        CheckoutRepository {
+            provider: "local".to_owned(),
+            provider_id: None,
+            remote_locator: origin.to_str().expect("origin path").to_owned(),
+            remote: origin.to_str().expect("origin path").to_owned(),
+            target_branch: "main".to_owned(),
+            credential_kind: "environment".to_owned(),
+            credential_reference: None,
+            credential_env: Some("HOME".to_owned()),
+            review_credential_env: None,
+            instructions_path: "AGENTS.md".into(),
+            policy_generation: "policy-1".to_owned(),
+            review_profile: "local".to_owned(),
+            review_provider: "local".to_owned(),
+            review_policy_generation: "review-1".to_owned(),
+            required_checks: false,
+            required_review: false,
+            merge_method: None,
+        },
+    )
+}
+
+fn commit_file(source: &std::path::Path, name: &str, contents: &str, message: &str) -> String {
+    std::fs::write(source.join(name), contents).expect("fixture file should be written");
+    git(source, &["add", name]);
+    git(source, &["commit", "-m", message]);
+    git(source, &["push", "origin", "main"]);
+    git(source, &["rev-parse", "HEAD"])
+}
+
+fn squash_merge_fixture(source: &std::path::Path) -> String {
+    git(source, &["checkout", "-b", "feature-squash"]);
+    std::fs::write(
+        source.join("a1-feature.txt"),
+        "feature commit replaced by squash\n",
+    )
+    .expect("squash feature should be written");
+    git(source, &["add", "a1-feature.txt"]);
+    git(source, &["commit", "-m", "feature commit for squash"]);
+    git(source, &["checkout", "main"]);
+    git(source, &["merge", "--squash", "feature-squash"]);
+    git(source, &["commit", "-m", "squash merge result"]);
+    git(source, &["push", "origin", "main"]);
+    git(source, &["rev-parse", "HEAD"])
+}
+
+fn rebase_merge_fixture(source: &std::path::Path) -> String {
+    git(source, &["checkout", "-b", "feature-rebase"]);
+    std::fs::write(
+        source.join("a2-feature.txt"),
+        "feature commit rebased before merge\n",
+    )
+    .expect("rebase feature should be written");
+    git(source, &["add", "a2-feature.txt"]);
+    git(source, &["commit", "-m", "feature commit before rebase"]);
+    git(source, &["checkout", "main"]);
+    commit_file(
+        source,
+        "base-advance.txt",
+        "target advanced before rebase\n",
+        "advance target before rebase",
+    );
+    git(source, &["rebase", "main", "feature-rebase"]);
+    git(source, &["checkout", "main"]);
+    git(source, &["merge", "--ff-only", "feature-rebase"]);
+    git(source, &["push", "origin", "main"]);
+    git(source, &["rev-parse", "HEAD"])
+}
+
+#[tokio::test]
+async fn parent_execution_root_reuses_three_repositories_and_preserves_children() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let (source_a, binding_a, repository_a) = repository_fixture(temp_dir.path(), "repository-a");
+    let (source_b, binding_b, repository_b) = repository_fixture(temp_dir.path(), "repository-b");
+    let (source_c, binding_c, repository_c) = repository_fixture(temp_dir.path(), "repository-c");
+    let merge_a1 = squash_merge_fixture(&source_a);
+    let manager = WorkspaceManager::new(manager_config(
+        &temp_dir.path().join("workspaces"),
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build")
+    .with_repository_checkouts(BTreeMap::from([
+        (binding_a.repository_id().to_string(), repository_a),
+        (binding_b.repository_id().to_string(), repository_b),
+        (binding_c.repository_id().to_string(), repository_c),
+    ]));
+
+    let mut child_a1 = sample_issue("COE-A1");
+    child_a1.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding_a.clone()));
+    let child_a1 = manager
+        .ensure(&child_a1)
+        .await
+        .expect("first repository-a child should exist");
+    let child_a1_head = git(child_a1.handle.workspace_path(), &["rev-parse", "HEAD"]);
+    let merge_a2 = rebase_merge_fixture(&source_a);
+
+    let mut child_a2 = sample_issue("COE-A2");
+    child_a2.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding_a.clone()));
+    let child_a2 = manager
+        .ensure(&child_a2)
+        .await
+        .expect("second repository-a child should exist");
+    let mut child_b = sample_issue("COE-B");
+    child_b.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding_b.clone()));
+    let child_b = manager
+        .ensure(&child_b)
+        .await
+        .expect("repository-b child should exist");
+    let mut child_c = sample_issue("COE-C");
+    child_c.repository_binding = Some(RepositoryBindingOutcome::Resolved(binding_c.clone()));
+    let child_c = manager
+        .ensure(&child_c)
+        .await
+        .expect("repository-c child should exist");
+    let child_c_git_dir = child_c.handle.workspace_path().join(".git");
+    std::fs::write(
+        child_c_git_dir.join("shallow"),
+        format!(
+            "{}\n",
+            git(child_c.handle.workspace_path(), &["rev-parse", "HEAD"])
+        ),
+    )
+    .expect("shallow boundary should be written");
+    let child_c_manifest_path = child_c.handle.checkout_manifest_path();
+    let mut child_c_manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&child_c_manifest_path).expect("child manifest should be readable"),
+    )
+    .expect("child manifest should decode");
+    child_c_manifest["shallow"] = serde_json::Value::Bool(true);
+    std::fs::write(
+        &child_c_manifest_path,
+        serde_json::to_vec_pretty(&child_c_manifest).expect("child manifest should encode"),
+    )
+    .expect("child manifest should be updated for the shallow fixture");
+    assert_eq!(
+        git(
+            child_c.handle.workspace_path(),
+            &["rev-parse", "--is-shallow-repository"]
+        ),
+        "true"
+    );
+
+    let child_snapshot = [
+        child_a1.handle.clone(),
+        child_a2.handle.clone(),
+        child_b.handle.clone(),
+        child_c.handle.clone(),
+    ]
+    .map(|handle| {
+        (
+            handle.clone(),
+            git(handle.workspace_path(), &["rev-parse", "HEAD"]),
+            git(
+                handle.workspace_path(),
+                &["status", "--porcelain", "--untracked-files=all"],
+            ),
+            std::fs::read(handle.checkout_manifest_path())
+                .expect("child manifest should be readable"),
+        )
+    });
+    let mut parent = sample_issue("COE-PARENT");
+    parent.issue_id = "parent-id".to_owned();
+    let requests = vec![
+        ParentCheckoutRequest {
+            issue_id: child_a1.handle.issue_id().to_owned(),
+            repository_id: binding_a.repository_id().to_string(),
+            checkout_generation: child_a1
+                .handle
+                .checkout_generation()
+                .expect("generation")
+                .to_owned(),
+            lease_owner: "ancestor-integration:parent-id".to_owned(),
+            required_merge_commits: vec![merge_a1],
+        },
+        ParentCheckoutRequest {
+            issue_id: child_a2.handle.issue_id().to_owned(),
+            repository_id: binding_a.repository_id().to_string(),
+            checkout_generation: child_a2
+                .handle
+                .checkout_generation()
+                .expect("generation")
+                .to_owned(),
+            lease_owner: "ancestor-integration:parent-id".to_owned(),
+            required_merge_commits: vec![merge_a2.clone()],
+        },
+        ParentCheckoutRequest {
+            issue_id: child_b.handle.issue_id().to_owned(),
+            repository_id: binding_b.repository_id().to_string(),
+            checkout_generation: child_b
+                .handle
+                .checkout_generation()
+                .expect("generation")
+                .to_owned(),
+            lease_owner: "ancestor-integration:parent-id".to_owned(),
+            required_merge_commits: vec![git(&source_b, &["rev-parse", "HEAD"])],
+        },
+        ParentCheckoutRequest {
+            issue_id: child_c.handle.issue_id().to_owned(),
+            repository_id: binding_c.repository_id().to_string(),
+            checkout_generation: child_c
+                .handle
+                .checkout_generation()
+                .expect("generation")
+                .to_owned(),
+            lease_owner: "ancestor-integration:parent-id".to_owned(),
+            required_merge_commits: vec![git(&source_c, &["rev-parse", "HEAD"])],
+        },
+    ];
+    let mut stale_requests = requests.clone();
+    stale_requests[0].checkout_generation = "stale-generation".to_owned();
+    assert!(matches!(
+        manager.prepare_parent_execution_root(&parent, 4, stale_requests).await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("generation is unavailable")
+    ));
+
+    std::fs::write(child_b.handle.workspace_path().join("dirty.txt"), "dirty\n")
+        .expect("dirty marker should be written");
+    assert!(matches!(
+        manager.prepare_parent_execution_root(&parent, 5, requests.clone()).await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("dirty")
+    ));
+    std::fs::remove_file(child_b.handle.workspace_path().join("dirty.txt"))
+        .expect("dirty marker should be removed");
+
+    let expected_remote = git(
+        child_c.handle.workspace_path(),
+        &["remote", "get-url", "origin"],
+    );
+    git(
+        child_c.handle.workspace_path(),
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            source_b.to_str().expect("wrong remote path"),
+        ],
+    );
+    assert!(matches!(
+        manager.prepare_parent_execution_root(&parent, 6, requests.clone()).await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("remote fingerprint")
+    ));
+    git(
+        child_c.handle.workspace_path(),
+        &["remote", "set-url", "origin", &expected_remote],
+    );
+
+    let prepared = manager
+        .prepare_parent_execution_root(&parent, 7, requests)
+        .await
+        .expect("parent root should be prepared from retained storage");
+
+    assert!(!prepared.handle.workspace_path().join(".git").exists());
+    assert_eq!(prepared.child_checkout_map.repositories.len(), 3);
+    let repository_a = prepared
+        .child_checkout_map
+        .repositories
+        .get(binding_a.repository_id().as_str())
+        .expect("repository-a checkout should exist");
+    assert_eq!(repository_a.retained_checkouts.len(), 2);
+    assert_eq!(repository_a.target_commit, merge_a2);
+    for (handle, head, status, manifest) in child_snapshot {
+        assert_eq!(git(handle.workspace_path(), &["rev-parse", "HEAD"]), head);
+        assert_eq!(
+            git(
+                handle.workspace_path(),
+                &["status", "--porcelain", "--untracked-files=all"],
+            ),
+            status
+        );
+        assert_eq!(
+            std::fs::read(handle.checkout_manifest_path())
+                .expect("child manifest should remain readable"),
+            manifest
+        );
+    }
+    for checkout in prepared.child_checkout_map.repositories.values() {
+        let path = manager
+            .resolve_parent_checkout(&prepared, &checkout.checkout_handle)
+            .await
+            .expect("opaque checkout handle should resolve");
+        assert_eq!(git(&path, &["rev-parse", "HEAD"]), checkout.target_commit);
+        assert!(
+            path.join(".git").is_file(),
+            "a linked worktree uses a .git file"
+        );
+    }
+    assert_eq!(
+        git(child_a1.handle.workspace_path(), &["rev-parse", "HEAD"]),
+        child_a1_head
+    );
+    assert!(matches!(
+        manager.resolve_parent_checkout(&prepared, "../arbitrary").await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("not present")
+    ));
+
+    let mut changed_requests = prepared
+        .child_checkout_map
+        .repositories
+        .values()
+        .flat_map(|repository| {
+            repository
+                .retained_checkouts
+                .iter()
+                .map(|checkout| ParentCheckoutRequest {
+                    issue_id: checkout.issue_id.clone(),
+                    repository_id: repository.repository_id.clone(),
+                    checkout_generation: checkout.checkout_generation.clone(),
+                    lease_owner: checkout.lease_owner.clone(),
+                    required_merge_commits: repository.required_merge_commits.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
+    changed_requests[0].lease_owner = "ancestor-integration:other-parent".to_owned();
+    assert!(matches!(
+        manager.prepare_parent_execution_root(&parent, 7, changed_requests).await,
+        Err(WorkspaceError::CheckoutVerification { reason, .. })
+            if reason.contains("does not match")
+    ));
+
+    let repository_instructions = manager
+        .parent_repository_instructions(&prepared)
+        .await
+        .expect("repository instructions should load");
+    let openhands = manager.parent_runtime_envelope(
+        &prepared,
+        ParentRuntimeDescriptor {
+            run_id: "run-parent".to_owned(),
+            attempt: 1,
+            integration_instruction: None,
+            harness: "openhands_agent_server".to_owned(),
+            model_profile: "default".to_owned(),
+            model: None,
+            effective_containment: "trusted_host".to_owned(),
+        },
+    );
+    let codex = manager.parent_runtime_envelope(
+        &prepared,
+        ParentRuntimeDescriptor {
+            run_id: "run-parent".to_owned(),
+            attempt: 1,
+            integration_instruction: None,
+            harness: "codex_app_server".to_owned(),
+            model_profile: "default".to_owned(),
+            model: None,
+            effective_containment: "trusted_host".to_owned(),
+        },
+    );
+    assert_eq!(openhands.workspace_path, codex.workspace_path);
+    assert_eq!(openhands.checkouts, codex.checkouts);
+    assert_eq!(openhands.requested_execution_scope, "parent_multi_checkout");
+    assert_eq!(codex.effective_containment, "trusted_host");
+    let prompt = compose_parent_prompt(
+        "generic lifecycle policy",
+        "acceptance criteria",
+        &codex,
+        Some("project-set instructions"),
+        &repository_instructions,
+    );
+    assert!(prompt.contains(binding_a.repository_id().as_str()));
+    assert!(prompt.contains("project-set instructions"));
+    assert!(!prompt.contains("frontend repository"));
+
+    #[cfg(unix)]
+    {
+        let integration = prepared
+            .handle
+            .workspace_path()
+            .join(&repository_a.relative_path);
+        git(
+            child_a1.handle.workspace_path(),
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                integration.to_str().expect("integration path"),
+            ],
+        );
+        let outside = temp_dir.path().join("outside-parent-root");
+        std::fs::create_dir_all(&outside).expect("outside directory should exist");
+        symlink(&outside, &integration).expect("integration symlink should be created");
+        assert!(matches!(
+            manager
+                .resolve_parent_checkout(&prepared, &repository_a.checkout_handle)
+                .await,
+            Err(WorkspaceError::PathEscape { .. })
+                | Err(WorkspaceError::ManagedPathSymlink { .. })
+                | Err(WorkspaceError::CheckoutVerification { .. })
+        ));
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn parent_execution_root_rejects_a_symlinked_parent_directory_before_git() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let outside = temp_dir.path().join("outside");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root should exist");
+    std::fs::create_dir_all(&outside).expect("outside should exist");
+    symlink(&outside, workspace_root.join("parents"))
+        .expect("parent directory symlink should be created");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+
+    assert!(matches!(
+        manager
+            .prepare_parent_execution_root(
+                &sample_issue("COE-PARENT-SYMLINK"),
+                1,
+                vec![ParentCheckoutRequest {
+                    issue_id: "child-id".to_owned(),
+                    repository_id: "local:repository:child".to_owned(),
+                    checkout_generation: "generation-1".to_owned(),
+                    lease_owner: "ancestor-integration:parent-id".to_owned(),
+                    required_merge_commits: Vec::new(),
+                }],
+            )
+            .await,
+        Err(WorkspaceError::InstructionPathEscape { .. })
+    ));
+    assert!(
+        std::fs::read_dir(&outside)
+            .expect("outside should remain readable")
+            .next()
+            .is_none()
+    );
 }
 
 #[cfg(unix)]

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -347,6 +347,13 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
     ));
     std::fs::remove_file(child_b.handle.workspace_path().join("dirty.txt"))
         .expect("dirty marker should be removed");
+    assert!(
+        !manager
+            .config()
+            .root
+            .join("parents/parent-COE-PARENT/5")
+            .exists()
+    );
 
     let expected_remote = git(
         child_c.handle.workspace_path(),
@@ -371,10 +378,11 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         &["remote", "set-url", "origin", &expected_remote],
     );
 
+    let repeat_requests = requests.clone();
     let prepared = manager
-        .prepare_parent_execution_root(&parent, 7, requests)
+        .prepare_parent_execution_root(&parent, 5, requests)
         .await
-        .expect("parent root should be prepared from retained storage");
+        .expect("same generation should retry after incomplete preparation is rolled back");
 
     assert!(!prepared.handle.workspace_path().join(".git").exists());
     assert_eq!(prepared.child_checkout_map.repositories.len(), 3);
@@ -415,11 +423,77 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         git(child_a1.handle.workspace_path(), &["rev-parse", "HEAD"]),
         child_a1_head
     );
+    assert_eq!(
+        git(
+            child_c.handle.workspace_path(),
+            &["rev-parse", "--is-shallow-repository"]
+        ),
+        "false"
+    );
+    manager
+        .prepare_parent_execution_root(&parent, 8, repeat_requests)
+        .await
+        .expect("a deepened retained child should support a later parent generation");
     assert!(matches!(
         manager.resolve_parent_checkout(&prepared, "../arbitrary").await,
         Err(WorkspaceError::CheckoutVerification { reason, .. })
             if reason.contains("not present")
     ));
+
+    std::fs::write(
+        child_a2
+            .handle
+            .workspace_path()
+            .join("late-child-drift.txt"),
+        "must be detected\n",
+    )
+    .expect("late child drift marker should be written");
+    let child_drift_error = manager
+        .open_parent_execution_root_at(&parent, prepared.handle.workspace_path())
+        .await
+        .expect_err("a dirty non-source child must invalidate the parent root");
+    assert!(
+        child_drift_error.to_string().contains("dirty"),
+        "unexpected child-drift error: {child_drift_error}"
+    );
+    std::fs::remove_file(
+        child_a2
+            .handle
+            .workspace_path()
+            .join("late-child-drift.txt"),
+    )
+    .expect("late child drift marker should be removed");
+
+    let integration = prepared
+        .handle
+        .workspace_path()
+        .join(&repository_a.relative_path);
+    std::fs::write(
+        integration.join("parent-change.txt"),
+        "preserve across retry\n",
+    )
+    .expect("parent change should be written");
+    let parent_drift_error = manager
+        .open_parent_execution_root_at(&parent, prepared.handle.workspace_path())
+        .await
+        .expect_err("strict reopen must reject dirty parent integration work");
+    assert!(
+        parent_drift_error.to_string().contains("dirty"),
+        "unexpected parent-drift error: {parent_drift_error}"
+    );
+    manager
+        .open_parent_execution_root_at_for_retry(&parent, prepared.handle.workspace_path())
+        .await
+        .expect("retry attachment should preserve parent integration changes");
+    assert_eq!(
+        manager
+            .resolve_parent_checkout(&prepared, &repository_a.checkout_handle)
+            .await
+            .expect("handle resolution should permit parent-owned changes"),
+        integration
+    );
+    std::fs::remove_file(integration.join("parent-change.txt"))
+        .expect("parent change should be removed before manifest mismatch validation");
 
     let mut changed_requests = prepared
         .child_checkout_map
@@ -440,7 +514,7 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         .collect::<Vec<_>>();
     changed_requests[0].lease_owner = "ancestor-integration:other-parent".to_owned();
     assert!(matches!(
-        manager.prepare_parent_execution_root(&parent, 7, changed_requests).await,
+        manager.prepare_parent_execution_root(&parent, 5, changed_requests).await,
         Err(WorkspaceError::CheckoutVerification { reason, .. })
             if reason.contains("does not match")
     ));
@@ -490,31 +564,49 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
 
     #[cfg(unix)]
     {
-        let integration = prepared
-            .handle
-            .workspace_path()
-            .join(&repository_a.relative_path);
-        git(
-            child_a1.handle.workspace_path(),
-            &[
-                "worktree",
-                "remove",
-                "--force",
-                integration.to_str().expect("integration path"),
-            ],
-        );
+        let repositories = prepared.handle.workspace_path().join("repositories");
         let outside = temp_dir.path().join("outside-parent-root");
-        std::fs::create_dir_all(&outside).expect("outside directory should exist");
-        symlink(&outside, &integration).expect("integration symlink should be created");
+        std::fs::rename(&repositories, &outside)
+            .expect("repository worktrees should move outside the parent root");
+        symlink(&outside, &repositories).expect("repositories symlink should be created");
         assert!(matches!(
             manager
                 .resolve_parent_checkout(&prepared, &repository_a.checkout_handle)
                 .await,
             Err(WorkspaceError::PathEscape { .. })
                 | Err(WorkspaceError::ManagedPathSymlink { .. })
+                | Err(WorkspaceError::InstructionPathEscape { .. })
                 | Err(WorkspaceError::CheckoutVerification { .. })
         ));
     }
+}
+
+#[tokio::test]
+async fn parent_execution_root_supports_no_required_child_checkouts() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let manager = WorkspaceManager::new(manager_config(
+        &temp_dir.path().join("workspaces"),
+        HookConfig::default(),
+        CleanupConfig::default(),
+    ))
+    .expect("manager should build");
+    let mut parent = sample_issue("COE-CANCELED-PARENT");
+    parent.issue_id = "canceled-parent-id".to_owned();
+
+    let prepared = manager
+        .prepare_parent_execution_root(&parent, 1, Vec::new())
+        .await
+        .expect("a parent with no required child checkouts should still get an execution root");
+
+    assert!(!prepared.handle.workspace_path().join(".git").exists());
+    assert!(prepared.child_checkout_map.repositories.is_empty());
+    assert!(
+        prepared
+            .handle
+            .workspace_path()
+            .join("repositories")
+            .is_dir()
+    );
 }
 
 #[cfg(unix)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,17 @@ after terminal orchestrator outcomes and retained checkout-generation lease
 resources are present; scope changes after freeze are recorded as
 `HierarchyChanged` and cannot silently widen the parent run.
 
+An eligible parent is materialized as a repository-neutral execution root for
+the frozen hierarchy generation. The workspace backend resolves only active
+ancestor leases, groups their retained generations by canonical repository ID,
+and asks the workspace manager for one contained integration worktree per
+repository. Those worktrees share a selected child's Git object store, refresh
+the configured target through that repository's credential provider, and pin
+the provider merge-result commits used for admission. The parent worker starts
+once with this root as `cwd`, a relative checkout-handle map, and a generic
+`parent_multi_checkout` envelope; neither the directory layout nor the prompt
+assigns repository roles.
+
 ### 3.2 OpenHands is the execution adapter
 
 OpenHands provides:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,10 @@ ancestor leases, groups their retained generations by canonical repository ID,
 and asks the workspace manager for one contained integration worktree per
 repository. Those worktrees share a selected child's Git object store, refresh
 the configured target through that repository's credential provider, and pin
-the provider merge-result commits used for admission. The parent worker starts
+the provider merge-result commits used for admission. An orchestrator-owned
+copy of the checkout map remains outside the parent runtime root, and every
+reopen compares the runtime map to that copy before rechecking target and merge
+ancestry. The parent worker starts
 once with this root as `cwd`, a relative checkout-handle map, and a generic
 `parent_multi_checkout` envelope; neither the directory layout nor the prompt
 assigns repository roles.

--- a/docs/codex-app-server-harness.md
+++ b/docs/codex-app-server-harness.md
@@ -92,6 +92,13 @@ input plus the maximum-permission turn profile:
 }
 ```
 
+Parent threads use the repository-neutral parent root as that working
+directory. Their conversation manifest binds the same relative checkout map and
+`parent_multi_checkout` scope used by OpenHands, while recording effective
+`trusted_host` containment for the local danger-full-access profile. Codex does
+not receive a synthetic leaf checkout envelope or a parent memory grant owned
+by the later parent-controller lifecycle.
+
 `approvalPolicy: "never"` means OpenSymphony does not wait for human approval
 callbacks from Codex. Execution failures are streamed back through Codex and
 handled by the model loop. `dangerFullAccess` intentionally carries no

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,13 @@ envelope, and refuse attach when binding or provenance is incompatible.
 home configuration. `memory init` refuses to treat a selected central config
 as a repository-local memory file; initialize the local memory config instead.
 
+When a project set supplies hash-pinned integration instructions, the resolved
+artifact is carried into parent worker construction. Parent launch rereads the
+artifact and verifies its configured hash before composing the prompt. The
+artifact may describe topology-specific commands, but repository instructions
+remain separate sections keyed by canonical repository ID and the runtime does
+not convert those instructions into repository roles.
+
 Every run records one `sha256:` config generation in startup diagnostics and
 the initial control-plane event. Resolved credential values are never part of
 the central model or its serialized diagnostics.

--- a/docs/openhands-agent-server.md
+++ b/docs/openhands-agent-server.md
@@ -96,6 +96,15 @@ truthful trusted-host process-`cwd` containment receipt. A compatible persisted
 conversation may be reused only when its envelope matches; a mismatch is
 rejected before attach.
 
+For an eligible parent, `workspace.working_dir` is the non-Git parent execution
+root. The conversation manifest binds the parent envelope to the OpenHands
+conversation ID and records the complete relative checkout map with requested
+`parent_multi_checkout` scope. Trusted local OpenHands runs report
+`trusted_host`; the prompt and `cwd` do not claim filesystem sandboxing. The
+full first prompt combines the generic parent lifecycle, optional verified
+project-set integration instructions, parent task facts, the checkout map, and
+repository instructions keyed by canonical repository ID.
+
 When the local memory server issues a process-scoped worker grant, the grant
 is also part of conversation compatibility. The agent-server create contract
 does not provide a conversation MCP-config update operation, so a persisted

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -707,6 +707,17 @@ manually reset a quarantined checkout into service. The runtime envelope also
 records that current local containment is process `cwd` containment on a
 trusted host, not a sandbox boundary.
 
+Parent runs publish a separate generation-scoped root below
+`workspace.root/parents/`. Inspect `parent-manifest.json`,
+`child-checkouts.json`, and `.opensymphony/parent-runtime.json` together when a
+parent cannot launch. Preparation blocks before a repository operation when a
+required child subtree lacks an active ancestor lease, a retained generation is
+stale or dirty, merge evidence is ambiguous across repositories, a remote no
+longer matches policy, or a contained worktree fails its shared-storage and
+path checks. Do not repair those files or substitute a filesystem path for the
+recorded opaque handle; reconcile the hierarchy/lease evidence or retained
+checkout and retry the same generation.
+
 Strict `opensymphony rehydrate` also derives the desired repository, harness,
 model, and generation envelope from the current central routing inventory before
 creating a replacement conversation. If that envelope differs from the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -710,13 +710,18 @@ trusted host, not a sandbox boundary.
 Parent runs publish a separate generation-scoped root below
 `workspace.root/parents/`. Inspect `parent-manifest.json`,
 `child-checkouts.json`, and `.opensymphony/parent-runtime.json` together when a
-parent cannot launch. Preparation blocks before a repository operation when a
+parent cannot launch. The workspace manager also keeps the authoritative copy
+of each generation's checkout map below
+`workspace.root/.opensymphony-parent-pins/`; a mismatch means the runtime copy
+was modified and must not be repaired in place. Preparation blocks before a repository operation when a
 required child subtree lacks an active ancestor lease, a retained generation is
 stale or dirty, merge evidence is ambiguous across repositories, a remote no
 longer matches policy, or a contained worktree fails its shared-storage and
 path checks. Do not repair those files or substitute a filesystem path for the
 recorded opaque handle; reconcile the hierarchy/lease evidence or retained
-checkout and retry the same generation.
+checkout and rematerialize the generation. A configured `after_create` hook is
+required for parent roots too; its failure rolls back the incomplete root, and
+reuse requires its completion receipt.
 
 Strict `opensymphony rehydrate` also derives the desired repository, harness,
 model, and generation envelope from the current central routing inventory before

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -720,11 +720,15 @@ longer matches policy, or a contained worktree fails its shared-storage and
 path checks. Parent preparation also rejects retained-checkout local/worktree
 HTTP, credential, transport, SSH-command, protocol, and URL-rewrite settings
 before an authenticated fetch; remove or reconcile those settings before
-retrying. Do not repair generated parent files or substitute a filesystem path
-for the recorded opaque handle; reconcile the hierarchy/lease evidence or
-retained checkout and rematerialize the generation. A configured
+retrying. Checkout-controlled process filters are rejected before integration
+worktree creation, while retained hooks and host-level Git configuration are
+disabled for that operation. Do not repair generated parent files or substitute
+a filesystem path for the recorded opaque handle; reconcile the hierarchy/lease
+evidence or retained checkout and rematerialize the generation. A configured
 `after_create` hook is required for parent roots too; its failure rolls back the
-incomplete root, and reuse requires its completion receipt.
+incomplete root, a hook-created root-level Git repository also fails and rolls
+back, and reuse requires the hook completion receipt. Parent paths include a
+stable issue-identity digest after the sanitized identifier.
 
 Strict `opensymphony rehydrate` also derives the desired repository, harness,
 model, and generation envelope from the current central routing inventory before

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -717,11 +717,14 @@ was modified and must not be repaired in place. Preparation blocks before a repo
 required child subtree lacks an active ancestor lease, a retained generation is
 stale or dirty, merge evidence is ambiguous across repositories, a remote no
 longer matches policy, or a contained worktree fails its shared-storage and
-path checks. Do not repair those files or substitute a filesystem path for the
-recorded opaque handle; reconcile the hierarchy/lease evidence or retained
-checkout and rematerialize the generation. A configured `after_create` hook is
-required for parent roots too; its failure rolls back the incomplete root, and
-reuse requires its completion receipt.
+path checks. Parent preparation also rejects retained-checkout local/worktree
+HTTP, credential, transport, SSH-command, protocol, and URL-rewrite settings
+before an authenticated fetch; remove or reconcile those settings before
+retrying. Do not repair generated parent files or substitute a filesystem path
+for the recorded opaque handle; reconcile the hierarchy/lease evidence or
+retained checkout and rematerialize the generation. A configured
+`after_create` hook is required for parent roots too; its failure rolls back the
+incomplete root, and reuse requires its completion receipt.
 
 Strict `opensymphony rehydrate` also derives the desired repository, harness,
 model, and generation envelope from the current central routing inventory before

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -511,12 +511,18 @@ and rejection of stale generations, missing ancestor leases, ambiguous merge
 evidence, dirty children, wrong remotes, arbitrary handles, changed root
 requests, runtime-map target repinning, and symlink escapes. It also proves
 checkout-local HTTP transport configuration is rejected before credential
-exposure, parent `after_create` receipt/reuse/failure behavior, and uses a
-blocking integration-only Git fsmonitor hook under paused time to prove the
-complete integration verification path times out and rolls back. Focused
+exposure, checkout-controlled process filters are rejected, retained
+`post-checkout` hooks do not run during worktree creation, colliding sanitized
+parent identifiers remain distinct, and `after_create` cannot turn a parent root
+into a Git repository. It also covers parent `after_create` receipt/reuse/failure
+behavior and uses a blocking integration-only Git fsmonitor hook under paused
+time to prove the complete integration verification path times out and rolls
+back. Focused
 OpenHands and Codex tests bind the same logical `parent_multi_checkout` envelope
 while preserving truthful `trusted_host` containment and omitting a leaf runtime
 envelope.
+The parent launch tests re-read project-set integration instructions after the
+lifecycle hook boundary and reject changed bytes before harness attachment.
 
 ### Scenario B: conversation reuse
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -510,11 +510,13 @@ provider merge-result reachability, unchanged child HEAD/status/manifest bytes,
 and rejection of stale generations, missing ancestor leases, ambiguous merge
 evidence, dirty children, wrong remotes, arbitrary handles, changed root
 requests, runtime-map target repinning, and symlink escapes. It also proves
-parent `after_create` receipt/reuse/failure behavior and uses a blocking
-integration-only Git fsmonitor hook under paused time to prove the complete
-integration verification path times out and rolls back. Focused OpenHands and Codex tests bind the same
-logical `parent_multi_checkout` envelope while preserving truthful
-`trusted_host` containment and omitting a leaf runtime envelope.
+checkout-local HTTP transport configuration is rejected before credential
+exposure, parent `after_create` receipt/reuse/failure behavior, and uses a
+blocking integration-only Git fsmonitor hook under paused time to prove the
+complete integration verification path times out and rolls back. Focused
+OpenHands and Codex tests bind the same logical `parent_multi_checkout` envelope
+while preserving truthful `trusted_host` containment and omitting a leaf runtime
+envelope.
 
 ### Scenario B: conversation reuse
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -509,7 +509,10 @@ root, one shared-object worktree per canonical repository, exact target and
 provider merge-result reachability, unchanged child HEAD/status/manifest bytes,
 and rejection of stale generations, missing ancestor leases, ambiguous merge
 evidence, dirty children, wrong remotes, arbitrary handles, changed root
-requests, and symlink escapes. Focused OpenHands and Codex tests bind the same
+requests, runtime-map target repinning, and symlink escapes. It also proves
+parent `after_create` receipt/reuse/failure behavior and uses a blocking
+integration-only Git fsmonitor hook under paused time to prove the complete
+integration verification path times out and rolls back. Focused OpenHands and Codex tests bind the same
 logical `parent_multi_checkout` envelope while preserving truthful
 `trusted_host` containment and omitting a leaf runtime envelope.
 

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -511,13 +511,16 @@ and rejection of stale generations, missing ancestor leases, ambiguous merge
 evidence, dirty children, wrong remotes, arbitrary handles, changed root
 requests, runtime-map target repinning, and symlink escapes. It also proves
 checkout-local HTTP transport configuration is rejected before credential
-exposure, checkout-controlled process filters are rejected, retained
-`post-checkout` hooks do not run during worktree creation, colliding sanitized
-parent identifiers remain distinct, and `after_create` cannot turn a parent root
-into a Git repository. It also covers parent `after_create` receipt/reuse/failure
-behavior and uses a blocking integration-only Git fsmonitor hook under paused
-time to prove the complete integration verification path times out and rolls
-back. Focused
+exposure; checkout-controlled process filters, fsmonitor, custom hooks paths,
+and conditional includes are rejected before parent verification; retained
+`post-checkout` hooks do not run during worktree creation; colliding sanitized
+parent identifiers remain distinct; and `after_create` cannot turn a parent
+root into a Git repository. It also covers parent `after_create`
+receipt/reuse/failure behavior and proves a child-controlled direct or
+worktree-conditional fsmonitor executable is rejected without running before
+the incomplete parent root is rolled back. A lower-level regression proves the
+orchestrator Git command overrides checkout-controlled fsmonitor configuration
+and default repository hooks at execution time. Focused
 OpenHands and Codex tests bind the same logical `parent_multi_checkout` envelope
 while preserving truthful `trusted_host` containment and omitting a leaf runtime
 envelope.

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -502,6 +502,17 @@ prove atomic staged publication, target-branch and non-shallow verification,
 clean-worktree enforcement, wrong-remote quarantine, collision-resistant
 checkout keys, instruction hashing, and repository-only prompt composition.
 
+The parent execution-root fixture uses three temporary remotes, multiple
+children in one repository, an actual squash merge, an actual rebase and
+fast-forward merge, and a recorded shallow generation. It proves one non-Git
+root, one shared-object worktree per canonical repository, exact target and
+provider merge-result reachability, unchanged child HEAD/status/manifest bytes,
+and rejection of stale generations, missing ancestor leases, ambiguous merge
+evidence, dirty children, wrong remotes, arbitrary handles, changed root
+requests, and symlink escapes. Focused OpenHands and Codex tests bind the same
+logical `parent_multi_checkout` envelope while preserving truthful
+`trusted_host` containment and omitting a leaf runtime envelope.
+
 ### Scenario B: conversation reuse
 
 - run the same issue a second time against the same workspace

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -149,11 +149,12 @@ moving a child branch or HEAD. It can accept a recorded shallow generation,
 then fetch and deepen the configured target through the repository credential
 provider before adding a detached integration worktree. A shallow-to-complete
 storage transition remains valid against the immutable child manifest on later
-parent generations. Preparation bounds both authenticated fetches and worktree
-creation, terminates their process groups on timeout, and rolls back incomplete
-roots so the same hierarchy generation can retry. Credentialed fetches disable
-repository-local credential helpers before exposing the configured secret to
-Git's orchestrator-owned askpass process. The new worktree must
+parent generations and ordinary child retry/reuse. Preparation bounds both
+authenticated fetches and worktree creation, terminates their process groups on
+timeout, and rolls back incomplete roots so the same hierarchy generation can
+retry. Credentialed fetches disable repository-local credential helpers before
+exposing the configured secret to Git's orchestrator-owned askpass process. The
+new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
 match both fetch and push remote fingerprints, be clean, and point at the
 recorded target commit. Several children in one repository share one handle;
@@ -164,7 +165,10 @@ The initial launch requires the integration worktrees to match their prepared
 targets exactly. A continuation or failure retry may reattach when the recorded
 target remains an ancestor of the current integration HEAD, preserving
 parent-owned committed and uncommitted work. Repository instruction bytes share
-one aggregate size budget across the entire parent prompt.
+one aggregate size budget across the entire parent prompt. Fresh conversations
+always reload the pinned repository instructions; reused conversations rely on
+their existing full prompt. The runtime revalidates the parent root and envelope
+after the `before_run` hook and before harness attachment.
 
 The parent runtime artifact records the complete relative checkout map,
 requested `parent_multi_checkout` scope, harness/model selection, and truthful

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -153,8 +153,8 @@ parent generations and ordinary child retry/reuse. Preparation bounds both
 authenticated fetches and worktree creation, terminates their process groups on
 timeout, and rolls back incomplete roots so the same hierarchy generation can
 retry. Credentialed fetches disable repository-local credential helpers before
-exposing the configured secret to Git's orchestrator-owned askpass process. The
-new worktree must
+exposing the configured secret to Git's orchestrator-owned askpass process and
+route Git hooks to a fresh empty directory. The new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
 match both the provider identity and locator fingerprints for fetch and push
 remotes, be clean, and point at the recorded target commit. Several children in
@@ -170,7 +170,8 @@ one aggregate size budget across the entire parent prompt. Every launch reloads
 the pinned repository instructions so any path that creates a fresh conversation
 has a complete prompt; reused conversations consume continuation guidance. The
 runtime revalidates the parent root, envelope, and instructions after the
-`before_run` hook and before harness attachment.
+`before_run` hook and before harness attachment. `WORKFLOW.md` instruction hashes
+and prompt content both exclude its front matter.
 
 The parent runtime artifact records the complete relative checkout map,
 requested `parent_multi_checkout` scope, harness/model selection, and truthful

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -133,6 +133,9 @@ A frozen parent hierarchy uses a separate non-Git root:
   integration-plan.md
   evidence/
   repositories/<opaque-checkout-handle>/
+
+<workspace.root>/.opensymphony-parent-pins/
+  parent-<sanitized-identifier>/<hierarchy-generation>.json
 ```
 
 `child-checkouts.json` is the durable handle boundary. It groups every leased
@@ -143,16 +146,29 @@ the incoming generation, lease owners, children, and merge results still match
 that map, then revalidates every retained child generation before use. A parent
 whose children are all canceled still gets a valid root with an empty checkout
 map. Arbitrary paths and handles that are absent from the map are rejected.
+The workspace manager publishes an exact orchestrator-owned copy outside the
+parent runtime root and requires the runtime-visible map to match it on every
+reopen. A parent turn therefore cannot authorize an older integration target by
+rewriting its local map. Reopen also repeats provider merge-result reachability
+checks against the pinned target.
+
+Parent roots follow the same `after_create` contract as leaf workspaces. A new
+empty root runs the configured hook before metadata bootstrap, writes the
+root-scoped completion receipt, and publishes repository artifacts only after
+the hook succeeds. Hook failure removes the incomplete generation. Reuse
+requires the matching receipt and does not rerun the hook.
 
 Parent preparation verifies retained child identity and cleanliness without
 moving a child branch or HEAD. It can accept a recorded shallow generation,
 then fetch and deepen the configured target through the repository credential
 provider before adding a detached integration worktree. A shallow-to-complete
 storage transition remains valid against the immutable child manifest on later
-parent generations and ordinary child retry/reuse. Preparation bounds both
-authenticated fetches and worktree creation, terminates their process groups on
-timeout, and rolls back incomplete roots so the same hierarchy generation can
-retry. Credentialed fetches disable repository-local credential helpers before
+parent generations and ordinary child retry/reuse. Preparation gives every
+retained child generation an independent verification deadline. It also applies
+one deadline to integration worktree creation, instruction loading, and every
+final Git verification probe. Timed-out Git process groups are terminated and
+incomplete roots are rolled back so the same hierarchy generation can retry.
+Credentialed fetches disable repository-local credential helpers before
 exposing the configured secret to Git's orchestrator-owned askpass process and
 route Git hooks to a fresh empty directory. The new worktree must
 remain below `repositories/`, share the selected child's Git common directory,

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -127,7 +127,7 @@ changed edges, so rejecting a stale replan cannot discard reparented evidence.
 A frozen parent hierarchy uses a separate non-Git root:
 
 ```text
-<workspace.root>/parents/parent-<sanitized-identifier>/<hierarchy-generation>/
+<workspace.root>/parents/parent-<sanitized-identifier>-<identity-digest>/<hierarchy-generation>/
   parent-manifest.json
   child-checkouts.json
   integration-plan.md
@@ -155,8 +155,11 @@ checks against the pinned target.
 Parent roots follow the same `after_create` contract as leaf workspaces. A new
 empty root runs the configured hook before metadata bootstrap, writes the
 root-scoped completion receipt, and publishes repository artifacts only after
-the hook succeeds. Hook failure removes the incomplete generation. Reuse
-requires the matching receipt and does not rerun the hook.
+the hook succeeds. The manager rechecks that the hook did not initialize a
+root-level Git repository before publication. Hook failure or invariant drift
+removes the incomplete generation. Reuse requires the matching receipt and does
+not rerun the hook. Parent workspace keys include an issue-identity digest so
+identifiers that sanitize to the same display value remain distinct.
 
 Parent preparation verifies retained child identity and cleanliness without
 moving a child branch or HEAD. It can accept a recorded shallow generation,
@@ -173,7 +176,11 @@ checkout-local and worktree HTTP, credential, transport, SSH-command, protocol,
 and URL-rewrite settings before exposing the configured secret, disable
 repository-local credential helpers, and route Git hooks to a fresh empty
 directory. Git receives credentials only through the orchestrator-owned askpass
-process. The new worktree must
+process. Timed-out authenticated Git process trees are terminated and awaited
+before askpass state is removed on every supported platform. Integration
+worktree creation uses an empty hooks directory and isolated system/global Git
+configuration, and rejects retained-checkout process-filter configuration. The
+new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
 match both the provider identity and locator fingerprints for fetch and push
 remotes, be clean, and point at the recorded target commit. Several children in
@@ -190,7 +197,9 @@ the pinned repository instructions so any path that creates a fresh conversation
 has a complete prompt; reused conversations consume continuation guidance. The
 runtime revalidates the parent root, envelope, and instructions after the
 `before_run` hook and before harness attachment. `WORKFLOW.md` instruction hashes
-and prompt content both exclude its front matter.
+and prompt content both exclude its front matter. Project-set integration
+instructions are also re-read and hash-checked after `before_run`; the parent
+prompt is composed only from those final verified bytes.
 
 The parent runtime artifact records the complete relative checkout map,
 requested `parent_multi_checkout` scope, harness/model selection, and truthful

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -122,6 +122,42 @@ scope and leases and requests a full tracker observation on the next tick.
 Generation-checked replans also fetch full reachability before reconciling
 changed edges, so rejecting a stale replan cannot discard reparented evidence.
 
+### Parent execution roots
+
+A frozen parent hierarchy uses a separate non-Git root:
+
+```text
+<workspace.root>/parents/parent-<sanitized-identifier>/<hierarchy-generation>/
+  parent-manifest.json
+  child-checkouts.json
+  integration-plan.md
+  evidence/
+  repositories/<opaque-checkout-handle>/
+```
+
+`child-checkouts.json` is the durable handle boundary. It groups every leased
+child generation by canonical repository, records the safe remote fingerprint,
+target and provider merge-result commits, instruction provenance, and the
+selected shared-storage generation. Reopening an existing root verifies that
+the incoming generation, lease owners, children, and merge results still match
+that map. Arbitrary paths and handles that are absent from the map are rejected.
+
+Parent preparation verifies retained child identity and cleanliness without
+moving a child branch or HEAD. It can accept a recorded shallow generation,
+then fetch and deepen the configured target through the repository credential
+provider before adding a detached integration worktree. The new worktree must
+remain below `repositories/`, share the selected child's Git common directory,
+match both fetch and push remote fingerprints, be clean, and point at the
+recorded target commit. Several children in one repository share one handle;
+the target must contain every provider merge-result commit, while replaced
+feature commits from squash or rebase are not required.
+
+The parent runtime artifact records the complete relative checkout map,
+requested `parent_multi_checkout` scope, harness/model selection, and truthful
+`trusted_host` or `workspace_confined` containment. Parent memory grants remain
+owned by the later parent-controller lifecycle and are not synthesized from a
+leaf checkout grant.
+
 ## 4. Workspace directory layout
 
 Recommended layout inside each issue workspace:

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -179,8 +179,12 @@ directory. Git receives credentials only through the orchestrator-owned askpass
 process. Timed-out authenticated Git process trees are terminated and awaited
 before askpass state is removed on every supported platform. Integration
 worktree creation uses an empty hooks directory and isolated system/global Git
-configuration, and rejects retained-checkout process-filter configuration. The
-new worktree must
+configuration, and rejects retained-checkout process-filter, fsmonitor, custom
+hooks-path, and conditional-include configuration before any parent verification
+probe. Every workspace-manager Git probe also supplies a version-compatible
+empty `core.fsmonitor` value and a fresh empty `core.hooksPath` on the command
+itself so mutable included configuration and default repository hooks cannot
+activate an executable between validation and use. The new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
 match both the provider identity and locator fingerprints for fetch and push
 remotes, be clean, and point at the recorded target commit. Several children in

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -156,8 +156,9 @@ retry. Credentialed fetches disable repository-local credential helpers before
 exposing the configured secret to Git's orchestrator-owned askpass process. The
 new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
-match both fetch and push remote fingerprints, be clean, and point at the
-recorded target commit. Several children in one repository share one handle;
+match both the provider identity and locator fingerprints for fetch and push
+remotes, be clean, and point at the recorded target commit. Several children in
+one repository share one handle;
 the target must contain every provider merge-result commit, while replaced
 feature commits from squash or rebase are not required.
 
@@ -165,10 +166,11 @@ The initial launch requires the integration worktrees to match their prepared
 targets exactly. A continuation or failure retry may reattach when the recorded
 target remains an ancestor of the current integration HEAD, preserving
 parent-owned committed and uncommitted work. Repository instruction bytes share
-one aggregate size budget across the entire parent prompt. Fresh conversations
-always reload the pinned repository instructions; reused conversations rely on
-their existing full prompt. The runtime revalidates the parent root and envelope
-after the `before_run` hook and before harness attachment.
+one aggregate size budget across the entire parent prompt. Every launch reloads
+the pinned repository instructions so any path that creates a fresh conversation
+has a complete prompt; reused conversations consume continuation guidance. The
+runtime revalidates the parent root, envelope, and instructions after the
+`before_run` hook and before harness attachment.
 
 The parent runtime artifact records the complete relative checkout map,
 requested `parent_multi_checkout` scope, harness/model selection, and truthful

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -168,9 +168,12 @@ retained child generation an independent verification deadline. It also applies
 one deadline to integration worktree creation, instruction loading, and every
 final Git verification probe. Timed-out Git process groups are terminated and
 incomplete roots are rolled back so the same hierarchy generation can retry.
-Credentialed fetches disable repository-local credential helpers before
-exposing the configured secret to Git's orchestrator-owned askpass process and
-route Git hooks to a fresh empty directory. The new worktree must
+Credentialed fetches use the configured repository remote directly, reject
+checkout-local and worktree HTTP, credential, transport, SSH-command, protocol,
+and URL-rewrite settings before exposing the configured secret, disable
+repository-local credential helpers, and route Git hooks to a fresh empty
+directory. Git receives credentials only through the orchestrator-owned askpass
+process. The new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
 match both the provider identity and locator fingerprints for fetch and push
 remotes, be clean, and point at the recorded target commit. Several children in

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -140,17 +140,31 @@ child generation by canonical repository, records the safe remote fingerprint,
 target and provider merge-result commits, instruction provenance, and the
 selected shared-storage generation. Reopening an existing root verifies that
 the incoming generation, lease owners, children, and merge results still match
-that map. Arbitrary paths and handles that are absent from the map are rejected.
+that map, then revalidates every retained child generation before use. A parent
+whose children are all canceled still gets a valid root with an empty checkout
+map. Arbitrary paths and handles that are absent from the map are rejected.
 
 Parent preparation verifies retained child identity and cleanliness without
 moving a child branch or HEAD. It can accept a recorded shallow generation,
 then fetch and deepen the configured target through the repository credential
-provider before adding a detached integration worktree. The new worktree must
+provider before adding a detached integration worktree. A shallow-to-complete
+storage transition remains valid against the immutable child manifest on later
+parent generations. Preparation bounds both authenticated fetches and worktree
+creation, terminates their process groups on timeout, and rolls back incomplete
+roots so the same hierarchy generation can retry. Credentialed fetches disable
+repository-local credential helpers before exposing the configured secret to
+Git's orchestrator-owned askpass process. The new worktree must
 remain below `repositories/`, share the selected child's Git common directory,
 match both fetch and push remote fingerprints, be clean, and point at the
 recorded target commit. Several children in one repository share one handle;
 the target must contain every provider merge-result commit, while replaced
 feature commits from squash or rebase are not required.
+
+The initial launch requires the integration worktrees to match their prepared
+targets exactly. A continuation or failure retry may reattach when the recorded
+target remains an ancestor of the current integration HEAD, preserving
+parent-owned committed and uncommitted work. Repository instruction bytes share
+one aggregate size budget across the entire parent prompt.
 
 The parent runtime artifact records the complete relative checkout map,
 requested `parent_multi_checkout` scope, harness/model selection, and truthful


### PR DESCRIPTION
## Summary

COE-553 requires repository-neutral parent issues to integrate completed child work without cloning or mutating child evidence. This change prepares one non-Git parent root per hierarchy generation, creates one verified shared-object integration worktree per canonical repository, and gives OpenHands and Codex the same immutable multi-checkout execution scope.

## Changes

- Persist generation-bound parent manifests, runtime-visible child-checkout maps, orchestrator-owned checkout-map pins outside the parent runtime root, integration plans, evidence directories, opaque checkout handles, and runtime envelopes, including valid empty maps after every required child is canceled. Collision-resistant parent keys include issue identity. Run and receipt `after_create`, then recheck the non-Git invariant before publishing a new root.
- Group descendants by canonical repository, compare every retained lease/generation/remote/cleanliness/HEAD/branch claim to live Git state, deepen recorded shallow history, and create contained detached worktrees at target commits that contain every recorded provider merge result.
- Roll back incomplete roots, give every retained child an independent reopen deadline, bound full integration creation/instruction/verification under one deadline, and preserve verified parent integration changes across continuation/recovery retries. Authenticated fetches use the configured remote directly, reject checkout-controlled transport settings, and terminate the complete process tree before askpass cleanup on timeout. Integration worktree creation rejects checkout-controlled process filters and disables retained hooks plus host-level Git configuration.
- Compose a provider-neutral parent prompt from the lifecycle procedure, acceptance text, project-set integration instructions, canonical repository IDs, verified handles, and hash-bound repository instructions.
- Bind identical logical parent scope into OpenHands and Codex manifests while recording their actual trusted-host containment; load and revalidate pinned repository and project-set integration instructions after lifecycle hooks, using the same front-matter normalization as provenance, so every fresh conversation has a complete prompt composed from final verified bytes.
- Document the parent-root layout, security checks, operator evidence, and required test matrix.

## Evidence

### Test output

```text
$ duckdb --version
v1.5.3 ...

$ cargo test-system-duckdb --test workspace_manager parent_
running 7 tests
...parent_execution_root_rejects_a_symlinked_parent_directory_before_git ... ok
...parent_execution_root_rolls_back_after_create_failure ... ok
...parent_execution_root_supports_no_required_child_checkouts ... ok
...parent_execution_roots_keep_colliding_sanitized_identifiers_distinct ... ok
...parent_execution_root_rolls_back_when_after_create_initializes_git ... ok
...parent_preparation_times_out_stalled_integration_verification ... ok
...parent_execution_root_reuses_three_repositories_and_preserves_children ... ok
test result: ok. 7 passed; 0 failed

$ cargo test-system-duckdb --lib openhands_binds_parent_scope_without_creating_a_leaf_envelope
... ok
$ cargo test-system-duckdb --lib codex_manifest_binds_the_same_parent_execution_scope
... ok
$ cargo test-system-duckdb --lib parent_checkout_requests_require_generation_bound_leases_and_scoped_merges
... ok

$ GIT_CONFIG_GLOBAL=/dev/null cargo test-system-duckdb
running 1300 tests
...
test result: ok. 1300 passed; 0 failed
# Every non-opt-in integration suite also passed; live credential tests remained ignored as designed.

$ cargo clippy-system-duckdb
Finished `dev` profile

$ cargo fmt --check
# clean

$ git diff --check
# clean
```

### Verification

The temporary Git fixture creates three bare repositories and retained child generations, including two children in one repository, a squash-merged result, a rebased/fast-forwarded result, and a recorded shallow source. It verifies:

- the parent root is not a Git checkout;
- exactly one linked integration worktree is created for each canonical repository;
- the target commits contain every provider merge result;
- linked worktrees share retained Git storage and no clone path is used;
- child HEAD, status, and evidence-manifest bytes remain unchanged;
- stale generation, changed lease owner, dirty checkout, wrong fetch or push locator (including worktree-specific overrides with native provider IDs), unknown handle, and symlink escape attempts fail closed;
- failed preparation can retry the same generation through the production preparation path; credentialed fetches cannot expose secrets to retained hooks or checkout-controlled HTTP transport configuration; authenticated timeout cleanup terminates the process tree before removing askpass state; integration creation rejects process filters and does not run retained `post-checkout` hooks; all retained children are compared with live Git state under independent deadlines; runtime map rewrites cannot repin a target; full integration verification times out and rolls back when Git stalls; collision-resistant parent keys separate sanitized identifiers; `after_create` runs once, is receipted, and cannot initialize root Git; empty maps remain usable; continuation retries preserve verified parent work; and parent-deepened children remain reusable for ordinary retries;
- the prompt uses canonical repository IDs without repository roles;
- OpenHands and Codex bind the same checkout map and report truthful containment; project-set integration instructions are re-read after `before_run`, and changed bytes fail before harness attachment.

## Checklist

- [x] Tests pass (`cargo test-system-duckdb`)
- [x] Code is formatted (`cargo fmt --check`)
- [x] Clippy is clean (`cargo clippy-system-duckdb`)
- [x] Documentation updated (behavior changed)
- [ ] `AGENTS.md` updated (not required; no durable repository instruction changed)
- [x] Evidence section filled out (substantive change)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Breaking changes

None. Existing single-checkout leaf execution remains unchanged.

## Related issues

- Linear: COE-553

## Additional notes

This change preserves the adjacent milestone boundaries: COE-554 owns parent controller/final verification and parent memory grants, COE-555 owns repair PRs, and COE-556 owns parent cleanup.


