### PR TITLE
COE-556: Add bottom-up subtree cleanup and recovery

### DIFF
--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -14913,6 +14913,7 @@ Public memory concept.
             updated_at: now,
             status_detail: None,
             hooks: Vec::new(),
+            cleanup_intent: None,
         };
         std::fs::write(
             workspace.join(".opensymphony/run.json"),

--- a/crates/opensymphony-cli/src/memory.rs
+++ b/crates/opensymphony-cli/src/memory.rs
@@ -771,9 +771,6 @@ fn completed_parent_capture_commits(
     run: &RunManifest,
     envelope: &crate::opensymphony_workspace::ParentRuntimeEnvelope,
 ) -> Result<Option<BTreeMap<String, String>>, MemoryError> {
-    if run.status != RunStatus::Succeeded {
-        return Ok(None);
-    }
     let state_path = workspace_root.join(".opensymphony-orchestrator-state.json");
     let raw = match fs::read_to_string(&state_path) {
         Ok(raw) => raw,
@@ -802,9 +799,22 @@ fn completed_parent_capture_commits(
     else {
         return Ok(None);
     };
-    if controller.state != ParentIntegrationState::Completed
-        || controller.hierarchy_generation != envelope.hierarchy_generation
-    {
+    if controller.hierarchy_generation != envelope.hierarchy_generation {
+        return Ok(None);
+    }
+    if matches!(
+        controller.state,
+        ParentIntegrationState::Failed { .. } | ParentIntegrationState::Canceled { .. }
+    ) && matches!(
+        run.status,
+        RunStatus::Succeeded
+            | RunStatus::Failed
+            | RunStatus::Cancelled
+            | RunStatus::PreparationFailed
+    ) {
+        return Ok(Some(BTreeMap::new()));
+    }
+    if controller.state != ParentIntegrationState::Completed || run.status != RunStatus::Succeeded {
         return Ok(None);
     }
     let Some(final_evidence) = controller.final_evidence.as_ref() else {
@@ -15208,6 +15218,33 @@ Public memory concept.
                 .expect("failed parent capture scan")
                 .is_empty(),
             "a failed parent run must not publish prepared commits"
+        );
+        let mut failed_parent_state = parent_state.clone();
+        let failed_controller = failed_parent_state
+            .parent_integrations
+            .get_mut(&crate::opensymphony_domain::IssueId::new("issue-554").expect("parent id"))
+            .expect("parent controller");
+        failed_controller.state =
+            crate::opensymphony_orchestrator::ParentIntegrationState::Failed {
+                reason: "final verification failed".to_owned(),
+            };
+        failed_controller.final_evidence = None;
+        std::fs::write(
+            workspace_root
+                .path()
+                .join(".opensymphony-orchestrator-state.json"),
+            serde_json::to_vec(&failed_parent_state).expect("failed parent controller state"),
+        )
+        .expect("failed parent controller state");
+        let failed_parent_bindings =
+            super::load_terminal_capture_bindings(workspace_root.path(), &["COE-554".to_owned()])
+                .expect("terminal failed parent capture binding");
+        assert!(failed_parent_bindings["coe-554"].parent_integration);
+        assert!(
+            failed_parent_bindings["coe-554"]
+                .repository_commits
+                .is_empty(),
+            "failed parents must route neutral diagnostic capture without claiming commits"
         );
         parent_run.status = RunStatus::Succeeded;
         std::fs::write(

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -3980,6 +3980,9 @@ impl RuntimeWorkspaceBackend {
                     (handle.workspace_path() == workspace.path).then_some(handle)
                 });
             let Some(handle) = handle else {
+                if let (Some(scope_grants), Some(target)) = (&self.scope_grants, cleanup_target) {
+                    scope_grants.revoke_issue(&target.identifier);
+                }
                 if let Some(target) = cleanup_target {
                     if prepare_only {
                         self.manager.prepare_cleanup_target(target).await?;
@@ -3991,6 +3994,17 @@ impl RuntimeWorkspaceBackend {
             };
             if let Some(scope_grants) = &self.scope_grants {
                 scope_grants.revoke_issue(handle.identifier());
+            }
+            if let Some(target) = cleanup_target
+                && self.manager.cleanup_target_deletion_started(target).await?
+            {
+                if prepare_only {
+                    self.manager.prepare_cleanup_target(target).await?;
+                } else {
+                    self.manager.cleanup_target(target).await?;
+                }
+                self.terminal_cleanup_paths.insert(workspace.path.clone());
+                return Ok(());
             }
             let removes_workspace = cleanup_target.is_some()
                 || force_remove
@@ -11866,6 +11880,210 @@ mod tests {
         assert!(!ensured.handle.workspace_path().exists());
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runtime_parent_cleanup_archives_codex_before_preparing_nested_root_removal() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspaces");
+        let workflow = sample_workflow(tempdir.path(), &workspace_root);
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let mut issue = sample_terminal_issue();
+        issue.id = IssueId::new("parent-cleanup").expect("parent id");
+        issue.identifier = IssueIdentifier::new("COE-PARENT-CLEANUP").expect("parent identifier");
+        let parent = workspace_manager
+            .prepare_parent_execution_root(&issue_descriptor(&issue), 9, Vec::new())
+            .await
+            .expect("nested parent root should be prepared");
+        let mut manifest = sample_conversation_manifest("fake-thread");
+        manifest.issue_id = issue.id.clone();
+        manifest.identifier = issue.identifier.clone();
+        manifest.transport_target = Some(CODEX_APP_SERVER_KIND.to_owned());
+        manifest.runtime_contract_version = Some(CODEX_APP_SERVER_CONTRACT.to_owned());
+        workspace_manager
+            .write_json_artifact(
+                &parent.handle,
+                &parent.handle.conversation_manifest_path(),
+                &manifest,
+            )
+            .await
+            .expect("parent conversation manifest should persist");
+        let log_path = tempdir.path().join("fake-parent-cleanup-codex.log");
+        let fake_codex = tempdir.path().join("fake-parent-cleanup-codex");
+        write_fake_codex_child(&fake_codex, &log_path);
+        let target = crate::opensymphony_workspace::CleanupTarget {
+            issue_id: issue.id.to_string(),
+            identifier: issue.identifier.to_string(),
+            workspace: crate::opensymphony_domain::WorkspaceRecord {
+                path: parent.handle.workspace_path().to_path_buf(),
+                workspace_key: WorkspaceKey::new(parent.handle.workspace_key().to_owned())
+                    .expect("parent workspace key"),
+                created_now: false,
+                created_at: None,
+                updated_at: None,
+                last_seen_tracker_refresh_at: None,
+            },
+            generation: "parent:9".to_owned(),
+            outcome: crate::opensymphony_workspace::CleanupTerminalOutcome::Succeeded,
+        };
+        let mut backend = RuntimeWorkspaceBackend::new(workspace_manager, &workflow);
+        backend.codex_bin = fake_codex.to_string_lossy().into_owned();
+
+        backend
+            .prepare_cleanup_generation(&target)
+            .await
+            .expect("parent archive fence and cleanup preparation should succeed");
+
+        assert!(parent.handle.workspace_path().is_dir());
+        let log = fs::read_to_string(log_path).expect("Codex lifecycle log should exist");
+        assert!(log.contains(r#""method":"thread/archive""#));
+    }
+
+    #[tokio::test]
+    async fn runtime_cleanup_resumes_exact_tombstone_when_checkout_run_manifest_is_missing() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspaces");
+        let workflow = sample_workflow(tempdir.path(), &workspace_root);
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let issue = sample_terminal_issue();
+        let ensured = workspace_manager
+            .ensure(&issue_descriptor(&issue))
+            .await
+            .expect("workspace should be ensured");
+        let binding = crate::opensymphony_domain::RepositoryBinding {
+            alias: "test".to_owned(),
+            repository: crate::opensymphony_domain::RepositoryIdentity {
+                id: CanonicalRepositoryId::new("github:repository:test").expect("repository id"),
+                safe_remote_fingerprint:
+                    crate::opensymphony_domain::SafeRemoteFingerprint::from_remote(
+                        "github",
+                        Some("test"),
+                        "example/test",
+                    )
+                    .expect("remote fingerprint"),
+            },
+            config_generation: "config-1".to_owned(),
+            inventory_generation: "inventory-1".to_owned(),
+        };
+        let mut issue_manifest = workspace_manager
+            .load_issue_manifest(&ensured.handle)
+            .await
+            .expect("issue manifest should load")
+            .expect("issue manifest should exist");
+        issue_manifest.repository_binding =
+            Some(RepositoryBindingOutcome::Resolved(binding.clone()));
+        workspace_manager
+            .write_issue_manifest(&ensured.handle, &issue_manifest)
+            .await
+            .expect("repository-bound issue manifest should persist");
+        let now = chrono::Utc::now();
+        let checkout = crate::opensymphony_workspace::CheckoutManifest {
+            schema_version: 1,
+            generation: "checkout-generation-1".to_owned(),
+            issue_id: issue.id.to_string(),
+            identifier: issue.identifier.to_string(),
+            run_id: "checkout-run-1".to_owned(),
+            sanitized_workspace_key: ensured.handle.workspace_key().to_owned(),
+            workspace_path: ensured.handle.workspace_path().to_path_buf(),
+            repository_binding: binding,
+            policy_generation: "policy-1".to_owned(),
+            review_profile: String::new(),
+            review_provider: String::new(),
+            review_policy_generation: String::new(),
+            remote_fingerprint: "sha256:test".to_owned(),
+            target_branch: "develop".to_owned(),
+            target_commit: "abc123".to_owned(),
+            current_branch: "feat/test".to_owned(),
+            head: "abc123".to_owned(),
+            shallow: false,
+            clean: true,
+            instruction: crate::opensymphony_workspace::InstructionProvenance {
+                path: PathBuf::from("AGENTS.md"),
+                content_hash: "sha256:instructions".to_owned(),
+                source_commit: "abc123".to_owned(),
+                source: "AGENTS.md".to_owned(),
+                native_discovery_paths: Vec::new(),
+                native_discovery_hashes: BTreeMap::new(),
+            },
+            created_at: now,
+            verified_at: now,
+            quarantined: false,
+            quarantine_reason: None,
+        };
+        workspace_manager
+            .write_json_artifact(
+                &ensured.handle,
+                &ensured.handle.checkout_manifest_path(),
+                &checkout,
+            )
+            .await
+            .expect("checkout manifest should persist");
+        let target = crate::opensymphony_workspace::CleanupTarget {
+            issue_id: issue.id.to_string(),
+            identifier: issue.identifier.to_string(),
+            workspace: crate::opensymphony_domain::WorkspaceRecord {
+                path: ensured.handle.workspace_path().to_path_buf(),
+                workspace_key: WorkspaceKey::new(ensured.handle.workspace_key().to_owned())
+                    .expect("workspace key"),
+                created_now: false,
+                created_at: None,
+                updated_at: None,
+                last_seen_tracker_refresh_at: None,
+            },
+            generation: checkout.generation.clone(),
+            outcome: crate::opensymphony_workspace::CleanupTerminalOutcome::Succeeded,
+        };
+        let issue_bytes = serde_json::to_vec_pretty(&issue_manifest).expect("encode issue");
+        let checkout_bytes = serde_json::to_vec_pretty(&checkout).expect("encode checkout");
+        workspace_manager
+            .cleanup_target(&target)
+            .await
+            .expect("initial cleanup should create a receipt");
+        let tombstone_path = fs::read_dir(workspace_root.join(".opensymphony-cleanup-tombstones"))
+            .expect("tombstone directory")
+            .next()
+            .expect("tombstone entry")
+            .expect("tombstone path")
+            .path();
+        let mut tombstone: serde_json::Value = serde_json::from_slice(
+            &fs::read(&tombstone_path).expect("completed tombstone should be readable"),
+        )
+        .expect("tombstone should decode");
+        tombstone["deleted_at"] = serde_json::Value::Null;
+        fs::write(
+            &tombstone_path,
+            serde_json::to_vec_pretty(&tombstone).expect("encode incomplete tombstone"),
+        )
+        .expect("incomplete tombstone should persist");
+        fs::create_dir_all(ensured.handle.metadata_dir()).expect("partial workspace should exist");
+        fs::write(ensured.handle.issue_manifest_path(), issue_bytes)
+            .expect("partial issue manifest should persist");
+        fs::write(ensured.handle.checkout_manifest_path(), checkout_bytes)
+            .expect("partial checkout manifest should persist");
+        let mut conversation = sample_conversation_manifest("stale-thread");
+        conversation.transport_target = Some(CODEX_APP_SERVER_KIND.to_owned());
+        conversation.runtime_contract_version = Some(CODEX_APP_SERVER_CONTRACT.to_owned());
+        fs::write(
+            ensured.handle.conversation_manifest_path(),
+            serde_json::to_vec_pretty(&conversation).expect("encode conversation"),
+        )
+        .expect("partial conversation manifest should persist");
+        assert!(!ensured.handle.run_manifest_path().exists());
+        let mut backend = RuntimeWorkspaceBackend::new(workspace_manager, &workflow);
+
+        backend
+            .cleanup_generation(&target)
+            .await
+            .expect("exact deletion-started tombstone should bypass missing run metadata");
+
+        assert!(!ensured.handle.workspace_path().exists());
+    }
+
     #[tokio::test]
     async fn runtime_failed_cleanup_retires_openhands_before_removal() {
         let tempdir = TempDir::new().expect("tempdir should exist");
@@ -13769,6 +13987,49 @@ mod tests {
             RuntimeStreamState::Closed
         );
         assert_eq!(recovered.workspace.path, ensured.handle.workspace_path());
+    }
+
+    #[tokio::test]
+    async fn recover_workspaces_discovers_completed_nested_parent_roots() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let workspace_root = tempdir.path().join("workspace-root");
+        let workflow = sample_workflow(tempdir.path(), &workspace_root);
+        let workspace_manager = Arc::new(
+            WorkspaceManager::new(build_workspace_manager_config(&workflow))
+                .expect("workspace manager should be constructed"),
+        );
+        let mut issue = sample_terminal_issue();
+        issue.id = IssueId::new("parent-recovery").expect("parent id");
+        issue.identifier = IssueIdentifier::new("COE-PARENT-RECOVERY").expect("parent identifier");
+        let parent = workspace_manager
+            .prepare_parent_execution_root(&issue_descriptor(&issue), 7, Vec::new())
+            .await
+            .expect("nested parent root should be prepared");
+        let mut run = workspace_manager
+            .start_run(
+                &parent.handle,
+                &RunDescriptor::new("parent-run-recovery", 1),
+            )
+            .await
+            .expect("parent run should start");
+        run.status = RunStatus::Succeeded;
+        workspace_manager
+            .write_run_manifest(&parent.handle, &run)
+            .await
+            .expect("completed parent run should persist");
+
+        let mut backend = RuntimeWorkspaceBackend::new(workspace_manager, &workflow);
+        let recoveries = backend
+            .recover_workspaces()
+            .await
+            .expect("nested parent recovery should succeed");
+
+        let recovered = recoveries
+            .iter()
+            .find(|record| record.issue.id == issue.id)
+            .expect("nested parent should be returned to the scheduler");
+        assert_eq!(recovered.workspace.path, parent.handle.workspace_path());
+        assert!(recovered.successful_run);
     }
 
     #[tokio::test]

--- a/crates/opensymphony-cli/src/orchestrator_run/backends.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/backends.rs
@@ -3960,6 +3960,8 @@ impl RuntimeWorkspaceBackend {
         workspace: &crate::opensymphony_domain::WorkspaceRecord,
         terminal: bool,
         force_remove: bool,
+        cleanup_target: Option<&crate::opensymphony_workspace::CleanupTarget>,
+        prepare_only: bool,
     ) -> Result<(), CliWorkspaceError> {
         if terminal && (force_remove || !self.terminal_cleanup_paths.contains(&workspace.path)) {
             if self.workspace_has_active_lease(workspace).await? {
@@ -3969,21 +3971,29 @@ impl RuntimeWorkspaceBackend {
                 );
                 return Err(CliWorkspaceError::CleanupDeferred);
             }
-            let Some(handle) = self
+            let handle = self
                 .manager
                 .list_all_workspaces()
                 .await?
                 .into_iter()
                 .find_map(|(handle, _)| {
                     (handle.workspace_path() == workspace.path).then_some(handle)
-                })
-            else {
+                });
+            let Some(handle) = handle else {
+                if let Some(target) = cleanup_target {
+                    if prepare_only {
+                        self.manager.prepare_cleanup_target(target).await?;
+                    } else {
+                        self.manager.cleanup_target(target).await?;
+                    }
+                }
                 return Ok(());
             };
             if let Some(scope_grants) = &self.scope_grants {
                 scope_grants.revoke_issue(handle.identifier());
             }
-            let removes_workspace = force_remove
+            let removes_workspace = cleanup_target.is_some()
+                || force_remove
                 || self.manager.cleanup_decision(IssueLifecycleState::Terminal)
                     == crate::opensymphony_workspace::CleanupDecision::Remove;
             let mut cleanup_run_manifest = self.manager.load_run_manifest(&handle).await?;
@@ -4153,7 +4163,13 @@ impl RuntimeWorkspaceBackend {
                     }
                 }
             }
-            if force_remove {
+            if let Some(target) = cleanup_target {
+                if prepare_only {
+                    self.manager.prepare_cleanup_target(target).await?;
+                } else {
+                    self.manager.cleanup_target(target).await?;
+                }
+            } else if force_remove {
                 self.manager
                     .cleanup_failed_terminal_workspace(&handle)
                     .await?;
@@ -4441,6 +4457,45 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         Ok(state.active_for(&resource))
     }
 
+    async fn cleanup_target_for_resource(
+        &mut self,
+        resource: &LeaseResource,
+        outcome: crate::opensymphony_workspace::CleanupTerminalOutcome,
+    ) -> Result<Option<crate::opensymphony_workspace::CleanupTarget>, Self::Error> {
+        Ok(self
+            .manager
+            .list_all_workspaces()
+            .await?
+            .into_iter()
+            .find_map(|(handle, manifest)| {
+                let repository_matches = manifest
+                    .repository_binding
+                    .as_ref()
+                    .and_then(RepositoryBindingOutcome::repository_id)
+                    == Some(&resource.repository_id);
+                (manifest.issue_id == resource.issue_id.as_str()
+                    && handle.checkout_generation() == Some(&resource.checkout_generation)
+                    && repository_matches)
+                    .then(|| crate::opensymphony_workspace::CleanupTarget {
+                        issue_id: manifest.issue_id,
+                        identifier: manifest.identifier,
+                        workspace: crate::opensymphony_domain::WorkspaceRecord {
+                            path: handle.workspace_path().to_path_buf(),
+                            workspace_key: WorkspaceKey::new(handle.workspace_key().to_owned())
+                                .expect("managed workspace keys are already validated"),
+                            created_now: false,
+                            created_at: Some(datetime_to_timestamp_ms(manifest.created_at)),
+                            updated_at: Some(datetime_to_timestamp_ms(manifest.updated_at)),
+                            last_seen_tracker_refresh_at: manifest
+                                .last_seen_tracker_refresh_at
+                                .map(datetime_to_timestamp_ms),
+                        },
+                        generation: resource.checkout_generation.clone(),
+                        outcome,
+                    })
+            }))
+    }
+
     async fn parent_workspace_targets(
         &mut self,
         issue: &NormalizedIssue,
@@ -4694,7 +4749,7 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         workspace: &crate::opensymphony_domain::WorkspaceRecord,
         terminal: bool,
     ) -> Result<(), Self::Error> {
-        self.cleanup_workspace_with_policy(workspace, terminal, false)
+        self.cleanup_workspace_with_policy(workspace, terminal, false, None, false)
             .await
     }
 
@@ -4702,7 +4757,7 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         &mut self,
         workspace: &crate::opensymphony_domain::WorkspaceRecord,
     ) -> Result<(), Self::Error> {
-        self.cleanup_workspace_with_policy(workspace, true, true)
+        self.cleanup_workspace_with_policy(workspace, true, true, None, false)
             .await
     }
 
@@ -4710,7 +4765,23 @@ impl WorkspaceBackend for RuntimeWorkspaceBackend {
         &mut self,
         workspace: &crate::opensymphony_domain::WorkspaceRecord,
     ) -> Result<(), Self::Error> {
-        self.cleanup_workspace_with_policy(workspace, true, true)
+        self.cleanup_workspace_with_policy(workspace, true, true, None, false)
+            .await
+    }
+
+    async fn cleanup_generation(
+        &mut self,
+        target: &crate::opensymphony_workspace::CleanupTarget,
+    ) -> Result<(), Self::Error> {
+        self.cleanup_workspace_with_policy(&target.workspace, true, true, Some(target), false)
+            .await
+    }
+
+    async fn prepare_cleanup_generation(
+        &mut self,
+        target: &crate::opensymphony_workspace::CleanupTarget,
+    ) -> Result<(), Self::Error> {
+        self.cleanup_workspace_with_policy(&target.workspace, true, true, Some(target), true)
             .await
     }
 
@@ -10680,6 +10751,7 @@ mod tests {
             updated_at: now,
             status_detail: None,
             hooks: Vec::new(),
+            cleanup_intent: None,
         };
         let mut conversation_manifest = sample_conversation_manifest("legacy-openhands");
         conversation_manifest.prepared_run_id = Some(run_manifest.run_id.clone());
@@ -10756,6 +10828,7 @@ mod tests {
             updated_at: now,
             status_detail: None,
             hooks: Vec::new(),
+            cleanup_intent: None,
         };
         let mut conversation_manifest = sample_conversation_manifest("conv-pending");
         conversation_manifest.workflow_prompt_seeded = false;
@@ -10840,6 +10913,7 @@ mod tests {
             updated_at: now,
             status_detail: None,
             hooks: Vec::new(),
+            cleanup_intent: None,
         };
         let mut conversation_manifest = sample_conversation_manifest("conv-unsent-prompt");
         conversation_manifest.workflow_prompt_seeded = true;

--- a/crates/opensymphony-cli/src/orchestrator_run/mod.rs
+++ b/crates/opensymphony-cli/src/orchestrator_run/mod.rs
@@ -1372,11 +1372,35 @@ async fn run_orchestrator(args: RunArgs) -> Result<(), RunCommandError> {
                                 }
                                 Err(error) => Err(error),
                             };
-                            mark_auto_capture_completed(
-                                &mut auto_capture_completed_issues,
-                                &auto_capture_candidates,
-                                &auto_capture_result,
-                            );
+                            let cleanup_acknowledged = match &auto_capture_result {
+                                Ok(report) if report.workflow_completed() => {
+                                    let completed = if report.completed_issue_keys.is_empty()
+                                        && report.warnings.is_empty()
+                                    {
+                                        auto_capture_candidates.clone()
+                                    } else {
+                                        report.completed_issue_keys.clone()
+                                    };
+                                    match scheduler
+                                        .acknowledge_terminal_capture(&completed, observed_at)
+                                        .await
+                                    {
+                                        Ok(()) => true,
+                                        Err(error) => {
+                                            warn!(%error, "failed to persist terminal capture acknowledgement; cleanup will wait for retry");
+                                            false
+                                        }
+                                    }
+                                }
+                                _ => true,
+                            };
+                            if cleanup_acknowledged {
+                                mark_auto_capture_completed(
+                                    &mut auto_capture_completed_issues,
+                                    &auto_capture_candidates,
+                                    &auto_capture_result,
+                                );
+                            }
                             publish_auto_capture_event(
                                 auto_capture_result,
                                 &snapshot,

--- a/crates/opensymphony-orchestrator/src/hierarchy.rs
+++ b/crates/opensymphony-orchestrator/src/hierarchy.rs
@@ -711,6 +711,27 @@ impl DurableOrchestratorState {
             {
                 return Err("durable parent integration controller is inconsistent".to_owned());
             }
+            if let Some(cleanup) = controller.subtree_cleanup.as_ref() {
+                let mut resources = BTreeSet::new();
+                if cleanup.hierarchy_generation != controller.hierarchy_generation
+                    || cleanup.parent_root.resource.is_some()
+                    || cleanup.descendants.iter().any(|target| {
+                        target.resource.as_ref().is_none_or(|resource| {
+                            resource.checkout_generation != target.cleanup.generation
+                                || !resources.insert(resource.clone())
+                        })
+                    })
+                    || (cleanup.status == super::ParentSubtreeCleanupStatus::Completed
+                        && (cleanup.parent_root.prepared_at.is_none()
+                            || cleanup.parent_root.cleaned_at.is_none()
+                            || cleanup
+                                .descendants
+                                .iter()
+                                .any(|target| target.cleaned_at.is_none())))
+                {
+                    return Err("durable parent subtree cleanup intent is inconsistent".to_owned());
+                }
+            }
             let mut repair_ids = BTreeSet::new();
             let mut repair_numbers = BTreeSet::new();
             for repair in &controller.repair_attempts {
@@ -828,6 +849,33 @@ impl DurableOrchestratorState {
         released_at: u64,
     ) -> bool {
         self.release_parent_leases_inner(parent_id, released_at, false)
+    }
+
+    pub fn release_parent_resource_leases(
+        &mut self,
+        parent_id: &IssueId,
+        resource: &LeaseResource,
+        released_at: u64,
+    ) -> bool {
+        let ancestor_owner = LeaseOwner::ancestor(parent_id);
+        let repair_owner = LeaseOwner::repair(parent_id);
+        let review_prefix = format!("review:{parent_id}:");
+        let mut released = false;
+        for lease in &mut self.leases {
+            if lease.active()
+                && lease.resource == *resource
+                && (lease.owner == ancestor_owner
+                    || lease.owner == repair_owner
+                    || (lease.kind == LeaseKind::Review
+                        && lease.owner.kind == "review"
+                        && lease.owner.id.starts_with(&review_prefix)))
+            {
+                lease.released_at = Some(released_at);
+                released = true;
+            }
+        }
+        self.compact_lease_history();
+        released
     }
 
     fn release_parent_leases_inner(
@@ -1323,9 +1371,13 @@ impl DurableOrchestratorState {
     }
 
     pub fn active_for(&self, resource: &LeaseResource) -> bool {
+        self.active_for_at(resource, current_epoch_millis())
+    }
+
+    pub fn active_for_at(&self, resource: &LeaseResource, now: u64) -> bool {
         self.leases
             .iter()
-            .any(|lease| lease.active() && lease.resource == *resource)
+            .any(|lease| lease.active_at(now) && lease.resource == *resource)
     }
 
     pub fn has_ancestor_edge(&self, child_id: &IssueId) -> bool {
@@ -2016,6 +2068,15 @@ mod tests {
                     expires_at: None,
                     released_at: None,
                 },
+                LeaseRecord {
+                    kind: LeaseKind::DiagnosticHold,
+                    resource: resource.clone(),
+                    owner: LeaseOwner::diagnostic("operator"),
+                    hierarchy_generation: 2,
+                    acquired_at: 3,
+                    expires_at: Some(10),
+                    released_at: None,
+                },
             ])
             .expect("nested leases should acquire");
 
@@ -2023,11 +2084,21 @@ mod tests {
             state.descendant_resources_for(&intermediate),
             vec![resource.clone()]
         );
-        assert!(state.release_parent_leases(&intermediate, 4));
+        assert!(state.release_parent_resource_leases(&intermediate, &resource, 4));
         assert!(
             state.leases.iter().any(|lease| {
                 lease.owner == LeaseOwner::ancestor(&higher) && lease.active_at(4)
             })
+        );
+        assert!(state.leases.iter().any(|lease| {
+            lease.owner == LeaseOwner::diagnostic("operator") && lease.active_at(4)
+        }));
+        assert!(state.active_for_at(&resource, 4));
+        assert!(
+            !state.leases.iter().any(|lease| {
+                lease.owner == LeaseOwner::diagnostic("operator") && lease.active_at(10)
+            }),
+            "diagnostic holds expire at their bounded deadline"
         );
         assert!(
             state

--- a/crates/opensymphony-orchestrator/src/lib.rs
+++ b/crates/opensymphony-orchestrator/src/lib.rs
@@ -27,8 +27,9 @@ pub use parent_integration::{
     ParentIntegrationState, ParentProviderOperation, ParentProviderOperationKind,
     ParentRepairAttempt, ParentRepairPolicy, ParentRepairProviderSnapshot, ParentRepairStatus,
     ParentRepositoryTarget, ParentResourceReceipt, ParentResourceStatus, ParentRetryClassification,
-    ParentReviewFeedback, ParentSideEffectIntent, ParentSideEffectReceipt, ParentTransition,
-    ParentVerificationAttempt, parent_command_identity,
+    ParentReviewFeedback, ParentSideEffectIntent, ParentSideEffectReceipt,
+    ParentSubtreeCleanupIntent, ParentSubtreeCleanupStatus, ParentSubtreeCleanupTarget,
+    ParentTransition, ParentVerificationAttempt, parent_command_identity,
 };
 pub use scheduler::{
     HarnessRouteDecision, RecoveredRun, RecoveryRecord, RetryExhaustionRecord, RetryPendingRecord,

--- a/crates/opensymphony-orchestrator/src/parent_integration.rs
+++ b/crates/opensymphony-orchestrator/src/parent_integration.rs
@@ -3,10 +3,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use super::hierarchy::LeaseResource;
 use crate::opensymphony_domain::{
     CanonicalRepositoryId, IssueId, ParentVerificationEvidence, TimestampMs,
 };
-use crate::opensymphony_workspace::redact_runtime_diagnostic;
+use crate::opensymphony_workspace::{
+    CleanupTarget, CleanupTerminalOutcome, redact_runtime_diagnostic,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -424,6 +427,41 @@ pub struct ParentFinalEvidence {
     pub recorded_at: TimestampMs,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParentSubtreeCleanupStatus {
+    Pending,
+    Removing,
+    Retained,
+    Completed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentSubtreeCleanupTarget {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<LeaseResource>,
+    pub cleanup: CleanupTarget,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prepared_at: Option<TimestampMs>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleaned_at: Option<TimestampMs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParentSubtreeCleanupIntent {
+    pub hierarchy_generation: u64,
+    pub capture_acknowledged_at: TimestampMs,
+    pub requested_at: TimestampMs,
+    pub outcome: CleanupTerminalOutcome,
+    pub status: ParentSubtreeCleanupStatus,
+    pub parent_root: ParentSubtreeCleanupTarget,
+    pub descendants: Vec<ParentSubtreeCleanupTarget>,
+    #[serde(default)]
+    pub retry_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParentIntegrationController {
     pub parent_id: IssueId,
@@ -449,6 +487,8 @@ pub struct ParentIntegrationController {
     pub repair_attempts: Vec<ParentRepairAttempt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub final_evidence: Option<ParentFinalEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subtree_cleanup: Option<ParentSubtreeCleanupIntent>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -513,6 +553,7 @@ impl ParentIntegrationController {
             attempts: Vec::new(),
             repair_attempts: Vec::new(),
             final_evidence: None,
+            subtree_cleanup: None,
         })
     }
 

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -2387,7 +2387,7 @@ where
                     });
                 }
             };
-            let retained = outcome != CleanupTerminalOutcome::Succeeded
+            let retained = outcome == CleanupTerminalOutcome::Failed
                 && self.workspace.retain_failed_workspaces();
             let resources = self.hierarchy_state.descendant_resources_for(&parent_id);
             let mut descendants = Vec::with_capacity(resources.len());
@@ -2466,6 +2466,21 @@ where
         &mut self,
         observed_at: TimestampMs,
     ) -> Result<(), SchedulerError> {
+        let retain_failed = self.workspace.retain_failed_workspaces();
+        let mut retention_changed = false;
+        for controller in self.hierarchy_state.parent_integrations.values_mut() {
+            if let Some(cleanup) = controller.subtree_cleanup.as_mut()
+                && cleanup.status == ParentSubtreeCleanupStatus::Retained
+                && (cleanup.outcome != CleanupTerminalOutcome::Failed || !retain_failed)
+            {
+                cleanup.status = ParentSubtreeCleanupStatus::Pending;
+                cleanup.last_error = None;
+                retention_changed = true;
+            }
+        }
+        if retention_changed {
+            self.persist_orchestrator_state().await?;
+        }
         let parent_ids = self
             .hierarchy_state
             .parent_integrations

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -20,7 +20,8 @@ use crate::opensymphony_domain::{
 use crate::opensymphony_gateway_schema::capability::{HarnessCapability, HarnessKind};
 use crate::opensymphony_workflow::{ResolvedWorkflow, RoutingConfig};
 use crate::opensymphony_workspace::{
-    checkout_workspace_key, redact_runtime_diagnostic, sanitize_workspace_key,
+    CleanupTarget, CleanupTerminalOutcome, checkout_workspace_key, redact_runtime_diagnostic,
+    sanitize_workspace_key,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -37,7 +38,8 @@ use super::{
     LeaseResource, ParentAttemptRoot, ParentAttemptStatus, ParentCleanupReceipt,
     ParentCleanupStatus, ParentEligibilityEvidence, ParentIntegrationController,
     ParentIntegrationError, ParentProviderOperationKind, ParentRepairAttempt, ParentRepairPolicy,
-    ParentRepairStatus, ParentRepositoryTarget,
+    ParentRepairStatus, ParentRepositoryTarget, ParentSubtreeCleanupIntent,
+    ParentSubtreeCleanupStatus, ParentSubtreeCleanupTarget,
 };
 
 const DISABLED_STALL_TIMEOUT_MS: u64 = u64::MAX / 4;
@@ -470,6 +472,14 @@ pub trait WorkspaceBackend {
         Ok(false)
     }
 
+    async fn cleanup_target_for_resource(
+        &mut self,
+        _resource: &LeaseResource,
+        _outcome: CleanupTerminalOutcome,
+    ) -> Result<Option<CleanupTarget>, Self::Error> {
+        Ok(None)
+    }
+
     async fn parent_workspace_targets(
         &mut self,
         _issue: &NormalizedIssue,
@@ -553,6 +563,17 @@ pub trait WorkspaceBackend {
 
     async fn remove_workspace(&mut self, workspace: &WorkspaceRecord) -> Result<(), Self::Error> {
         self.cleanup_workspace(workspace, true).await
+    }
+
+    async fn cleanup_generation(&mut self, target: &CleanupTarget) -> Result<(), Self::Error> {
+        self.cleanup_workspace(&target.workspace, true).await
+    }
+
+    async fn prepare_cleanup_generation(
+        &mut self,
+        _target: &CleanupTarget,
+    ) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     async fn persist_retry_count(
@@ -2132,6 +2153,7 @@ where
         self.load_recovery_state().await?;
         self.flush_pending_retry_persistence().await?;
         self.flush_pending_retry_exhaustion_persistence().await?;
+        self.reconcile_parent_subtree_cleanup(observed_at).await?;
 
         self.expire_linear_cooldown(observed_at);
         let mut pre_update_full_snapshot = if !self.linear_cooldown_active(observed_at)
@@ -2291,6 +2313,364 @@ where
         self.last_poll_at = Some(observed_at);
         self.refresh_health_from_linear_cooldown(observed_at);
         Ok(self.snapshot(observed_at))
+    }
+
+    pub async fn acknowledge_terminal_capture(
+        &mut self,
+        issue_identifiers: &[String],
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        let captured = issue_identifiers.iter().collect::<BTreeSet<_>>();
+        let parent_ids = self
+            .executions
+            .iter()
+            .filter(|(_, execution)| {
+                captured.contains(&execution.issue().identifier.to_string())
+                    && self
+                        .hierarchy_state
+                        .parent_integrations
+                        .contains_key(&execution.issue().id)
+            })
+            .map(|(issue_id, _)| issue_id.clone())
+            .collect::<Vec<_>>();
+        let mut changed = false;
+        for parent_id in parent_ids {
+            let Some(execution) = self.executions.get(&parent_id).cloned() else {
+                continue;
+            };
+            let Some(parent_workspace) = execution.workspace().cloned() else {
+                continue;
+            };
+            let Some(controller) = self
+                .hierarchy_state
+                .parent_integrations
+                .get(&parent_id)
+                .cloned()
+            else {
+                continue;
+            };
+            if controller.subtree_cleanup.is_some() {
+                continue;
+            }
+            if controller.has_unreconciled_harness() {
+                return Err(SchedulerError::Workspace {
+                    detail: format!(
+                        "captured parent {parent_id} still has an unreconciled harness cleanup fence"
+                    ),
+                });
+            }
+            let outcome = match controller.state {
+                super::ParentIntegrationState::Completed => {
+                    if controller.final_evidence.is_none()
+                        || controller.repair_attempts.iter().any(|repair| {
+                            repair.status != ParentRepairStatus::Completed
+                                || repair.operations.iter().any(|operation| {
+                                    operation.receipt.is_none() || operation.completed_at.is_none()
+                                })
+                        })
+                    {
+                        return Err(SchedulerError::Workspace {
+                            detail: format!(
+                                "captured parent {parent_id} is missing final evidence or repair receipts"
+                            ),
+                        });
+                    }
+                    CleanupTerminalOutcome::Succeeded
+                }
+                super::ParentIntegrationState::Failed { .. } => CleanupTerminalOutcome::Failed,
+                super::ParentIntegrationState::Canceled { .. } => CleanupTerminalOutcome::Canceled,
+                _ => {
+                    return Err(SchedulerError::Workspace {
+                        detail: format!(
+                            "captured parent {parent_id} has not reached a terminal controller state"
+                        ),
+                    });
+                }
+            };
+            let retained = outcome != CleanupTerminalOutcome::Succeeded
+                && self.workspace.retain_failed_workspaces();
+            let resources = self.hierarchy_state.descendant_resources_for(&parent_id);
+            let mut descendants = Vec::with_capacity(resources.len());
+            for resource in resources {
+                let cleanup = if let Some(descendant) = self.executions.get(&resource.issue_id)
+                    && let Some(workspace) = descendant.workspace().cloned()
+                {
+                    CleanupTarget {
+                        issue_id: resource.issue_id.to_string(),
+                        identifier: descendant.issue().identifier.to_string(),
+                        workspace,
+                        generation: resource.checkout_generation.clone(),
+                        outcome: CleanupTerminalOutcome::Succeeded,
+                    }
+                } else {
+                    self.workspace
+                        .cleanup_target_for_resource(&resource, CleanupTerminalOutcome::Succeeded)
+                        .await
+                        .map_err(|error| SchedulerError::Workspace {
+                            detail: error.to_string(),
+                        })?
+                        .ok_or_else(|| SchedulerError::Workspace {
+                            detail: format!(
+                                "captured parent {} is missing retained workspace generation {}",
+                                parent_id, resource.checkout_generation
+                            ),
+                        })?
+                };
+                descendants.push(ParentSubtreeCleanupTarget {
+                    resource: Some(resource.clone()),
+                    cleanup,
+                    prepared_at: None,
+                    cleaned_at: None,
+                });
+            }
+            descendants.sort_by(|left, right| {
+                let left_resource = left.resource.as_ref().expect("descendant resource");
+                let right_resource = right.resource.as_ref().expect("descendant resource");
+                hierarchy_depth(&self.hierarchy_state, &parent_id, &right_resource.issue_id)
+                    .cmp(&hierarchy_depth(
+                        &self.hierarchy_state,
+                        &parent_id,
+                        &left_resource.issue_id,
+                    ))
+                    .then_with(|| left_resource.cmp(right_resource))
+            });
+            let intent = ParentSubtreeCleanupIntent {
+                hierarchy_generation: controller.hierarchy_generation,
+                capture_acknowledged_at: observed_at,
+                requested_at: observed_at,
+                outcome,
+                status: if retained {
+                    ParentSubtreeCleanupStatus::Retained
+                } else {
+                    ParentSubtreeCleanupStatus::Pending
+                },
+                parent_root: ParentSubtreeCleanupTarget {
+                    resource: None,
+                    cleanup: CleanupTarget {
+                        issue_id: parent_id.to_string(),
+                        identifier: execution.issue().identifier.to_string(),
+                        workspace: parent_workspace,
+                        generation: format!("parent:{}", controller.hierarchy_generation),
+                        outcome,
+                    },
+                    prepared_at: None,
+                    cleaned_at: None,
+                },
+                descendants,
+                retry_count: 0,
+                last_error: None,
+            };
+            self.hierarchy_state
+                .parent_integrations
+                .get_mut(&parent_id)
+                .expect("parent controller was cloned")
+                .subtree_cleanup = Some(intent);
+            changed = true;
+        }
+        if changed {
+            self.persist_orchestrator_state().await?;
+        }
+        self.reconcile_parent_subtree_cleanup(observed_at).await
+    }
+
+    async fn reconcile_parent_subtree_cleanup(
+        &mut self,
+        observed_at: TimestampMs,
+    ) -> Result<(), SchedulerError> {
+        let parent_ids = self
+            .hierarchy_state
+            .parent_integrations
+            .iter()
+            .filter(|(_, controller)| {
+                controller.subtree_cleanup.as_ref().is_some_and(|cleanup| {
+                    matches!(
+                        cleanup.status,
+                        ParentSubtreeCleanupStatus::Pending | ParentSubtreeCleanupStatus::Removing
+                    )
+                })
+            })
+            .map(|(parent_id, _)| parent_id.clone())
+            .collect::<Vec<_>>();
+        for parent_id in parent_ids {
+            let parent_root = self
+                .hierarchy_state
+                .parent_integrations
+                .get(&parent_id)
+                .and_then(|controller| controller.subtree_cleanup.as_ref())
+                .map(|cleanup| cleanup.parent_root.clone())
+                .expect("cleanup intent exists");
+            if parent_root.prepared_at.is_none() {
+                match self
+                    .workspace
+                    .prepare_cleanup_generation(&parent_root.cleanup)
+                    .await
+                {
+                    Ok(()) => {
+                        self.hierarchy_state
+                            .parent_integrations
+                            .get_mut(&parent_id)
+                            .and_then(|controller| controller.subtree_cleanup.as_mut())
+                            .expect("cleanup intent exists")
+                            .parent_root
+                            .prepared_at = Some(observed_at);
+                        self.persist_orchestrator_state().await?;
+                    }
+                    Err(error) => {
+                        let cleanup = self
+                            .hierarchy_state
+                            .parent_integrations
+                            .get_mut(&parent_id)
+                            .and_then(|controller| controller.subtree_cleanup.as_mut())
+                            .expect("cleanup intent exists");
+                        cleanup.status = ParentSubtreeCleanupStatus::Pending;
+                        cleanup.retry_count = cleanup.retry_count.saturating_add(1);
+                        cleanup.last_error = Some(redact_runtime_diagnostic(&error.to_string()));
+                        self.persist_orchestrator_state().await?;
+                        continue;
+                    }
+                }
+            }
+            let descendants = self
+                .hierarchy_state
+                .parent_integrations
+                .get(&parent_id)
+                .and_then(|controller| controller.subtree_cleanup.as_ref())
+                .map(|cleanup| cleanup.descendants.clone())
+                .unwrap_or_default();
+            for target in &descendants {
+                let resource = target.resource.as_ref().expect("descendant resource");
+                if self.hierarchy_state.release_parent_resource_leases(
+                    &parent_id,
+                    resource,
+                    observed_at.as_u64(),
+                ) {
+                    self.persist_orchestrator_state().await?;
+                }
+            }
+            if let Some(cleanup) = self
+                .hierarchy_state
+                .parent_integrations
+                .get_mut(&parent_id)
+                .and_then(|controller| controller.subtree_cleanup.as_mut())
+            {
+                cleanup.status = ParentSubtreeCleanupStatus::Removing;
+                cleanup.last_error = None;
+            }
+            self.persist_orchestrator_state().await?;
+
+            let mut failed = false;
+            for (index, target) in descendants.iter().enumerate() {
+                if target.cleaned_at.is_some() {
+                    continue;
+                }
+                let resource = target.resource.as_ref().expect("descendant resource");
+                if self
+                    .hierarchy_state
+                    .active_for_at(resource, observed_at.as_u64())
+                {
+                    continue;
+                }
+                match self.workspace.cleanup_generation(&target.cleanup).await {
+                    Ok(()) => {
+                        if let Some(execution) = self.executions.get_mut(&resource.issue_id)
+                            && execution.workspace().is_some_and(|workspace| {
+                                workspace.path == target.cleanup.workspace.path
+                            })
+                        {
+                            execution.clear_workspace();
+                        }
+                        self.hierarchy_state
+                            .parent_integrations
+                            .get_mut(&parent_id)
+                            .and_then(|controller| controller.subtree_cleanup.as_mut())
+                            .expect("cleanup intent exists")
+                            .descendants[index]
+                            .cleaned_at = Some(observed_at);
+                        self.persist_orchestrator_state().await?;
+                    }
+                    Err(error) => {
+                        let cleanup = self
+                            .hierarchy_state
+                            .parent_integrations
+                            .get_mut(&parent_id)
+                            .and_then(|controller| controller.subtree_cleanup.as_mut())
+                            .expect("cleanup intent exists");
+                        cleanup.status = ParentSubtreeCleanupStatus::Pending;
+                        cleanup.retry_count = cleanup.retry_count.saturating_add(1);
+                        cleanup.last_error = Some(redact_runtime_diagnostic(&error.to_string()));
+                        self.persist_orchestrator_state().await?;
+                        failed = true;
+                        break;
+                    }
+                }
+            }
+            if failed {
+                continue;
+            }
+            let cleanup = self
+                .hierarchy_state
+                .parent_integrations
+                .get(&parent_id)
+                .and_then(|controller| controller.subtree_cleanup.as_ref())
+                .expect("cleanup intent exists")
+                .clone();
+            if cleanup
+                .descendants
+                .iter()
+                .any(|target| target.cleaned_at.is_none())
+            {
+                if let Some(cleanup) = self
+                    .hierarchy_state
+                    .parent_integrations
+                    .get_mut(&parent_id)
+                    .and_then(|controller| controller.subtree_cleanup.as_mut())
+                {
+                    cleanup.status = ParentSubtreeCleanupStatus::Pending;
+                }
+                self.persist_orchestrator_state().await?;
+                continue;
+            }
+            if cleanup.parent_root.cleaned_at.is_none() {
+                match self
+                    .workspace
+                    .cleanup_generation(&cleanup.parent_root.cleanup)
+                    .await
+                {
+                    Ok(()) => {
+                        if let Some(execution) = self.executions.get_mut(&parent_id)
+                            && execution.workspace().is_some_and(|workspace| {
+                                workspace.path == cleanup.parent_root.cleanup.workspace.path
+                            })
+                        {
+                            execution.clear_workspace();
+                        }
+                        let cleanup = self
+                            .hierarchy_state
+                            .parent_integrations
+                            .get_mut(&parent_id)
+                            .and_then(|controller| controller.subtree_cleanup.as_mut())
+                            .expect("cleanup intent exists");
+                        cleanup.parent_root.cleaned_at = Some(observed_at);
+                        cleanup.status = ParentSubtreeCleanupStatus::Completed;
+                        cleanup.last_error = None;
+                        self.persist_orchestrator_state().await?;
+                    }
+                    Err(error) => {
+                        let cleanup = self
+                            .hierarchy_state
+                            .parent_integrations
+                            .get_mut(&parent_id)
+                            .and_then(|controller| controller.subtree_cleanup.as_mut())
+                            .expect("cleanup intent exists");
+                        cleanup.status = ParentSubtreeCleanupStatus::Pending;
+                        cleanup.retry_count = cleanup.retry_count.saturating_add(1);
+                        cleanup.last_error = Some(redact_runtime_diagnostic(&error.to_string()));
+                        self.persist_orchestrator_state().await?;
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     pub async fn interrupt_operator_cancel(
@@ -8888,6 +9268,33 @@ fn current_epoch_millis() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+fn hierarchy_depth(
+    state: &DurableOrchestratorState,
+    parent_id: &IssueId,
+    target_id: &IssueId,
+) -> usize {
+    let mut pending = vec![(parent_id.clone(), 0usize)];
+    let mut visited = BTreeSet::new();
+    while let Some((issue_id, depth)) = pending.pop() {
+        if !visited.insert(issue_id.clone()) {
+            continue;
+        }
+        if &issue_id == target_id {
+            return depth;
+        }
+        if let Some(snapshot) = state.hierarchy.get(&issue_id) {
+            pending.extend(
+                snapshot
+                    .required_child_edges
+                    .iter()
+                    .filter(|edge| edge.required)
+                    .map(|edge| (edge.child_id.clone(), depth.saturating_add(1))),
+            );
+        }
+    }
+    0
 }
 
 fn conversation_id_suffix(value: &str) -> &str {

--- a/crates/opensymphony-orchestrator/src/scheduler.rs
+++ b/crates/opensymphony-orchestrator/src/scheduler.rs
@@ -2392,30 +2392,19 @@ where
             let resources = self.hierarchy_state.descendant_resources_for(&parent_id);
             let mut descendants = Vec::with_capacity(resources.len());
             for resource in resources {
-                let cleanup = if let Some(descendant) = self.executions.get(&resource.issue_id)
-                    && let Some(workspace) = descendant.workspace().cloned()
-                {
-                    CleanupTarget {
-                        issue_id: resource.issue_id.to_string(),
-                        identifier: descendant.issue().identifier.to_string(),
-                        workspace,
-                        generation: resource.checkout_generation.clone(),
-                        outcome: CleanupTerminalOutcome::Succeeded,
-                    }
-                } else {
-                    self.workspace
-                        .cleanup_target_for_resource(&resource, CleanupTerminalOutcome::Succeeded)
-                        .await
-                        .map_err(|error| SchedulerError::Workspace {
-                            detail: error.to_string(),
-                        })?
-                        .ok_or_else(|| SchedulerError::Workspace {
-                            detail: format!(
-                                "captured parent {} is missing retained workspace generation {}",
-                                parent_id, resource.checkout_generation
-                            ),
-                        })?
-                };
+                let cleanup = self
+                    .workspace
+                    .cleanup_target_for_resource(&resource, CleanupTerminalOutcome::Succeeded)
+                    .await
+                    .map_err(|error| SchedulerError::Workspace {
+                        detail: error.to_string(),
+                    })?
+                    .ok_or_else(|| SchedulerError::Workspace {
+                        detail: format!(
+                            "captured parent {} is missing retained workspace generation {}",
+                            parent_id, resource.checkout_generation
+                        ),
+                    })?;
                 descendants.push(ParentSubtreeCleanupTarget {
                     resource: Some(resource.clone()),
                     cleanup,
@@ -4350,6 +4339,19 @@ where
                             .map_err(|error| SchedulerError::Workspace {
                                 detail: error.to_string(),
                             })?;
+                        if parent_workspace {
+                            let mut execution =
+                                IssueExecution::new(record.issue.clone(), observed_at);
+                            execution.attach_workspace(record.workspace.clone())?;
+                            self.insert_execution(
+                                issue_id.clone(),
+                                execution.release(
+                                    observed_at,
+                                    ReleaseReason::TrackerTerminal,
+                                    None,
+                                )?,
+                            );
+                        }
                     }
                     Err(error) => {
                         tracing::warn!(issue = %issue_id, %error, "deferring terminal workspace cleanup retry");

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -594,6 +594,7 @@ struct FakeWorkspace {
     repair_refresh_commit: Option<String>,
     repair_refresh_instruction_hash: Option<String>,
     repair_refresh_instruction_path: Option<PathBuf>,
+    cleanup_target_requests: Vec<LeaseResource>,
     generation_cleanups: Vec<crate::opensymphony_workspace::CleanupTarget>,
     generation_cleanup_steps: Vec<String>,
 }
@@ -770,6 +771,7 @@ impl WorkspaceBackend for FakeWorkspace {
         resource: &LeaseResource,
         outcome: crate::opensymphony_workspace::CleanupTerminalOutcome,
     ) -> Result<Option<crate::opensymphony_workspace::CleanupTarget>, Self::Error> {
+        self.cleanup_target_requests.push(resource.clone());
         Ok(Some(crate::opensymphony_workspace::CleanupTarget {
             issue_id: resource.issue_id.to_string(),
             identifier: resource.issue_id.to_string(),
@@ -2897,6 +2899,22 @@ async fn completed_parent_stays_materialized_across_later_capture_retries() {
         restarted_state.leases.iter().any(LeaseRecord::active),
         "restart must retain the leases that protect parent evidence"
     );
+
+    restarted
+        .acknowledge_terminal_capture(&[format!("COE-PARENT-{suffix}")], ts(3_600_310))
+        .await
+        .expect("a recovered completed parent must remain capture eligible");
+    let captured_state: crate::opensymphony_orchestrator::DurableOrchestratorState =
+        serde_json::from_value(
+            restarted
+                .workspace()
+                .durable_state
+                .clone()
+                .expect("captured state"),
+        )
+        .expect("decode captured state");
+    assert!(captured_state.leases.iter().all(|lease| !lease.active()));
+    assert_eq!(restarted.workspace().generation_cleanups.len(), 2);
 }
 
 #[tokio::test]
@@ -2928,6 +2946,16 @@ async fn captured_parent_releases_owned_leases_and_cleans_descendants_before_roo
     assert_eq!(cleaned.len(), 2);
     assert_eq!(cleaned[0].issue_id, format!("child-{suffix}"));
     assert_eq!(cleaned[1].issue_id, parent_id.to_string());
+    assert_eq!(
+        scheduler.workspace().cleanup_target_requests,
+        vec![LeaseResource {
+            issue_id: IssueId::new(format!("child-{suffix}")).expect("child id"),
+            repository_id: CanonicalRepositoryId::new(format!("github:repository:{suffix}"))
+                .expect("repository id"),
+            checkout_generation: format!("checkout-{suffix}"),
+        }],
+        "cleanup must resolve the exact retained generation through the workspace backend"
+    );
     assert_eq!(
         scheduler.workspace().generation_cleanup_steps,
         vec![

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -1755,7 +1755,7 @@ async fn terminal_parent_between_repair_turns_cancels_and_persists_its_controlle
     scheduler
         .acknowledge_terminal_capture(&[format!("COE-PARENT-{suffix}")], ts(7_300_400))
         .await
-        .expect("canceled parent capture should preserve retained diagnostics");
+        .expect("canceled parent capture should use the cancellation policy");
     let retained: crate::opensymphony_orchestrator::DurableOrchestratorState =
         serde_json::from_value(scheduler.workspace().durable_state.clone().expect("state"))
             .expect("decode retained cleanup policy");
@@ -1765,9 +1765,53 @@ async fn terminal_parent_between_repair_turns_cancels_and_persists_its_controlle
             .as_ref()
             .expect("capture acknowledgement")
             .status,
-        crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Retained
+        crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Completed
     );
-    assert!(scheduler.workspace().generation_cleanup_steps.is_empty());
+    assert_eq!(scheduler.workspace().generation_cleanup_steps.len(), 3);
+
+    let mut legacy_retained = retained;
+    let controller = legacy_retained
+        .parent_integrations
+        .get_mut(&parent_id)
+        .expect("parent controller");
+    controller.state = crate::opensymphony_orchestrator::ParentIntegrationState::Failed {
+        reason: "diagnostic failure".to_owned(),
+    };
+    let cleanup = controller.subtree_cleanup.as_mut().expect("cleanup intent");
+    cleanup.outcome = crate::opensymphony_workspace::CleanupTerminalOutcome::Failed;
+    cleanup.status = crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Retained;
+    cleanup.parent_root.cleanup.outcome =
+        crate::opensymphony_workspace::CleanupTerminalOutcome::Failed;
+    cleanup.parent_root.prepared_at = None;
+    cleanup.parent_root.cleaned_at = None;
+    for descendant in &mut cleanup.descendants {
+        descendant.cleaned_at = None;
+    }
+    let mut resumed = Scheduler::new(
+        FakeTracker::default(),
+        FakeWorkspace {
+            durable_state: Some(serde_json::to_value(&legacy_retained).expect("retained state")),
+            retain_failed: false,
+            ..Default::default()
+        },
+        FakeWorker::default(),
+        scheduler_config(),
+    );
+    resumed
+        .tick(ts(7_300_500))
+        .await
+        .expect("disabling failed retention must resume durable cleanup");
+    let resumed_state: crate::opensymphony_orchestrator::DurableOrchestratorState =
+        serde_json::from_value(resumed.workspace().durable_state.clone().expect("state"))
+            .expect("resumed state");
+    assert_eq!(
+        resumed_state.parent_integrations[&parent_id]
+            .subtree_cleanup
+            .as_ref()
+            .expect("cleanup")
+            .status,
+        crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Completed
+    );
 }
 
 #[tokio::test]

--- a/crates/opensymphony-orchestrator/tests/scheduler.rs
+++ b/crates/opensymphony-orchestrator/tests/scheduler.rs
@@ -594,6 +594,8 @@ struct FakeWorkspace {
     repair_refresh_commit: Option<String>,
     repair_refresh_instruction_hash: Option<String>,
     repair_refresh_instruction_path: Option<PathBuf>,
+    generation_cleanups: Vec<crate::opensymphony_workspace::CleanupTarget>,
+    generation_cleanup_steps: Vec<String>,
 }
 
 impl WorkspaceBackend for FakeWorkspace {
@@ -760,6 +762,42 @@ impl WorkspaceBackend for FakeWorkspace {
     ) -> Result<(), Self::Error> {
         self.cleaned
             .push((workspace.workspace_key.to_string(), terminal));
+        self.cleanup_results.pop_front().unwrap_or(Ok(()))
+    }
+
+    async fn cleanup_target_for_resource(
+        &mut self,
+        resource: &LeaseResource,
+        outcome: crate::opensymphony_workspace::CleanupTerminalOutcome,
+    ) -> Result<Option<crate::opensymphony_workspace::CleanupTarget>, Self::Error> {
+        Ok(Some(crate::opensymphony_workspace::CleanupTarget {
+            issue_id: resource.issue_id.to_string(),
+            identifier: resource.issue_id.to_string(),
+            workspace: workspace_record(
+                resource.issue_id.as_str(),
+                &format!("/tmp/workspaces/{}", resource.issue_id),
+            ),
+            generation: resource.checkout_generation.clone(),
+            outcome,
+        }))
+    }
+
+    async fn cleanup_generation(
+        &mut self,
+        target: &crate::opensymphony_workspace::CleanupTarget,
+    ) -> Result<(), Self::Error> {
+        self.generation_cleanup_steps
+            .push(format!("cleanup:{}", target.issue_id));
+        self.generation_cleanups.push(target.clone());
+        self.cleanup_workspace(&target.workspace, true).await
+    }
+
+    async fn prepare_cleanup_generation(
+        &mut self,
+        target: &crate::opensymphony_workspace::CleanupTarget,
+    ) -> Result<(), Self::Error> {
+        self.generation_cleanup_steps
+            .push(format!("prepare:{}", target.issue_id));
         self.cleanup_results.pop_front().unwrap_or(Ok(()))
     }
 
@@ -1710,6 +1748,24 @@ async fn terminal_parent_between_repair_turns_cancels_and_persists_its_controlle
         review_requests_before_terminal,
         "fresh terminal state must fence review writes before repair advancement"
     );
+
+    scheduler.workspace_mut().retain_failed = true;
+    scheduler
+        .acknowledge_terminal_capture(&[format!("COE-PARENT-{suffix}")], ts(7_300_400))
+        .await
+        .expect("canceled parent capture should preserve retained diagnostics");
+    let retained: crate::opensymphony_orchestrator::DurableOrchestratorState =
+        serde_json::from_value(scheduler.workspace().durable_state.clone().expect("state"))
+            .expect("decode retained cleanup policy");
+    assert_eq!(
+        retained.parent_integrations[&parent_id]
+            .subtree_cleanup
+            .as_ref()
+            .expect("capture acknowledgement")
+            .status,
+        crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Retained
+    );
+    assert!(scheduler.workspace().generation_cleanup_steps.is_empty());
 }
 
 #[tokio::test]
@@ -2840,6 +2896,136 @@ async fn completed_parent_stays_materialized_across_later_capture_retries() {
     assert!(
         restarted_state.leases.iter().any(LeaseRecord::active),
         "restart must retain the leases that protect parent evidence"
+    );
+}
+
+#[tokio::test]
+async fn captured_parent_releases_owned_leases_and_cleans_descendants_before_root_once() {
+    let suffix = "CAPTURE-CLEANUP";
+    let (mut scheduler, parent_id) = launched_parent_scheduler(suffix).await;
+    let mut terminal = tracker_state_snapshot(
+        parent_id.as_str(),
+        &format!("COE-PARENT-{suffix}"),
+        "Done",
+        "completed",
+        140,
+    );
+    terminal.is_parent = true;
+    scheduler.tracker_mut().active.clear();
+    scheduler
+        .tracker_mut()
+        .states
+        .insert(parent_id.to_string(), terminal);
+    enqueue_successful_parent_completion(&mut scheduler, suffix, 150);
+    scheduler.tick(ts(150)).await.expect("complete parent");
+
+    scheduler
+        .acknowledge_terminal_capture(&[format!("COE-PARENT-{suffix}")], ts(160))
+        .await
+        .expect("capture acknowledgement should drive cleanup");
+
+    let cleaned = &scheduler.workspace().generation_cleanups;
+    assert_eq!(cleaned.len(), 2);
+    assert_eq!(cleaned[0].issue_id, format!("child-{suffix}"));
+    assert_eq!(cleaned[1].issue_id, parent_id.to_string());
+    assert_eq!(
+        scheduler.workspace().generation_cleanup_steps,
+        vec![
+            format!("prepare:{parent_id}"),
+            format!("cleanup:child-{suffix}"),
+            format!("cleanup:{parent_id}"),
+        ],
+        "parent integration worktrees must be detached before source generations"
+    );
+    let state: crate::opensymphony_orchestrator::DurableOrchestratorState =
+        serde_json::from_value(scheduler.workspace().durable_state.clone().expect("state"))
+            .expect("decode state");
+    assert!(state.leases.iter().all(|lease| !lease.active()));
+    let cleanup = state.parent_integrations[&parent_id]
+        .subtree_cleanup
+        .as_ref()
+        .expect("cleanup intent");
+    assert_eq!(
+        cleanup.status,
+        crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Completed
+    );
+    assert_eq!(cleanup.capture_acknowledged_at, ts(160));
+
+    scheduler.tick(ts(170)).await.expect("repeat cleanup tick");
+    assert_eq!(
+        scheduler.workspace().generation_cleanups.len(),
+        2,
+        "completed cleanup receipts must make retries no-ops"
+    );
+}
+
+#[tokio::test]
+async fn failed_subtree_cleanup_retries_only_incomplete_receipts() {
+    let suffix = "CAPTURE-CLEANUP-RETRY";
+    let (mut scheduler, parent_id) = launched_parent_scheduler(suffix).await;
+    let mut terminal = tracker_state_snapshot(
+        parent_id.as_str(),
+        &format!("COE-PARENT-{suffix}"),
+        "Done",
+        "completed",
+        140,
+    );
+    terminal.is_parent = true;
+    scheduler.tracker_mut().active.clear();
+    scheduler
+        .tracker_mut()
+        .states
+        .insert(parent_id.to_string(), terminal);
+    enqueue_successful_parent_completion(&mut scheduler, suffix, 150);
+    scheduler.tick(ts(150)).await.expect("complete parent");
+    scheduler.workspace_mut().cleanup_results = VecDeque::from([
+        Ok(()),
+        Err(FakeError {
+            message: "permission denied".to_owned(),
+            category: None,
+            retry_after: None,
+        }),
+        Ok(()),
+        Ok(()),
+    ]);
+
+    scheduler
+        .acknowledge_terminal_capture(&[format!("COE-PARENT-{suffix}")], ts(160))
+        .await
+        .expect("cleanup failures are durable retry state");
+    let failed_state: crate::opensymphony_orchestrator::DurableOrchestratorState =
+        serde_json::from_value(scheduler.workspace().durable_state.clone().expect("state"))
+            .expect("decode state");
+    let failed = failed_state.parent_integrations[&parent_id]
+        .subtree_cleanup
+        .as_ref()
+        .expect("cleanup intent");
+    assert_eq!(failed.retry_count, 1);
+    assert_eq!(failed.last_error.as_deref(), Some("permission denied"));
+    assert!(failed.parent_root.prepared_at.is_some());
+    assert!(failed.descendants[0].cleaned_at.is_none());
+
+    scheduler.tick(ts(170)).await.expect("retry cleanup");
+    let recovered_state: crate::opensymphony_orchestrator::DurableOrchestratorState =
+        serde_json::from_value(scheduler.workspace().durable_state.clone().expect("state"))
+            .expect("decode state");
+    let recovered = recovered_state.parent_integrations[&parent_id]
+        .subtree_cleanup
+        .as_ref()
+        .expect("cleanup intent");
+    assert_eq!(
+        recovered.status,
+        crate::opensymphony_orchestrator::ParentSubtreeCleanupStatus::Completed
+    );
+    assert_eq!(
+        scheduler.workspace().generation_cleanup_steps,
+        vec![
+            format!("prepare:{parent_id}"),
+            format!("cleanup:child-{suffix}"),
+            format!("cleanup:child-{suffix}"),
+            format!("cleanup:{parent_id}"),
+        ],
+        "the durable parent preparation receipt must not be repeated"
     );
 }
 

--- a/crates/opensymphony-workspace/src/error.rs
+++ b/crates/opensymphony-workspace/src/error.rs
@@ -103,6 +103,20 @@ pub enum WorkspaceError {
     },
     #[error("failed to remove workspace {path}: {source}")]
     RemoveWorkspace { path: PathBuf, source: io::Error },
+    #[error("workspace cleanup generation mismatch at {path}: expected {expected}, found {actual}")]
+    CleanupGenerationMismatch {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    #[error("workspace cleanup outcome mismatch at {path}: expected {expected}, found {actual}")]
+    CleanupOutcomeMismatch {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
+    #[error("missing matching cleanup tombstone for generation {generation} at {path}")]
+    MissingCleanupTombstone { path: PathBuf, generation: String },
     #[error("checkout generation {generation} at {path} is not attachable: {reason}")]
     CheckoutVerification {
         path: PathBuf,

--- a/crates/opensymphony-workspace/src/lib.rs
+++ b/crates/opensymphony-workspace/src/lib.rs
@@ -9,7 +9,8 @@ pub use manager::{
     compose_terminal_prompt,
 };
 pub use models::{
-    CheckoutManifest, CheckoutRepository, CleanupConfig, CleanupDecision, CleanupOutcome,
+    CheckoutManifest, CheckoutRepository, CleanupConfig, CleanupDecision, CleanupIntent,
+    CleanupOutcome, CleanupRequest, CleanupTarget, CleanupTerminalOutcome, CleanupTombstone,
     ConversationManifest, EnsureWorkspaceResult, HookConfig, HookDefinition, HookExecutionRecord,
     HookExecutionStatus, HookKind, InstructionProvenance, IssueContextArtifact, IssueDescriptor,
     IssueLifecycleState, IssueManifest, ParentCheckoutRequest, ParentChildCheckoutMap,

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -4741,6 +4741,14 @@ impl WorkspaceManager {
                     generation: request.generation,
                 });
         }
+        self.validate_workspace_handle(&workspace).await?;
+        if self
+            .matching_cleanup_tombstone(&workspace, &request)
+            .await?
+            .is_some_and(|tombstone| tombstone.deleted_at.is_none())
+        {
+            return Ok(());
+        }
         let actual_generation = self.cleanup_generation(&workspace).await?;
         if actual_generation != request.generation {
             return Err(WorkspaceError::CleanupGenerationMismatch {
@@ -4793,7 +4801,7 @@ impl WorkspaceManager {
             }
             return Ok(CleanupOutcome {
                 decision: CleanupDecision::Remove,
-                before_remove: None,
+                before_remove: tombstone.before_remove.clone(),
                 tombstone: Some(tombstone),
             });
         }
@@ -4804,6 +4812,30 @@ impl WorkspaceManager {
                 decision: CleanupDecision::Retain,
                 before_remove: None,
                 tombstone: None,
+            });
+        }
+
+        if request.remove
+            && let Some(mut tombstone) =
+                self.matching_cleanup_tombstone(workspace, &request).await?
+            && tombstone.deleted_at.is_none()
+        {
+            match fs::remove_dir_all(workspace.workspace_path()).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(WorkspaceError::RemoveWorkspace {
+                        path: workspace.workspace_path().to_path_buf(),
+                        source: error,
+                    });
+                }
+            }
+            tombstone.deleted_at = Some(Utc::now());
+            self.write_cleanup_tombstone(workspace, &tombstone).await?;
+            return Ok(CleanupOutcome {
+                decision: CleanupDecision::Remove,
+                before_remove: tombstone.before_remove.clone(),
+                tombstone: Some(tombstone),
             });
         }
 
@@ -4857,6 +4889,10 @@ impl WorkspaceManager {
             generation: request.generation,
             outcome: request.outcome,
             deletion_started_at,
+            before_remove: run_manifest
+                .cleanup_intent
+                .as_ref()
+                .and_then(|intent| intent.before_remove.clone()),
             deleted_at: None,
         };
         self.write_cleanup_tombstone(workspace, &tombstone).await?;
@@ -5036,8 +5072,38 @@ impl WorkspaceManager {
         &self,
         workspace: &WorkspaceHandle,
     ) -> Result<String, WorkspaceError> {
-        if let Some(generation) = workspace.checkout_generation() {
-            return Ok(generation.to_owned());
+        if workspace.checkout_generation().is_some() {
+            let checkout = self
+                .load_manifest::<CheckoutManifest>(workspace, &workspace.checkout_manifest_path())
+                .await?
+                .ok_or_else(|| {
+                    checkout_verification(
+                        workspace.workspace_path(),
+                        "cleanup target checkout manifest is missing",
+                    )
+                })?;
+            let issue = self
+                .load_manifest::<IssueManifest>(workspace, &workspace.issue_manifest_path())
+                .await?
+                .ok_or_else(|| {
+                    checkout_verification(
+                        workspace.workspace_path(),
+                        "cleanup target issue manifest is missing",
+                    )
+                })?;
+            if checkout.schema_version != 1
+                || checkout.quarantined
+                || issue.issue_id != workspace.issue_id()
+                || issue.identifier != workspace.identifier()
+                || !issue_manifest_claims_workspace(workspace, &issue)
+                || !issue_manifest_owns_checkout(workspace, &issue, &checkout)
+            {
+                return Err(checkout_verification(
+                    workspace.workspace_path(),
+                    "cleanup target ownership manifests are inconsistent",
+                ));
+            }
+            return Ok(checkout.generation);
         }
         if path_exists(workspace.workspace_path()).await?
             && let Some(parent) = self
@@ -5047,9 +5113,37 @@ impl WorkspaceManager {
                 )
                 .await?
         {
+            if parent.schema_version != 1
+                || parent.parent_issue_id != workspace.issue_id()
+                || parent.parent_identifier != workspace.identifier()
+                || normalize_absolute_path(&parent.workspace_path)? != workspace.workspace_path()
+            {
+                return Err(checkout_verification(
+                    workspace.workspace_path(),
+                    "parent cleanup target manifest is inconsistent",
+                ));
+            }
             return Ok(format!("parent:{}", parent.hierarchy_generation));
         }
         if path_exists(workspace.workspace_path()).await? {
+            let issue = self
+                .load_manifest::<IssueManifest>(workspace, &workspace.issue_manifest_path())
+                .await?
+                .ok_or_else(|| {
+                    checkout_verification(
+                        workspace.workspace_path(),
+                        "cleanup target issue manifest is missing",
+                    )
+                })?;
+            if issue.issue_id != workspace.issue_id()
+                || issue.identifier != workspace.identifier()
+                || !issue_manifest_claims_workspace(workspace, &issue)
+            {
+                return Err(checkout_verification(
+                    workspace.workspace_path(),
+                    "cleanup target issue manifest is inconsistent",
+                ));
+            }
             return Ok(format!("workspace:{}", workspace.issue_id()));
         }
         Err(WorkspaceError::MissingCleanupTombstone {

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -29,7 +29,8 @@ use url::Url;
 use uuid::Uuid;
 
 use super::{
-    CheckoutManifest, CheckoutRepository, CleanupDecision, CleanupOutcome, ConversationManifest,
+    CheckoutManifest, CheckoutRepository, CleanupDecision, CleanupIntent, CleanupOutcome,
+    CleanupRequest, CleanupTarget, CleanupTerminalOutcome, CleanupTombstone, ConversationManifest,
     EnsureWorkspaceResult, HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind,
     IssueContextArtifact, IssueDescriptor, IssueLifecycleState, IssueManifest,
     ParentCheckoutRequest, ParentChildCheckoutMap, ParentExecutionManifest, ParentExecutionRoot,
@@ -594,6 +595,8 @@ impl WorkspaceManager {
                 .await?;
             let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
             debug_assert_eq!(issue_manifest.workspace_path, handle.workspace_path());
+            self.remove_cleanup_tombstone(&handle, &format!("parent:{hierarchy_generation}"))
+                .await?;
             Ok(ParentExecutionRoot {
                 handle,
                 manifest,
@@ -2369,6 +2372,10 @@ impl WorkspaceManager {
         };
         self.bootstrap_workspace_layout(&handle).await?;
         let issue_manifest = self.upsert_issue_manifest(issue, &handle).await?;
+        if created {
+            self.remove_cleanup_tombstone(&handle, &format!("workspace:{}", issue.issue_id))
+                .await?;
+        }
 
         Ok(EnsureWorkspaceResult {
             handle,
@@ -4664,10 +4671,15 @@ impl WorkspaceManager {
         workspace: &WorkspaceHandle,
         state: IssueLifecycleState,
     ) -> Result<CleanupOutcome, WorkspaceError> {
-        self.cleanup_with_terminal_removal(
+        let generation = self.cleanup_generation(workspace).await?;
+        self.cleanup_with_request(
             workspace,
             state,
-            self.config.cleanup.remove_terminal_workspaces,
+            CleanupRequest {
+                generation,
+                outcome: CleanupTerminalOutcome::Succeeded,
+                remove: self.config.cleanup.remove_terminal_workspaces,
+            },
         )
         .await
     }
@@ -4679,24 +4691,110 @@ impl WorkspaceManager {
         &self,
         workspace: &WorkspaceHandle,
     ) -> Result<CleanupOutcome, WorkspaceError> {
-        self.cleanup_with_terminal_removal(workspace, IssueLifecycleState::Terminal, true)
-            .await
+        let generation = self.cleanup_generation(workspace).await?;
+        self.cleanup_with_request(
+            workspace,
+            IssueLifecycleState::Terminal,
+            CleanupRequest {
+                generation,
+                outcome: CleanupTerminalOutcome::Failed,
+                remove: true,
+            },
+        )
+        .await
     }
 
-    async fn cleanup_with_terminal_removal(
+    pub async fn cleanup_target(
+        &self,
+        target: &CleanupTarget,
+    ) -> Result<CleanupOutcome, WorkspaceError> {
+        let workspace = Self::workspace_handle_for_cleanup_target(target);
+        self.cleanup_with_request(
+            &workspace,
+            IssueLifecycleState::Terminal,
+            CleanupRequest {
+                generation: target.generation.clone(),
+                outcome: target.outcome,
+                remove: true,
+            },
+        )
+        .await
+    }
+
+    pub async fn prepare_cleanup_target(
+        &self,
+        target: &CleanupTarget,
+    ) -> Result<(), WorkspaceError> {
+        let workspace = Self::workspace_handle_for_cleanup_target(target);
+        let request = CleanupRequest {
+            generation: target.generation.clone(),
+            outcome: target.outcome,
+            remove: true,
+        };
+        if !path_exists(workspace.workspace_path()).await? {
+            return self
+                .matching_cleanup_tombstone(&workspace, &request)
+                .await?
+                .map(|_| ())
+                .ok_or_else(|| WorkspaceError::MissingCleanupTombstone {
+                    path: workspace.workspace_path().to_path_buf(),
+                    generation: request.generation,
+                });
+        }
+        let actual_generation = self.cleanup_generation(&workspace).await?;
+        if actual_generation != request.generation {
+            return Err(WorkspaceError::CleanupGenerationMismatch {
+                path: workspace.workspace_path().to_path_buf(),
+                expected: request.generation,
+                actual: actual_generation,
+            });
+        }
+        self.prepare_removal(&workspace, &request).await?;
+        Ok(())
+    }
+
+    fn workspace_handle_for_cleanup_target(target: &CleanupTarget) -> WorkspaceHandle {
+        let mut workspace = WorkspaceHandle::new(
+            target.issue_id.clone(),
+            target.identifier.clone(),
+            target.workspace.workspace_key.to_string(),
+            target.workspace.path.clone(),
+        );
+        if !target.generation.starts_with("parent:") && !target.generation.starts_with("workspace:")
+        {
+            workspace = workspace.with_checkout_generation(target.generation.clone());
+        }
+        workspace
+    }
+
+    pub async fn cleanup_with_request(
         &self,
         workspace: &WorkspaceHandle,
         state: IssueLifecycleState,
-        remove_terminal_workspaces: bool,
+        request: CleanupRequest,
     ) -> Result<CleanupOutcome, WorkspaceError> {
         if !path_exists(workspace.workspace_path()).await? {
+            if state != IssueLifecycleState::Terminal || !request.remove {
+                return Err(WorkspaceError::MissingCleanupTombstone {
+                    path: workspace.workspace_path().to_path_buf(),
+                    generation: request.generation,
+                });
+            }
+            let mut tombstone = self
+                .matching_cleanup_tombstone(workspace, &request)
+                .await?
+                .ok_or_else(|| WorkspaceError::MissingCleanupTombstone {
+                    path: workspace.workspace_path().to_path_buf(),
+                    generation: request.generation.clone(),
+                })?;
+            if tombstone.deleted_at.is_none() {
+                tombstone.deleted_at = Some(Utc::now());
+                self.write_cleanup_tombstone(workspace, &tombstone).await?;
+            }
             return Ok(CleanupOutcome {
-                decision: if state == IssueLifecycleState::Terminal && remove_terminal_workspaces {
-                    CleanupDecision::Remove
-                } else {
-                    CleanupDecision::Retain
-                },
+                decision: CleanupDecision::Remove,
                 before_remove: None,
+                tombstone: Some(tombstone),
             });
         }
 
@@ -4705,43 +4803,177 @@ impl WorkspaceManager {
             return Ok(CleanupOutcome {
                 decision: CleanupDecision::Retain,
                 before_remove: None,
+                tombstone: None,
             });
         }
 
-        let before_remove = match self.execute_hook(HookKind::BeforeRemove, workspace).await {
-            Ok(record) => record,
-            Err(failure) => Some(failure.record),
-        };
-        let decision = if remove_terminal_workspaces {
+        let actual_generation = self.cleanup_generation(workspace).await?;
+        if actual_generation != request.generation {
+            return Err(WorkspaceError::CleanupGenerationMismatch {
+                path: workspace.workspace_path().to_path_buf(),
+                expected: request.generation,
+                actual: actual_generation,
+            });
+        }
+        let decision = if request.remove {
             CleanupDecision::Remove
         } else {
             CleanupDecision::Retain
         };
 
-        if decision == CleanupDecision::Remove {
-            self.unregister_parent_integration_worktrees(workspace)
-                .await?;
-            match fs::remove_dir_all(workspace.workspace_path()).await {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(WorkspaceError::RemoveWorkspace {
-                        path: workspace.workspace_path().to_path_buf(),
-                        source: error,
-                    });
+        if decision == CleanupDecision::Retain {
+            let before_remove = match self.execute_hook(HookKind::BeforeRemove, workspace).await {
+                Ok(record) => record,
+                Err(failure) => Some(failure.record),
+            };
+            return Ok(CleanupOutcome {
+                decision,
+                before_remove,
+                tombstone: None,
+            });
+        }
+
+        let mut run_manifest = self.prepare_removal(workspace, &request).await?;
+        let deletion_started_at = run_manifest
+            .cleanup_intent
+            .as_ref()
+            .and_then(|intent| intent.deletion_started_at)
+            .unwrap_or_else(Utc::now);
+        {
+            let intent = run_manifest
+                .cleanup_intent
+                .as_mut()
+                .expect("cleanup intent was initialized");
+            intent.deletion_started_at = Some(deletion_started_at);
+            intent.last_error = None;
+        }
+        self.write_run_manifest(workspace, &run_manifest).await?;
+        let mut tombstone = CleanupTombstone {
+            schema_version: 1,
+            issue_id: workspace.issue_id().to_owned(),
+            identifier: workspace.identifier().to_owned(),
+            sanitized_workspace_key: workspace.workspace_key().to_owned(),
+            workspace_path: workspace.workspace_path().to_path_buf(),
+            generation: request.generation,
+            outcome: request.outcome,
+            deletion_started_at,
+            deleted_at: None,
+        };
+        self.write_cleanup_tombstone(workspace, &tombstone).await?;
+        match fs::remove_dir_all(workspace.workspace_path()).await {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(WorkspaceError::RemoveWorkspace {
+                    path: workspace.workspace_path().to_path_buf(),
+                    source: error,
+                });
+            }
+        }
+        tombstone.deleted_at = Some(Utc::now());
+        self.write_cleanup_tombstone(workspace, &tombstone).await?;
+        Ok(CleanupOutcome {
+            decision,
+            before_remove: run_manifest
+                .cleanup_intent
+                .and_then(|intent| intent.before_remove),
+            tombstone: Some(tombstone),
+        })
+    }
+
+    async fn prepare_removal(
+        &self,
+        workspace: &WorkspaceHandle,
+        request: &CleanupRequest,
+    ) -> Result<RunManifest, WorkspaceError> {
+        let mut run_manifest = match self.load_run_manifest(workspace).await? {
+            Some(manifest) => manifest,
+            None => RunManifest::new(
+                workspace,
+                &RunDescriptor::new(format!("cleanup:{}", request.generation), 0),
+            ),
+        };
+        match run_manifest.cleanup_intent.as_ref() {
+            Some(intent) if intent.generation != request.generation => {
+                return Err(WorkspaceError::CleanupGenerationMismatch {
+                    path: workspace.workspace_path().to_path_buf(),
+                    expected: request.generation.clone(),
+                    actual: intent.generation.clone(),
+                });
+            }
+            Some(intent) if intent.outcome != request.outcome => {
+                return Err(WorkspaceError::CleanupOutcomeMismatch {
+                    path: workspace.workspace_path().to_path_buf(),
+                    expected: format!("{:?}", request.outcome),
+                    actual: format!("{:?}", intent.outcome),
+                });
+            }
+            Some(_) => {}
+            None => {
+                run_manifest.cleanup_intent = Some(CleanupIntent::new(request));
+                self.write_run_manifest(workspace, &run_manifest).await?;
+            }
+        }
+
+        let before_remove_succeeded = run_manifest
+            .cleanup_intent
+            .as_ref()
+            .and_then(|intent| intent.before_remove.as_ref())
+            .is_some_and(|receipt| receipt.status == HookExecutionStatus::Succeeded);
+        if !before_remove_succeeded {
+            match self.execute_hook(HookKind::BeforeRemove, workspace).await {
+                Ok(record) => {
+                    if let Some(record) = record {
+                        run_manifest.hooks.push(record.clone());
+                        run_manifest
+                            .cleanup_intent
+                            .as_mut()
+                            .expect("cleanup intent was initialized")
+                            .before_remove = Some(record);
+                    }
+                    let intent = run_manifest
+                        .cleanup_intent
+                        .as_mut()
+                        .expect("cleanup intent was initialized");
+                    intent.last_error = None;
+                    self.write_run_manifest(workspace, &run_manifest).await?;
+                }
+                Err(failure) => {
+                    run_manifest.hooks.push(failure.record.clone());
+                    let intent = run_manifest
+                        .cleanup_intent
+                        .as_mut()
+                        .expect("cleanup intent was initialized");
+                    intent.before_remove = Some(failure.record);
+                    intent.retry_count = intent.retry_count.saturating_add(1);
+                    intent.last_error = Some(failure.error.to_string());
+                    self.write_run_manifest(workspace, &run_manifest).await?;
+                    return Err(failure.error);
                 }
             }
         }
 
-        Ok(CleanupOutcome {
-            decision,
-            before_remove,
-        })
+        if let Err(error) = self
+            .unregister_parent_integration_worktrees(workspace, &mut run_manifest)
+            .await
+        {
+            let intent = run_manifest
+                .cleanup_intent
+                .as_mut()
+                .expect("cleanup intent was initialized");
+            intent.retry_count = intent.retry_count.saturating_add(1);
+            intent.last_error = Some(error.to_string());
+            self.write_run_manifest(workspace, &run_manifest).await?;
+            return Err(error);
+        }
+
+        Ok(run_manifest)
     }
 
     async fn unregister_parent_integration_worktrees(
         &self,
         workspace: &WorkspaceHandle,
+        run_manifest: &mut RunManifest,
     ) -> Result<(), WorkspaceError> {
         let Some(_manifest) = self
             .load_manifest::<ParentExecutionManifest>(workspace, &workspace.parent_manifest_path())
@@ -4759,6 +4991,13 @@ impl WorkspaceManager {
                 )
             })?;
         for record in checkout_map.repositories.values() {
+            if run_manifest.cleanup_intent.as_ref().is_some_and(|intent| {
+                intent
+                    .removed_integration_worktrees
+                    .contains(&record.checkout_handle)
+            }) {
+                continue;
+            }
             let source = self.validate_parent_retained_checkouts(record).await?;
             let integration =
                 resolve_path_within_root(workspace.workspace_path(), &record.relative_path)?;
@@ -4782,8 +5021,110 @@ impl WorkspaceManager {
                 )
                 .await?;
             }
+            run_manifest
+                .cleanup_intent
+                .as_mut()
+                .expect("parent worktree cleanup requires an initialized intent")
+                .removed_integration_worktrees
+                .insert(record.checkout_handle.clone());
+            self.write_run_manifest(workspace, run_manifest).await?;
         }
         Ok(())
+    }
+
+    async fn cleanup_generation(
+        &self,
+        workspace: &WorkspaceHandle,
+    ) -> Result<String, WorkspaceError> {
+        if let Some(generation) = workspace.checkout_generation() {
+            return Ok(generation.to_owned());
+        }
+        if path_exists(workspace.workspace_path()).await?
+            && let Some(parent) = self
+                .load_manifest::<ParentExecutionManifest>(
+                    workspace,
+                    &workspace.parent_manifest_path(),
+                )
+                .await?
+        {
+            return Ok(format!("parent:{}", parent.hierarchy_generation));
+        }
+        if path_exists(workspace.workspace_path()).await? {
+            return Ok(format!("workspace:{}", workspace.issue_id()));
+        }
+        Err(WorkspaceError::MissingCleanupTombstone {
+            path: workspace.workspace_path().to_path_buf(),
+            generation: "unknown".to_owned(),
+        })
+    }
+
+    async fn matching_cleanup_tombstone(
+        &self,
+        workspace: &WorkspaceHandle,
+        request: &CleanupRequest,
+    ) -> Result<Option<CleanupTombstone>, WorkspaceError> {
+        if !path_exists(&self.config.root).await? {
+            return Ok(None);
+        }
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let handle = self.orchestrator_state_handle(canonical_root.clone());
+        let path = self.cleanup_tombstone_path(&canonical_root, workspace, &request.generation);
+        let tombstone = self
+            .load_manifest::<CleanupTombstone>(&handle, &path)
+            .await?;
+        Ok(tombstone.filter(|tombstone| {
+            tombstone.schema_version == 1
+                && tombstone.issue_id == workspace.issue_id()
+                && tombstone.identifier == workspace.identifier()
+                && tombstone.sanitized_workspace_key == workspace.workspace_key()
+                && tombstone.workspace_path == workspace.workspace_path()
+                && tombstone.generation == request.generation
+                && tombstone.outcome == request.outcome
+        }))
+    }
+
+    async fn write_cleanup_tombstone(
+        &self,
+        workspace: &WorkspaceHandle,
+        tombstone: &CleanupTombstone,
+    ) -> Result<(), WorkspaceError> {
+        self.create_directory(&self.config.root).await?;
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let handle = self.orchestrator_state_handle(canonical_root.clone());
+        let path = self.cleanup_tombstone_path(&canonical_root, workspace, &tombstone.generation);
+        self.write_manifest_atomically(&handle, &path, tombstone)
+            .await
+    }
+
+    async fn remove_cleanup_tombstone(
+        &self,
+        workspace: &WorkspaceHandle,
+        generation: &str,
+    ) -> Result<(), WorkspaceError> {
+        let canonical_root = self.canonicalize_path(&self.config.root).await?;
+        let path = self.cleanup_tombstone_path(&canonical_root, workspace, generation);
+        match fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(WorkspaceError::WriteManifest { path, source }),
+        }
+    }
+
+    fn cleanup_tombstone_path(
+        &self,
+        canonical_root: &Path,
+        workspace: &WorkspaceHandle,
+        generation: &str,
+    ) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(workspace.issue_id().as_bytes());
+        hasher.update([0]);
+        hasher.update(workspace.workspace_path().as_os_str().as_encoded_bytes());
+        hasher.update([0]);
+        hasher.update(generation.as_bytes());
+        canonical_root
+            .join(".opensymphony-cleanup-tombstones")
+            .join(format!("{:x}.json", hasher.finalize()))
     }
 
     pub async fn load_issue_manifest(
@@ -5094,6 +5435,14 @@ impl WorkspaceManager {
             hook.command = redact_runtime_diagnostic(&hook.command);
             hook.stdout = redact_runtime_diagnostic(&hook.stdout);
             hook.stderr = redact_runtime_diagnostic(&hook.stderr);
+        }
+        if let Some(cleanup) = sanitized.cleanup_intent.as_mut() {
+            cleanup.last_error = cleanup.last_error.as_deref().map(redact_runtime_diagnostic);
+            if let Some(hook) = cleanup.before_remove.as_mut() {
+                hook.command = redact_runtime_diagnostic(&hook.command);
+                hook.stdout = redact_runtime_diagnostic(&hook.stdout);
+                hook.stderr = redact_runtime_diagnostic(&hook.stderr);
+            }
         }
         self.write_manifest_atomically(workspace, &workspace.run_manifest_path(), &sanitized)
             .await

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -4721,6 +4721,22 @@ impl WorkspaceManager {
         .await
     }
 
+    pub async fn cleanup_target_deletion_started(
+        &self,
+        target: &CleanupTarget,
+    ) -> Result<bool, WorkspaceError> {
+        let workspace = Self::workspace_handle_for_cleanup_target(target);
+        let request = CleanupRequest {
+            generation: target.generation.clone(),
+            outcome: target.outcome,
+            remove: true,
+        };
+        Ok(self
+            .matching_cleanup_tombstone(&workspace, &request)
+            .await?
+            .is_some_and(|tombstone| tombstone.deleted_at.is_none()))
+    }
+
     pub async fn prepare_cleanup_target(
         &self,
         target: &CleanupTarget,
@@ -5185,7 +5201,11 @@ impl WorkspaceManager {
         let canonical_root = self.canonicalize_path(&self.config.root).await?;
         let handle = self.orchestrator_state_handle(canonical_root.clone());
         let path = self.cleanup_tombstone_path(&canonical_root, workspace, &tombstone.generation);
-        self.write_manifest_atomically(&handle, &path, tombstone)
+        let mut sanitized = tombstone.clone();
+        if let Some(hook) = sanitized.before_remove.as_mut() {
+            redact_hook_execution_record(hook);
+        }
+        self.write_manifest_atomically(&handle, &path, &sanitized)
             .await
     }
 
@@ -5487,6 +5507,132 @@ impl WorkspaceManager {
             }
         }
 
+        let parents_root = self.config.root.join("parents");
+        self.reject_symlinked_path_components(&self.config.root, Path::new("parents"))
+            .await?;
+        let mut parent_keys = match fs::read_dir(&parents_root).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(workspaces),
+            Err(source) => {
+                return Err(WorkspaceError::ReadDirectory {
+                    path: parents_root,
+                    source,
+                });
+            }
+        };
+        while let Some(parent_key) =
+            parent_keys
+                .next_entry()
+                .await
+                .map_err(|source| WorkspaceError::ReadDirectory {
+                    path: parents_root.clone(),
+                    source,
+                })?
+        {
+            if !parent_key
+                .file_type()
+                .await
+                .map_err(|source| WorkspaceError::ReadDirectory {
+                    path: parent_key.path(),
+                    source,
+                })?
+                .is_dir()
+            {
+                continue;
+            }
+            let parent_key_path = parent_key.path();
+            let mut generations = fs::read_dir(&parent_key_path).await.map_err(|source| {
+                WorkspaceError::ReadDirectory {
+                    path: parent_key_path.clone(),
+                    source,
+                }
+            })?;
+            while let Some(generation) =
+                generations
+                    .next_entry()
+                    .await
+                    .map_err(|source| WorkspaceError::ReadDirectory {
+                        path: parent_key_path.clone(),
+                        source,
+                    })?
+            {
+                if !generation
+                    .file_type()
+                    .await
+                    .map_err(|source| WorkspaceError::ReadDirectory {
+                        path: generation.path(),
+                        source,
+                    })?
+                    .is_dir()
+                {
+                    continue;
+                }
+                let path = generation.path();
+                let loaded = match self.load_workspace_from_directory(&path).await {
+                    Ok(loaded) => loaded,
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            %error,
+                            "skipping invalid parent execution root during recovery"
+                        );
+                        continue;
+                    }
+                };
+                let Some((handle, issue)) = loaded else {
+                    continue;
+                };
+                let parent = match self
+                    .load_manifest::<ParentExecutionManifest>(
+                        &handle,
+                        &handle.parent_manifest_path(),
+                    )
+                    .await
+                {
+                    Ok(Some(parent)) => parent,
+                    Ok(None) => continue,
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            %error,
+                            "skipping parent execution root with invalid manifest during recovery"
+                        );
+                        continue;
+                    }
+                };
+                let expected_generation = generation
+                    .file_name()
+                    .to_str()
+                    .and_then(|name| name.parse::<u64>().ok());
+                let expected_key = parent_key.file_name();
+                let generated_key = parent_workspace_key(&issue.identifier, &issue.issue_id).ok();
+                if parent.schema_version != 1
+                    || parent.parent_issue_id != issue.issue_id
+                    || parent.parent_identifier != issue.identifier
+                    || handle.checkout_generation().is_some()
+                    || expected_generation != Some(parent.hierarchy_generation)
+                    || expected_key.to_str() != Some(handle.workspace_key())
+                    || generated_key.as_deref() != Some(handle.workspace_key())
+                    || normalize_absolute_path(&parent.workspace_path)
+                        .ok()
+                        .as_deref()
+                        != Some(handle.workspace_path())
+                    || parent.child_checkout_map != Path::new("child-checkouts.json")
+                    || parent.integration_plan != Path::new("integration-plan.md")
+                    || parent.evidence_directory != Path::new("evidence")
+                    || parent.repositories_directory != Path::new("repositories")
+                    || path_exists(&handle.workspace_path().join(".git")).await?
+                {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "skipping parent execution root with inconsistent identity during recovery"
+                    );
+                    continue;
+                }
+                workspaces.push((handle, issue));
+            }
+        }
+
         Ok(workspaces)
     }
 
@@ -5525,16 +5671,12 @@ impl WorkspaceManager {
             .as_deref()
             .map(redact_runtime_diagnostic);
         for hook in &mut sanitized.hooks {
-            hook.command = redact_runtime_diagnostic(&hook.command);
-            hook.stdout = redact_runtime_diagnostic(&hook.stdout);
-            hook.stderr = redact_runtime_diagnostic(&hook.stderr);
+            redact_hook_execution_record(hook);
         }
         if let Some(cleanup) = sanitized.cleanup_intent.as_mut() {
             cleanup.last_error = cleanup.last_error.as_deref().map(redact_runtime_diagnostic);
             if let Some(hook) = cleanup.before_remove.as_mut() {
-                hook.command = redact_runtime_diagnostic(&hook.command);
-                hook.stdout = redact_runtime_diagnostic(&hook.stdout);
-                hook.stderr = redact_runtime_diagnostic(&hook.stderr);
+                redact_hook_execution_record(hook);
             }
         }
         self.write_manifest_atomically(workspace, &workspace.run_manifest_path(), &sanitized)
@@ -7725,6 +7867,12 @@ fn issue_manifest_owns_checkout(
         && checkout.sanitized_workspace_key == manifest.sanitized_workspace_key
         && checkout.workspace_path == handle.workspace_path()
         && issue_manifest_binding_matches_checkout(manifest, checkout)
+}
+
+fn redact_hook_execution_record(record: &mut HookExecutionRecord) {
+    record.command = redact_runtime_diagnostic(&record.command);
+    record.stdout = redact_runtime_diagnostic(&record.stdout);
+    record.stderr = redact_runtime_diagnostic(&record.stderr);
 }
 
 fn ensure_descendant(root: &Path, candidate: &Path) -> Result<(), WorkspaceError> {

--- a/crates/opensymphony-workspace/src/manager.rs
+++ b/crates/opensymphony-workspace/src/manager.rs
@@ -4951,12 +4951,12 @@ impl WorkspaceManager {
             }
         }
 
-        let before_remove_succeeded = run_manifest
+        let before_remove_recorded = run_manifest
             .cleanup_intent
             .as_ref()
             .and_then(|intent| intent.before_remove.as_ref())
-            .is_some_and(|receipt| receipt.status == HookExecutionStatus::Succeeded);
-        if !before_remove_succeeded {
+            .is_some();
+        if !before_remove_recorded {
             match self.execute_hook(HookKind::BeforeRemove, workspace).await {
                 Ok(record) => {
                     if let Some(record) = record {
@@ -4984,7 +4984,6 @@ impl WorkspaceManager {
                     intent.retry_count = intent.retry_count.saturating_add(1);
                     intent.last_error = Some(failure.error.to_string());
                     self.write_run_manifest(workspace, &run_manifest).await?;
-                    return Err(failure.error);
                 }
             }
         }

--- a/crates/opensymphony-workspace/src/models.rs
+++ b/crates/opensymphony-workspace/src/models.rs
@@ -1011,6 +1011,8 @@ pub struct CleanupTombstone {
     pub outcome: CleanupTerminalOutcome,
     pub deletion_started_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_remove: Option<HookExecutionRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deleted_at: Option<DateTime<Utc>>,
 }
 

--- a/crates/opensymphony-workspace/src/models.rs
+++ b/crates/opensymphony-workspace/src/models.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt,
     path::{Path, PathBuf},
     time::Duration,
@@ -8,7 +8,7 @@ use std::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::opensymphony_domain::{RepositoryBinding, RepositoryBindingOutcome};
+use crate::opensymphony_domain::{RepositoryBinding, RepositoryBindingOutcome, WorkspaceRecord};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckoutRepository {
@@ -53,8 +53,8 @@ pub fn environment_variable_names_equal(left: &str, right: &str) -> bool {
 
 pub fn checkout_credential_environment_variables(
     repositories: &BTreeMap<String, CheckoutRepository>,
-) -> std::collections::BTreeSet<String> {
-    let mut variables = std::collections::BTreeSet::new();
+) -> BTreeSet<String> {
+    let mut variables = BTreeSet::new();
     for repository in repositories.values() {
         if let Some(variable) = repository.credential_env.as_ref() {
             variables.insert(variable.clone());
@@ -944,10 +944,81 @@ pub enum CleanupDecision {
     Remove,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupTerminalOutcome {
+    Succeeded,
+    Failed,
+    Canceled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanupRequest {
+    pub generation: String,
+    pub outcome: CleanupTerminalOutcome,
+    pub remove: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CleanupTarget {
+    pub issue_id: String,
+    pub identifier: String,
+    pub workspace: WorkspaceRecord,
+    pub generation: String,
+    pub outcome: CleanupTerminalOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CleanupIntent {
+    pub generation: String,
+    pub outcome: CleanupTerminalOutcome,
+    pub requested_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_remove: Option<HookExecutionRecord>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub removed_integration_worktrees: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletion_started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub retry_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+impl CleanupIntent {
+    pub fn new(request: &CleanupRequest) -> Self {
+        Self {
+            generation: request.generation.clone(),
+            outcome: request.outcome,
+            requested_at: Utc::now(),
+            before_remove: None,
+            removed_integration_worktrees: BTreeSet::new(),
+            deletion_started_at: None,
+            retry_count: 0,
+            last_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CleanupTombstone {
+    pub schema_version: u32,
+    pub issue_id: String,
+    pub identifier: String,
+    pub sanitized_workspace_key: String,
+    pub workspace_path: PathBuf,
+    pub generation: String,
+    pub outcome: CleanupTerminalOutcome,
+    pub deletion_started_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CleanupOutcome {
     pub decision: CleanupDecision,
     pub before_remove: Option<HookExecutionRecord>,
+    pub tombstone: Option<CleanupTombstone>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1088,6 +1159,8 @@ pub struct RunManifest {
     pub status_detail: Option<String>,
     #[serde(default)]
     pub hooks: Vec<HookExecutionRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_intent: Option<CleanupIntent>,
 }
 
 impl RunManifest {
@@ -1117,6 +1190,7 @@ impl RunManifest {
             updated_at: now,
             status_detail: None,
             hooks: Vec::new(),
+            cleanup_intent: None,
         }
     }
 }

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -3976,7 +3976,7 @@ async fn terminal_cleanup_can_delete_workspace() {
 }
 
 #[tokio::test]
-async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_tombstone() {
+async fn terminal_cleanup_receipts_best_effort_hook_and_accepts_only_its_generation_tombstone() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
     let workspace_root = temp_dir.path().join("workspaces");
     let manager = WorkspaceManager::new(manager_config(
@@ -4003,15 +4003,24 @@ async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_to
         remove: true,
     };
 
-    let first = manager
-        .cleanup_with_request(
-            &ensured.handle,
-            IssueLifecycleState::Terminal,
-            request.clone(),
-        )
+    manager
+        .prepare_cleanup_target(&CleanupTarget {
+            issue_id: issue.issue_id.clone(),
+            identifier: issue.identifier.clone(),
+            workspace: WorkspaceRecord {
+                path: ensured.handle.workspace_path().to_path_buf(),
+                workspace_key: WorkspaceKey::new(ensured.handle.workspace_key().to_owned())
+                    .expect("managed key"),
+                created_now: false,
+                created_at: None,
+                updated_at: None,
+                last_seen_tracker_refresh_at: None,
+            },
+            generation: request.generation.clone(),
+            outcome: request.outcome,
+        })
         .await
-        .expect_err("failed hook must keep the workspace for retry");
-    assert!(matches!(first, WorkspaceError::HookFailed { .. }));
+        .expect("a best-effort hook failure must not block cleanup preparation");
     assert!(ensured.handle.workspace_path().exists());
     let failed_manifest = manager
         .load_run_manifest(&ensured.handle)
@@ -4022,7 +4031,6 @@ async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_to
         failed_manifest.cleanup_intent.expect("intent").retry_count,
         1
     );
-
     let tombstone_directory = workspace_root.join(".opensymphony-cleanup-tombstones");
     std::fs::write(&tombstone_directory, "blocked")
         .expect("simulate a tombstone permission/path failure");
@@ -4093,8 +4101,8 @@ async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_to
             .expect("hook count")
             .lines()
             .count(),
-        2,
-        "the successful hook receipt must not be rerun after deletion"
+        1,
+        "a best-effort hook receipt must not be rerun after deletion starts"
     );
 
     let recreated = manager

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -2,16 +2,16 @@ use std::{collections::BTreeMap, process::Command, time::Duration};
 
 use crate::opensymphony_domain::{
     CanonicalRepositoryId, RepositoryBinding, RepositoryBindingOutcome, RepositoryIdentity,
-    SafeRemoteFingerprint,
+    SafeRemoteFingerprint, WorkspaceKey, WorkspaceRecord,
 };
 use crate::opensymphony_workspace::{
-    CheckoutManifest, CheckoutRepository, CleanupConfig, CleanupDecision, ConversationManifest,
-    HookConfig, HookDefinition, HookExecutionRecord, HookExecutionStatus, HookKind,
-    IssueContextArtifact, IssueDescriptor, IssueLifecycleState, ParentCheckoutRequest,
-    ParentRuntimeDescriptor, PromptCaptureDescriptor, PromptKind, RunDescriptor, RunManifest,
-    RunStatus, SessionContextArtifact, WorkspaceError, WorkspaceManager, WorkspaceManagerConfig,
-    compose_parent_continuation_prompt, compose_parent_prompt, compose_terminal_prompt,
-    parent_workspace_key,
+    CheckoutManifest, CheckoutRepository, CleanupConfig, CleanupDecision, CleanupRequest,
+    CleanupTarget, CleanupTerminalOutcome, ConversationManifest, HookConfig, HookDefinition,
+    HookExecutionRecord, HookExecutionStatus, HookKind, IssueContextArtifact, IssueDescriptor,
+    IssueLifecycleState, ParentCheckoutRequest, ParentRuntimeDescriptor, PromptCaptureDescriptor,
+    PromptKind, RunDescriptor, RunManifest, RunStatus, SessionContextArtifact, WorkspaceError,
+    WorkspaceManager, WorkspaceManagerConfig, compose_parent_continuation_prompt,
+    compose_parent_prompt, compose_terminal_prompt, parent_workspace_key,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -1092,11 +1092,29 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
                 .join(&checkout.relative_path)
         })
         .collect::<Vec<_>>();
+    let cleanup_target = CleanupTarget {
+        issue_id: parent.issue_id.clone(),
+        identifier: parent.identifier.clone(),
+        workspace: WorkspaceRecord {
+            path: cleanup_parent.handle.workspace_path().to_path_buf(),
+            workspace_key: WorkspaceKey::new(cleanup_parent.handle.workspace_key().to_owned())
+                .expect("managed key"),
+            created_now: false,
+            created_at: None,
+            updated_at: None,
+            last_seen_tracker_refresh_at: None,
+        },
+        generation: "parent:9".to_owned(),
+        outcome: CleanupTerminalOutcome::Succeeded,
+    };
     manager
-        .cleanup_failed_terminal_workspace(&cleanup_parent.handle)
+        .prepare_cleanup_target(&cleanup_target)
         .await
-        .expect("terminal parent cleanup should unregister integration worktrees");
-    assert!(!cleanup_parent.handle.workspace_path().exists());
+        .expect("parent preparation should unregister integration worktrees");
+    assert!(
+        cleanup_parent.handle.workspace_path().exists(),
+        "preparation must preserve the parent root until descendants are cleaned"
+    );
     let registered_worktrees = [
         child_a1.handle.workspace_path(),
         child_b.handle.workspace_path(),
@@ -1112,6 +1130,11 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
             "terminal cleanup must remove the Git worktree registration"
         );
     }
+    manager
+        .cleanup_target(&cleanup_target)
+        .await
+        .expect("terminal parent cleanup should remove its prepared root");
+    assert!(!cleanup_parent.handle.workspace_path().exists());
     manager
         .prepare_parent_execution_root(&parent, 9, repeat_requests.clone())
         .await
@@ -3926,6 +3949,198 @@ async fn terminal_cleanup_can_delete_workspace() {
             .await
             .is_err()
     );
+}
+
+#[tokio::test]
+async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_tombstone() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig {
+            before_remove: Some(HookDefinition::shell(
+                "printf 'run\\n' >> ../hook-count; if [ -f .cleanup-ready ]; then exit 0; else touch .cleanup-ready; exit 7; fi",
+            )),
+            ..HookConfig::default()
+        },
+        CleanupConfig {
+            remove_terminal_workspaces: true,
+        },
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263-terminal-retry");
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("workspace should exist");
+    let request = CleanupRequest {
+        generation: format!("workspace:{}", issue.issue_id),
+        outcome: CleanupTerminalOutcome::Succeeded,
+        remove: true,
+    };
+
+    let first = manager
+        .cleanup_with_request(
+            &ensured.handle,
+            IssueLifecycleState::Terminal,
+            request.clone(),
+        )
+        .await
+        .expect_err("failed hook must keep the workspace for retry");
+    assert!(matches!(first, WorkspaceError::HookFailed { .. }));
+    assert!(ensured.handle.workspace_path().exists());
+    let failed_manifest = manager
+        .load_run_manifest(&ensured.handle)
+        .await
+        .expect("manifest should load")
+        .expect("cleanup intent should exist");
+    assert_eq!(
+        failed_manifest.cleanup_intent.expect("intent").retry_count,
+        1
+    );
+
+    let tombstone_directory = workspace_root.join(".opensymphony-cleanup-tombstones");
+    std::fs::write(&tombstone_directory, "blocked")
+        .expect("simulate a tombstone permission/path failure");
+    manager
+        .cleanup_with_request(
+            &ensured.handle,
+            IssueLifecycleState::Terminal,
+            request.clone(),
+        )
+        .await
+        .expect_err("tombstone failure must leave the prepared workspace retryable");
+    assert!(ensured.handle.workspace_path().exists());
+    std::fs::remove_file(&tombstone_directory).expect("repair tombstone directory");
+
+    let removed = manager
+        .cleanup_with_request(
+            &ensured.handle,
+            IssueLifecycleState::Terminal,
+            request.clone(),
+        )
+        .await
+        .expect("retry should remove the intended generation");
+    assert!(
+        removed
+            .tombstone
+            .as_ref()
+            .and_then(|t| t.deleted_at)
+            .is_some()
+    );
+    let tombstone_path = std::fs::read_dir(&tombstone_directory)
+        .expect("tombstone directory")
+        .next()
+        .expect("tombstone entry")
+        .expect("tombstone path")
+        .path();
+    let mut incomplete: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&tombstone_path).expect("read completed tombstone"))
+            .expect("decode tombstone");
+    incomplete["deleted_at"] = serde_json::Value::Null;
+    std::fs::write(
+        &tombstone_path,
+        serde_json::to_vec_pretty(&incomplete).expect("encode incomplete tombstone"),
+    )
+    .expect("simulate a crash after deletion and before completion receipt");
+    let resumed = manager
+        .cleanup_with_request(&ensured.handle, IssueLifecycleState::Terminal, request)
+        .await
+        .expect("matching tombstone should make restart cleanup idempotent");
+    assert!(
+        resumed
+            .tombstone
+            .as_ref()
+            .and_then(|tombstone| tombstone.deleted_at)
+            .is_some(),
+        "restart should complete a deletion-started tombstone"
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace_root.join("hook-count"))
+            .expect("hook count")
+            .lines()
+            .count(),
+        2,
+        "the successful hook receipt must not be rerun after deletion"
+    );
+
+    let recreated = manager
+        .ensure(&issue)
+        .await
+        .expect("the issue workspace may be recreated after cleanup");
+    std::fs::remove_dir_all(recreated.handle.workspace_path())
+        .expect("simulate deletion of the recreated generation");
+    let stale = manager
+        .cleanup_with_request(
+            &recreated.handle,
+            IssueLifecycleState::Terminal,
+            CleanupRequest {
+                generation: format!("workspace:{}", issue.issue_id),
+                outcome: CleanupTerminalOutcome::Succeeded,
+                remove: true,
+            },
+        )
+        .await
+        .expect_err("recreation must invalidate the earlier tombstone");
+    assert!(matches!(
+        stale,
+        WorkspaceError::MissingCleanupTombstone { .. }
+    ));
+}
+
+#[tokio::test]
+async fn missing_workspace_without_matching_generation_tombstone_is_not_cleanup_success() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let workspace_root = temp_dir.path().join("workspaces");
+    let manager = WorkspaceManager::new(manager_config(
+        &workspace_root,
+        HookConfig::default(),
+        CleanupConfig {
+            remove_terminal_workspaces: true,
+        },
+    ))
+    .expect("manager should build");
+    let issue = sample_issue("COE-263-missing-no-tombstone");
+    let ensured = manager
+        .ensure(&issue)
+        .await
+        .expect("workspace should exist");
+    let mismatch = manager
+        .cleanup_with_request(
+            &ensured.handle,
+            IssueLifecycleState::Terminal,
+            CleanupRequest {
+                generation: "workspace:other-generation".to_owned(),
+                outcome: CleanupTerminalOutcome::Succeeded,
+                remove: true,
+            },
+        )
+        .await
+        .expect_err("a live workspace must reject another generation");
+    assert!(matches!(
+        mismatch,
+        WorkspaceError::CleanupGenerationMismatch { .. }
+    ));
+    tokio::fs::remove_dir_all(ensured.handle.workspace_path())
+        .await
+        .expect("simulate external deletion");
+
+    let error = manager
+        .cleanup_with_request(
+            &ensured.handle,
+            IssueLifecycleState::Terminal,
+            CleanupRequest {
+                generation: format!("workspace:{}", issue.issue_id),
+                outcome: CleanupTerminalOutcome::Succeeded,
+                remove: true,
+            },
+        )
+        .await
+        .expect_err("missing path without a tombstone must remain visible");
+    assert!(matches!(
+        error,
+        WorkspaceError::MissingCleanupTombstone { .. }
+    ));
 }
 
 #[tokio::test]

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -1107,6 +1107,30 @@ async fn parent_execution_root_reuses_three_repositories_and_preserves_children(
         generation: "parent:9".to_owned(),
         outcome: CleanupTerminalOutcome::Succeeded,
     };
+    let stale_child_target = CleanupTarget {
+        issue_id: child_a1.handle.issue_id().to_owned(),
+        identifier: child_a1.handle.identifier().to_owned(),
+        workspace: WorkspaceRecord {
+            path: child_a1.handle.workspace_path().to_path_buf(),
+            workspace_key: WorkspaceKey::new(child_a1.handle.workspace_key().to_owned())
+                .expect("managed key"),
+            created_now: false,
+            created_at: None,
+            updated_at: None,
+            last_seen_tracker_refresh_at: None,
+        },
+        generation: "stale-retained-generation".to_owned(),
+        outcome: CleanupTerminalOutcome::Succeeded,
+    };
+    assert!(matches!(
+        manager.cleanup_target(&stale_child_target).await,
+        Err(WorkspaceError::CleanupGenerationMismatch { actual, .. })
+            if actual == child_a1.handle.checkout_generation().expect("generation")
+    ));
+    assert!(
+        child_a1.handle.workspace_path().exists(),
+        "an old retained generation must not delete the current checkout"
+    );
     manager
         .prepare_cleanup_target(&cleanup_target)
         .await
@@ -4043,10 +4067,14 @@ async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_to
         serde_json::to_vec_pretty(&incomplete).expect("encode incomplete tombstone"),
     )
     .expect("simulate a crash after deletion and before completion receipt");
+    std::fs::create_dir_all(ensured.handle.metadata_dir())
+        .expect("simulate a partially removed workspace root");
+    std::fs::write(ensured.handle.workspace_path().join("undeleted"), "blocked")
+        .expect("partial deletion should leave visible residue");
     let resumed = manager
         .cleanup_with_request(&ensured.handle, IssueLifecycleState::Terminal, request)
         .await
-        .expect("matching tombstone should make restart cleanup idempotent");
+        .expect("matching tombstone should resume partial deletion");
     assert!(
         resumed
             .tombstone
@@ -4055,6 +4083,11 @@ async fn terminal_cleanup_retries_failed_hook_and_accepts_only_its_generation_to
             .is_some(),
         "restart should complete a deletion-started tombstone"
     );
+    assert!(
+        resumed.before_remove.is_some(),
+        "the external tombstone must preserve the successful hook receipt"
+    );
+    assert!(!ensured.handle.workspace_path().exists());
     assert_eq!(
         std::fs::read_to_string(workspace_root.join("hook-count"))
             .expect("hook count")

--- a/crates/opensymphony-workspace/tests/workspace_manager.rs
+++ b/crates/opensymphony-workspace/tests/workspace_manager.rs
@@ -1203,6 +1203,15 @@ async fn parent_execution_root_supports_no_required_child_checkouts() {
         .await
         .expect("a parent with no required child checkouts should still get an execution root");
 
+    let discovered = manager
+        .list_all_workspaces()
+        .await
+        .expect("nested parent roots should be discoverable for recovery");
+    assert!(discovered.iter().any(|(handle, manifest)| {
+        handle.workspace_path() == prepared.handle.workspace_path()
+            && manifest.issue_id == parent.issue_id
+    }));
+
     assert!(!prepared.handle.workspace_path().join(".git").exists());
     assert!(prepared.child_checkout_map.repositories.is_empty());
     assert!(
@@ -3983,7 +3992,7 @@ async fn terminal_cleanup_receipts_best_effort_hook_and_accepts_only_its_generat
         &workspace_root,
         HookConfig {
             before_remove: Some(HookDefinition::shell(
-                "printf 'run\\n' >> ../hook-count; if [ -f .cleanup-ready ]; then exit 0; else touch .cleanup-ready; exit 7; fi",
+                "printf 'token=hook-secret\\n' >> ../hook-count; if [ -f .cleanup-ready ]; then exit 0; else touch .cleanup-ready; exit 7; fi",
             )),
             ..HookConfig::default()
         },
@@ -4069,6 +4078,10 @@ async fn terminal_cleanup_receipts_best_effort_hook_and_accepts_only_its_generat
     let mut incomplete: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&tombstone_path).expect("read completed tombstone"))
             .expect("decode tombstone");
+    let completed_tombstone =
+        std::fs::read_to_string(&tombstone_path).expect("read tombstone text");
+    assert!(!completed_tombstone.contains("hook-secret"));
+    assert!(completed_tombstone.contains("[redacted]"));
     incomplete["deleted_at"] = serde_json::Value::Null;
     std::fs::write(
         &tombstone_path,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,7 +187,23 @@ instructions remain in the bound conversation rather than being replayed.
 Terminal success is gated by the durable controller's completed state in both
 live and recovery release paths. Completed parent roots and their descendant
 leases remain durable for capture retry; OSYM-893 consumes that terminal state
-for ordered worktree cleanup and lease release.
+for ordered worktree cleanup and lease release. After automatic capture commits
+all selected parent capsules, the run loop asks the scheduler to persist a
+generation-bound subtree cleanup intent. Cleanup first archives the stopped
+harness conversation and asks the workspace manager to receipt the
+`before_remove` hook and detach every parent integration worktree through Git.
+Only then does the scheduler release that parent's lease owners and remove
+unleased descendant generations from deepest to shallowest, followed by the
+non-Git parent root. A lease owned by another ancestor or by an unexpired
+diagnostic hold continues to block its generation.
+
+The scheduler receipts every prepared or deleted target in the durable parent
+controller. Workspace run manifests hold the hook and integration-worktree
+receipts, while root-level generation tombstones bracket recursive deletion.
+Restart repeats only an incomplete step. A missing path is successful only when
+the tombstone matches its issue, workspace key, path, terminal outcome, and
+generation. Failed and canceled parents use the existing failed-workspace
+retention policy instead of changing terminal classification during cleanup.
 
 ### 3.2 OpenHands is the execution adapter
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -541,7 +541,12 @@ Completed parent roots remain retained across reconciliation and restart so a
 transient capture failure cannot erase the repository/run provenance needed for
 the next attempt. Their descendant leases remain active with the root so leaf
 cleanup cannot invalidate registered integration worktrees before OSYM-893
-records capture acknowledgement and performs ordered cleanup.
+records capture acknowledgement and performs ordered cleanup. The run loop
+records that acknowledgement only after the capture workflow completes for the
+selected parent. Cleanup first receipts hook execution and detaches the parent
+integration worktrees, then removes unleased descendants bottom-up and the
+parent root last. Failure to persist the acknowledgement leaves the capture
+candidate eligible for retry.
 For a parent, the capture path also reads validated durable controller state
 and requires the matching lifecycle to be `completed`, its final attempt to be
 passed for the same run and input version, its final evidence to be bound to the

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -548,13 +548,16 @@ integration worktrees, then removes unleased descendants bottom-up and the
 parent root last. Failure to persist the acknowledgement leaves the capture
 candidate eligible for retry.
 For a parent, the capture path also reads validated durable controller state
-and requires the matching lifecycle to be `completed`, its final attempt to be
-passed for the same run and input version, its final evidence to be bound to the
-same conversation, and its exact repository commit map to equal the runtime
-envelope. A terminal run manifest or harness success by itself cannot authorize
-parent capture. The durable binding explicitly marks a parent even when this
-verified commit map is empty, so repository-neutral capture cannot inherit a
-configured default leaf repository. That empty-target capture still records one
+and requires a matching terminal lifecycle. Successful completion additionally
+requires its final attempt to be passed for the same run and input version, its
+final evidence to be bound to the same conversation, and its exact repository
+commit map to equal the runtime envelope. A terminal run manifest or harness
+success by itself cannot authorize successful parent capture. Failed and
+canceled controllers receive a repository-neutral parent binding with no
+verified commit claims so their diagnostics can be captured before the explicit
+retention policy runs. The durable binding explicitly marks a parent even when
+its commit map is empty, so repository-neutral capture cannot inherit a
+configured default leaf repository. That capture still records one
 repository-neutral parent-runtime source reference with the durable run and
 attempt identifiers.
 Retained legacy run envelopes that lack usable run/attempt provenance are

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,6 +24,13 @@ hierarchy and lease artifact before reconciling terminal workspaces. The
 artifact is an internal durable record; operators should not edit it manually.
 Recovery rebuilds ancestor retention before cleanup, and cleanup remains
 blocked while any owner-identified lease for the checkout generation is active.
+For a captured terminal parent, recovery also resumes its durable subtree
+cleanup intent. The persisted order is parent worktree detachment, release of
+that parent's lease owners, deepest-first descendant deletion, and parent-root
+deletion. A higher-ancestor lease or an unexpired diagnostic hold keeps the
+affected generation pending. Cleanup errors remain in the controller and are
+retried on later ticks; operators should correct the reported hook, Git, or
+filesystem condition rather than delete the path manually.
 
 ## 2. First-run flow
 
@@ -527,6 +534,10 @@ downloaded fallback `cargo check-dev`, `cargo test-dev`, and `cargo clippy-dev`
 aliases. Treat that native dependency as part of the hosted deployment threat
 model before enabling memory in a multi-tenant service.
 Memory capture does not archive Linear issues.
+When automatic capture completes a terminal parent capsule, `opensymphony run`
+persists a capture acknowledgement before allowing subtree cleanup. A failed
+capture is not acknowledged, so the parent evidence and protecting leases stay
+available for the next capture attempt.
 
 Read commands such as `memory status`, `memory brief`, `memory related`, and
 `memory context` open the DuckDB index in read-only mode and do not run schema

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -554,8 +554,10 @@ exist, then removes the parent root and proves the same generation can be
 prepared again without a stale Git registration. Scheduler regressions prove
 capture acknowledgement, parent preparation before descendant removal,
 deepest-first receipt recovery, hook-once behavior, exact-generation
-tombstones, higher-owner preservation, failed/canceled retention, and retry of
-visible cleanup failures. A lower-level regression proves the
+tombstones, partial-directory deletion recovery, on-disk checkout generation
+validation, completed-parent capture after restart, higher-owner preservation,
+failed/canceled retention, and retry of visible cleanup failures. A lower-level
+regression proves the
 orchestrator Git command overrides checkout-controlled fsmonitor configuration
 and default repository hooks at execution time. Focused
 OpenHands and Codex tests bind the same logical `parent_multi_checkout` envelope

--- a/docs/testing-and-operations.md
+++ b/docs/testing-and-operations.md
@@ -549,8 +549,13 @@ root into a Git repository. It also covers parent `after_create`
 receipt/reuse/failure behavior and proves a child-controlled direct or
 worktree-conditional fsmonitor executable is rejected without running before
 the incomplete parent root is rolled back. Terminal cleanup also unregisters
-the real integration worktrees and proves the same generation can be prepared
-again without a stale Git registration. A lower-level regression proves the
+the real integration worktrees while the parent and source generations still
+exist, then removes the parent root and proves the same generation can be
+prepared again without a stale Git registration. Scheduler regressions prove
+capture acknowledgement, parent preparation before descendant removal,
+deepest-first receipt recovery, hook-once behavior, exact-generation
+tombstones, higher-owner preservation, failed/canceled retention, and retry of
+visible cleanup failures. A lower-level regression proves the
 orchestrator Git command overrides checkout-controlled fsmonitor configuration
 and default repository hooks at execution time. Focused
 OpenHands and Codex tests bind the same logical `parent_multi_checkout` envelope

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -244,13 +244,17 @@ failed `before_remove` receipt remains visible but does not block deletion or
 run the best-effort hook again.
 Generation tombstones outside the deleted workspace are written before root
 deletion and completed afterward; they also copy the successful hook receipt so
-a partially removed metadata directory cannot cause the hook to run twice. On
-restart, an incomplete tombstone resumes deletion even when part of the root
-remains, while an already missing path is accepted only for an exact issue,
-key, path, outcome, and generation match. Live checkout deletion reads the
-generation and ownership from its on-disk manifests instead of trusting a
-requested handle. Completed parent executions are restored as capture
-candidates during restart recovery. Hook, Git, manifest,
+a partially removed metadata directory cannot cause the hook to run twice. The
+external copy applies the same diagnostic redaction as the run manifest. On
+restart, an incomplete tombstone proves that archival and cleanup preparation
+already completed and resumes deletion even when part of the root remains or
+its run manifest is gone. An already missing path is accepted only for an exact
+issue, key, path, outcome, and generation match. Live checkout deletion reads
+the generation and ownership from its on-disk manifests instead of trusting a
+requested handle. Recovery enumerates both checkout roots and nested
+`parents/<key>/<generation>` roots, so completed parent executions return as
+capture candidates and their conversations pass through the archival fence.
+Hook, Git, manifest,
 tombstone, permission, and filesystem failures remain visible on the durable
 cleanup intent and retry on later scheduler ticks.
 

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -224,8 +224,11 @@ reconciliation or operator recovery.
 A completed parent stays materialized until automatic terminal capture reports
 that its workflow completed. The scheduler then persists the parent root and
 every leased descendant as one hierarchy-generation cleanup intent. Failed and
-canceled parents record the same acknowledgement but remain retained when the
-existing failed-workspace policy requests diagnostics retention.
+canceled parents record the same acknowledgement. Failed parents remain
+retained when the existing failed-workspace policy requests diagnostics
+retention; canceled parents follow the existing cancellation cleanup policy.
+Changing failed-workspace retention from enabled to disabled resumes a durable
+retained cleanup intent on the next reconciliation tick.
 
 Removal has two ordered phases. First, the runtime backend applies its normal
 conversation archival fence and the workspace manager receipts the parent
@@ -236,7 +239,9 @@ removes descendants deepest first when no other active owner remains. The
 parent root is removed last. Higher ancestors and bounded diagnostic holds
 therefore preserve their checkout generations.
 
-Run-manifest receipts make the hook and each worktree removal idempotent.
+Run-manifest receipts make the hook and each worktree removal idempotent. A
+failed `before_remove` receipt remains visible but does not block deletion or
+run the best-effort hook again.
 Generation tombstones outside the deleted workspace are written before root
 deletion and completed afterward; they also copy the successful hook receipt so
 a partially removed metadata directory cannot cause the hook to run twice. On

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -238,9 +238,14 @@ therefore preserve their checkout generations.
 
 Run-manifest receipts make the hook and each worktree removal idempotent.
 Generation tombstones outside the deleted workspace are written before root
-deletion and completed afterward. On restart, an incomplete tombstone resumes
-the deletion, while an already missing path is accepted only for an exact
-issue, key, path, outcome, and generation match. Hook, Git, manifest,
+deletion and completed afterward; they also copy the successful hook receipt so
+a partially removed metadata directory cannot cause the hook to run twice. On
+restart, an incomplete tombstone resumes deletion even when part of the root
+remains, while an already missing path is accepted only for an exact issue,
+key, path, outcome, and generation match. Live checkout deletion reads the
+generation and ownership from its on-disk manifests instead of trusting a
+requested handle. Completed parent executions are restored as capture
+candidates during restart recovery. Hook, Git, manifest,
 tombstone, permission, and filesystem failures remain visible on the durable
 cleanup intent and retry on later scheduler ticks.
 

--- a/docs/workspace-and-lifecycle.md
+++ b/docs/workspace-and-lifecycle.md
@@ -219,6 +219,31 @@ acknowledgement only after every attempt has conclusive stopped and cleanup
 evidence. A conversation-bound indeterminate attempt remains retained for stop
 reconciliation or operator recovery.
 
+### Capture-acknowledged subtree cleanup
+
+A completed parent stays materialized until automatic terminal capture reports
+that its workflow completed. The scheduler then persists the parent root and
+every leased descendant as one hierarchy-generation cleanup intent. Failed and
+canceled parents record the same acknowledgement but remain retained when the
+existing failed-workspace policy requests diagnostics retention.
+
+Removal has two ordered phases. First, the runtime backend applies its normal
+conversation archival fence and the workspace manager receipts the parent
+`before_remove` hook and removes each registered integration worktree with
+`git worktree remove`. The parent root remains present during this phase.
+Second, the scheduler releases only lease owners belonging to that parent and
+removes descendants deepest first when no other active owner remains. The
+parent root is removed last. Higher ancestors and bounded diagnostic holds
+therefore preserve their checkout generations.
+
+Run-manifest receipts make the hook and each worktree removal idempotent.
+Generation tombstones outside the deleted workspace are written before root
+deletion and completed afterward. On restart, an incomplete tombstone resumes
+the deletion, while an already missing path is accepted only for an exact
+issue, key, path, outcome, and generation match. Hook, Git, manifest,
+tombstone, permission, and filesystem failures remain visible on the durable
+cleanup intent and retry on later scheduler ticks.
+
 The final-verification receipt selects an exact harness-observed foreground
 command. The trusted loader computes its SHA-256 identity from the transient
 exact text, then persists only the identity and a bounded redacted diagnostic.
@@ -273,8 +298,9 @@ controller authorizes terminal success only while its hierarchy generation
 still matches the current unblocked snapshot. COE-554 retains the completed
 parent root and its evidence-protecting leases across later reconciliation and
 daemon restart so automatic capture can retry without losing its runtime
-envelope or source checkouts. OSYM-893 owns durable capture acknowledgement,
-ordered lease release, cleanup intent, tombstones, and deletion.
+envelope or source checkouts. The capture acknowledgement starts durable
+bottom-up cleanup as described above; capture failure leaves the parent root
+and leases unchanged for retry.
 A recovered parent worker must find the exact conversation manifest recorded by
 the controller. Its expected identity crosses the scheduler-to-worker request,
 and a missing or different manifest fails before any harness session is


### PR DESCRIPTION
## Summary

Completing a parent now records capture acknowledgement and removes its retained subtree through a durable, lease-aware cleanup phase. Parent Git worktrees are detached before descendant source checkouts, descendant generations are removed deepest-first only after this parent's lease owners are released, and the non-Git parent root is deleted last.

## Changes

- Persist parent subtree cleanup intent and per-target preparation/deletion receipts in the existing durable controller state.
- Persist generation-specific hook/worktree receipts and external deletion tombstones through the workspace manager's atomic artifact boundary.
- Route cleanup through the production runtime backend so OpenHands/Codex archival fences run before workspace mutation.
- Preserve higher-ancestor and bounded diagnostic-hold leases, roll back unpersisted owner-lease release, retain failed/canceled outcomes by policy, and retry incomplete cleanup after restart.
- Persist the `before_remove` attempt fence before hook execution, fail closed on malformed or unavailable generation-bound runtime state, and recover completed parent capture markers after root deletion.
- Fence retry-queued generations, roll back unpersisted completion, and revoke only the cleanup target generation’s memory grant so a newer run remains authorized.
- Refresh tracker state immediately before destructive cleanup retries, fence the exact active generation, and require generation-bound harness archival evidence before removal.
- Keep retained failed cleanup on the normal tracker cadence until a policy change makes it eligible for removal.
- Document the capture acknowledgement and bottom-up cleanup lifecycle.

## Evidence

### Test output

```text
GIT_CONFIG_GLOBAL=/dev/null CARGO_INCREMENTAL=0 cargo test-system-duckdb
  lib: 1370 passed, 0 failed
  scheduler: 145 passed, 0 failed
  workspace_manager: 44 passed, 0 failed
  all remaining integration suites passed; live credential tests remained ignored

CARGO_INCREMENTAL=0 cargo clippy-system-duckdb
  Finished dev profile; no warnings

CARGO_INCREMENTAL=0 cargo check-system-duckdb
  Finished dev profile
```

### Verification

Final exact-head portable validation passed cleanly on `c1d3b094`. An earlier `11844e57` run hit one unrelated concurrent gateway readiness-cache assertion; that exact test passed immediately in isolation and all subsequent complete required runs were green. The final exact-commit Sol/high review found no actionable issues after the tracker-refresh, missing-manifest archival, and retained-refresh fixes.


The existing three-repository temporary-worktree fixture now separates parent preparation from deletion and verifies that every real Git worktree registration is removed while the source generations and parent root still exist. Scheduler tests verify preparation-before-source-deletion order, deepest-first durable receipts, cleanup failure retry, cancellation retention, higher-owner preservation, restart without leaf-lease reacquisition, active-generation fencing, and no repeated cleanup after completion. Runtime tests discover nested parent roots for restart recovery, attach collision-safe parent workspace keys, recover exact prelaunch parent capture bindings without fabricating runtime evidence, enforce Codex archival before parent preparation, and resume an exact deletion-started checkout tombstone when `run.json` is missing. Workspace tests inject hook and tombstone-write failures, redact token-bearing external hook receipts, simulate a crash after deletion but before tombstone completion, reject wrong or missing generation proof, and invalidate stale tombstones when a workspace is recreated.

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Clippy is clean (`cargo clippy`)
- [x] Documentation updated (if behavior changed)
- [x] `AGENTS.md` updated (if repo knowledge changed)
- [x] Evidence section filled out (for substantive changes)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Breaking changes

None.

## Related issues

Linear COE-556 / OSYM-893.

## Additional notes

The first clean build exhausted the host disk through incremental artifacts. Validation was rerun successfully with `CARGO_INCREMENTAL=0`; this changes build caching only and does not change test coverage or runtime behavior.


